### PR TITLE
feat(chat): DID-based API routes + WebSocket subscriptions

### DIFF
--- a/apps/chat/src/app/api/d/[did]/messages/[msgId]/reactions/route.ts
+++ b/apps/chat/src/app/api/d/[did]/messages/[msgId]/reactions/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest } from 'next/server';
+import { eq, and } from 'drizzle-orm';
+import { db, messagesV2, messageReactionsV2 } from '@/db';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse, corsHeaders, corsOptions } from '@/lib/utils';
+
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
+
+async function verifyDidAccess(did: string, cookieHeader: string | null): Promise<boolean> {
+  try {
+    const res = await fetch(`${AUTH_SERVICE_URL}/api/access/${encodeURIComponent(did)}`, {
+      headers: cookieHeader ? { Cookie: cookieHeader } : {},
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * OPTIONS /api/d/:did/messages/:msgId/reactions - CORS preflight
+ */
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * POST /api/d/:did/messages/:msgId/reactions - Add a reaction
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string; msgId: string }> }
+) {
+  const cors = corsHeaders(request);
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status, cors);
+  }
+
+  const { identity } = authResult;
+  const { did, msgId } = await params;
+
+  const cookieHeader = request.headers.get('Cookie');
+  const hasAccess = await verifyDidAccess(did, cookieHeader);
+  if (!hasAccess) {
+    return errorResponse('Access denied', 403, cors);
+  }
+
+  try {
+    const message = await db.query.messagesV2.findFirst({
+      where: and(
+        eq(messagesV2.id, msgId),
+        eq(messagesV2.conversationDid, did)
+      ),
+    });
+
+    if (!message) {
+      return errorResponse('Message not found', 404, cors);
+    }
+
+    const body = await request.json();
+    const { emoji } = body;
+
+    if (!emoji || typeof emoji !== 'string') {
+      return errorResponse('emoji is required', 400, cors);
+    }
+
+    await db.insert(messageReactionsV2).values({
+      messageId: msgId,
+      did: identity.id,
+      emoji,
+    }).onConflictDoNothing();
+
+    return jsonResponse({ ok: true }, 201, cors);
+  } catch (error) {
+    console.error('Failed to add reaction:', error);
+    return errorResponse('Failed to add reaction', 500, cors);
+  }
+}
+
+/**
+ * DELETE /api/d/:did/messages/:msgId/reactions - Remove a reaction
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string; msgId: string }> }
+) {
+  const cors = corsHeaders(request);
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status, cors);
+  }
+
+  const { identity } = authResult;
+  const { did, msgId } = await params;
+
+  const cookieHeader = request.headers.get('Cookie');
+  const hasAccess = await verifyDidAccess(did, cookieHeader);
+  if (!hasAccess) {
+    return errorResponse('Access denied', 403, cors);
+  }
+
+  try {
+    const body = await request.json();
+    const { emoji } = body;
+
+    if (!emoji || typeof emoji !== 'string') {
+      return errorResponse('emoji is required', 400, cors);
+    }
+
+    await db.delete(messageReactionsV2).where(
+      and(
+        eq(messageReactionsV2.messageId, msgId),
+        eq(messageReactionsV2.did, identity.id),
+        eq(messageReactionsV2.emoji, emoji)
+      )
+    );
+
+    return new Response(null, { status: 204, headers: cors });
+  } catch (error) {
+    console.error('Failed to remove reaction:', error);
+    return errorResponse('Failed to remove reaction', 500, cors);
+  }
+}

--- a/apps/chat/src/app/api/d/[did]/messages/[msgId]/route.ts
+++ b/apps/chat/src/app/api/d/[did]/messages/[msgId]/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from 'next/server';
+import { eq, and } from 'drizzle-orm';
+import { db, messagesV2 } from '@/db';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse, corsHeaders, corsOptions } from '@/lib/utils';
+
+/**
+ * OPTIONS /api/d/:did/messages/:msgId - CORS preflight
+ */
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * PATCH /api/d/:did/messages/:msgId - Edit a message
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string; msgId: string }> }
+) {
+  const cors = corsHeaders(request);
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status, cors);
+  }
+
+  const { identity } = authResult;
+  const { did, msgId } = await params;
+
+  try {
+    const existing = await db.query.messagesV2.findFirst({
+      where: and(
+        eq(messagesV2.id, msgId),
+        eq(messagesV2.conversationDid, did)
+      ),
+    });
+
+    if (!existing) {
+      return errorResponse('Message not found', 404, cors);
+    }
+
+    if (existing.fromDid !== identity.id) {
+      return errorResponse('You can only edit your own messages', 403, cors);
+    }
+
+    if (existing.deletedAt) {
+      return errorResponse('Cannot edit a deleted message', 400, cors);
+    }
+
+    const body = await request.json();
+    const { content } = body;
+
+    if (!content || typeof content !== 'object') {
+      return errorResponse('content is required and must be an object', 400, cors);
+    }
+
+    await db
+      .update(messagesV2)
+      .set({ content, editedAt: new Date() })
+      .where(eq(messagesV2.id, msgId));
+
+    const updated = await db.query.messagesV2.findFirst({
+      where: eq(messagesV2.id, msgId),
+    });
+
+    return jsonResponse({ message: updated }, 200, cors);
+  } catch (error) {
+    console.error('Failed to edit message:', error);
+    return errorResponse('Failed to edit message', 500, cors);
+  }
+}
+
+/**
+ * DELETE /api/d/:did/messages/:msgId - Soft delete a message
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string; msgId: string }> }
+) {
+  const cors = corsHeaders(request);
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status, cors);
+  }
+
+  const { identity } = authResult;
+  const { did, msgId } = await params;
+
+  try {
+    const existing = await db.query.messagesV2.findFirst({
+      where: and(
+        eq(messagesV2.id, msgId),
+        eq(messagesV2.conversationDid, did)
+      ),
+    });
+
+    if (!existing) {
+      return errorResponse('Message not found', 404, cors);
+    }
+
+    if (existing.fromDid !== identity.id) {
+      return errorResponse('You can only delete your own messages', 403, cors);
+    }
+
+    await db
+      .update(messagesV2)
+      .set({ deletedAt: new Date() })
+      .where(eq(messagesV2.id, msgId));
+
+    return new Response(null, { status: 204, headers: cors });
+  } catch (error) {
+    console.error('Failed to delete message:', error);
+    return errorResponse('Failed to delete message', 500, cors);
+  }
+}

--- a/apps/chat/src/app/api/d/[did]/messages/route.ts
+++ b/apps/chat/src/app/api/d/[did]/messages/route.ts
@@ -1,0 +1,225 @@
+import { NextRequest } from 'next/server';
+import { eq, and, desc, lt, isNull, inArray } from 'drizzle-orm';
+import { db, conversationsV2, messagesV2, messageReactionsV2 } from '@/db';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse, generateId, corsHeaders, corsOptions } from '@/lib/utils';
+import { parseConversationDid } from '@/lib/conversation-did';
+
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
+
+async function verifyDidAccess(did: string, cookieHeader: string | null): Promise<boolean> {
+  try {
+    const res = await fetch(`${AUTH_SERVICE_URL}/api/access/${encodeURIComponent(did)}`, {
+      headers: cookieHeader ? { Cookie: cookieHeader } : {},
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * OPTIONS /api/d/:did/messages - CORS preflight
+ */
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * GET /api/d/:did/messages - Paginated messages for a DID-keyed conversation
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const cors = corsHeaders(request);
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status, cors);
+  }
+
+  const { did } = await params;
+
+  // Verify access
+  const cookieHeader = request.headers.get('Cookie');
+  const hasAccess = await verifyDidAccess(did, cookieHeader);
+  if (!hasAccess) {
+    return errorResponse('Access denied', 403, cors);
+  }
+
+  // Pagination
+  const url = new URL(request.url);
+  const limit = Math.min(parseInt(url.searchParams.get('limit') || '50'), 100);
+  const before = url.searchParams.get('before');
+
+  try {
+    let query = db
+      .select()
+      .from(messagesV2)
+      .where(
+        and(
+          eq(messagesV2.conversationDid, did),
+          isNull(messagesV2.deletedAt)
+        )
+      )
+      .orderBy(desc(messagesV2.createdAt))
+      .limit(limit);
+
+    if (before) {
+      const cursorMessage = await db.query.messagesV2.findFirst({
+        where: eq(messagesV2.id, before),
+      });
+      if (cursorMessage?.createdAt) {
+        query = db
+          .select()
+          .from(messagesV2)
+          .where(
+            and(
+              eq(messagesV2.conversationDid, did),
+              isNull(messagesV2.deletedAt),
+              lt(messagesV2.createdAt, cursorMessage.createdAt)
+            )
+          )
+          .orderBy(desc(messagesV2.createdAt))
+          .limit(limit);
+      }
+    }
+
+    const result = await query;
+
+    // Fetch reactions for these messages
+    const messageIds = result.map(m => m.id);
+    const reactions = messageIds.length > 0
+      ? await db
+          .select()
+          .from(messageReactionsV2)
+          .where(inArray(messageReactionsV2.messageId, messageIds))
+      : [];
+
+    // Group reactions by messageId
+    const reactionsByMessage = reactions.reduce<Record<string, typeof reactions>>((acc, r) => {
+      if (!acc[r.messageId]) acc[r.messageId] = [];
+      acc[r.messageId].push(r);
+      return acc;
+    }, {});
+
+    const messagesWithReactions = result.reverse().map(m => ({
+      ...m,
+      reactions: reactionsByMessage[m.id] || [],
+    }));
+
+    return jsonResponse({
+      messages: messagesWithReactions,
+      hasMore: result.length === limit,
+    }, 200, cors);
+  } catch (error) {
+    console.error('Failed to get messages:', error);
+    return errorResponse('Failed to get messages', 500, cors);
+  }
+}
+
+/**
+ * POST /api/d/:did/messages - Send a message to a DID-keyed conversation
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const cors = corsHeaders(request);
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status, cors);
+  }
+
+  const { identity } = authResult;
+  const { did } = await params;
+
+  // Verify access
+  const cookieHeader = request.headers.get('Cookie');
+  const hasAccess = await verifyDidAccess(did, cookieHeader);
+  if (!hasAccess) {
+    return errorResponse('Access denied', 403, cors);
+  }
+
+  try {
+    const body = await request.json();
+    const { content, replyToMessageId, mediaType, mediaPath, mediaMeta } = body;
+
+    if (!content || typeof content !== 'object') {
+      return errorResponse('content is required and must be an object', 400, cors);
+    }
+
+    const contentType = body.contentType || content.type || 'text';
+    const validContentTypes = ['text', 'system', 'media', 'voice', 'location'];
+    if (!validContentTypes.includes(contentType)) {
+      return errorResponse(`Invalid contentType: ${contentType}`, 400, cors);
+    }
+
+    // Auto-create conversation if it doesn't exist
+    const existing = await db.query.conversationsV2.findFirst({
+      where: eq(conversationsV2.did, did),
+    });
+
+    if (!existing) {
+      const parsed = parseConversationDid(did);
+      const name = parsed.type !== 'unknown' ? `${parsed.type}:${parsed.slug ?? ''}` : did;
+      await db.insert(conversationsV2).values({
+        did,
+        name,
+        createdBy: identity.id,
+      }).onConflictDoNothing();
+    }
+
+    // Validate reply if provided
+    if (replyToMessageId) {
+      const replyMessage = await db.query.messagesV2.findFirst({
+        where: and(
+          eq(messagesV2.id, replyToMessageId),
+          eq(messagesV2.conversationDid, did)
+        ),
+      });
+      if (!replyMessage) {
+        return errorResponse('Reply message not found', 404, cors);
+      }
+    }
+
+    const messageId = generateId('msg');
+
+    await db.insert(messagesV2).values({
+      id: messageId,
+      conversationDid: did,
+      fromDid: identity.id,
+      content,
+      contentType,
+      replyToMessageId: replyToMessageId || null,
+      mediaType: mediaType || null,
+      mediaPath: mediaPath || null,
+      mediaMeta: mediaMeta || null,
+    });
+
+    // Update lastMessageAt
+    await db
+      .update(conversationsV2)
+      .set({ lastMessageAt: new Date(), updatedAt: new Date() })
+      .where(eq(conversationsV2.did, did));
+
+    const message = await db.query.messagesV2.findFirst({
+      where: eq(messagesV2.id, messageId),
+    });
+
+    // Broadcast via WebSocket
+    if (message) {
+      const port = process.env.PORT || '3007';
+      fetch(`http://localhost:${port}/__ws_broadcast`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ conversationId: did, message }),
+      }).catch(() => {});
+    }
+
+    return jsonResponse({ message }, 201, cors);
+  } catch (error) {
+    console.error('Failed to send message:', error);
+    return errorResponse('Failed to send message', 500, cors);
+  }
+}

--- a/apps/chat/src/app/api/d/[did]/read/route.ts
+++ b/apps/chat/src/app/api/d/[did]/read/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from 'next/server';
+import { db, conversationReadsV2 } from '@/db';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse, corsHeaders, corsOptions } from '@/lib/utils';
+
+/**
+ * OPTIONS /api/d/:did/read - CORS preflight
+ */
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * POST /api/d/:did/read - Mark a DID-keyed conversation as read
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const cors = corsHeaders(request);
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status, cors);
+  }
+
+  const { identity } = authResult;
+  const { did } = await params;
+
+  try {
+    await db.insert(conversationReadsV2).values({
+      conversationDid: did,
+      did: identity.id,
+      lastReadAt: new Date(),
+    }).onConflictDoUpdate({
+      target: [conversationReadsV2.conversationDid, conversationReadsV2.did],
+      set: { lastReadAt: new Date() },
+    });
+
+    return jsonResponse({ ok: true }, 200, cors);
+  } catch (error) {
+    console.error('Failed to mark as read:', error);
+    return errorResponse('Failed to mark as read', 500, cors);
+  }
+}

--- a/apps/chat/src/db/index.ts
+++ b/apps/chat/src/db/index.ts
@@ -1,5 +1,7 @@
 import { createDb } from '@imajin/db';
 import * as schema from './schema';
+import * as schemaV2 from './schema-v2';
 
-export const db = createDb(schema);
+export const db = createDb({ ...schema, ...schemaV2 });
 export * from './schema';
+export * from './schema-v2';

--- a/apps/chat/ws-server.js
+++ b/apps/chat/ws-server.js
@@ -191,12 +191,15 @@ function setupWebSocket(server) {
           const msg = JSON.parse(raw.toString());
           if (msg.type === 'ping') {
             ws.send(JSON.stringify({ type: 'pong' }));
-          } else if (msg.type === 'subscribe' && msg.conversationId) {
-            meta.subscriptions.add(msg.conversationId);
-          } else if (msg.type === 'typing' && msg.conversationId) {
-            handleTyping(msg.conversationId, did, msg.name || null);
-          } else if (msg.type === 'stop_typing' && msg.conversationId) {
-            handleStopTyping(msg.conversationId, did);
+          } else if (msg.type === 'subscribe') {
+            if (msg.conversationId) meta.subscriptions.add(msg.conversationId);
+            if (msg.did) meta.subscriptions.add(msg.did);
+          } else if (msg.type === 'typing') {
+            const channel = msg.did || msg.conversationId;
+            if (channel) handleTyping(channel, did, msg.name || null);
+          } else if (msg.type === 'stop_typing') {
+            const channel = msg.did || msg.conversationId;
+            if (channel) handleStopTyping(channel, did);
           }
         } catch {
           ws.send(JSON.stringify({ type: 'error', message: 'Invalid message' }));
@@ -235,7 +238,8 @@ function setupWebSocket(server) {
 }
 
 /**
- * Broadcast a new message to all connected sockets subscribed to this conversation.
+ * Broadcast a new message to all connected sockets subscribed to this conversation or DID.
+ * conversationId may be a legacy UUID or a DID (did:imajin:...).
  */
 function broadcastMessage(conversationId, message) {
   if (!wss) return;


### PR DESCRIPTION
Parent: #278 | Closes #285

## What

New DID-based API routes alongside existing conversation routes:

- `GET /api/d/:did/messages` — paginated messages with reactions
- `POST /api/d/:did/messages` — send (auto-creates conversation on first message)
- `PATCH /api/d/:did/messages/:id` — edit
- `DELETE /api/d/:did/messages/:id` — soft delete
- `POST /api/d/:did/messages/:id/reactions` — add reaction
- `DELETE /api/d/:did/messages/:id/reactions` — remove reaction
- `POST /api/d/:did/read` — mark as read

All routes verify access via `GET auth/api/access/:did` (Phase 1).

WebSocket updated to accept DID-based subscriptions (`{ type: 'subscribe', did }`) alongside legacy conversationId.