### PR TITLE
fix: consolidate invite tables into unified model (closes #205)

### DIFF
--- a/apps/connections/app/invitations-tab.tsx
+++ b/apps/connections/app/invitations-tab.tsx
@@ -106,8 +106,7 @@ export default function InvitationsTab({ onCountUpdate }: { onCountUpdate?: (pen
           remaining: data.remaining,
         };
         setQuota(q);
-        const trustPending = sentTrustInvites.filter(i => i.status === 'pending').length;
-        onCountUpdate?.(q.pending + trustPending, q.remaining);
+        onCountUpdate?.(q.pending, q.remaining);
       }
     } catch {}
   }


### PR DESCRIPTION
Consolidates two separate invite systems into one unified model.

## Changes

**Schema** — Merged `invites` + `trustGraphInvites` into single `invites` table with new columns: `delivery`, `status`, `toDid`, `acceptedAt`, `expiresAt`, `role` (all additive with defaults, safe for existing prod data)

**API** — Single `/api/invites` endpoint handles both link and email delivery. Email invites require hard DID + trust graph membership + cooldown (same rules as before). Deleted entire `/api/trust-invites/` directory.

**UI** — `InvitationsTab` now uses one fetch, one list. Icon driven by `delivery` field. Deleted standalone `trust-invites/page.tsx`.

**Migration script** — Removed `trust_graph_invites` entry.

12 files changed, 252 insertions(+), 933 deletions(-)

Closes #205