### PR TITLE
Replace nodemailer/SMTP with SendGrid API

### DIFF
--- a/apps/events/package.json
+++ b/apps/events/package.json
@@ -10,19 +10,17 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
+    "@imajin/db": "workspace:*",
+    "@imajin/ui": "workspace:*",
     "@noble/ed25519": "^3.0.0",
     "@noble/hashes": "^2.0.1",
     "drizzle-orm": "^0.45.1",
     "next": "14.2.35",
-    "nodemailer": "^8.0.1",
     "react": "^18",
-    "react-dom": "^18",
-    "@imajin/db": "workspace:*",
-    "@imajin/ui": "workspace:*"
+    "react-dom": "^18"
   },
   "devDependencies": {
     "@types/node": "^20",
-    "@types/nodemailer": "^7.0.10",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.24",

--- a/apps/events/src/lib/email.ts
+++ b/apps/events/src/lib/email.ts
@@ -1,23 +1,15 @@
 /**
- * Email service using Proton Mail Bridge
+ * Email service using SendGrid API
  * 
  * Simple HTML templates - no fancy framework needed.
+ * 
+ * Required env vars:
+ *   SENDGRID_API_KEY - API key (starts with SG.)
+ *   SENDGRID_FROM    - Verified sender (e.g. "Jin <jin@imajin.ai>")
  */
 
-import nodemailer from 'nodemailer';
-
-const transporter = nodemailer.createTransport({
-  host: process.env.SMTP_HOST || '127.0.0.1',
-  port: parseInt(process.env.SMTP_PORT || '1025'),
-  secure: false,
-  auth: {
-    user: process.env.SMTP_USER || 'jin@imajin.ai',
-    pass: process.env.SMTP_PASSWORD,
-  },
-  tls: {
-    rejectUnauthorized: false, // Proton Bridge uses self-signed cert
-  },
-});
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
+const SENDGRID_FROM = process.env.SENDGRID_FROM || 'Jin <jin@imajin.ai>';
 
 interface SendEmailOptions {
   to: string;
@@ -27,23 +19,47 @@ interface SendEmailOptions {
 }
 
 export async function sendEmail(options: SendEmailOptions) {
-  const from = process.env.SMTP_FROM || 'Jin <jin@imajin.ai>';
-  
+  if (!SENDGRID_API_KEY) {
+    console.warn('SENDGRID_API_KEY not set — skipping email to', options.to);
+    return { success: false, error: 'No API key configured' };
+  }
+
   try {
-    const result = await transporter.sendMail({
-      from,
-      to: options.to,
-      subject: options.subject,
-      html: options.html,
-      text: options.text || stripHtml(options.html),
+    const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${SENDGRID_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email: options.to }] }],
+        from: parseSender(SENDGRID_FROM),
+        subject: options.subject,
+        content: [
+          { type: 'text/plain', value: options.text || stripHtml(options.html) },
+          { type: 'text/html', value: options.html },
+        ],
+      }),
     });
-    
-    console.log('Email sent:', result.messageId);
-    return { success: true, messageId: result.messageId };
+
+    if (res.status === 202) {
+      console.log('Email sent via SendGrid to', options.to);
+      return { success: true, messageId: res.headers.get('x-message-id') };
+    } else {
+      const body = await res.text();
+      console.error('SendGrid error:', res.status, body);
+      return { success: false, error: `SendGrid ${res.status}: ${body}` };
+    }
   } catch (error) {
     console.error('Email send failed:', error);
     return { success: false, error };
   }
+}
+
+function parseSender(from: string): { email: string; name?: string } {
+  const match = from.match(/^(.+)\s*<(.+)>$/);
+  if (match) return { name: match[1].trim(), email: match[2].trim() };
+  return { email: from };
 }
 
 function stripHtml(html: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,9 +331,6 @@ importers:
       next:
         specifier: 14.2.35
         version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      nodemailer:
-        specifier: ^8.0.1
-        version: 8.0.1
       react:
         specifier: ^18
         version: 18.3.1
@@ -344,9 +341,6 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.33
-      '@types/nodemailer':
-        specifier: ^7.0.10
-        version: 7.0.11
       '@types/react':
         specifier: ^18
         version: 18.3.28
@@ -1806,9 +1800,6 @@ packages:
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
-
-  '@types/nodemailer@7.0.11':
-    resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
 
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
@@ -3440,10 +3431,6 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
-
-  nodemailer@8.0.1:
-    resolution: {integrity: sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==}
-    engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -5142,10 +5129,6 @@ snapshots:
   '@types/node@22.19.11':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/nodemailer@7.0.11':
-    dependencies:
-      '@types/node': 22.19.11
 
   '@types/pg@8.16.0':
     dependencies:
@@ -7061,8 +7044,6 @@ snapshots:
     optional: true
 
   node-releases@2.0.27: {}
-
-  nodemailer@8.0.1: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
Closes #100. Swaps SMTP/nodemailer for SendGrid's REST API. Zero dependencies added — uses native fetch. Requires SENDGRID_API_KEY and SENDGRID_FROM env vars.