### PR TITLE
feat(chat): API hooks, WebSocket client, and ChatProvider

### DIFF
--- a/packages/chat/src/ChatProvider.tsx
+++ b/packages/chat/src/ChatProvider.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+interface ChatConfig {
+  chatUrl: string;
+  authUrl: string;
+}
+
+const ChatContext = createContext<ChatConfig | null>(null);
+
+export function useChatConfig(): ChatConfig {
+  const ctx = useContext(ChatContext);
+  if (!ctx) throw new Error('useChatConfig must be used within a ChatProvider');
+  return ctx;
+}
+
+export function ChatProvider({
+  chatUrl,
+  authUrl,
+  children,
+}: ChatConfig & { children: React.ReactNode }) {
+  return (
+    <ChatContext.Provider value={{ chatUrl, authUrl }}>
+      {children}
+    </ChatContext.Provider>
+  );
+}

--- a/packages/chat/src/hooks/useChatAccess.ts
+++ b/packages/chat/src/hooks/useChatAccess.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { useChatConfig } from '../ChatProvider';
+
+interface AccessResult {
+  allowed: boolean;
+  role: string;
+  governance: Record<string, unknown>;
+}
+
+interface UseChatAccessResult {
+  allowed: boolean;
+  role: string;
+  governance: Record<string, unknown>;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const cache = new Map<string, AccessResult>();
+
+export function useChatAccess(did: string): UseChatAccessResult {
+  const { authUrl } = useChatConfig();
+  const cacheKey = `${authUrl}|${did}`;
+
+  const cached = cache.get(cacheKey);
+  const [result, setResult] = useState<AccessResult | null>(cached ?? null);
+  const [isLoading, setIsLoading] = useState(!cached);
+  const [error, setError] = useState<Error | null>(null);
+  const fetchedKey = useRef<string | null>(cached ? cacheKey : null);
+
+  useEffect(() => {
+    if (fetchedKey.current === cacheKey) return;
+    fetchedKey.current = cacheKey;
+
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      setResult(cached);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    fetch(`${authUrl}/api/access/${did}`, { credentials: 'include' })
+      .then(res => {
+        if (!res.ok) throw new Error(`Access check failed: ${res.status}`);
+        return res.json() as Promise<AccessResult>;
+      })
+      .then(data => {
+        cache.set(cacheKey, data);
+        setResult(data);
+      })
+      .catch(err => setError(err instanceof Error ? err : new Error(String(err))))
+      .finally(() => setIsLoading(false));
+  }, [cacheKey, authUrl, did]);
+
+  return {
+    allowed: result?.allowed ?? false,
+    role: result?.role ?? '',
+    governance: result?.governance ?? {},
+    isLoading,
+    error,
+  };
+}

--- a/packages/chat/src/hooks/useChatActions.ts
+++ b/packages/chat/src/hooks/useChatActions.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useChatConfig } from '../ChatProvider';
+
+interface SendOptions {
+  replyTo?: string;
+}
+
+interface UseChatActionsResult {
+  sendMessage: (content: { type: string; text?: string; [key: string]: unknown }, options?: SendOptions) => Promise<void>;
+  addReaction: (messageId: string, emoji: string) => Promise<void>;
+  removeReaction: (messageId: string, emoji: string) => Promise<void>;
+  editMessage: (messageId: string, content: object) => Promise<void>;
+  deleteMessage: (messageId: string) => Promise<void>;
+  markRead: () => Promise<void>;
+  isSending: boolean;
+}
+
+export function useChatActions(did: string): UseChatActionsResult {
+  const { chatUrl } = useChatConfig();
+  const [isSending, setIsSending] = useState(false);
+
+  const request = useCallback(
+    async (method: string, path: string, body?: object) => {
+      const res = await fetch(`${chatUrl}${path}`, {
+        method,
+        credentials: 'include',
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!res.ok) throw new Error(`${method} ${path} failed: ${res.status}`);
+      return res;
+    },
+    [chatUrl]
+  );
+
+  const sendMessage = useCallback(
+    async (content: { type: string; text?: string; [key: string]: unknown }, options?: SendOptions) => {
+      setIsSending(true);
+      try {
+        await request('POST', `/api/d/${did}/messages`, { content, ...options });
+      } finally {
+        setIsSending(false);
+      }
+    },
+    [did, request]
+  );
+
+  const addReaction = useCallback(
+    (messageId: string, emoji: string) =>
+      request('POST', `/api/d/${did}/messages/${messageId}/reactions`, { emoji }).then(() => undefined),
+    [did, request]
+  );
+
+  const removeReaction = useCallback(
+    (messageId: string, emoji: string) =>
+      request('DELETE', `/api/d/${did}/messages/${messageId}/reactions`, { emoji }).then(() => undefined),
+    [did, request]
+  );
+
+  const editMessage = useCallback(
+    (messageId: string, content: object) =>
+      request('PATCH', `/api/d/${did}/messages/${messageId}`, { content }).then(() => undefined),
+    [did, request]
+  );
+
+  const deleteMessage = useCallback(
+    (messageId: string) =>
+      request('DELETE', `/api/d/${did}/messages/${messageId}`).then(() => undefined),
+    [did, request]
+  );
+
+  const markRead = useCallback(
+    () => request('POST', `/api/d/${did}/read`).then(() => undefined),
+    [did, request]
+  );
+
+  return { sendMessage, addReaction, removeReaction, editMessage, deleteMessage, markRead, isSending };
+}

--- a/packages/chat/src/hooks/useChatMessages.ts
+++ b/packages/chat/src/hooks/useChatMessages.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useChatConfig } from '../ChatProvider';
+
+export interface ChatMessage {
+  id: string;
+  did: string;
+  senderDid: string;
+  content: { type: string; text?: string; [key: string]: unknown };
+  replyTo?: string;
+  reactions?: { emoji: string; senderDid: string }[];
+  createdAt: string;
+  editedAt?: string;
+}
+
+interface UseChatMessagesResult {
+  messages: ChatMessage[];
+  hasMore: boolean;
+  loadMore: () => void;
+  isLoading: boolean;
+  error: Error | null;
+  pushMessage: (message: ChatMessage) => void;
+}
+
+export function useChatMessages(did: string): UseChatMessagesResult {
+  const { chatUrl } = useChatConfig();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const cursorRef = useRef<string | undefined>(undefined);
+  const initialLoadDone = useRef(false);
+
+  const fetchMessages = useCallback(async (before?: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ limit: '50' });
+      if (before) params.set('before', before);
+      const res = await fetch(
+        `${chatUrl}/api/d/${did}/messages?${params}`,
+        { credentials: 'include' }
+      );
+      if (!res.ok) throw new Error(`Failed to fetch messages: ${res.status}`);
+      const data = await res.json();
+      const fetched: ChatMessage[] = data.messages ?? data;
+      // Oldest first
+      const sorted = [...fetched].sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      );
+      if (before) {
+        setMessages(prev => [...sorted, ...prev]);
+      } else {
+        setMessages(sorted);
+      }
+      setHasMore(data.hasMore ?? fetched.length === 50);
+      if (sorted.length > 0) {
+        cursorRef.current = sorted[0].id;
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [chatUrl, did]);
+
+  useEffect(() => {
+    if (!initialLoadDone.current) {
+      initialLoadDone.current = true;
+      cursorRef.current = undefined;
+      setMessages([]);
+      fetchMessages();
+    }
+  }, [fetchMessages]);
+
+  // Reset when did changes
+  useEffect(() => {
+    initialLoadDone.current = false;
+    cursorRef.current = undefined;
+    setMessages([]);
+    setHasMore(false);
+    setError(null);
+    fetchMessages();
+  }, [did]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const loadMore = useCallback(() => {
+    if (!isLoading && hasMore) {
+      fetchMessages(cursorRef.current);
+    }
+  }, [isLoading, hasMore, fetchMessages]);
+
+  const pushMessage = useCallback((message: ChatMessage) => {
+    setMessages(prev => {
+      if (prev.some(m => m.id === message.id)) return prev;
+      return [...prev, message];
+    });
+  }, []);
+
+  return { messages, hasMore, loadMore, isLoading, error, pushMessage };
+}

--- a/packages/chat/src/hooks/useChatWebSocket.ts
+++ b/packages/chat/src/hooks/useChatWebSocket.ts
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useChatConfig } from '../ChatProvider';
+
+interface WSMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface TypingUser {
+  did: string;
+  name?: string;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+interface UseChatWebSocketResult {
+  isConnected: boolean;
+  lastMessage: WSMessage | null;
+  typingUsers: Map<string, TypingUser>;
+  sendTyping: () => void;
+  stopTyping: () => void;
+}
+
+function chatUrlToWsUrl(chatUrl: string): string {
+  return chatUrl.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
+}
+
+export function useChatWebSocket(did: string): UseChatWebSocketResult {
+  const { chatUrl } = useChatConfig();
+  const wsUrl = `${chatUrlToWsUrl(chatUrl)}/ws`;
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [lastMessage, setLastMessage] = useState<WSMessage | null>(null);
+  const [typingUsers, setTypingUsers] = useState<Map<string, TypingUser>>(new Map());
+  const reconnectDelay = useRef(1000);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pingTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const mountedRef = useRef(true);
+  const didRef = useRef(did);
+  didRef.current = did;
+
+  const cleanup = useCallback(() => {
+    if (pingTimer.current) clearInterval(pingTimer.current);
+    if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+    pingTimer.current = null;
+    reconnectTimer.current = null;
+  }, []);
+
+  const connect = useCallback(() => {
+    if (!mountedRef.current) return;
+    cleanup();
+
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (!mountedRef.current) { ws.close(); return; }
+      setIsConnected(true);
+      reconnectDelay.current = 1000;
+      ws.send(JSON.stringify({ type: 'subscribe', did: didRef.current }));
+      pingTimer.current = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'ping' }));
+        }
+      }, 30000);
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data: WSMessage = JSON.parse(event.data as string);
+        if (data.type === 'pong' || data.type === 'connected') return;
+
+        if (data.type === 'user_typing') {
+          const senderDid = data.did as string;
+          if (!senderDid || senderDid === didRef.current) return;
+          setTypingUsers(prev => {
+            const next = new Map(prev);
+            const existing = next.get(senderDid);
+            if (existing) clearTimeout(existing.timeout);
+            const timeout = setTimeout(() => {
+              setTypingUsers(m => {
+                const n = new Map(m);
+                n.delete(senderDid);
+                return n;
+              });
+            }, 5000);
+            next.set(senderDid, { did: senderDid, name: data.name as string | undefined, timeout });
+            return next;
+          });
+          return;
+        }
+
+        if (data.type === 'user_stop_typing') {
+          const senderDid = data.did as string;
+          if (!senderDid) return;
+          setTypingUsers(prev => {
+            const existing = prev.get(senderDid);
+            if (existing) clearTimeout(existing.timeout);
+            const next = new Map(prev);
+            next.delete(senderDid);
+            return next;
+          });
+          return;
+        }
+
+        setLastMessage(data);
+      } catch {}
+    };
+
+    ws.onclose = () => {
+      setIsConnected(false);
+      cleanup();
+      if (mountedRef.current) {
+        reconnectTimer.current = setTimeout(() => {
+          reconnectDelay.current = Math.min(reconnectDelay.current * 2, 30000);
+          connect();
+        }, reconnectDelay.current);
+      }
+    };
+
+    ws.onerror = () => {
+      ws.close();
+    };
+  }, [wsUrl, cleanup]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    connect();
+    return () => {
+      mountedRef.current = false;
+      cleanup();
+      wsRef.current?.close();
+    };
+  }, [connect, cleanup]);
+
+  // Re-subscribe when did changes while connected
+  useEffect(() => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'subscribe', did }));
+    }
+    setTypingUsers(new Map());
+  }, [did]);
+
+  const sendTyping = useCallback(() => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'typing', did: didRef.current }));
+    }
+  }, []);
+
+  const stopTyping = useCallback(() => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'stop_typing', did: didRef.current }));
+    }
+  }, []);
+
+  return { isConnected, lastMessage, typingUsers, sendTyping, stopTyping };
+}

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -6,3 +6,10 @@ export { LocationMessage } from './LocationMessage';
 export { ReactionPicker } from './ReactionPicker';
 export { LinkPreviewCard } from './LinkPreviewCard';
 export type { MessageContent, TextContent, VoiceContent, MediaContent, LocationContent } from './message-types';
+
+export { ChatProvider, useChatConfig } from './ChatProvider';
+export { useChatMessages } from './hooks/useChatMessages';
+export type { ChatMessage } from './hooks/useChatMessages';
+export { useChatActions } from './hooks/useChatActions';
+export { useChatWebSocket } from './hooks/useChatWebSocket';
+export { useChatAccess } from './hooks/useChatAccess';


### PR DESCRIPTION
Closes #284 (Phase 3 of #278)

## What

Adds React hooks and ChatProvider to `@imajin/chat` so any app can wire up real-time chat with just a DID.

### New Files
- `packages/chat/src/ChatProvider.tsx` — context provider for chatUrl + authUrl
- `packages/chat/src/hooks/useChatMessages.ts` — fetch + paginate + receive WS messages
- `packages/chat/src/hooks/useChatActions.ts` — send, react, edit, delete, mark read
- `packages/chat/src/hooks/useChatWebSocket.ts` — DID-based WS with auto-reconnect
- `packages/chat/src/hooks/useChatAccess.ts` — access check via auth endpoint

### Notes
- Hooks consume Phase 2's API routes (`/api/d/:did/messages`) — built against the interface
- All hooks use ChatProvider context (throw if not wrapped)
- Existing UI components (MessageBubble etc.) untouched