### PR TITLE
docs: Update deployment guide, environments, add developer onboarding (#221)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,48 +1,141 @@
 # Deployment Guide
 
-## Monorepo Services
+## Infrastructure
 
-This repo contains multiple services in `apps/`:
-- `auth` — Identity service (auth.imajin.ai)
-- `profile` — User profiles (profile.imajin.ai)  
-- `pay` — Payments (pay.imajin.ai)
-- `registry` — Node federation (registry.imajin.ai)
+| Component | Details |
+|-----------|---------|
+| Server | HP ProLiant ML350p Gen8, Ubuntu 24.04 LTS |
+| IP | 192.168.1.193 |
+| User | jin (SSH key auth) |
+| Process manager | pm2 |
+| Reverse proxy | Caddy (auto-SSL) |
+| CI runner | GitHub Actions self-hosted (org-level, label: `imajin`) |
+| GPU node | 192.168.1.124 (RTX 3080 Ti — Whisper, Ollama) |
 
-## ⚠️ DO NOT deploy via Vercel CLI from subdirectories
+## Environments
 
-Vercel CLI uploads only the directory you deploy from. Monorepo commands like `cd ../..` or workspace dependencies (`workspace:*`) will fail because parent directories don't exist in the deploy.
+| Environment | Repo path | Database | pm2 prefix |
+|-------------|-----------|----------|------------|
+| Production | `~/prod/imajin-ai` | `imajin_prod` | bare (`www`, `auth`) |
+| Development | `~/dev/imajin-ai` | `imajin_dev` | `dev-` (`dev-www`, `dev-auth`) |
 
-## ✅ Correct: Configure via Vercel Dashboard
+## CI/CD Pipeline
 
-Each service needs its own Vercel project configured via the dashboard:
+### Automatic (standard)
 
-1. **Add New Project** → Import `ima-jin/imajin-ai`
-2. **Root Directory**: Set to `apps/[service]` (e.g., `apps/registry`)
-3. **Framework**: Next.js (auto-detect)
-4. **Build/Output**: Leave defaults (`pnpm build`, `.next`)
-5. **Environment Variables**: Add `DATABASE_URL`
+```
+Push to main → GitHub Actions → build → deploy to dev
+Push v* tag  → GitHub Actions → build → deploy to prod
+```
 
-Vercel auto-detects the monorepo and runs `pnpm install` at the repo root before building in the app directory.
+The pipeline:
+1. Runner pulls latest to `~/dev/imajin-ai` (or `~/prod/imajin-ai`)
+2. `pnpm install && pnpm build`
+3. `drizzle-kit push` for schema changes
+4. `pm2 restart` affected services
 
-## Why This Works
+### Iteration Workflow (skip CI)
 
-- Vercel's GitHub integration clones the full repo
-- It detects `pnpm-workspace.yaml` and runs install at root
-- Workspace dependencies (`@imajin/auth: workspace:*`) resolve correctly
-- Build runs in the app's directory
+For active development when iterating quickly:
 
-## Services Configuration
+```bash
+# 1. Commit with [skip ci]
+git commit -m "fix: whatever [skip ci]"
+git push
 
-| Service | Root Directory | Domain |
-|---------|---------------|--------|
-| auth | `apps/auth` | auth.imajin.ai |
-| profile | `apps/profile` | profile.imajin.ai |
-| pay | `apps/pay` | pay.imajin.ai |
-| registry | `apps/registry` | registry.imajin.ai |
+# 2. Manually pull and rebuild on server
+ssh jin@192.168.1.193 'export PATH=/home/jin/.nvm/versions/node/v22.22.0/bin:$PATH && \
+  cd ~/dev/imajin-ai && git pull origin main && \
+  pnpm --filter @imajin/SERVICE-NAME build && \
+  pm2 restart dev-SERVICE'
+```
+
+### Branch Workflow (clean history)
+
+For feature work where commit history matters:
+
+1. Create a branch, iterate freely
+2. Squash merge to main with one clean commit
+3. CI + deploy runs automatically
+
+## Adding a New Service
+
+### 1. Port Assignment
+
+Follow the port convention (see [ENVIRONMENTS.md](./docs/ENVIRONMENTS.md)):
+- `x000-x099` — Core platform services
+- `x100-x199` — Imajin apps (account-based, DID-linked)
+- `x400-x499` — Client apps (standalone repos)
+
+Dev ports are `3xxx`, prod ports are `7xxx` (1:1 mapping).
+
+### 2. pm2 Configuration
+
+Add to `~/dev/ecosystem.config.js` (and `~/prod/ecosystem.config.js`):
+
+```javascript
+{
+  name: 'dev-myservice',      // or just 'myservice' for prod
+  cwd: './imajin-ai/apps/myservice',
+  script: 'npm',
+  args: 'start',
+  env: {
+    PORT: 3xxx,               // dev port
+    NODE_ENV: 'production',
+  },
+}
+```
+
+### 3. Caddy Configuration
+
+Add to `/etc/caddy/Caddyfile`:
+
+```
+dev-myservice.imajin.ai {
+    reverse_proxy localhost:3xxx
+}
+
+myservice.imajin.ai {
+    reverse_proxy localhost:7xxx
+}
+```
+
+Then reload: `sudo systemctl reload caddy`
+
+### 4. Database Schema
+
+If the service needs its own schema:
+
+```bash
+cd ~/dev/imajin-ai/apps/myservice
+DATABASE_URL=$(grep DATABASE_URL .env.local | cut -d'"' -f2) npx drizzle-kit push --force
+```
+
+### 5. DNS
+
+Add A records for `dev-myservice.imajin.ai` and `myservice.imajin.ai` pointing to the server (or use wildcard if configured).
+
+## Important Notes
+
+- **Dev services run `npm start` (production builds)**, not `npm run dev`. Source edits require `npx next build` + `pm2 restart` to take effect.
+- **`rm -rf .next`** is needed when shared package changes (like `@imajin/ui`) aren't picked up by incremental builds.
+- **Service-to-service URLs** come from `.env.local` env vars (`AUTH_SERVICE_URL`, `PAY_SERVICE_URL`, etc.) — never hardcode URLs.
+- **Never edit code on the server.** Edit locally → push → pipeline deploys.
 
 ## Standalone Repos
 
-These services are in separate repos and deploy normally:
-- `imajin-events` → events.imajin.ai
-- `imajin-chat` → chat.imajin.ai
-- `imajin-web` → imajin.ai (www)
+These services are in separate repos and have their own deployment:
+
+| Repo | Server path (dev) | Server path (prod) |
+|------|-------------------|-------------------|
+| [imajin-fixready](https://github.com/ima-jin/imajin-fixready) | `~/dev/imajin-fixready` | `~/prod/imajin-fixready` |
+| [imajin-karaoke](https://github.com/ima-jin/imajin-karaoke) | `~/dev/imajin-karaoke` | `~/prod/imajin-karaoke` |
+
+## Config Files
+
+| File | Location |
+|------|----------|
+| Caddy | `/etc/caddy/Caddyfile` |
+| pm2 prod | `~/prod/ecosystem.config.js` |
+| pm2 dev | `~/dev/ecosystem.config.js` |
+| Env files | `.env.local` in each app directory |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Shared libraries used across all apps.
 | [@imajin/ui](./packages/ui) | Shared UI components |
 | [@imajin/input](./packages/input) | Input components (emoji, voice, GPS, file upload) |
 | [@imajin/media](./packages/media) | Media browser & asset display components |
+| [@imajin/fair](./packages/fair) | .fair attribution (types, validator, editor components) |
 
 ---
 
@@ -271,7 +272,7 @@ Built with this stack. Tickets signed by the event's DID.
 
 This is early. The architecture is stabilizing but APIs will change.
 
-If you want to run your own node or build on the stack, open an issue or find us on [Discord](https://discord.gg/kWGHUY8wbe).
+If you want to run your own node or build on the stack, start with the [Developer Guide](./docs/DEVELOPER.md), then open an issue or find us on [Discord](https://discord.gg/kWGHUY8wbe).
 
 ### Rules
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,0 +1,247 @@
+# Developer Guide
+
+Getting started with the imajin-ai monorepo.
+
+## Prerequisites
+
+- **Node.js 22+** (use [nvm](https://github.com/nvm-sh/nvm))
+- **pnpm** (`npm install -g pnpm`)
+- **PostgreSQL** (local install or SSH tunnel to server)
+
+## Setup
+
+```bash
+# Clone
+git clone https://github.com/ima-jin/imajin-ai.git
+cd imajin-ai
+
+# Install all dependencies
+pnpm install
+```
+
+## Database
+
+### Option A: SSH Tunnel (recommended for dev)
+
+Connect to the server's Postgres:
+
+```bash
+ssh -f -N -L 5432:127.0.0.1:5432 jin@192.168.1.193
+```
+
+Then use `postgresql://imajin_dev:PASSWORD@localhost:5432/imajin_dev` in your `.env.local`.
+
+### Option B: Local Postgres
+
+Create a database and set `DATABASE_URL` in `.env.local`:
+
+```bash
+createdb imajin_dev
+```
+
+Push schemas:
+
+```bash
+cd apps/auth && DATABASE_URL="postgresql://..." npx drizzle-kit push --force
+```
+
+## Environment Variables
+
+Each app needs a `.env.local` file. Start from the example:
+
+```bash
+cd apps/events
+cp .env.example .env.local
+# Edit with your DATABASE_URL and service URLs
+```
+
+Key variables every service needs:
+
+| Variable | Example |
+|----------|---------|
+| `DATABASE_URL` | `postgresql://imajin_dev:pass@localhost:5432/imajin_dev` |
+| `AUTH_SERVICE_URL` | `http://localhost:3001` |
+
+Service-to-service URLs must point to wherever each service is running. In local dev, that's `http://localhost:PORT`.
+
+## Running Services
+
+```bash
+# Run a single service in dev mode
+pnpm --filter @imajin/auth dev         # localhost:3001
+pnpm --filter @imajin/events dev       # localhost:3006
+pnpm --filter @imajin/learn-service dev # localhost:3103
+
+# Build a service
+pnpm --filter @imajin/www build
+
+# Build all
+pnpm build
+```
+
+### Port Assignments
+
+See [ENVIRONMENTS.md](./ENVIRONMENTS.md) for the full port table. The convention:
+
+- `3xxx` = dev, `7xxx` = prod
+- `x000-x099` = core platform
+- `x100-x199` = imajin apps
+- `x400-x499` = client apps
+
+## Shared Packages
+
+Code shared across services lives in `packages/`:
+
+| Package | What it does |
+|---------|-------------|
+| `@imajin/auth` | Ed25519 signing, DIDs, identity |
+| `@imajin/db` | Database (postgres-js + drizzle-orm) |
+| `@imajin/pay` | Stripe + Solana payments |
+| `@imajin/ui` | Shared React components (NavBar, Footer) |
+| `@imajin/input` | Input widgets (emoji, voice, GPS, upload) |
+| `@imajin/media` | Media browser components |
+| `@imajin/fair` | .fair attribution standard |
+| `@imajin/config` | Shared configuration |
+
+### When shared packages change
+
+If you edit a shared package (e.g., `@imajin/ui`), the consuming app may not pick it up due to Next.js incremental build caching.
+
+Fix: delete the build cache and rebuild:
+
+```bash
+cd apps/events
+rm -rf .next
+pnpm build
+```
+
+## Database Schemas
+
+Each service owns a Postgres schema within the shared database. They don't share tables — only the database.
+
+| Schema | Service | Key tables |
+|--------|---------|-----------|
+| `auth` | auth | identities, sessions, challenges |
+| `profile` | profile | profiles |
+| `events` | events | events, tickets |
+| `coffee` | coffee | pages, tips |
+| `chat` | chat | conversations, messages |
+| `connections` | connections | connections |
+| `input` | input | transcriptions |
+| `media` | media | assets, folders |
+| `learn` | learn | courses, modules, lessons, enrollments, lesson_progress |
+
+To push schema changes:
+
+```bash
+cd apps/SERVICE
+DATABASE_URL="..." npx drizzle-kit push --force
+```
+
+To inspect the schema:
+
+```bash
+DATABASE_URL="..." npx drizzle-kit studio
+```
+
+## Adding a New Service
+
+1. **Copy an existing app** (e.g., `apps/coffee`) as a starting point
+2. **Update `package.json`**: name, port in dev script
+3. **Create schema**: new pgSchema in `src/db/schema.ts`
+4. **Copy auth lib**: `src/lib/auth.ts` from any existing app
+5. **Create `.env.example`** with required variables
+6. **Assign port**: follow the convention in ENVIRONMENTS.md
+7. **Build and verify**: `pnpm --filter @imajin/new-service build`
+
+See [DEPLOYMENT.md](../DEPLOYMENT.md) for server-side setup (pm2, Caddy, DNS).
+
+## Code Patterns
+
+### Auth
+
+Every service validates sessions the same way — call the auth service:
+
+```typescript
+import { requireAuth, requireHardDID, getSession } from '@/lib/auth';
+
+// In API routes — require any auth
+const authResult = await requireAuth(request);
+if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
+
+// Require hard DID (keypair-based, not magic link)
+const authResult = await requireHardDID(request);
+
+// In server components
+const session = await getSession();
+```
+
+### API Routes
+
+Next.js App Router API routes in `app/api/`:
+
+```typescript
+import { NextRequest } from 'next/server';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+
+export async function GET(request: NextRequest) {
+  // ...
+  return jsonResponse(data);
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  // ...
+  return jsonResponse(created, 201);
+}
+```
+
+### ID Generation
+
+All IDs use a prefix + timestamp + random pattern:
+
+```typescript
+function generateId(prefix: string): string {
+  const random = crypto.randomUUID().replace(/-/g, '').substring(0, 13);
+  const timestamp = Date.now().toString(36);
+  return `${prefix}_${timestamp}${random}`;
+}
+
+// Examples: crs_m1abc123, lsn_m1def456, enr_m1ghi789
+```
+
+## Testing
+
+- **End-to-end test cases:** `tests/HAPPY_PATH.md`
+- **Security audit checklist:** `tests/AUDIT.md`
+
+## Troubleshooting
+
+### "Module not found" for shared packages
+
+Run `pnpm install` from the repo root. Workspace dependencies resolve via pnpm's workspace protocol.
+
+### Changes not appearing after build
+
+The build cache may be stale. Delete `.next` and rebuild:
+
+```bash
+rm -rf apps/SERVICE/.next
+pnpm --filter @imajin/SERVICE build
+```
+
+### Database connection errors
+
+If developing locally, ensure your SSH tunnel is running:
+
+```bash
+ssh -f -N -L 5432:127.0.0.1:5432 jin@192.168.1.193
+```
+
+### Build fails with "DATABASE_URL not set"
+
+Some services need DATABASE_URL at build time (for drizzle schema imports). Set a dummy value:
+
+```bash
+DATABASE_URL="postgresql://x:x@localhost:5432/x" pnpm --filter @imajin/SERVICE build
+```

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -9,7 +9,28 @@ All environments run on the self-hosted server (`imajin-server`, 192.168.1.193).
 | Production | `imajin_prod` | `imajin` | 5432 |
 | Development | `imajin_dev` | `imajin_dev` | 5432 |
 
-Database schemas: `auth`, `profile`, `events`, `coffee`, `chat`, `connections`, `input`, `media` (one schema per service, shared database).
+Standalone app databases:
+
+| App | Production | Development |
+|-----|-----------|-------------|
+| fixready | `fixready_prod` | `fixready_dev` |
+| karaoke | `karaoke_prod` | `karaoke_dev` |
+
+### Schemas
+
+Each service owns a schema within the shared database:
+
+| Schema | Service(s) |
+|--------|-----------|
+| `auth` | auth |
+| `profile` | profile |
+| `events` | events |
+| `coffee` | coffee |
+| `chat` | chat |
+| `connections` | connections |
+| `input` | input |
+| `media` | media |
+| `learn` | learn |
 
 Connection string format:
 ```
@@ -29,42 +50,65 @@ All services run via **pm2** on the server. **Caddy** handles reverse proxy with
 - `x100-x199` — **Imajin apps** (coffee, dykil, links, learn — account-based, DID-linked)
 - `x400-x499` — **Client apps** (fixready, karaoke — standalone repos, own databases)
 
-| Tier | Service | Dev | Prod |
-|------|---------|-----|------|
-| Core | www | 3000 | 7000 |
-| Core | auth | 3001 | 7001 |
-| Core | registry | 3002 | 7002 |
-| Core | connections | 3003 | 7003 |
-| Core | pay | 3004 | 7004 |
-| Core | profile | 3005 | 7005 |
-| Core | events | 3006 | 7006 |
-| Core | chat | 3007 | 7007 |
-| Core | input | 3008 | 7008 |
-| Core | media | 3009 | 7009 |
-| Imajin | coffee | 3100 | 7100 |
-| Imajin | dykil | 3101 | 7101 |
-| Imajin | links | 3102 | 7102 |
-| Imajin | learn | 3103 | 7103 |
-| Client | fixready | 3400 | 7400 |
-| Client | karaoke | 3401 | 7401 |
+| Tier | Service | Dev | Prod | Domain |
+|------|---------|-----|------|--------|
+| Core | www | 3000 | 7000 | imajin.ai |
+| Core | auth | 3001 | 7001 | auth.imajin.ai |
+| Core | registry | 3002 | 7002 | registry.imajin.ai |
+| Core | connections | 3003 | 7003 | connections.imajin.ai |
+| Core | pay | 3004 | 7004 | pay.imajin.ai |
+| Core | profile | 3005 | 7005 | profile.imajin.ai |
+| Core | events | 3006 | 7006 | events.imajin.ai |
+| Core | chat | 3007 | 7007 | chat.imajin.ai |
+| Core | input | 3008 | 7008 | input.imajin.ai |
+| Core | media | 3009 | 7009 | media.imajin.ai |
+| Imajin | coffee | 3100 | 7100 | coffee.imajin.ai |
+| Imajin | dykil | 3101 | 7101 | dykil.imajin.ai |
+| Imajin | links | 3102 | 7102 | links.imajin.ai |
+| Imajin | learn | 3103 | 7103 | learn.imajin.ai |
+| Client | fixready | 3400 | 7400 | fixready.imajin.ai |
+| Client | karaoke | 3401 | 7401 | karaoke.imajin.ai |
 
 ### pm2 Naming
 
 - **Bare names** = production (e.g., `www`, `auth`, `events`)
 - **`dev-*` prefix** = development (e.g., `dev-www`, `dev-auth`, `dev-events`)
 
+## Shared Packages
+
+| Package | Purpose |
+|---------|---------|
+| `@imajin/auth` | Ed25519 signing, verification, DID creation |
+| `@imajin/db` | Database layer (postgres-js + drizzle-orm) |
+| `@imajin/pay` | Unified payments (Stripe + Solana) |
+| `@imajin/config` | Shared configuration |
+| `@imajin/ui` | Shared UI components (NavBar, Footer, dark theme) |
+| `@imajin/input` | Input components (emoji, voice, GPS, file upload) |
+| `@imajin/media` | Media browser & asset display components |
+| `@imajin/fair` | .fair attribution (types, validator, FairEditor, FairAccordion) |
+
+## Environment Variables
+
+Each service has a `.env.local` file. Common variables:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DATABASE_URL` | Postgres connection string | `postgresql://imajin_dev:pass@localhost:5432/imajin_dev` |
+| `AUTH_SERVICE_URL` | Auth service base URL | `http://localhost:3001` |
+| `PAY_SERVICE_URL` | Pay service base URL | `http://localhost:3004` |
+| `CONNECTIONS_SERVICE_URL` | Connections service URL | `http://localhost:3003` |
+| `PROFILE_SERVICE_URL` | Profile service URL | `http://localhost:3005` |
+| `NEXT_PUBLIC_SERVICE_PREFIX` | URL scheme prefix | `https://` (prod) or `http://` (dev) |
+| `NEXT_PUBLIC_DOMAIN` | Base domain | `imajin.ai` |
+| `NEXT_PUBLIC_BASE_URL` | Service's own base URL | `http://localhost:3006` |
+
+**⚠️ Service-to-service URLs must come from env vars — never hardcode URLs.**
+
+Every app that uses env vars should have a matching `.env.example` file.
+
 ## Deployment
 
-- **GitHub Actions self-hosted runner** on imajin-server (org-level, label: `imajin`)
-- Push to `main` → CI → auto-deploy to **dev**
-- Push `v*` tag → deploy to **prod**
-
-### Deploy Pipeline
-
-1. Runner pulls latest to `~/dev/imajin-ai` (or `~/prod/imajin-ai`)
-2. `pnpm install && pnpm build`
-3. `drizzle-kit push` for schema changes
-4. `pm2 restart` affected services
+See [DEPLOYMENT.md](../DEPLOYMENT.md) for the full deployment pipeline.
 
 ## Database Migrations
 
@@ -85,12 +129,12 @@ ML/compute services run on a dedicated GPU node (`192.168.1.124`), not the ProLi
 | Service | Port | Model | Purpose |
 |---------|------|-------|---------|
 | Whisper | 8765 | large-v3 (CUDA float16) | Speech-to-text transcription |
+| Ollama | 11434 | qwen2.5-coder:7b, nomic-embed-text | Code refactoring, embeddings |
 
 The input service relays audio to the GPU node over LAN. No public subdomain — internal only.
 
 - **Repo:** [ima-jin/imajin-ml](https://github.com/ima-jin/imajin-ml)
 - **Server path:** `~/imajin-ml`
-- **Process:** uvicorn (systemd planned)
 
 ## Local Development
 
@@ -101,10 +145,11 @@ ssh -f -N -L 5432:127.0.0.1:5432 jin@192.168.1.193
 
 Then use `localhost:5432` in your `.env.local`.
 
-## Config
+## Config Files
 
-- **Caddy:** `/etc/caddy/Caddyfile`
-- **pm2 prod:** `~/prod/ecosystem.config.js`
-- **pm2 dev:** `~/dev/ecosystem.config.js`
-- **Env files:** `.env.local` in each app directory
-
+| File | Location |
+|------|----------|
+| Caddy | `/etc/caddy/Caddyfile` |
+| pm2 prod | `~/prod/ecosystem.config.js` |
+| pm2 dev | `~/dev/ecosystem.config.js` |
+| Env files | `.env.local` in each app directory |


### PR DESCRIPTION
## Summary

Overhaul project documentation for accuracy and developer onboarding.

**Closes:** #221

## Changes

### `DEPLOYMENT.md` — Rewritten
- Removed all Vercel references
- Documented self-hosted pipeline (GitHub Actions → pm2 → Caddy)
- Added iteration workflow (`[skip ci]` + manual deploy)
- Added "Adding a New Service" guide (port, pm2, Caddy, schema, DNS)

### `docs/ENVIRONMENTS.md` — Updated
- Added learn service (port 3103/7103, learn schema)
- Added `@imajin/fair` to shared packages
- Added common environment variables reference table
- Added domain column to port table

### `docs/DEVELOPER.md` — New
- Prerequisites (Node 22+, pnpm, Postgres)
- Clone, install, env setup
- Running services locally
- Database (SSH tunnel or local, schema push, drizzle studio)
- Shared packages + cache invalidation
- Code patterns (auth, API routes, ID generation)
- Adding new services checklist
- Troubleshooting section

### `README.md` — Minor
- Added `@imajin/fair` to packages table
- Linked to DEVELOPER.md in Contributing section