### PR TITLE
feat: Learn app — full course platform (#53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ apps/www/.env.development
 
 # Personal
 *.raw.md
-scripts/launch-local.ts
+scripts/launch-local.tsimajin-courses/

--- a/apps/learn/.env.example
+++ b/apps/learn/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL="postgresql://imajin_dev:password@localhost:5432/imajin_dev"
+AUTH_SERVICE_URL="http://localhost:3001"
+PAY_SERVICE_URL="http://localhost:3004"
+CONNECTIONS_SERVICE_URL="http://localhost:3003"

--- a/apps/learn/app/[handle]/page.tsx
+++ b/apps/learn/app/[handle]/page.tsx
@@ -1,0 +1,103 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+
+interface PageProps {
+  params: { handle: string };
+}
+
+async function getCreatorCourses(handle: string) {
+  const authUrl = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3103';
+
+  try {
+    // Resolve handle → DID
+    const identityRes = await fetch(`${authUrl}/api/identity/${handle}`, { cache: 'no-store' });
+    if (!identityRes.ok) return null;
+    const identity = await identityRes.json();
+
+    // Get creator's published courses
+    const coursesRes = await fetch(
+      `${baseUrl}/api/courses?creator_did=${encodeURIComponent(identity.did)}&status=published`,
+      { cache: 'no-store' }
+    );
+    if (!coursesRes.ok) return null;
+    const data = await coursesRes.json();
+
+    return {
+      identity,
+      courses: data.courses,
+    };
+  } catch (error) {
+    console.error('Failed to fetch creator courses:', error);
+    return null;
+  }
+}
+
+export default async function CreatorCoursesPage({ params }: PageProps) {
+  if (params.handle.includes('.') || params.handle === 'favicon') {
+    notFound();
+  }
+
+  const data = await getCreatorCourses(params.handle);
+
+  if (!data) {
+    notFound();
+  }
+
+  const { identity, courses } = data;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
+      <div className="container mx-auto px-4 py-12 max-w-4xl">
+        {/* Creator info */}
+        <div className="text-center mb-12">
+          {identity.avatar && (
+            <img src={identity.avatar} alt={identity.name} className="w-20 h-20 rounded-full mx-auto mb-4 object-cover" />
+          )}
+          <h1 className="text-2xl font-bold">{identity.name || params.handle}</h1>
+          <p className="text-gray-500">@{params.handle}</p>
+          {identity.bio && <p className="text-gray-600 dark:text-gray-400 mt-2 max-w-lg mx-auto">{identity.bio}</p>}
+        </div>
+
+        {/* Courses */}
+        {courses.length === 0 ? (
+          <div className="text-center py-12 text-gray-500">
+            <p>No published courses yet.</p>
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2">
+            {courses.map((course: any) => (
+              <Link
+                key={course.id}
+                href={`/course/${course.slug}`}
+                className="block bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-lg transition-shadow"
+              >
+                {course.imageUrl && (
+                  <div className="aspect-video bg-gray-100 dark:bg-gray-700">
+                    <img src={course.imageUrl} alt={course.title} className="w-full h-full object-cover" />
+                  </div>
+                )}
+                <div className="p-5">
+                  <h3 className="font-semibold text-lg mb-2">{course.title}</h3>
+                  {course.description && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 line-clamp-2">{course.description}</p>
+                  )}
+                  <div className="flex items-center justify-between text-sm text-gray-500">
+                    <span>{course.moduleCount} modules · {course.lessonCount} lessons</span>
+                    <span className="font-medium">
+                      {course.price === 0 ? (
+                        <span className="text-green-600 dark:text-green-400">Free</span>
+                      ) : (
+                        `$${(course.price / 100).toFixed(2)}`
+                      )}
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/learn/app/api/courses/[slug]/enroll/route.ts
+++ b/apps/learn/app/api/courses/[slug]/enroll/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, enrollments, lessons, modules, lessonProgress } from '@/db/schema';
+import { requireAuth } from '@/lib/auth';
+import { generateId, jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and } from 'drizzle-orm';
+
+const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL || 'http://localhost:3004';
+
+type RouteParams = { params: Promise<{ slug: string }> };
+
+/**
+ * POST /api/courses/[slug]/enroll — Enroll in course (free) or initiate payment (paid)
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { slug } = await params;
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const { identity } = authResult;
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+
+  const course = courseResult[0];
+
+  if (course.status !== 'published') return errorResponse('Course is not available for enrollment', 400);
+
+  // Check if already enrolled
+  const existing = await db.select().from(enrollments)
+    .where(and(
+      eq(enrollments.courseId, course.id),
+      eq(enrollments.studentDid, identity.id),
+    )).limit(1);
+
+  if (existing.length > 0) {
+    return jsonResponse({ enrolled: true, enrollment: existing[0] });
+  }
+
+  // Free enrollment
+  if (!course.price || course.price === 0) {
+    const enrollment = {
+      id: generateId('enr'),
+      courseId: course.id,
+      studentDid: identity.id,
+      paymentId: null,
+    };
+
+    await db.insert(enrollments).values(enrollment);
+
+    // Initialize progress for all lessons
+    const courseModules = await db.select().from(modules).where(eq(modules.courseId, course.id));
+    for (const mod of courseModules) {
+      const moduleLessons = await db.select({ id: lessons.id }).from(lessons).where(eq(lessons.moduleId, mod.id));
+      if (moduleLessons.length > 0) {
+        await db.insert(lessonProgress).values(
+          moduleLessons.map(l => ({
+            enrollmentId: enrollment.id,
+            lessonId: l.id,
+            status: 'not_started',
+          }))
+        );
+      }
+    }
+
+    return jsonResponse({ enrolled: true, enrollment }, 201);
+  }
+
+  // Paid enrollment — redirect to pay service
+  const body = await request.json().catch(() => ({}));
+  const successUrl = body.successUrl || `${request.headers.get('origin') || ''}/api/courses/${slug}/enroll/callback`;
+  const cancelUrl = body.cancelUrl || `${request.headers.get('origin') || ''}/${slug}`;
+
+  try {
+    const checkoutResponse = await fetch(`${PAY_SERVICE_URL}/api/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [{
+          name: course.title,
+          description: `Enrollment in "${course.title}"`,
+          amount: course.price,
+          currency: course.currency || 'CAD',
+          quantity: 1,
+          metadata: {
+            type: 'course_enrollment',
+            courseId: course.id,
+            studentDid: identity.id,
+          },
+        }],
+        successUrl,
+        cancelUrl,
+        metadata: {
+          source: 'learn',
+          courseId: course.id,
+          studentDid: identity.id,
+        },
+      }),
+    });
+
+    if (!checkoutResponse.ok) {
+      const error = await checkoutResponse.text();
+      console.error('Pay service error:', error);
+      return errorResponse('Payment initiation failed', 502);
+    }
+
+    const checkout = await checkoutResponse.json();
+    return jsonResponse({ enrolled: false, checkoutUrl: checkout.url });
+  } catch (error) {
+    console.error('Pay service unreachable:', error);
+    return errorResponse('Payment service unavailable', 503);
+  }
+}

--- a/apps/learn/app/api/courses/[slug]/lessons/[lessonId]/complete/route.ts
+++ b/apps/learn/app/api/courses/[slug]/lessons/[lessonId]/complete/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, enrollments, lessonProgress, lessons, modules } from '@/db/schema';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and, sql } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string; lessonId: string }> };
+
+/**
+ * POST /api/courses/[slug]/lessons/[lessonId]/complete — Mark lesson complete
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { slug, lessonId } = await params;
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const { identity } = authResult;
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+
+  const course = courseResult[0];
+
+  // Verify enrollment
+  const enrollResult = await db.select().from(enrollments)
+    .where(and(
+      eq(enrollments.courseId, course.id),
+      eq(enrollments.studentDid, identity.id),
+    )).limit(1);
+
+  if (enrollResult.length === 0) {
+    return errorResponse('Not enrolled in this course', 403);
+  }
+
+  const enrollment = enrollResult[0];
+
+  // Verify lesson exists in this course
+  const lessonResult = await db.select().from(lessons)
+    .innerJoin(modules, eq(lessons.moduleId, modules.id))
+    .where(and(
+      eq(lessons.id, lessonId),
+      eq(modules.courseId, course.id),
+    )).limit(1);
+
+  if (lessonResult.length === 0) {
+    return errorResponse('Lesson not found in this course', 404);
+  }
+
+  // Upsert progress
+  const existingProgress = await db.select().from(lessonProgress)
+    .where(and(
+      eq(lessonProgress.enrollmentId, enrollment.id),
+      eq(lessonProgress.lessonId, lessonId),
+    )).limit(1);
+
+  const now = new Date();
+
+  if (existingProgress.length === 0) {
+    await db.insert(lessonProgress).values({
+      enrollmentId: enrollment.id,
+      lessonId,
+      status: 'completed',
+      completedAt: now,
+    });
+  } else {
+    await db.update(lessonProgress)
+      .set({ status: 'completed', completedAt: now })
+      .where(and(
+        eq(lessonProgress.enrollmentId, enrollment.id),
+        eq(lessonProgress.lessonId, lessonId),
+      ));
+  }
+
+  // Check if all lessons are complete → mark course complete
+  const totalLessons = await db.select({ count: sql<number>`count(*)` })
+    .from(lessons)
+    .innerJoin(modules, eq(lessons.moduleId, modules.id))
+    .where(eq(modules.courseId, course.id));
+
+  const completedLessons = await db.select({ count: sql<number>`count(*)` })
+    .from(lessonProgress)
+    .where(and(
+      eq(lessonProgress.enrollmentId, enrollment.id),
+      eq(lessonProgress.status, 'completed'),
+    ));
+
+  const total = Number(totalLessons[0]?.count || 0);
+  const completed = Number(completedLessons[0]?.count || 0);
+
+  if (completed >= total && total > 0 && !enrollment.completedAt) {
+    await db.update(enrollments)
+      .set({ completedAt: now })
+      .where(eq(enrollments.id, enrollment.id));
+  }
+
+  return jsonResponse({
+    lessonId,
+    status: 'completed',
+    completedAt: now,
+    courseProgress: { total, completed, percentage: total > 0 ? Math.round((completed / total) * 100) : 0 },
+  });
+}

--- a/apps/learn/app/api/courses/[slug]/modules/[moduleId]/lessons/[lessonId]/route.ts
+++ b/apps/learn/app/api/courses/[slug]/modules/[moduleId]/lessons/[lessonId]/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, modules, lessons, enrollments } from '@/db/schema';
+import { requireHardDID, getSessionFromCookie } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string; moduleId: string; lessonId: string }> };
+
+/**
+ * GET /api/courses/[slug]/modules/[moduleId]/lessons/[lessonId] — Get lesson content
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { slug, moduleId, lessonId } = await params;
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+
+  const course = courseResult[0];
+
+  const lessonResult = await db.select().from(lessons).where(eq(lessons.id, lessonId)).limit(1);
+  if (!lessonResult[0]) return errorResponse('Lesson not found', 404);
+
+  const lesson = lessonResult[0];
+
+  // For paid courses, check enrollment
+  if (course.price && course.price > 0) {
+    const cookieHeader = request.headers.get('Cookie');
+    const identity = await getSessionFromCookie(cookieHeader);
+
+    // Creator always has access
+    if (identity?.id !== course.creatorDid) {
+      if (!identity) return errorResponse('Authentication required for paid courses', 401);
+
+      const enrolled = await db.select().from(enrollments)
+        .where(and(
+          eq(enrollments.courseId, course.id),
+          eq(enrollments.studentDid, identity.id),
+        )).limit(1);
+
+      if (enrolled.length === 0) {
+        // Return lesson metadata but not content
+        return jsonResponse({
+          id: lesson.id,
+          title: lesson.title,
+          contentType: lesson.contentType,
+          durationMinutes: lesson.durationMinutes,
+          sortOrder: lesson.sortOrder,
+          content: null,
+          locked: true,
+        });
+      }
+    }
+  }
+
+  return jsonResponse(lesson);
+}
+
+/**
+ * PATCH /api/courses/[slug]/modules/[moduleId]/lessons/[lessonId] — Update lesson
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const { slug, moduleId, lessonId } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+  if (courseResult[0].creatorDid !== authResult.identity.id) return errorResponse('Not authorized', 403);
+
+  const body = await request.json();
+  const updates: Record<string, any> = {};
+  const allowed = ['title', 'contentType', 'content', 'durationMinutes', 'sortOrder', 'metadata'];
+
+  for (const field of allowed) {
+    if (body[field] !== undefined) updates[field] = body[field];
+  }
+
+  if (Object.keys(updates).length === 0) return errorResponse('No fields to update');
+  updates.updatedAt = new Date();
+
+  await db.update(lessons).set(updates).where(eq(lessons.id, lessonId));
+
+  const updated = await db.select().from(lessons).where(eq(lessons.id, lessonId)).limit(1);
+  return jsonResponse(updated[0]);
+}
+
+/**
+ * DELETE /api/courses/[slug]/modules/[moduleId]/lessons/[lessonId] — Delete lesson
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const { slug, moduleId, lessonId } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+  if (courseResult[0].creatorDid !== authResult.identity.id) return errorResponse('Not authorized', 403);
+
+  await db.delete(lessons).where(eq(lessons.id, lessonId));
+  return jsonResponse({ success: true });
+}

--- a/apps/learn/app/api/courses/[slug]/modules/[moduleId]/lessons/reorder/route.ts
+++ b/apps/learn/app/api/courses/[slug]/modules/[moduleId]/lessons/reorder/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, modules, lessons } from '@/db/schema';
+import { requireHardDID } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and, asc } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string; moduleId: string }> };
+
+/**
+ * PATCH /api/courses/[slug]/modules/[moduleId]/lessons/reorder — Reorder lessons
+ * Body: { order: ["lsn_abc", "lsn_def", ...] }
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const { slug, moduleId } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+  if (courseResult[0].creatorDid !== authResult.identity.id) return errorResponse('Not authorized', 403);
+
+  const body = await request.json();
+  const { order } = body;
+  if (!Array.isArray(order)) return errorResponse('order must be an array of lesson IDs');
+
+  await Promise.all(order.map((id: string, index: number) =>
+    db.update(lessons).set({ sortOrder: index }).where(eq(lessons.id, id))
+  ));
+
+  const updated = await db.select().from(lessons)
+    .where(eq(lessons.moduleId, moduleId))
+    .orderBy(asc(lessons.sortOrder));
+
+  return jsonResponse({ lessons: updated });
+}

--- a/apps/learn/app/api/courses/[slug]/modules/[moduleId]/lessons/route.ts
+++ b/apps/learn/app/api/courses/[slug]/modules/[moduleId]/lessons/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, modules, lessons } from '@/db/schema';
+import { requireHardDID, getSessionFromCookie } from '@/lib/auth';
+import { generateId, jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and, asc, sql } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string; moduleId: string }> };
+
+/**
+ * POST /api/courses/[slug]/modules/[moduleId]/lessons — Add lesson
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { slug, moduleId } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+  if (courseResult[0].creatorDid !== authResult.identity.id) return errorResponse('Not authorized', 403);
+
+  const modResult = await db.select().from(modules)
+    .where(and(eq(modules.id, moduleId), eq(modules.courseId, courseResult[0].id))).limit(1);
+  if (!modResult[0]) return errorResponse('Module not found', 404);
+
+  const body = await request.json();
+  if (!body.title?.trim()) return errorResponse('Title is required');
+
+  const maxOrder = await db.select({ max: sql<number>`coalesce(max(sort_order), -1)` })
+    .from(lessons).where(eq(lessons.moduleId, moduleId));
+
+  const lesson = {
+    id: generateId('lsn'),
+    moduleId,
+    title: body.title.trim(),
+    contentType: body.contentType || 'markdown',
+    content: body.content || null,
+    durationMinutes: body.durationMinutes || null,
+    sortOrder: body.sortOrder ?? (Number(maxOrder[0]?.max ?? -1) + 1),
+    metadata: body.metadata || {},
+  };
+
+  await db.insert(lessons).values(lesson);
+  return jsonResponse(lesson, 201);
+}
+
+/**
+ * GET /api/courses/[slug]/modules/[moduleId]/lessons — List lessons in module
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { slug, moduleId } = await params;
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+
+  const result = await db.select()
+    .from(lessons)
+    .where(eq(lessons.moduleId, moduleId))
+    .orderBy(asc(lessons.sortOrder));
+
+  return jsonResponse({ lessons: result });
+}

--- a/apps/learn/app/api/courses/[slug]/modules/[moduleId]/route.ts
+++ b/apps/learn/app/api/courses/[slug]/modules/[moduleId]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, modules } from '@/db/schema';
+import { requireHardDID } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string; moduleId: string }> };
+
+async function getOwnerCourseModule(slug: string, moduleId: string, ownerDid: string): Promise<{ error: string; status: number } | { course: any; module: any }> {
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  const course = courseResult[0];
+  if (!course) return { error: 'Course not found', status: 404 };
+  if (course.creatorDid !== ownerDid) return { error: 'Not authorized', status: 403 };
+
+  const modResult = await db.select().from(modules)
+    .where(and(eq(modules.id, moduleId), eq(modules.courseId, course.id))).limit(1);
+  if (!modResult[0]) return { error: 'Module not found', status: 404 };
+
+  return { course, module: modResult[0] };
+}
+
+/**
+ * PATCH /api/courses/[slug]/modules/[moduleId] — Update module
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const { slug, moduleId } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const result = await getOwnerCourseModule(slug, moduleId, authResult.identity.id);
+  if ('error' in result) return errorResponse(result.error, result.status);
+
+  const body = await request.json();
+  const updates: Record<string, any> = {};
+  if (body.title !== undefined) updates.title = body.title.trim();
+  if (body.description !== undefined) updates.description = body.description?.trim() || null;
+  if (body.sortOrder !== undefined) updates.sortOrder = body.sortOrder;
+
+  if (Object.keys(updates).length === 0) return errorResponse('No fields to update');
+
+  await db.update(modules).set(updates).where(eq(modules.id, moduleId));
+
+  const updated = await db.select().from(modules).where(eq(modules.id, moduleId)).limit(1);
+  return jsonResponse(updated[0]);
+}
+
+/**
+ * DELETE /api/courses/[slug]/modules/[moduleId] — Delete module (cascades lessons)
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const { slug, moduleId } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const result = await getOwnerCourseModule(slug, moduleId, authResult.identity.id);
+  if ('error' in result) return errorResponse(result.error, result.status);
+
+  await db.delete(modules).where(eq(modules.id, moduleId));
+  return jsonResponse({ success: true });
+}

--- a/apps/learn/app/api/courses/[slug]/modules/reorder/route.ts
+++ b/apps/learn/app/api/courses/[slug]/modules/reorder/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, modules } from '@/db/schema';
+import { requireHardDID } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, asc } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string }> };
+
+/**
+ * PATCH /api/courses/[slug]/modules/reorder — Reorder modules
+ * Body: { order: ["mod_abc", "mod_def", ...] }
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const { slug } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+  if (courseResult[0].creatorDid !== authResult.identity.id) return errorResponse('Not authorized', 403);
+
+  const body = await request.json();
+  const { order } = body;
+  if (!Array.isArray(order)) return errorResponse('order must be an array of module IDs');
+
+  // Update sort_order for each module
+  await Promise.all(order.map((id: string, index: number) =>
+    db.update(modules).set({ sortOrder: index }).where(eq(modules.id, id))
+  ));
+
+  const updated = await db.select().from(modules)
+    .where(eq(modules.courseId, courseResult[0].id))
+    .orderBy(asc(modules.sortOrder));
+
+  return jsonResponse({ modules: updated });
+}

--- a/apps/learn/app/api/courses/[slug]/modules/route.ts
+++ b/apps/learn/app/api/courses/[slug]/modules/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, modules } from '@/db/schema';
+import { requireHardDID } from '@/lib/auth';
+import { generateId, jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and, asc, sql } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string }> };
+
+async function getCourseBySlug(slug: string) {
+  const result = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  return result[0] || null;
+}
+
+/**
+ * POST /api/courses/[slug]/modules — Add module
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { slug } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const course = await getCourseBySlug(slug);
+  if (!course) return errorResponse('Course not found', 404);
+  if (course.creatorDid !== authResult.identity.id) return errorResponse('Not authorized', 403);
+
+  const body = await request.json();
+  if (!body.title?.trim()) return errorResponse('Title is required');
+
+  // Get next sort order
+  const maxOrder = await db.select({ max: sql<number>`coalesce(max(sort_order), -1)` })
+    .from(modules).where(eq(modules.courseId, course.id));
+
+  const mod = {
+    id: generateId('mod'),
+    courseId: course.id,
+    title: body.title.trim(),
+    description: body.description?.trim() || null,
+    sortOrder: body.sortOrder ?? (Number(maxOrder[0]?.max ?? -1) + 1),
+  };
+
+  await db.insert(modules).values(mod);
+  return jsonResponse(mod, 201);
+}
+
+/**
+ * GET /api/courses/[slug]/modules — List modules
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { slug } = await params;
+
+  const course = await getCourseBySlug(slug);
+  if (!course) return errorResponse('Course not found', 404);
+
+  const result = await db.select()
+    .from(modules)
+    .where(eq(modules.courseId, course.id))
+    .orderBy(asc(modules.sortOrder));
+
+  return jsonResponse({ modules: result });
+}

--- a/apps/learn/app/api/courses/[slug]/progress/route.ts
+++ b/apps/learn/app/api/courses/[slug]/progress/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, enrollments, lessonProgress, lessons, modules } from '@/db/schema';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and, asc } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string }> };
+
+/**
+ * GET /api/courses/[slug]/progress — Get enrollment status + lesson progress
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { slug } = await params;
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const { identity } = authResult;
+
+  const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
+  if (!courseResult[0]) return errorResponse('Course not found', 404);
+
+  const course = courseResult[0];
+
+  const enrollResult = await db.select().from(enrollments)
+    .where(and(
+      eq(enrollments.courseId, course.id),
+      eq(enrollments.studentDid, identity.id),
+    )).limit(1);
+
+  if (enrollResult.length === 0) {
+    return errorResponse('Not enrolled in this course', 403);
+  }
+
+  const enrollment = enrollResult[0];
+
+  // Get all progress records
+  const progress = await db.select().from(lessonProgress)
+    .where(eq(lessonProgress.enrollmentId, enrollment.id));
+
+  // Build module → lesson → progress map
+  const courseModules = await db.select().from(modules)
+    .where(eq(modules.courseId, course.id))
+    .orderBy(asc(modules.sortOrder));
+
+  const moduleProgress = await Promise.all(courseModules.map(async (mod) => {
+    const moduleLessons = await db.select().from(lessons)
+      .where(eq(lessons.moduleId, mod.id))
+      .orderBy(asc(lessons.sortOrder));
+
+    const lessonsWithProgress = moduleLessons.map(lesson => {
+      const lp = progress.find(p => p.lessonId === lesson.id);
+      return {
+        id: lesson.id,
+        title: lesson.title,
+        contentType: lesson.contentType,
+        durationMinutes: lesson.durationMinutes,
+        status: lp?.status || 'not_started',
+        completedAt: lp?.completedAt || null,
+      };
+    });
+
+    const completed = lessonsWithProgress.filter(l => l.status === 'completed').length;
+
+    return {
+      id: mod.id,
+      title: mod.title,
+      lessons: lessonsWithProgress,
+      completed,
+      total: lessonsWithProgress.length,
+    };
+  }));
+
+  const totalLessons = moduleProgress.reduce((sum, m) => sum + m.total, 0);
+  const completedLessons = moduleProgress.reduce((sum, m) => sum + m.completed, 0);
+
+  return jsonResponse({
+    enrollment: {
+      id: enrollment.id,
+      enrolledAt: enrollment.enrolledAt,
+      completedAt: enrollment.completedAt,
+    },
+    progress: {
+      total: totalLessons,
+      completed: completedLessons,
+      percentage: totalLessons > 0 ? Math.round((completedLessons / totalLessons) * 100) : 0,
+    },
+    modules: moduleProgress,
+  });
+}

--- a/apps/learn/app/api/courses/[slug]/route.ts
+++ b/apps/learn/app/api/courses/[slug]/route.ts
@@ -1,0 +1,189 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, modules, lessons, enrollments, lessonProgress } from '@/db/schema';
+import { requireAuth, requireHardDID, getSessionFromCookie } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and, sql, asc } from 'drizzle-orm';
+
+type RouteParams = { params: Promise<{ slug: string }> };
+
+/**
+ * GET /api/courses/[slug] — Get course detail
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { slug } = await params;
+
+  const result = await db.select()
+    .from(courses)
+    .where(eq(courses.slug, slug))
+    .limit(1);
+
+  if (result.length === 0) {
+    return errorResponse('Course not found', 404);
+  }
+
+  const course = result[0];
+
+  // Check visibility
+  if (course.visibility === 'private') {
+    // Only creator can see private courses
+    const cookieHeader = request.headers.get('Cookie');
+    const identity = await getSessionFromCookie(cookieHeader);
+    if (!identity || identity.id !== course.creatorDid) {
+      return errorResponse('Course not found', 404);
+    }
+  }
+
+  // TODO: trust-bound visibility check via connections service
+
+  // Get modules with lessons
+  const courseModules = await db.select()
+    .from(modules)
+    .where(eq(modules.courseId, course.id))
+    .orderBy(asc(modules.sortOrder));
+
+  const modulesWithLessons = await Promise.all(courseModules.map(async (mod) => {
+    const moduleLessons = await db.select({
+      id: lessons.id,
+      title: lessons.title,
+      contentType: lessons.contentType,
+      durationMinutes: lessons.durationMinutes,
+      sortOrder: lessons.sortOrder,
+    })
+      .from(lessons)
+      .where(eq(lessons.moduleId, mod.id))
+      .orderBy(asc(lessons.sortOrder));
+
+    return { ...mod, lessons: moduleLessons };
+  }));
+
+  // Check enrollment for current user
+  let enrollment = null;
+  const cookieHeader = request.headers.get('Cookie');
+  const identity = await getSessionFromCookie(cookieHeader);
+  if (identity) {
+    const enrollResult = await db.select()
+      .from(enrollments)
+      .where(and(
+        eq(enrollments.courseId, course.id),
+        eq(enrollments.studentDid, identity.id),
+      ))
+      .limit(1);
+
+    if (enrollResult.length > 0) {
+      // Get progress
+      const progress = await db.select()
+        .from(lessonProgress)
+        .where(eq(lessonProgress.enrollmentId, enrollResult[0].id));
+
+      const totalLessons = modulesWithLessons.reduce((sum, m) => sum + m.lessons.length, 0);
+      const completedLessons = progress.filter(p => p.status === 'completed').length;
+
+      enrollment = {
+        ...enrollResult[0],
+        progress: { total: totalLessons, completed: completedLessons },
+      };
+    }
+  }
+
+  return jsonResponse({
+    ...course,
+    modules: modulesWithLessons,
+    enrollment,
+    isCreator: identity?.id === course.creatorDid,
+  });
+}
+
+/**
+ * PATCH /api/courses/[slug] — Update course (owner only)
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const { slug } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status);
+  }
+
+  const { identity } = authResult;
+
+  const result = await db.select()
+    .from(courses)
+    .where(eq(courses.slug, slug))
+    .limit(1);
+
+  if (result.length === 0) {
+    return errorResponse('Course not found', 404);
+  }
+
+  const course = result[0];
+  if (course.creatorDid !== identity.id) {
+    return errorResponse('Not authorized', 403);
+  }
+
+  const body = await request.json();
+  const allowedFields = ['title', 'description', 'slug', 'price', 'currency', 'visibility', 'imageUrl', 'tags', 'metadata', 'status'];
+  const updates: Record<string, any> = {};
+
+  for (const field of allowedFields) {
+    if (body[field] !== undefined) {
+      updates[field] = body[field];
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return errorResponse('No fields to update');
+  }
+
+  // Map camelCase to snake_case for image_url
+  if (updates.imageUrl !== undefined) {
+    updates.image_url = updates.imageUrl;
+    delete updates.imageUrl;
+  }
+
+  updates.updated_at = new Date();
+
+  await db.update(courses)
+    .set(updates)
+    .where(eq(courses.id, course.id));
+
+  const updated = await db.select()
+    .from(courses)
+    .where(eq(courses.id, course.id))
+    .limit(1);
+
+  return jsonResponse(updated[0]);
+}
+
+/**
+ * DELETE /api/courses/[slug] — Archive course (soft delete, owner only)
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const { slug } = await params;
+
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status);
+  }
+
+  const { identity } = authResult;
+
+  const result = await db.select()
+    .from(courses)
+    .where(eq(courses.slug, slug))
+    .limit(1);
+
+  if (result.length === 0) {
+    return errorResponse('Course not found', 404);
+  }
+
+  if (result[0].creatorDid !== identity.id) {
+    return errorResponse('Not authorized', 403);
+  }
+
+  await db.update(courses)
+    .set({ status: 'archived', updatedAt: new Date() })
+    .where(eq(courses.id, result[0].id));
+
+  return jsonResponse({ success: true });
+}

--- a/apps/learn/app/api/courses/route.ts
+++ b/apps/learn/app/api/courses/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, modules, lessons } from '@/db/schema';
+import { requireHardDID } from '@/lib/auth';
+import { generateId, slugify, jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, and, sql, desc } from 'drizzle-orm';
+
+/**
+ * POST /api/courses — Create a new course
+ */
+export async function POST(request: NextRequest) {
+  const authResult = await requireHardDID(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status);
+  }
+
+  const { identity } = authResult;
+  const body = await request.json();
+
+  const { title, description, slug, price, currency, visibility, imageUrl, tags, metadata } = body;
+
+  if (!title?.trim()) {
+    return errorResponse('Title is required');
+  }
+
+  const courseSlug = slug?.trim() || slugify(title);
+
+  // Check slug uniqueness
+  const existing = await db.select({ id: courses.id })
+    .from(courses)
+    .where(eq(courses.slug, courseSlug))
+    .limit(1);
+
+  if (existing.length > 0) {
+    return errorResponse('A course with this slug already exists', 409);
+  }
+
+  const course = {
+    id: generateId('crs'),
+    creatorDid: identity.id,
+    title: title.trim(),
+    description: description?.trim() || null,
+    slug: courseSlug,
+    price: price ?? 0,
+    currency: currency || 'CAD',
+    visibility: visibility || 'public',
+    imageUrl: imageUrl || null,
+    tags: tags || [],
+    metadata: metadata || {},
+    status: 'draft' as const,
+  };
+
+  await db.insert(courses).values(course);
+
+  return jsonResponse(course, 201);
+}
+
+/**
+ * GET /api/courses — List published courses (discovery)
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const creatorDid = searchParams.get('creator_did');
+  const tag = searchParams.get('tag');
+  const status = searchParams.get('status') || 'published';
+  const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100);
+  const offset = parseInt(searchParams.get('offset') || '0');
+
+  const conditions = [];
+
+  // Public discovery only shows published courses by default
+  conditions.push(eq(courses.status, status));
+
+  if (creatorDid) {
+    conditions.push(eq(courses.creatorDid, creatorDid));
+  }
+
+  // Visibility filter — only show public courses in discovery
+  // Trust-bound courses need connection check (handled in detail endpoint)
+  if (!creatorDid) {
+    conditions.push(eq(courses.visibility, 'public'));
+  }
+
+  const results = await db.select()
+    .from(courses)
+    .where(and(...conditions))
+    .orderBy(desc(courses.createdAt))
+    .limit(limit)
+    .offset(offset);
+
+  // Add module + lesson counts
+  const enriched = await Promise.all(results.map(async (course) => {
+    const moduleCounts = await db.select({
+      count: sql<number>`count(*)`,
+    }).from(modules).where(eq(modules.courseId, course.id));
+
+    const lessonCounts = await db.select({
+      count: sql<number>`count(*)`,
+    }).from(lessons)
+      .innerJoin(modules, eq(lessons.moduleId, modules.id))
+      .where(eq(modules.courseId, course.id));
+
+    return {
+      ...course,
+      moduleCount: Number(moduleCounts[0]?.count || 0),
+      lessonCount: Number(lessonCounts[0]?.count || 0),
+    };
+  }));
+
+  return jsonResponse({ courses: enriched, limit, offset });
+}

--- a/apps/learn/app/api/my/courses/route.ts
+++ b/apps/learn/app/api/my/courses/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, enrollments, lessonProgress } from '@/db/schema';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, sql } from 'drizzle-orm';
+
+/**
+ * GET /api/my/courses — List courses I'm enrolled in
+ */
+export async function GET(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const { identity } = authResult;
+
+  const myEnrollments = await db.select()
+    .from(enrollments)
+    .innerJoin(courses, eq(enrollments.courseId, courses.id))
+    .where(eq(enrollments.studentDid, identity.id));
+
+  const result = await Promise.all(myEnrollments.map(async (row) => {
+    const progress = await db.select({
+      total: sql<number>`count(*)`,
+      completed: sql<number>`count(*) filter (where status = 'completed')`,
+    }).from(lessonProgress).where(eq(lessonProgress.enrollmentId, row.enrollments.id));
+
+    const total = Number(progress[0]?.total || 0);
+    const completed = Number(progress[0]?.completed || 0);
+
+    return {
+      ...row.courses,
+      enrollment: {
+        id: row.enrollments.id,
+        enrolledAt: row.enrollments.enrolledAt,
+        completedAt: row.enrollments.completedAt,
+      },
+      progress: {
+        total,
+        completed,
+        percentage: total > 0 ? Math.round((completed / total) * 100) : 0,
+      },
+    };
+  }));
+
+  return jsonResponse({ courses: result });
+}

--- a/apps/learn/app/api/my/teaching/route.ts
+++ b/apps/learn/app/api/my/teaching/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/db';
+import { courses, enrollments, modules, lessons } from '@/db/schema';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq, sql, desc } from 'drizzle-orm';
+
+/**
+ * GET /api/my/teaching — List courses I created
+ */
+export async function GET(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+  const { identity } = authResult;
+
+  const myCourses = await db.select()
+    .from(courses)
+    .where(eq(courses.creatorDid, identity.id))
+    .orderBy(desc(courses.createdAt));
+
+  const result = await Promise.all(myCourses.map(async (course) => {
+    const enrollCount = await db.select({ count: sql<number>`count(*)` })
+      .from(enrollments).where(eq(enrollments.courseId, course.id));
+
+    const moduleCount = await db.select({ count: sql<number>`count(*)` })
+      .from(modules).where(eq(modules.courseId, course.id));
+
+    const lessonCount = await db.select({ count: sql<number>`count(*)` })
+      .from(lessons)
+      .innerJoin(modules, eq(lessons.moduleId, modules.id))
+      .where(eq(modules.courseId, course.id));
+
+    return {
+      ...course,
+      enrollmentCount: Number(enrollCount[0]?.count || 0),
+      moduleCount: Number(moduleCount[0]?.count || 0),
+      lessonCount: Number(lessonCount[0]?.count || 0),
+    };
+  }));
+
+  return jsonResponse({ courses: result });
+}

--- a/apps/learn/app/course/[slug]/[lessonId]/page.tsx
+++ b/apps/learn/app/course/[slug]/[lessonId]/page.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+interface Lesson {
+  id: string;
+  title: string;
+  contentType: string;
+  content: string | null;
+  durationMinutes: number | null;
+  metadata: any;
+  locked?: boolean;
+}
+
+interface ProgressLesson {
+  id: string;
+  title: string;
+  contentType: string;
+  status: string;
+}
+
+interface ProgressModule {
+  id: string;
+  title: string;
+  lessons: ProgressLesson[];
+}
+
+export default function LessonViewerPage() {
+  const params = useParams();
+  const router = useRouter();
+  const slug = params.slug as string;
+  const lessonId = params.lessonId as string;
+
+  const [lesson, setLesson] = useState<Lesson | null>(null);
+  const [progress, setProgress] = useState<{ modules: ProgressModule[] } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [completing, setCompleting] = useState(false);
+
+  // Find adjacent lessons for navigation
+  const allLessons = progress?.modules.flatMap(m => m.lessons) || [];
+  const currentIndex = allLessons.findIndex(l => l.id === lessonId);
+  const prevLesson = currentIndex > 0 ? allLessons[currentIndex - 1] : null;
+  const nextLesson = currentIndex < allLessons.length - 1 ? allLessons[currentIndex + 1] : null;
+  const currentProgress = allLessons.find(l => l.id === lessonId);
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      try {
+        // Load lesson content — we need to find its module ID first
+        // Use the progress endpoint to get the full structure
+        const progressRes = await fetch(`/api/courses/${slug}/progress`, { credentials: 'include' });
+        if (progressRes.ok) {
+          const prog = await progressRes.json();
+          setProgress(prog);
+
+          // Find which module this lesson belongs to
+          let moduleId = '';
+          for (const mod of prog.modules) {
+            if (mod.lessons.find((l: any) => l.id === lessonId)) {
+              moduleId = mod.id;
+              break;
+            }
+          }
+
+          if (moduleId) {
+            const lessonRes = await fetch(
+              `/api/courses/${slug}/modules/${moduleId}/lessons/${lessonId}`,
+              { credentials: 'include' }
+            );
+            if (lessonRes.ok) {
+              setLesson(await lessonRes.json());
+            }
+          }
+        }
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [slug, lessonId]);
+
+  async function markComplete() {
+    setCompleting(true);
+    try {
+      const res = await fetch(`/api/courses/${slug}/lessons/${lessonId}/complete`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (res.ok) {
+        // Move to next lesson or reload
+        if (nextLesson) {
+          router.push(`/course/${slug}/${nextLesson.id}`);
+        } else {
+          router.push(`/course/${slug}`);
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setCompleting(false);
+    }
+  }
+
+  if (loading) return <div className="container mx-auto px-4 py-16 text-center text-gray-500">Loading...</div>;
+  if (!lesson) return <div className="container mx-auto px-4 py-16 text-center text-gray-500">Lesson not found</div>;
+
+  if (lesson.locked) {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <div className="text-6xl mb-4">🔒</div>
+        <h1 className="text-2xl font-bold mb-4">{lesson.title}</h1>
+        <p className="text-gray-500 mb-6">This lesson requires enrollment to access.</p>
+        <Link href={`/course/${slug}`} className="px-6 py-3 bg-amber-500 text-white rounded-lg hover:bg-amber-600">
+          View Course
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-950">
+      <div className="flex">
+        {/* Sidebar — module navigation */}
+        <aside className="hidden lg:block w-72 border-r border-gray-200 dark:border-gray-800 min-h-screen p-4 overflow-y-auto">
+          <Link href={`/course/${slug}`} className="text-sm text-amber-500 hover:underline mb-4 block">
+            ← Back to course
+          </Link>
+          {progress?.modules.map((mod) => (
+            <div key={mod.id} className="mb-4">
+              <h4 className="font-medium text-sm text-gray-500 mb-2">{mod.title}</h4>
+              <ul className="space-y-1">
+                {mod.lessons.map((l) => (
+                  <li key={l.id}>
+                    <Link
+                      href={`/course/${slug}/${l.id}`}
+                      className={`block px-3 py-1.5 rounded text-sm ${
+                        l.id === lessonId
+                          ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 font-medium'
+                          : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+                      }`}
+                    >
+                      {l.status === 'completed' && <span className="mr-1">✓</span>}
+                      {l.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </aside>
+
+        {/* Main content */}
+        <main className="flex-1 max-w-3xl mx-auto px-6 py-8">
+          <div className="mb-2 text-sm text-gray-400">
+            {lesson.contentType === 'exercise' && '🛠️ Exercise'}
+            {lesson.contentType === 'slide' && '📊 Slide'}
+            {lesson.contentType === 'video' && '🎬 Video'}
+            {lesson.contentType === 'markdown' && '📝 Lesson'}
+            {lesson.durationMinutes && ` · ${lesson.durationMinutes} min`}
+          </div>
+
+          <h1 className="text-3xl font-bold mb-6">{lesson.title}</h1>
+
+          {/* Video content */}
+          {lesson.contentType === 'video' && lesson.metadata?.videoUrl && (
+            <div className="aspect-video mb-6 bg-black rounded-lg overflow-hidden">
+              <iframe
+                src={lesson.metadata.videoUrl}
+                className="w-full h-full"
+                allowFullScreen
+              />
+            </div>
+          )}
+
+          {/* Markdown content */}
+          {lesson.content && (
+            <div
+              className="prose prose-lg dark:prose-invert max-w-none mb-8"
+              dangerouslySetInnerHTML={{ __html: simpleMarkdown(lesson.content) }}
+            />
+          )}
+
+          {/* Exercise metadata */}
+          {lesson.contentType === 'exercise' && lesson.metadata?.instructions && (
+            <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-6 mb-8">
+              <h3 className="font-semibold mb-2">📋 Instructions</h3>
+              <div
+                className="prose dark:prose-invert"
+                dangerouslySetInnerHTML={{ __html: simpleMarkdown(lesson.metadata.instructions) }}
+              />
+            </div>
+          )}
+
+          {/* Navigation + Complete */}
+          <div className="flex items-center justify-between border-t border-gray-200 dark:border-gray-800 pt-6 mt-8">
+            <div>
+              {prevLesson && (
+                <Link
+                  href={`/course/${slug}/${prevLesson.id}`}
+                  className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+                >
+                  ← {prevLesson.title}
+                </Link>
+              )}
+            </div>
+            <div className="flex gap-3">
+              {currentProgress?.status !== 'completed' && (
+                <button
+                  onClick={markComplete}
+                  disabled={completing}
+                  className="px-5 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 text-sm font-medium disabled:opacity-50"
+                >
+                  {completing ? 'Saving...' : '✓ Mark Complete'}
+                </button>
+              )}
+              {nextLesson && (
+                <Link
+                  href={`/course/${slug}/${nextLesson.id}`}
+                  className="px-5 py-2 bg-amber-500 text-white rounded-lg hover:bg-amber-600 text-sm font-medium"
+                >
+                  Next →
+                </Link>
+              )}
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Simple markdown → HTML (no dependency needed for basic content)
+ */
+function simpleMarkdown(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/`(.+?)`/g, '<code>$1</code>')
+    .replace(/```(\w*)\n([\s\S]*?)```/g, '<pre><code>$2</code></pre>')
+    .replace(/^\- (.+)$/gm, '<li>$1</li>')
+    .replace(/(<li>[\s\S]*?<\/li>)/g, '<ul>$1</ul>')
+    .replace(/\n\n/g, '</p><p>')
+    .replace(/^(?!<[hulo])(.+)$/gm, '<p>$1</p>')
+    .replace(/<p><\/p>/g, '');
+}

--- a/apps/learn/app/course/[slug]/page.tsx
+++ b/apps/learn/app/course/[slug]/page.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+interface Lesson {
+  id: string;
+  title: string;
+  contentType: string;
+  durationMinutes: number | null;
+  sortOrder: number;
+}
+
+interface Module {
+  id: string;
+  title: string;
+  description: string | null;
+  sortOrder: number;
+  lessons: Lesson[];
+}
+
+interface Course {
+  id: string;
+  title: string;
+  description: string | null;
+  slug: string;
+  price: number;
+  currency: string;
+  creatorDid: string;
+  imageUrl: string | null;
+  tags: string[];
+  status: string;
+  modules: Module[];
+  enrollment: {
+    id: string;
+    enrolledAt: string;
+    progress: { total: number; completed: number };
+  } | null;
+  isCreator: boolean;
+}
+
+const contentTypeIcons: Record<string, string> = {
+  markdown: '📝',
+  exercise: '🛠️',
+  slide: '📊',
+  video: '🎬',
+};
+
+export default function CourseDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const slug = params.slug as string;
+
+  const [course, setCourse] = useState<Course | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [enrolling, setEnrolling] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/courses/${slug}`, { credentials: 'include' });
+        if (res.ok) {
+          setCourse(await res.json());
+        }
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [slug]);
+
+  async function handleEnroll() {
+    if (!course) return;
+    setEnrolling(true);
+    try {
+      const res = await fetch(`/api/courses/${slug}/enroll`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          successUrl: `${window.location.origin}/course/${slug}`,
+          cancelUrl: `${window.location.origin}/course/${slug}`,
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        alert(err.error || 'Enrollment failed');
+        return;
+      }
+
+      const data = await res.json();
+      if (data.checkoutUrl) {
+        window.location.href = data.checkoutUrl;
+      } else {
+        // Free enrollment — reload
+        window.location.reload();
+      }
+    } catch (e) {
+      alert('Enrollment failed');
+    } finally {
+      setEnrolling(false);
+    }
+  }
+
+  if (loading) return <div className="container mx-auto px-4 py-16 text-center text-gray-500">Loading...</div>;
+  if (!course) return <div className="container mx-auto px-4 py-16 text-center text-gray-500">Course not found</div>;
+
+  const totalDuration = course.modules.reduce(
+    (sum, m) => sum + m.lessons.reduce((s, l) => s + (l.durationMinutes || 0), 0), 0
+  );
+  const totalLessons = course.modules.reduce((sum, m) => sum + m.lessons.length, 0);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        {/* Header */}
+        <div className="mb-8">
+          {course.imageUrl && (
+            <div className="aspect-video rounded-xl overflow-hidden mb-6 bg-gray-100 dark:bg-gray-800">
+              <img src={course.imageUrl} alt={course.title} className="w-full h-full object-cover" />
+            </div>
+          )}
+
+          <h1 className="text-3xl font-bold mb-3">{course.title}</h1>
+          {course.description && (
+            <p className="text-lg text-gray-600 dark:text-gray-400 mb-4">{course.description}</p>
+          )}
+
+          <div className="flex flex-wrap gap-4 text-sm text-gray-500 mb-6">
+            <span>{course.modules.length} modules</span>
+            <span>·</span>
+            <span>{totalLessons} lessons</span>
+            {totalDuration > 0 && (
+              <>
+                <span>·</span>
+                <span>{totalDuration} min total</span>
+              </>
+            )}
+          </div>
+
+          {course.tags?.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-6">
+              {course.tags.map((tag: string) => (
+                <span key={tag} className="px-3 py-1 text-sm rounded-full bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex gap-3">
+            {course.isCreator ? (
+              <Link
+                href={`/dashboard/${course.slug}`}
+                className="px-6 py-3 bg-amber-500 text-white rounded-lg hover:bg-amber-600 font-medium"
+              >
+                Edit Course
+              </Link>
+            ) : course.enrollment ? (
+              <Link
+                href={`/course/${course.slug}/${course.modules[0]?.lessons[0]?.id || ''}`}
+                className="px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 font-medium"
+              >
+                {course.enrollment.progress.completed > 0 ? 'Continue Learning' : 'Start Learning'}
+                {course.enrollment.progress.total > 0 && (
+                  <span className="ml-2 text-sm opacity-80">
+                    ({Math.round((course.enrollment.progress.completed / course.enrollment.progress.total) * 100)}%)
+                  </span>
+                )}
+              </Link>
+            ) : (
+              <button
+                onClick={handleEnroll}
+                disabled={enrolling}
+                className="px-6 py-3 bg-amber-500 text-white rounded-lg hover:bg-amber-600 font-medium disabled:opacity-50"
+              >
+                {enrolling ? 'Enrolling...' : course.price === 0 ? 'Start Learning — Free' : `Enroll — $${(course.price / 100).toFixed(2)}`}
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Course outline */}
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold">Course Outline</h2>
+          {course.modules.map((mod, i) => (
+            <div key={mod.id} className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+              <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+                <h3 className="font-medium">
+                  <span className="text-gray-400 mr-2">Module {i + 1}</span>
+                  {mod.title}
+                </h3>
+                {mod.description && <p className="text-sm text-gray-500 mt-1">{mod.description}</p>}
+              </div>
+              <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+                {mod.lessons.map((lesson) => (
+                  <li key={lesson.id} className="px-5 py-3 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <span>{contentTypeIcons[lesson.contentType] || '📄'}</span>
+                      {course.enrollment ? (
+                        <Link
+                          href={`/course/${course.slug}/${lesson.id}`}
+                          className="hover:text-amber-500"
+                        >
+                          {lesson.title}
+                        </Link>
+                      ) : (
+                        <span>{lesson.title}</span>
+                      )}
+                    </div>
+                    {lesson.durationMinutes && (
+                      <span className="text-xs text-gray-400">{lesson.durationMinutes} min</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/learn/app/dashboard/[slug]/page.tsx
+++ b/apps/learn/app/dashboard/[slug]/page.tsx
@@ -1,0 +1,406 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+interface Lesson {
+  id: string;
+  title: string;
+  contentType: string;
+  content: string | null;
+  durationMinutes: number | null;
+  sortOrder: number;
+  metadata: any;
+}
+
+interface Module {
+  id: string;
+  title: string;
+  description: string | null;
+  sortOrder: number;
+}
+
+interface Course {
+  id: string;
+  title: string;
+  description: string | null;
+  slug: string;
+  price: number;
+  currency: string;
+  visibility: string;
+  status: string;
+  imageUrl: string | null;
+  tags: any;
+}
+
+export default function CourseEditorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const slug = params.slug as string;
+
+  const [course, setCourse] = useState<Course | null>(null);
+  const [modules, setModules] = useState<(Module & { lessons: Lesson[] })[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  // Edit states
+  const [editTitle, setEditTitle] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editPrice, setEditPrice] = useState(0);
+  const [editVisibility, setEditVisibility] = useState('public');
+  const [editStatus, setEditStatus] = useState('draft');
+
+  // Module/lesson creation
+  const [newModuleTitle, setNewModuleTitle] = useState('');
+  const [editingLesson, setEditingLesson] = useState<string | null>(null);
+  const [lessonForm, setLessonForm] = useState({ title: '', contentType: 'markdown', content: '', durationMinutes: '' });
+
+  const loadCourse = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/courses/${slug}`, { credentials: 'include' });
+      if (!res.ok) return;
+      const data = await res.json();
+      setCourse(data);
+      setModules(data.modules || []);
+      setEditTitle(data.title);
+      setEditDescription(data.description || '');
+      setEditPrice(data.price || 0);
+      setEditVisibility(data.visibility || 'public');
+      setEditStatus(data.status || 'draft');
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  }, [slug]);
+
+  useEffect(() => { loadCourse(); }, [loadCourse]);
+
+  async function saveCourse() {
+    setSaving(true);
+    try {
+      await fetch(`/api/courses/${slug}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: editTitle,
+          description: editDescription,
+          price: editPrice,
+          visibility: editVisibility,
+          status: editStatus,
+        }),
+      });
+      await loadCourse();
+    } catch (e) {
+      alert('Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function addModule() {
+    if (!newModuleTitle.trim()) return;
+    const res = await fetch(`/api/courses/${slug}/modules`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: newModuleTitle.trim() }),
+    });
+    if (res.ok) {
+      setNewModuleTitle('');
+      await loadCourse();
+    }
+  }
+
+  async function deleteModule(moduleId: string) {
+    if (!confirm('Delete this module and all its lessons?')) return;
+    await fetch(`/api/courses/${slug}/modules/${moduleId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    await loadCourse();
+  }
+
+  async function addLesson(moduleId: string) {
+    const title = prompt('Lesson title:');
+    if (!title?.trim()) return;
+    const res = await fetch(`/api/courses/${slug}/modules/${moduleId}/lessons`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: title.trim() }),
+    });
+    if (res.ok) await loadCourse();
+  }
+
+  async function saveLesson(moduleId: string, lessonId: string) {
+    await fetch(`/api/courses/${slug}/modules/${moduleId}/lessons/${lessonId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: lessonForm.title,
+        contentType: lessonForm.contentType,
+        content: lessonForm.content,
+        durationMinutes: lessonForm.durationMinutes ? parseInt(lessonForm.durationMinutes) : null,
+      }),
+    });
+    setEditingLesson(null);
+    await loadCourse();
+  }
+
+  async function deleteLesson(moduleId: string, lessonId: string) {
+    if (!confirm('Delete this lesson?')) return;
+    await fetch(`/api/courses/${slug}/modules/${moduleId}/lessons/${lessonId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    await loadCourse();
+  }
+
+  function startEditLesson(lesson: Lesson) {
+    setEditingLesson(lesson.id);
+    setLessonForm({
+      title: lesson.title,
+      contentType: lesson.contentType,
+      content: lesson.content || '',
+      durationMinutes: lesson.durationMinutes?.toString() || '',
+    });
+  }
+
+  if (loading) return <div className="container mx-auto px-4 py-16 text-center text-gray-500">Loading...</div>;
+  if (!course) return <div className="container mx-auto px-4 py-16 text-center text-gray-500">Course not found</div>;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        {/* Breadcrumb */}
+        <div className="mb-6 text-sm">
+          <Link href="/dashboard" className="text-amber-500 hover:underline">← My Courses</Link>
+          <span className="mx-2 text-gray-400">/</span>
+          <span className="text-gray-500">{course.title}</span>
+        </div>
+
+        {/* Course settings */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 mb-6">
+          <h2 className="font-semibold text-lg mb-4">Course Settings</h2>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Title</label>
+              <input
+                value={editTitle}
+                onChange={(e) => setEditTitle(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Description</label>
+              <textarea
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                rows={3}
+                className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Price (cents)</label>
+                <input
+                  type="number"
+                  value={editPrice}
+                  onChange={(e) => setEditPrice(parseInt(e.target.value) || 0)}
+                  className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Visibility</label>
+                <select
+                  value={editVisibility}
+                  onChange={(e) => setEditVisibility(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                >
+                  <option value="public">Public</option>
+                  <option value="trust-bound">Trust-bound</option>
+                  <option value="private">Private</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Status</label>
+                <select
+                  value={editStatus}
+                  onChange={(e) => setEditStatus(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                >
+                  <option value="draft">Draft</option>
+                  <option value="published">Published</option>
+                  <option value="archived">Archived</option>
+                </select>
+              </div>
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={saveCourse}
+                disabled={saving}
+                className="px-5 py-2 bg-amber-500 text-white rounded-lg hover:bg-amber-600 font-medium disabled:opacity-50"
+              >
+                {saving ? 'Saving...' : 'Save Changes'}
+              </button>
+              <Link
+                href={`/course/${slug}`}
+                className="px-5 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-sm"
+              >
+                View Public Page
+              </Link>
+              <Link
+                href={`/dashboard/${slug}/students`}
+                className="px-5 py-2 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-sm"
+              >
+                Students
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {/* Modules & lessons */}
+        <div className="mb-6">
+          <h2 className="font-semibold text-lg mb-4">Modules & Lessons</h2>
+
+          {modules.map((mod, i) => (
+            <div key={mod.id} className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 mb-4 overflow-hidden">
+              <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+                <h3 className="font-medium">
+                  <span className="text-gray-400 mr-2">Module {i + 1}</span>
+                  {mod.title}
+                </h3>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => addLesson(mod.id)}
+                    className="text-xs px-3 py-1 bg-gray-100 dark:bg-gray-700 rounded hover:bg-gray-200 dark:hover:bg-gray-600"
+                  >
+                    + Lesson
+                  </button>
+                  <button
+                    onClick={() => deleteModule(mod.id)}
+                    className="text-xs px-3 py-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+
+              <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+                {mod.lessons.map((lesson) => (
+                  <li key={lesson.id} className="px-5 py-3">
+                    {editingLesson === lesson.id ? (
+                      <div className="space-y-3">
+                        <input
+                          value={lessonForm.title}
+                          onChange={(e) => setLessonForm(f => ({ ...f, title: e.target.value }))}
+                          placeholder="Lesson title"
+                          className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                        />
+                        <div className="grid grid-cols-2 gap-3">
+                          <select
+                            value={lessonForm.contentType}
+                            onChange={(e) => setLessonForm(f => ({ ...f, contentType: e.target.value }))}
+                            className="px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                          >
+                            <option value="markdown">Markdown</option>
+                            <option value="exercise">Exercise</option>
+                            <option value="slide">Slide</option>
+                            <option value="video">Video</option>
+                          </select>
+                          <input
+                            type="number"
+                            value={lessonForm.durationMinutes}
+                            onChange={(e) => setLessonForm(f => ({ ...f, durationMinutes: e.target.value }))}
+                            placeholder="Duration (min)"
+                            className="px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                          />
+                        </div>
+                        <textarea
+                          value={lessonForm.content}
+                          onChange={(e) => setLessonForm(f => ({ ...f, content: e.target.value }))}
+                          rows={10}
+                          placeholder="Lesson content (markdown)"
+                          className="w-full px-3 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 font-mono text-sm"
+                        />
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() => saveLesson(mod.id, lesson.id)}
+                            className="px-4 py-1.5 bg-green-600 text-white rounded text-sm hover:bg-green-700"
+                          >
+                            Save
+                          </button>
+                          <button
+                            onClick={() => setEditingLesson(null)}
+                            className="px-4 py-1.5 border border-gray-300 dark:border-gray-600 rounded text-sm"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <span className="text-gray-400 text-sm">{lesson.sortOrder + 1}.</span>
+                          <span>{lesson.title}</span>
+                          <span className="text-xs text-gray-400 bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded">
+                            {lesson.contentType}
+                          </span>
+                          {lesson.durationMinutes && (
+                            <span className="text-xs text-gray-400">{lesson.durationMinutes}m</span>
+                          )}
+                        </div>
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() => startEditLesson(lesson)}
+                            className="text-xs px-3 py-1 text-amber-500 hover:bg-amber-50 dark:hover:bg-amber-900/20 rounded"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => deleteLesson(mod.id, lesson.id)}
+                            className="text-xs px-3 py-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </li>
+                ))}
+                {mod.lessons.length === 0 && (
+                  <li className="px-5 py-4 text-center text-gray-400 text-sm">
+                    No lessons yet. Click "+ Lesson" to add one.
+                  </li>
+                )}
+              </ul>
+            </div>
+          ))}
+
+          {/* Add module */}
+          <div className="flex gap-3 mt-4">
+            <input
+              type="text"
+              placeholder="New module title..."
+              value={newModuleTitle}
+              onChange={(e) => setNewModuleTitle(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && addModule()}
+              className="flex-1 px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+            />
+            <button
+              onClick={addModule}
+              disabled={!newModuleTitle.trim()}
+              className="px-5 py-2 bg-gray-800 dark:bg-gray-600 text-white rounded-lg hover:bg-gray-700 disabled:opacity-50"
+            >
+              + Module
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/learn/app/dashboard/[slug]/students/page.tsx
+++ b/apps/learn/app/dashboard/[slug]/students/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+
+interface Student {
+  studentDid: string;
+  enrolledAt: string;
+  completedAt: string | null;
+  progress: { total: number; completed: number; percentage: number };
+}
+
+export default function StudentsPage() {
+  const params = useParams();
+  const slug = params.slug as string;
+  const [course, setCourse] = useState<any>(null);
+  const [students, setStudents] = useState<Student[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        // Get course details
+        const courseRes = await fetch(`/api/courses/${slug}`, { credentials: 'include' });
+        if (courseRes.ok) setCourse(await courseRes.json());
+
+        // TODO: Need a dedicated endpoint for listing enrolled students
+        // For now, this page is a placeholder
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [slug]);
+
+  if (loading) return <div className="container mx-auto px-4 py-16 text-center text-gray-500">Loading...</div>;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <div className="mb-6 text-sm">
+          <Link href="/dashboard" className="text-amber-500 hover:underline">← My Courses</Link>
+          <span className="mx-2 text-gray-400">/</span>
+          <Link href={`/dashboard/${slug}`} className="text-amber-500 hover:underline">{course?.title || slug}</Link>
+          <span className="mx-2 text-gray-400">/</span>
+          <span className="text-gray-500">Students</span>
+        </div>
+
+        <h1 className="text-2xl font-bold mb-6">Enrolled Students</h1>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-8 text-center text-gray-500">
+          <div className="text-4xl mb-4">👥</div>
+          <p>Student list endpoint coming soon.</p>
+          <p className="text-sm mt-2">Enrollment data is tracked — this view will show enrolled students with their progress.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/learn/app/dashboard/page.tsx
+++ b/apps/learn/app/dashboard/page.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+interface Course {
+  id: string;
+  title: string;
+  slug: string;
+  status: string;
+  price: number;
+  currency: string;
+  enrollmentCount: number;
+  moduleCount: number;
+  lessonCount: number;
+  createdAt: string;
+}
+
+const statusColors: Record<string, string> = {
+  draft: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+  published: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  archived: 'bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400',
+};
+
+export default function DashboardPage() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+
+  useEffect(() => {
+    loadCourses();
+  }, []);
+
+  async function loadCourses() {
+    try {
+      const res = await fetch('/api/my/teaching', { credentials: 'include' });
+      if (res.status === 401) {
+        setError('Please sign in to access the dashboard.');
+        setLoading(false);
+        return;
+      }
+      if (res.ok) {
+        const data = await res.json();
+        setCourses(data.courses);
+      }
+    } catch (e) {
+      setError('Failed to load courses');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function createCourse() {
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    try {
+      const res = await fetch('/api/courses', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: newTitle.trim() }),
+      });
+      if (res.ok) {
+        const course = await res.json();
+        setNewTitle('');
+        window.location.href = `/dashboard/${course.slug}`;
+      } else {
+        const err = await res.json();
+        alert(err.error || 'Failed to create course');
+      }
+    } catch (e) {
+      alert('Failed to create course');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  if (loading) return <div className="container mx-auto px-4 py-16 text-center text-gray-500">Loading...</div>;
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <p className="text-gray-500">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-2xl font-bold">My Courses</h1>
+        </div>
+
+        {/* Create new course */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 mb-8">
+          <h2 className="font-medium mb-3">Create a new course</h2>
+          <div className="flex gap-3">
+            <input
+              type="text"
+              placeholder="Course title..."
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && createCourse()}
+              className="flex-1 px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+            />
+            <button
+              onClick={createCourse}
+              disabled={creating || !newTitle.trim()}
+              className="px-5 py-2 bg-amber-500 text-white rounded-lg hover:bg-amber-600 font-medium disabled:opacity-50"
+            >
+              {creating ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </div>
+
+        {/* Course list */}
+        {courses.length === 0 ? (
+          <div className="text-center py-12 text-gray-500">
+            <div className="text-4xl mb-4">📚</div>
+            <p>No courses yet. Create your first one above!</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {courses.map(course => (
+              <Link
+                key={course.id}
+                href={`/dashboard/${course.slug}`}
+                className="block bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 hover:shadow-md transition-shadow"
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <h3 className="font-semibold text-lg">{course.title}</h3>
+                    <div className="flex items-center gap-3 mt-2 text-sm text-gray-500">
+                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${statusColors[course.status] || statusColors.draft}`}>
+                        {course.status}
+                      </span>
+                      <span>{course.moduleCount} modules</span>
+                      <span>·</span>
+                      <span>{course.lessonCount} lessons</span>
+                      <span>·</span>
+                      <span>{course.enrollmentCount} students</span>
+                    </div>
+                  </div>
+                  <div className="text-sm text-gray-400">
+                    {course.price === 0 ? 'Free' : `$${(course.price / 100).toFixed(2)}`}
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/learn/app/layout.tsx
+++ b/apps/learn/app/layout.tsx
@@ -2,12 +2,9 @@ import type { Metadata } from 'next';
 import { NavBar } from '@imajin/ui';
 import './globals.css';
 
-const SERVICE_PREFIX = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
-const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
-
 export const metadata: Metadata = {
   title: 'Learn | Imajin',
-  description: 'AI workshops for humans. No hype, just skills.',
+  description: 'Courses and lessons on the Imajin network — teach and learn, sovereign and DID-linked',
 };
 
 export default function RootLayout({
@@ -15,17 +12,18 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const servicePrefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
+  const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
+
   return (
     <html lang="en" className="dark">
-      <body className="min-h-screen bg-black text-white">
+      <body className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100">
         <NavBar
           currentService="Learn"
-          servicePrefix={SERVICE_PREFIX}
-          domain={DOMAIN}
+          servicePrefix={servicePrefix}
+          domain={domain}
         />
-        <main className="max-w-4xl mx-auto px-4 py-8">
-          {children}
-        </main>
+        {children}
       </body>
     </html>
   );

--- a/apps/learn/app/page.tsx
+++ b/apps/learn/app/page.tsx
@@ -1,26 +1,133 @@
-export default function Home() {
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { ImajinFooter } from '@imajin/ui';
+
+interface Course {
+  id: string;
+  title: string;
+  description: string | null;
+  slug: string;
+  price: number;
+  currency: string;
+  creatorDid: string;
+  imageUrl: string | null;
+  tags: string[];
+  moduleCount: number;
+  lessonCount: number;
+}
+
+export default function DiscoveryPage() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    async function loadCourses() {
+      try {
+        const res = await fetch('/api/courses?status=published');
+        if (res.ok) {
+          const data = await res.json();
+          setCourses(data.courses);
+        }
+      } catch (e) {
+        console.error('Failed to load courses:', e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadCourses();
+  }, []);
+
+  const filtered = courses.filter(c =>
+    c.title.toLowerCase().includes(search.toLowerCase()) ||
+    c.description?.toLowerCase().includes(search.toLowerCase()) ||
+    c.tags?.some(t => t.toLowerCase().includes(search.toLowerCase()))
+  );
+
   return (
-    <div className="max-w-2xl mx-auto text-center py-16">
-      <div className="text-6xl mb-6">🧠</div>
-      <h1 className="text-4xl font-bold mb-4 text-white">
-        Imajin <span className="text-[#F59E0B]">Learn</span>
-      </h1>
-      <p className="text-xl text-gray-400 mb-8">
-        AI workshops for humans. No hype, just skills.
-      </p>
-      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8 mb-8">
-        <h2 className="text-xl font-semibold mb-3 text-white">Intro to AI</h2>
-        <p className="text-gray-400 mb-4">
-          3-hour hands-on workshop. Learn to use AI as a tool, not a replacement.
-          Build real things. Ask hard questions. Leave with skills.
-        </p>
-        <div className="flex justify-center gap-6 text-sm text-gray-500">
-          <span>⏱ 3 hours</span>
-          <span>👥 16 max</span>
-          <span>💰 $250/person</span>
+    <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
+      <div className="container mx-auto px-4 py-16">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-12">
+            <div className="text-6xl mb-4">📚</div>
+            <h1 className="text-4xl font-bold mb-4">learn.imajin.ai</h1>
+            <p className="text-lg text-gray-600 dark:text-gray-400">
+              Courses and lessons from creators on the sovereign network
+            </p>
+          </div>
+
+          {/* Search */}
+          <div className="mb-8">
+            <input
+              type="text"
+              placeholder="Search courses by title, description, or tag..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+            />
+          </div>
+
+          {/* Course Grid */}
+          {loading ? (
+            <div className="text-center py-12 text-gray-500">Loading courses...</div>
+          ) : filtered.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-gray-500 mb-4">
+                {search ? 'No courses match your search.' : 'No courses available yet.'}
+              </p>
+              <p className="text-sm text-gray-400">
+                Are you a creator? <Link href="/dashboard" className="text-amber-500 hover:underline">Create your first course</Link>
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {filtered.map(course => (
+                <Link
+                  key={course.id}
+                  href={`/course/${course.slug}`}
+                  className="block bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-lg transition-shadow"
+                >
+                  {course.imageUrl && (
+                    <div className="aspect-video bg-gray-100 dark:bg-gray-700">
+                      <img src={course.imageUrl} alt={course.title} className="w-full h-full object-cover" />
+                    </div>
+                  )}
+                  <div className="p-5">
+                    <h3 className="font-semibold text-lg mb-2">{course.title}</h3>
+                    {course.description && (
+                      <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 line-clamp-2">
+                        {course.description}
+                      </p>
+                    )}
+                    <div className="flex items-center justify-between text-sm text-gray-500">
+                      <span>{course.moduleCount} modules · {course.lessonCount} lessons</span>
+                      <span className="font-medium">
+                        {course.price === 0 ? (
+                          <span className="text-green-600 dark:text-green-400">Free</span>
+                        ) : (
+                          `$${(course.price / 100).toFixed(2)}`
+                        )}
+                      </span>
+                    </div>
+                    {course.tags?.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-3">
+                        {course.tags.slice(0, 3).map(tag => (
+                          <span key={tag} className="px-2 py-0.5 text-xs rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
       </div>
-      <p className="text-gray-500 text-sm">Sessions coming soon.</p>
+      <ImajinFooter />
     </div>
   );
 }

--- a/apps/learn/drizzle.config.ts
+++ b/apps/learn/drizzle.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+  schemaFilter: ['learn'],
+});

--- a/apps/learn/scripts/seed-intro-to-ai.ts
+++ b/apps/learn/scripts/seed-intro-to-ai.ts
@@ -1,0 +1,239 @@
+/**
+ * Seed script: Import intro-to-ai workshop as the first course
+ * 
+ * Usage: DATABASE_URL="..." npx tsx scripts/seed-intro-to-ai.ts
+ * 
+ * This creates:
+ * - 1 course: "Intro to AI: A 3-Hour Workshop"
+ * - 3 modules: Understanding, Using, Living With It
+ * - Lessons from schedule + exercises
+ */
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { courses, modules, lessons } from '../src/db/schema';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const CREATOR_DID = process.env.CREATOR_DID || 'did:imajin:ryan';
+
+function generateId(prefix: string): string {
+  const random = crypto.randomUUID().replace(/-/g, '').substring(0, 13);
+  const timestamp = Date.now().toString(36);
+  return `${prefix}_${timestamp}${random}`;
+}
+
+function readExercise(filename: string): string {
+  try {
+    return readFileSync(
+      join(__dirname, '..', '..', '..', 'imajin-courses', 'intro-to-ai', 'exercises', filename),
+      'utf-8'
+    );
+  } catch {
+    return `*Exercise content: ${filename}*`;
+  }
+}
+
+async function seed() {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+
+  const client = postgres(process.env.DATABASE_URL);
+  const db = drizzle(client);
+
+  // Ensure schema exists
+  await client`CREATE SCHEMA IF NOT EXISTS learn`;
+
+  console.log('Seeding intro-to-ai course...');
+
+  // Create course
+  const courseId = generateId('crs');
+  await db.insert(courses).values({
+    id: courseId,
+    creatorDid: CREATOR_DID,
+    title: 'Intro to AI: A 3-Hour Workshop',
+    description: 'For people who want to understand AI — not fear it. No tech background required. By the end, you\'ll have a real conversation with AI, use it to write and think, and set it up for your life.',
+    slug: 'intro-to-ai',
+    price: 0,
+    currency: 'CAD',
+    visibility: 'public',
+    tags: ['ai', 'beginner', 'workshop'],
+    metadata: {
+      duration: '3 hours',
+      classSize: '12-20 people',
+      audience: 'Anyone — no tech background required',
+      requirements: 'Laptop/tablet with internet access',
+    },
+    status: 'published',
+  });
+
+  console.log(`  Course: ${courseId} (intro-to-ai)`);
+
+  // Module 1: Understanding (Hour 1)
+  const mod1Id = generateId('mod');
+  await db.insert(modules).values({
+    id: mod1Id,
+    courseId,
+    title: 'Understanding',
+    description: 'Hour 1 — What AI is, what it\'s good at, what it\'s not.',
+    sortOrder: 0,
+  });
+
+  const mod1Lessons = [
+    {
+      title: 'Opening: What Are You Afraid Of?',
+      contentType: 'slide',
+      content: '# What Are You Afraid Of?\n\nOpen discussion (15 minutes)\n\n- What have you heard about AI?\n- What worries you?\n- What are you curious about?\n\nNo wrong answers. Every fear is valid. Let\'s talk about them.',
+      durationMinutes: 15,
+    },
+    {
+      title: 'How It Works: Pattern Completion, Not Magic',
+      contentType: 'slide',
+      content: '# How AI Actually Works\n\nAI is pattern completion. It\'s read most of the internet and learned to predict what comes next.\n\n**What it IS:**\n- A very good pattern matcher\n- A writing/thinking assistant\n- A patient tutor that never judges\n\n**What it ISN\'T:**\n- Conscious or aware\n- Always right\n- Coming for your job (probably)\n- Skynet\n\nIt\'s a tool. A very powerful one. Let\'s learn to use it.',
+      durationMinutes: 20,
+    },
+    {
+      title: 'Good vs Bad: Where AI Excels and Fails',
+      contentType: 'slide',
+      content: '# Good vs Bad\n\n**AI is great at:**\n- Writing first drafts\n- Explaining complex topics simply\n- Brainstorming and thinking through problems\n- Summarizing long documents\n- Translating between languages\n- Coding and technical tasks\n\n**AI is bad at:**\n- Facts and dates (it "hallucinates")\n- Math (seriously)\n- Knowing what happened recently\n- Understanding YOUR specific situation\n- Replacing human judgment\n- Emotional support (it can listen, but it doesn\'t care)\n\n**The key insight:** Use it where it\'s strong. Verify where it\'s weak.',
+      durationMinutes: 15,
+    },
+    {
+      title: 'Q&A Buffer',
+      contentType: 'markdown',
+      content: '# Q&A\n\nTime to address any lingering questions from Hour 1.\n\nCommon questions:\n- "Is it safe?"\n- "Can it see my data?"\n- "Will it replace my job?"\n- "Should I be worried?"\n\nHonest answers only. If we don\'t know, we say so.',
+      durationMinutes: 10,
+    },
+  ];
+
+  for (let i = 0; i < mod1Lessons.length; i++) {
+    await db.insert(lessons).values({
+      id: generateId('lsn'),
+      moduleId: mod1Id,
+      ...mod1Lessons[i],
+      sortOrder: i,
+      metadata: {},
+    });
+  }
+
+  console.log(`  Module 1: ${mod1Id} (Understanding) — ${mod1Lessons.length} lessons`);
+
+  // Module 2: Using (Hour 2)
+  const mod2Id = generateId('mod');
+  await db.insert(modules).values({
+    id: mod2Id,
+    courseId,
+    title: 'Using',
+    description: 'Hour 2 — Hands-on exercises. Everyone opens ChatGPT.',
+    sortOrder: 1,
+  });
+
+  const exerciseFiles = [
+    '01-first-conversation.md',
+    '02-write-something.md',
+    '03-explain-something.md',
+    '04-think-with-me.md',
+  ];
+
+  const mod2Lessons = [
+    {
+      title: 'Setup: Everyone Opens ChatGPT',
+      contentType: 'slide',
+      content: '# Let\'s Get Started\n\n1. Open your laptop or tablet\n2. Go to **chat.openai.com**\n3. Create a free account (or sign in if you have one)\n4. You should see a chat interface\n\nIf you get stuck, raise your hand. No judgment.\n\n*We\'re using ChatGPT because it\'s the most accessible. The same principles apply to Claude, Gemini, and others.*',
+      durationMinutes: 10,
+    },
+    ...exerciseFiles.map((file, i) => ({
+      title: `Exercise ${i + 1}: ${file.replace(/^\d+-/, '').replace('.md', '').replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}`,
+      contentType: 'exercise',
+      content: readExercise(file),
+      durationMinutes: 15,
+    })),
+    {
+      title: 'The Prompt: Why How You Ask Matters',
+      contentType: 'slide',
+      content: '# The Prompt Matters\n\nThe same question asked differently gets very different answers.\n\n**Vague:** "Tell me about dogs"\n**Better:** "I\'m adopting my first dog. I live in a small apartment and work from home. What breeds should I consider and why?"\n\n**The formula:**\n1. **Context** — Who you are, what situation\n2. **Task** — What you want it to do\n3. **Constraints** — Tone, length, format\n4. **Examples** — Show it what good looks like\n\nYou don\'t need to memorize this. Just be specific about what you need.',
+      durationMinutes: 5,
+    },
+  ];
+
+  for (let i = 0; i < mod2Lessons.length; i++) {
+    await db.insert(lessons).values({
+      id: generateId('lsn'),
+      moduleId: mod2Id,
+      ...mod2Lessons[i],
+      sortOrder: i,
+      metadata: mod2Lessons[i].contentType === 'exercise' ? { instructions: 'Follow the steps in the exercise content.' } : {},
+    });
+  }
+
+  console.log(`  Module 2: ${mod2Id} (Using) — ${mod2Lessons.length} lessons`);
+
+  // Module 3: Living With It (Hour 3)
+  const mod3Id = generateId('mod');
+  await db.insert(modules).values({
+    id: mod3Id,
+    courseId,
+    title: 'Living With It',
+    description: 'Hour 3 — Custom instructions, real talk about jobs, practice challenge.',
+    sortOrder: 2,
+  });
+
+  const mod3Lessons = [
+    {
+      title: 'Your AI: Custom Instructions',
+      contentType: 'exercise',
+      content: readExercise('05-custom-instructions.md'),
+      durationMinutes: 15,
+    },
+    {
+      title: 'Real Stories: How People Like You Are Using It',
+      contentType: 'slide',
+      content: '# Real Stories\n\n**The retired teacher** uses it to write down family stories — AI helps her structure the memories and fill in details she describes verbally.\n\n**The small business owner** uses it to write emails, create social posts, and draft proposals. Saves 5-10 hours a week.\n\n**The student** uses it as a tutor that never gets annoyed. "Explain this again" works every time.\n\n**The anxious parent** uses it to research medical symptoms without spiraling — "explain this like I\'m worried but rational."\n\n**The creative** uses it to brainstorm, not to create. "Give me 20 bad ideas for this project" → finds 2 good ones.\n\nNotice: none of these people are "tech people."',
+      durationMinutes: 15,
+    },
+    {
+      title: 'The Job Talk: Honest Conversation',
+      contentType: 'slide',
+      content: '# The Job Talk\n\nLet\'s be honest about this.\n\n**What\'s true:**\n- AI will change how many jobs work\n- Some tasks will be automated\n- New roles will emerge\n- The transition will be uneven and sometimes unfair\n\n**What\'s also true:**\n- People who learn to use AI will be more valuable\n- Judgment, empathy, and relationship skills matter more\n- We\'re in the "learning to use the new tool" phase\n- You started that today\n\n**The best advice:**\n- Don\'t ignore it and hope it goes away\n- Don\'t panic and assume the worst\n- DO learn to use it for YOUR work\n- DO stay curious\n- DO talk to people in your field about how they\'re using it',
+      durationMinutes: 15,
+    },
+    {
+      title: 'What\'s Next: Resources & One-Week Challenge',
+      contentType: 'markdown',
+      content: '# What\'s Next\n\n## One-Week Practice Challenge\n\nEvery day this week, use AI for ONE thing:\n\n- **Monday:** Write an email you\'ve been putting off\n- **Tuesday:** Ask it to explain something you\'ve never understood\n- **Wednesday:** Use it to plan something (a meal, a trip, a project)\n- **Thursday:** Ask it to help you think through a decision\n- **Friday:** Get creative — write a poem, a story, a joke\n- **Weekend:** Show someone else what you learned today\n\n## Resources\n\n- **ChatGPT:** chat.openai.com (free tier is plenty)\n- **Claude:** claude.ai (great for longer conversations)\n- **Gemini:** gemini.google.com (integrated with Google)\n\n## Remember\n\n- Be specific in your prompts\n- Verify important facts\n- It\'s a tool, not an oracle\n- The more you use it, the better you get\n- You started today. That matters.',
+      durationMinutes: 10,
+    },
+    {
+      title: 'Closing Q&A',
+      contentType: 'markdown',
+      content: '# Final Questions\n\nAnything goes. No question is too basic.\n\nThank you for spending three hours learning something new. That takes courage.',
+      durationMinutes: 5,
+    },
+  ];
+
+  for (let i = 0; i < mod3Lessons.length; i++) {
+    await db.insert(lessons).values({
+      id: generateId('lsn'),
+      moduleId: mod3Id,
+      ...mod3Lessons[i],
+      sortOrder: i,
+      metadata: mod3Lessons[i].contentType === 'exercise' ? { instructions: 'Follow the steps in the exercise content.' } : {},
+    });
+  }
+
+  console.log(`  Module 3: ${mod3Id} (Living With It) — ${mod3Lessons.length} lessons`);
+
+  console.log('\n✅ Seed complete!');
+  console.log(`   Course: intro-to-ai (${courseId})`);
+  console.log(`   Modules: 3`);
+  console.log(`   Lessons: ${mod1Lessons.length + mod2Lessons.length + mod3Lessons.length}`);
+
+  await client.end();
+}
+
+seed().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/apps/learn/src/db/index.ts
+++ b/apps/learn/src/db/index.ts
@@ -1,0 +1,6 @@
+import { createDb } from '@imajin/db';
+import * as schema from './schema';
+
+export const db = createDb(schema);
+
+export * from './schema';

--- a/apps/learn/src/db/schema.ts
+++ b/apps/learn/src/db/schema.ts
@@ -1,0 +1,85 @@
+import { pgTable, text, timestamp, jsonb, integer, boolean, index, pgSchema, uniqueIndex, primaryKey } from 'drizzle-orm/pg-core';
+
+export const learnSchema = pgSchema('learn');
+
+/**
+ * Courses — top-level learning containers
+ */
+export const courses = learnSchema.table('courses', {
+  id: text('id').primaryKey(),                                    // crs_xxx
+  creatorDid: text('creator_did').notNull(),
+  title: text('title').notNull(),
+  description: text('description'),
+  slug: text('slug').unique(),                                    // URL-friendly, learn.imajin.ai/{handle}/{slug}
+  price: integer('price').default(0),                             // cents (0 = free)
+  currency: text('currency').default('CAD'),
+  visibility: text('visibility').default('public'),               // public / trust-bound / private
+  imageUrl: text('image_url'),
+  tags: jsonb('tags').default([]),
+  metadata: jsonb('metadata').default({}),
+  status: text('status').default('draft'),                        // draft / published / archived
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  creatorDidIdx: index('idx_learn_courses_creator_did').on(table.creatorDid),
+  slugIdx: index('idx_learn_courses_slug').on(table.slug),
+}));
+
+/**
+ * Modules — sections within a course
+ */
+export const modules = learnSchema.table('modules', {
+  id: text('id').primaryKey(),                                    // mod_xxx
+  courseId: text('course_id').notNull().references(() => courses.id, { onDelete: 'cascade' }),
+  title: text('title').notNull(),
+  description: text('description'),
+  sortOrder: integer('sort_order').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  courseIdIdx: index('idx_learn_modules_course_id').on(table.courseId),
+}));
+
+/**
+ * Lessons — individual learning units within a module
+ */
+export const lessons = learnSchema.table('lessons', {
+  id: text('id').primaryKey(),                                    // lsn_xxx
+  moduleId: text('module_id').notNull().references(() => modules.id, { onDelete: 'cascade' }),
+  title: text('title').notNull(),
+  contentType: text('content_type').notNull().default('markdown'), // markdown / exercise / slide / video
+  content: text('content'),                                       // Markdown body
+  durationMinutes: integer('duration_minutes'),
+  sortOrder: integer('sort_order').notNull(),
+  metadata: jsonb('metadata').default({}),                        // Exercise instructions, video URL, etc.
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  moduleIdIdx: index('idx_learn_lessons_module_id').on(table.moduleId),
+}));
+
+/**
+ * Enrollments — student ↔ course relationship
+ */
+export const enrollments = learnSchema.table('enrollments', {
+  id: text('id').primaryKey(),                                    // enr_xxx
+  courseId: text('course_id').notNull().references(() => courses.id, { onDelete: 'cascade' }),
+  studentDid: text('student_did').notNull(),
+  paymentId: text('payment_id'),                                  // nullable — free courses
+  enrolledAt: timestamp('enrolled_at', { withTimezone: true }).defaultNow(),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+}, (table) => ({
+  studentDidIdx: index('idx_learn_enrollments_student_did').on(table.studentDid),
+  courseStudentUnique: uniqueIndex('idx_learn_enrollments_course_student').on(table.courseId, table.studentDid),
+}));
+
+/**
+ * Lesson Progress — per-lesson completion tracking
+ */
+export const lessonProgress = learnSchema.table('lesson_progress', {
+  enrollmentId: text('enrollment_id').notNull().references(() => enrollments.id, { onDelete: 'cascade' }),
+  lessonId: text('lesson_id').notNull().references(() => lessons.id, { onDelete: 'cascade' }),
+  status: text('status').default('not_started'),                  // not_started / in_progress / completed
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.enrollmentId, table.lessonId] }),
+}));

--- a/apps/learn/src/lib/auth.ts
+++ b/apps/learn/src/lib/auth.ts
@@ -1,0 +1,139 @@
+/**
+ * Auth utilities - validate sessions via cookie or Bearer token
+ */
+
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL!;
+const COOKIE_NAME = 'imajin_session';
+
+export interface Identity {
+  id: string;
+  type: string;
+  name?: string;
+  handle?: string;
+  tier?: 'soft' | 'hard';
+}
+
+/**
+ * Get session from cookie by calling auth service
+ */
+export async function getSessionFromCookie(cookieHeader: string | null): Promise<Identity | null> {
+  if (!cookieHeader) return null;
+  
+  // Extract session cookie
+  const cookies = cookieHeader.split(';').map(c => c.trim());
+  const sessionCookie = cookies.find(c => c.startsWith(`${COOKIE_NAME}=`));
+  if (!sessionCookie) return null;
+  
+  const token = sessionCookie.split('=')[1];
+  if (!token) return null;
+
+  try {
+    const response = await fetch(`${AUTH_SERVICE_URL}/api/session`, {
+      headers: {
+        Cookie: `${COOKIE_NAME}=${token}`,
+      },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) return null;
+    
+    const session = await response.json();
+    return {
+      id: session.did,
+      type: session.type,
+      name: session.name,
+      handle: session.handle,
+      tier: session.tier || 'hard',
+    };
+  } catch (error) {
+    console.error('Session validation failed:', error);
+    return null;
+  }
+}
+
+/**
+ * Validate Bearer token (legacy)
+ */
+export async function validateToken(token: string): Promise<{ valid: boolean; identity?: Identity }> {
+  try {
+    const response = await fetch(`${AUTH_SERVICE_URL}/api/validate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+
+    if (!response.ok) return { valid: false };
+    return response.json();
+  } catch (error) {
+    console.error('Token validation failed:', error);
+    return { valid: false };
+  }
+}
+
+export function extractToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  if (!auth?.startsWith('Bearer ')) return null;
+  return auth.slice(7);
+}
+
+/**
+ * Require auth - checks cookie first, then Bearer token
+ */
+export async function requireAuth(request: Request): Promise<{ identity: Identity } | { error: string; status: number }> {
+  // Try cookie first (cross-subdomain session)
+  const cookieHeader = request.headers.get('Cookie');
+  const sessionIdentity = await getSessionFromCookie(cookieHeader);
+  if (sessionIdentity) {
+    return { identity: sessionIdentity };
+  }
+
+  // Fall back to Bearer token
+  const token = extractToken(request);
+  if (!token) {
+    return { error: 'Not authenticated', status: 401 };
+  }
+
+  const result = await validateToken(token);
+  if (!result.valid || !result.identity) {
+    return { error: 'Invalid or expired token', status: 401 };
+  }
+
+  return { identity: result.identity };
+}
+
+/**
+ * Get session for server components (convenience wrapper)
+ */
+export async function getSession(): Promise<Identity | null> {
+  const { cookies } = await import('next/headers');
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(COOKIE_NAME);
+
+  if (!sessionCookie) return null;
+
+  const cookieHeader = `${COOKIE_NAME}=${sessionCookie.value}`;
+  return getSessionFromCookie(cookieHeader);
+}
+
+/**
+ * Require hard DID authentication (keypair-based identity)
+ */
+export async function requireHardDID(request: Request): Promise<{ identity: Identity } | { error: string; status: number }> {
+  const authResult = await requireAuth(request);
+
+  if ('error' in authResult) {
+    return authResult;
+  }
+
+  const { identity } = authResult;
+
+  // Check if this is a hard DID
+  if (identity.tier === 'soft') {
+    return {
+      error: 'This action requires a full identity (hard DID)',
+      status: 403,
+    };
+  }
+
+  return { identity };
+}

--- a/apps/learn/src/lib/utils.ts
+++ b/apps/learn/src/lib/utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Generate a random ID with prefix
+ */
+export function generateId(prefix: string): string {
+  const random = crypto.randomUUID().replace(/-/g, '').substring(0, 13);
+  const timestamp = Date.now().toString(36);
+  return `${prefix}_${timestamp}${random}`;
+}
+
+/**
+ * Generate URL-friendly slug from title
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .substring(0, 80);
+}
+
+/**
+ * Format cents to dollars
+ */
+export function formatMoney(cents: number, currency = 'CAD'): string {
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency,
+  }).format(cents / 100);
+}
+
+/**
+ * Standard JSON response helpers
+ */
+export function jsonResponse(data: any, status = 200) {
+  return Response.json(data, { status });
+}
+
+export function errorResponse(error: string, status = 400) {
+  return Response.json({ error }, { status });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,120 +26,10 @@ importers:
         version: 14.2.35(eslint@8.57.1)(typescript@5.9.3)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
-
-  ../imajin-fixready:
-    dependencies:
-      '@imajin/db':
-        specifier: workspace:*
-        version: link:../imajin-ai/packages/db
-      clsx:
-        specifier: ^2.1.0
-        version: 2.1.1
-      drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
-      js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.1
-      nanoid:
-        specifier: ^5.0.0
-        version: 5.1.6
-      next:
-        specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      qrcode:
-        specifier: ^1.5.3
-        version: 1.5.4
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
-    devDependencies:
-      '@types/js-yaml':
-        specifier: ^4.0.9
-        version: 4.0.9
-      '@types/node':
-        specifier: ^20
-        version: 20.19.33
-      '@types/qrcode':
-        specifier: ^1.5.5
-        version: 1.5.6
-      '@types/react':
-        specifier: ^18
-        version: 18.3.28
-      '@types/react-dom':
-        specifier: ^18
-        version: 18.3.7(@types/react@18.3.28)
-      autoprefixer:
-        specifier: ^10
-        version: 10.4.24(postcss@8.5.6)
-      drizzle-kit:
-        specifier: ^0.31.9
-        version: 0.31.9
-      eslint:
-        specifier: ^9.39.2
-        version: 9.39.3(jiti@1.21.7)
-      eslint-config-next:
-        specifier: ^16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      postcss:
-        specifier: ^8
-        version: 8.5.6
-      tailwindcss:
-        specifier: ^3.4.0
-        version: 3.4.19
-      typescript:
-        specifier: ^5
-        version: 5.9.3
-
-  ../imajin-karaoke:
-    dependencies:
-      '@imajin/db':
-        specifier: workspace:*
-        version: link:../imajin-ai/packages/db
-      drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
-      next:
-        specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
-    devDependencies:
-      '@types/node':
-        specifier: ^20
-        version: 20.19.33
-      '@types/react':
-        specifier: ^18
-        version: 18.3.28
-      '@types/react-dom':
-        specifier: ^18
-        version: 18.3.7(@types/react@18.3.28)
-      autoprefixer:
-        specifier: ^10
-        version: 10.4.24(postcss@8.5.6)
-      drizzle-kit:
-        specifier: ^0.31.9
-        version: 0.31.9
-      postcss:
-        specifier: ^8
-        version: 8.5.6
-      tailwindcss:
-        specifier: ^3.4.0
-        version: 3.4.19
-      typescript:
-        specifier: ^5
-        version: 5.9.3
 
   apps/auth:
     dependencies:
@@ -175,7 +65,7 @@ importers:
         version: 5.1.6
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -233,7 +123,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -297,7 +187,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -352,7 +242,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -401,7 +291,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -465,7 +355,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -523,7 +413,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -578,7 +468,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -627,7 +517,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -685,7 +575,7 @@ importers:
         version: 5.1.6
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
@@ -737,7 +627,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
@@ -798,7 +688,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -850,7 +740,7 @@ importers:
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -902,7 +792,7 @@ importers:
         version: 4.0.3
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -957,7 +847,7 @@ importers:
         version: 1.8.0
       next:
         specifier: ^14.0.0
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       typescript:
         specifier: ^5
@@ -970,7 +860,7 @@ importers:
     dependencies:
       next:
         specifier: '>=14'
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/db:
     dependencies:
@@ -1112,75 +1002,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@7.28.6':
-    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/template@7.28.6':
-    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@codemirror/autocomplete@6.20.1':
@@ -1753,41 +1576,13 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/config-helpers@0.4.2':
-    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/core@0.17.0':
-    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@eslint/eslintrc@3.3.4':
-    resolution: {integrity: sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@eslint/js@9.39.3':
-    resolution: {integrity: sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/object-schema@2.1.7':
-    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1810,14 +1605,6 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
-    engines: {node: '>=18.18.0'}
-
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -1830,10 +1617,6 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
-
-  '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1982,9 +1765,6 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
-
-  '@jridgewell/remapping@2.3.5':
-    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -2147,9 +1927,6 @@ packages:
 
   '@next/eslint-plugin-next@14.2.35':
     resolution: {integrity: sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==}
-
-  '@next/eslint-plugin-next@16.1.6':
-    resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
 
   '@next/swc-darwin-arm64@14.2.33':
     resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
@@ -2915,12 +2692,6 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
-
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
@@ -2982,14 +2753,6 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/eslint-plugin@8.56.1':
-    resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.56.1
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/parser@7.18.0':
     resolution: {integrity: sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -3000,32 +2763,9 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.56.1':
-    resolution: {integrity: sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.56.1':
-    resolution: {integrity: sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/scope-manager@7.18.0':
     resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
     engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/scope-manager@8.56.1':
-    resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.56.1':
-    resolution: {integrity: sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/type-utils@7.18.0':
     resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
@@ -3037,20 +2777,9 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/type-utils@8.56.1':
-    resolution: {integrity: sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/types@7.18.0':
     resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/types@8.56.1':
-    resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.18.0':
     resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
@@ -3061,32 +2790,15 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/typescript-estree@8.56.1':
-    resolution: {integrity: sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/utils@7.18.0':
     resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
 
-  '@typescript-eslint/utils@8.56.1':
-    resolution: {integrity: sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/visitor-keys@7.18.0':
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/visitor-keys@8.56.1':
-    resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -3251,9 +2963,6 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
-
   anser@2.3.5:
     resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
 
@@ -3376,10 +3085,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
-
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
@@ -3418,10 +3123,6 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3537,10 +3238,6 @@ packages:
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
-
   cm6-theme-basic-light@0.2.0:
     resolution: {integrity: sha512-1prg2gv44sYfpHscP26uLT/ePrh0mlmVwMSoSd3zYKQ92Ab3jPRLzyCnpyOCQLJbK+YdNs4HvMRqMNYdy4pMhA==}
     peerDependencies:
@@ -3585,9 +3282,6 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -3954,15 +3648,6 @@ packages:
       typescript:
         optional: true
 
-  eslint-config-next@16.1.6:
-    resolution: {integrity: sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==}
-    peerDependencies:
-      eslint: '>=9.0.0'
-      typescript: '>=3.3.1'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
 
@@ -4022,12 +3707,6 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
     engines: {node: '>=4'}
@@ -4038,21 +3717,9 @@ packages:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-scope@8.4.0:
-    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  eslint-visitor-keys@5.0.1:
-    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
@@ -4060,23 +3727,9 @@ packages:
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
-  eslint@9.39.3:
-    resolution: {integrity: sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
-
-  espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -4146,10 +3799,6 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-glob@3.3.1:
-    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
-    engines: {node: '>=8.6.0'}
-
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -4185,10 +3834,6 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
-  file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
-
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -4207,10 +3852,6 @@ packages:
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
-
-  flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
@@ -4251,10 +3892,6 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
-
-  gensync@1.0.0-beta.2:
-    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
-    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -4307,14 +3944,6 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
-
-  globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
-
-  globals@16.4.0:
-    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
-    engines: {node: '>=18'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -4381,12 +4010,6 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
-  hermes-estree@0.25.1:
-    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
-
-  hermes-parser@0.25.1:
-    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -4412,10 +4035,6 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -4631,11 +4250,6 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4650,11 +4264,6 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
-    hasBin: true
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
     hasBin: true
 
   jsx-ast-utils@3.3.5:
@@ -4728,9 +4337,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -4912,15 +4518,8 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -5762,12 +5361,6 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
-  ts-api-utils@2.4.0:
-    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -5807,13 +5400,6 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
-
-  typescript-eslint@8.56.1:
-    resolution: {integrity: sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -6091,9 +5677,6 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
-  yallist@3.1.1:
-    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -6114,12 +5697,6 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
-  zod-validation-error@4.0.2:
-    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -6130,107 +5707,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
-  '@babel/compat-data@7.29.0': {}
-
-  '@babel/core@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
-  '@babel/helper-compilation-targets@7.28.6':
-    dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
-  '@babel/helper-globals@7.28.0': {}
-
-  '@babel/helper-module-imports@7.28.6':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/helper-validator-option@7.27.1': {}
-
-  '@babel/helpers@7.28.6':
-    dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
-
-  '@babel/parser@7.29.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/runtime@7.28.6': {}
-
-  '@babel/template@7.28.6':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
-
-  '@babel/traverse@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -6779,28 +6256,7 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@1.21.7))':
-    dependencies:
-      eslint: 9.39.3(jiti@1.21.7)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/regexpp@4.12.2': {}
-
-  '@eslint/config-array@0.21.1':
-    dependencies:
-      '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/config-helpers@0.4.2':
-    dependencies:
-      '@eslint/core': 0.17.0
-
-  '@eslint/core@0.17.0':
-    dependencies:
-      '@types/json-schema': 7.0.15
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -6816,30 +6272,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/eslintrc@3.3.4':
-    dependencies:
-      ajv: 6.14.0
-      debug: 4.4.3
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.5
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@eslint/js@8.57.1': {}
-
-  '@eslint/js@9.39.3': {}
-
-  '@eslint/object-schema@2.1.7': {}
-
-  '@eslint/plugin-kit@0.4.1':
-    dependencies:
-      '@eslint/core': 0.17.0
-      levn: 0.4.1
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -6866,13 +6299,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@humanfs/core@0.19.1': {}
-
-  '@humanfs/node@0.16.7':
-    dependencies:
-      '@humanfs/core': 0.19.1
-      '@humanwhocodes/retry': 0.4.3
-
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -6884,8 +6310,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
-
-  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.1.0': {}
 
@@ -6999,11 +6423,6 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
-
-  '@jridgewell/remapping@2.3.5':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -7347,10 +6766,6 @@ snapshots:
   '@next/eslint-plugin-next@14.2.35':
     dependencies:
       glob: 10.3.10
-
-  '@next/eslint-plugin-next@16.1.6':
-    dependencies:
-      fast-glob: 3.3.1
 
   '@next/swc-darwin-arm64@14.2.33':
     optional: true
@@ -8082,10 +7497,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/js-yaml@4.0.9': {}
-
-  '@types/json-schema@7.0.15': {}
-
   '@types/json5@0.0.29': {}
 
   '@types/mdast@4.0.4':
@@ -8158,22 +7569,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/type-utils': 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.56.1
-      eslint: 9.39.3(jiti@1.21.7)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
@@ -8187,40 +7582,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3
-      eslint: 9.39.3(jiti@1.21.7)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-
-  '@typescript-eslint/scope-manager@8.56.1':
-    dependencies:
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/visitor-keys': 8.56.1
-
-  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
 
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -8234,21 +7599,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.3(jiti@1.21.7)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/types@7.18.0': {}
-
-  '@typescript-eslint/types@8.56.1': {}
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
     dependencies:
@@ -8265,21 +7616,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3
-      minimatch: 10.2.4
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
@@ -8291,26 +7627,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      eslint: 9.39.3(jiti@1.21.7)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/visitor-keys@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
-
-  '@typescript-eslint/visitor-keys@8.56.1':
-    dependencies:
-      '@typescript-eslint/types': 8.56.1
-      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -8463,13 +7783,6 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@6.14.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
   anser@2.3.5: {}
 
   ansi-regex@5.0.1: {}
@@ -8603,8 +7916,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  balanced-match@4.0.4: {}
-
   base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -8643,10 +7954,6 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.4:
-    dependencies:
-      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -8776,8 +8083,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
-  clsx@2.1.1: {}
-
   cm6-theme-basic-light@0.2.0(@codemirror/language@6.12.2)(@codemirror/state@6.5.4)(@codemirror/view@6.39.16)(@lezer/highlight@1.2.3):
     dependencies:
       '@codemirror/language': 6.12.2
@@ -8816,8 +8121,6 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
-
-  convert-source-map@2.0.0: {}
 
   crelt@1.0.6: {}
 
@@ -9232,46 +8535,11 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.1.6
-      eslint: 9.39.3(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.3(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.3(jiti@1.21.7))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.3(jiti@1.21.7))
-      globals: 16.4.0
-      typescript-eslint: 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.11
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.3(jiti@1.21.7)
-      get-tsconfig: 4.13.6
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -9298,17 +8566,6 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.3(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -9341,35 +8598,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.3(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7)))(eslint@9.39.3(jiti@1.21.7))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
     dependencies:
       aria-query: 5.3.2
@@ -9389,39 +8617,9 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.3(jiti@1.21.7)):
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.9
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.11.1
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 9.39.3(jiti@1.21.7)
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
-
   eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
-
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.3(jiti@1.21.7)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
-      eslint: 9.39.3(jiti@1.21.7)
-      hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
@@ -9445,43 +8643,12 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-react@7.37.5(eslint@9.39.3(jiti@1.21.7)):
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.2.2
-      eslint: 9.39.3(jiti@1.21.7)
-      estraverse: 5.3.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.6
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
-
   eslint-scope@7.2.2:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-scope@8.4.0:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
   eslint-visitor-keys@3.4.3: {}
-
-  eslint-visitor-keys@4.2.1: {}
-
-  eslint-visitor-keys@5.0.1: {}
 
   eslint@8.57.1:
     dependencies:
@@ -9526,59 +8693,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.39.3(jiti@1.21.7):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@1.21.7))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.4
-      '@eslint/js': 9.39.3
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 1.21.7
-    transitivePeerDependencies:
-      - supports-color
-
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
       event-emitter: 0.3.5
       type: 2.7.3
-
-  espree@10.4.0:
-    dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -9648,14 +8768,6 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-glob@3.3.1:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -9688,10 +8800,6 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
-  file-entry-cache@8.0.0:
-    dependencies:
-      flat-cache: 4.0.1
-
   file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
@@ -9713,11 +8821,6 @@ snapshots:
       flatted: 3.3.3
       keyv: 4.5.4
       rimraf: 3.0.2
-
-  flat-cache@4.0.1:
-    dependencies:
-      flatted: 3.3.3
-      keyv: 4.5.4
 
   flatted@3.3.3: {}
 
@@ -9753,8 +8856,6 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   generator-function@2.0.1: {}
-
-  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -9820,10 +8921,6 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
-
-  globals@14.0.0: {}
-
-  globals@16.4.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -9920,12 +9017,6 @@ snapshots:
 
   he@1.2.0: {}
 
-  hermes-estree@0.25.1: {}
-
-  hermes-parser@0.25.1:
-    dependencies:
-      hermes-estree: 0.25.1
-
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
@@ -9950,8 +9041,6 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
-
-  ignore@7.0.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -10174,8 +9263,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsesc@3.1.0: {}
-
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -10187,8 +9274,6 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
-
-  json5@2.2.3: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -10254,10 +9339,6 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@5.1.1:
-    dependencies:
-      yallist: 3.1.1
 
   lz-string@1.5.0: {}
 
@@ -10694,15 +9775,7 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.4
-
   minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 
@@ -10741,7 +9814,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -10751,7 +9824,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -11558,12 +10631,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.3.1):
+  styled-jsx@5.1.1(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   sucrase@3.35.1:
     dependencies:
@@ -11666,10 +10737,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
-    dependencies:
-      typescript: 5.9.3
-
   ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
@@ -11723,17 +10790,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-
-  typescript-eslint@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.3(jiti@1.21.7)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   typescript@5.9.3: {}
 
@@ -12087,8 +11143,6 @@ snapshots:
 
   y18n@4.0.3: {}
 
-  yallist@3.1.1: {}
-
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
@@ -12115,10 +11169,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
-
-  zod-validation-error@4.0.2(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Complete learn app implementation — courses, modules, lessons, enrollment, progress tracking, creator dashboard, and public pages.

**Closes:** #214, #215, #216, #217, #218, #219, #220
**Parent:** #53

## What's Built

### Database (#214)
- 5 tables in `learn` pgSchema: courses, modules, lessons, enrollments, lesson_progress
- Proper FK cascades, composite PK, unique constraints, indexes

### API Layer (#215, #216, #217)
- **Course CRUD** — create, list (discovery), detail, update, archive
- **Module CRUD** — add, update, delete, reorder
- **Lesson CRUD** — add, get (with enrollment gating for paid courses), update, delete, reorder
- **Enrollment** — free (instant) + paid (redirect to pay service checkout)
- **Progress** — mark lessons complete, auto-detect course completion, progress percentage
- **My courses** — enrolled courses + courses I teach

### UI (#218, #219)
- **Discovery page** (`/`) — search, course cards with tags/pricing
- **Course detail** (`/course/{slug}`) — outline, enroll button, progress indicator
- **Lesson viewer** (`/course/{slug}/{lessonId}`) — content render, sidebar nav, prev/next, mark complete
- **Creator dashboard** (`/dashboard`) — list courses, create new
- **Course editor** (`/dashboard/{slug}`) — settings, module/lesson management, inline markdown editor
- **Students page** (`/dashboard/{slug}/students`) — placeholder for student list
- **Creator profile** (`/{handle}`) — all published courses by creator

### Seed (#220)
- `scripts/seed-intro-to-ai.ts` — imports the intro-to-ai workshop (3 modules, 15 lessons)
- Content types: slide, exercise, markdown
- Reads exercise files from `imajin-courses/intro-to-ai/`

## Port
- Dev: 3103
- Prod: 7103
- URL: learn.imajin.ai

## Build
✅ `pnpm --filter @imajin/learn-service build` passes — all 14 API routes + 6 pages compile