### PR TITLE
feat(chat): group messaging UX — search, groups, DID-based navigation

### DIFF
--- a/apps/chat/src/app/api/conversations-v2/route.ts
+++ b/apps/chat/src/app/api/conversations-v2/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest } from 'next/server';
+import { eq, desc, and, gt, ne, inArray, sql } from 'drizzle-orm';
+import { db, conversationsV2, messagesV2, conversationReadsV2 } from '@/db';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { parseConversationDid } from '@/lib/conversation-did';
+
+/**
+ * GET /api/conversations-v2 - List DID-based conversations for authenticated user
+ * Optional: ?did=<did> to fetch info for a specific conversation DID
+ */
+export async function GET(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status);
+  }
+
+  const { identity } = authResult;
+  const url = new URL(request.url);
+  const specificDid = url.searchParams.get('did');
+
+  try {
+    // Find all conversation DIDs this user participates in
+    const [readRecords, sentMessages, createdConvs] = await Promise.all([
+      db
+        .select()
+        .from(conversationReadsV2)
+        .where(eq(conversationReadsV2.did, identity.id)),
+      db
+        .selectDistinct({ conversationDid: messagesV2.conversationDid })
+        .from(messagesV2)
+        .where(eq(messagesV2.fromDid, identity.id)),
+      db
+        .select({ did: conversationsV2.did })
+        .from(conversationsV2)
+        .where(eq(conversationsV2.createdBy, identity.id)),
+    ]);
+
+    const didSet = new Set<string>([
+      ...readRecords.map(r => r.conversationDid),
+      ...sentMessages.map(m => m.conversationDid),
+      ...createdConvs.map(c => c.did),
+    ]);
+
+    if (specificDid) {
+      if (!didSet.has(specificDid)) {
+        return errorResponse('Not found', 404);
+      }
+    }
+
+    if (didSet.size === 0) {
+      return jsonResponse({ conversations: [] });
+    }
+
+    const dids = specificDid ? [specificDid] : Array.from(didSet);
+
+    const convs = await db
+      .select()
+      .from(conversationsV2)
+      .where(inArray(conversationsV2.did, dids))
+      .orderBy(desc(conversationsV2.lastMessageAt));
+
+    const readMap = new Map(readRecords.map(r => [r.conversationDid, r.lastReadAt]));
+
+    const result = await Promise.all(
+      convs.map(async (conv) => {
+        const parsed = parseConversationDid(conv.did);
+
+        // Get last message preview
+        const [lastMsg] = await db
+          .select()
+          .from(messagesV2)
+          .where(eq(messagesV2.conversationDid, conv.did))
+          .orderBy(desc(messagesV2.createdAt))
+          .limit(1);
+
+        // Get unread count (messages from others after lastReadAt)
+        const lastReadAt = readMap.get(conv.did);
+        let unread = 0;
+        if (lastReadAt) {
+          const [row] = await db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(messagesV2)
+            .where(
+              and(
+                eq(messagesV2.conversationDid, conv.did),
+                gt(messagesV2.createdAt, lastReadAt),
+                ne(messagesV2.fromDid, identity.id),
+              )
+            );
+          unread = row?.count ?? 0;
+        } else {
+          // Never read — count all messages not from self
+          const [row] = await db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(messagesV2)
+            .where(
+              and(
+                eq(messagesV2.conversationDid, conv.did),
+                ne(messagesV2.fromDid, identity.id),
+              )
+            );
+          unread = row?.count ?? 0;
+        }
+
+        let lastMessagePreview = '';
+        if (lastMsg) {
+          const c = lastMsg.content as Record<string, unknown>;
+          if (c?.text && typeof c.text === 'string') {
+            lastMessagePreview = c.text.slice(0, 100);
+          } else if (c?.type === 'media') {
+            lastMessagePreview = '[Media]';
+          } else if (c?.type === 'voice') {
+            lastMessagePreview = '[Voice message]';
+          } else if (c?.type === 'location') {
+            lastMessagePreview = '[Location]';
+          }
+        }
+
+        return {
+          did: conv.did,
+          name: conv.name,
+          type: parsed.type,
+          slug: parsed.slug,
+          createdBy: conv.createdBy,
+          createdAt: conv.createdAt,
+          lastMessageAt: conv.lastMessageAt,
+          lastMessagePreview,
+          unread,
+        };
+      })
+    );
+
+    return jsonResponse({ conversations: result });
+  } catch (error) {
+    console.error('Failed to list v2 conversations:', error);
+    return errorResponse('Failed to list conversations', 500);
+  }
+}
+
+/**
+ * PATCH /api/conversations-v2 - Update a conversation's name
+ * Body: { did, name }
+ */
+export async function PATCH(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status);
+  }
+
+  const { identity } = authResult;
+
+  try {
+    const { did, name } = await request.json();
+    if (!did || !name) {
+      return errorResponse('did and name are required', 400);
+    }
+
+    const conv = await db.query.conversationsV2.findFirst({
+      where: eq(conversationsV2.did, did),
+    });
+
+    if (!conv) {
+      return errorResponse('Conversation not found', 404);
+    }
+
+    if (conv.createdBy !== identity.id) {
+      return errorResponse('Only the creator can update the name', 403);
+    }
+
+    await db
+      .update(conversationsV2)
+      .set({ name, updatedAt: new Date() })
+      .where(eq(conversationsV2.did, did));
+
+    return jsonResponse({ ok: true });
+  } catch (error) {
+    console.error('Failed to update conversation:', error);
+    return errorResponse('Failed to update conversation', 500);
+  }
+}

--- a/apps/chat/src/app/components/NewChatModal.tsx
+++ b/apps/chat/src/app/components/NewChatModal.tsx
@@ -2,6 +2,27 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useIdentity } from '@/contexts/IdentityContext';
+
+// Browser-safe DID derivation using Web Crypto API
+async function sha256hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function dmDid(did1: string, did2: string): Promise<string> {
+  const sorted = [did1, did2].sort();
+  const hash = (await sha256hex(sorted.join(':'))).slice(0, 16);
+  return `did:imajin:dm:${hash}`;
+}
+
+async function groupDid(members: string[]): Promise<string> {
+  const sorted = [...members].sort();
+  const hash = (await sha256hex(sorted.join(':'))).slice(0, 16);
+  return `did:imajin:group:${hash}`;
+}
 
 const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
 const SERVICE_PREFIX = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
@@ -16,30 +37,43 @@ interface Connection {
   podName: string;
 }
 
+function displayName(conn: Connection): string {
+  if (conn.name) return conn.name;
+  if (conn.handle) return `@${conn.handle}`;
+  return conn.did.slice(0, 24) + '...';
+}
+
 export function NewChatModal({ onClose }: { onClose: () => void }) {
   const router = useRouter();
+  const { identity } = useIdentity();
+  const [tab, setTab] = useState<'dm' | 'group'>('dm');
   const [connections, setConnections] = useState<Connection[]>([]);
   const [loading, setLoading] = useState(true);
-  const [creating, setCreating] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // DM state
+  const [creatingDm, setCreatingDm] = useState<string | null>(null);
+
+  // Group state
+  const [selectedDids, setSelectedDids] = useState<Set<string>>(new Set());
+  const [groupName, setGroupName] = useState('');
 
   useEffect(() => {
     async function loadConnections() {
       try {
-        // Fetch connections
         const connRes = await fetch(`${CONNECTIONS_URL}/api/connections`, {
           credentials: 'include',
         });
         if (!connRes.ok) throw new Error('Failed to load connections');
         const connData = await connRes.json();
 
-        // Resolve handles for each connection
         const resolved = await Promise.all(
-          (connData.connections || []).map(async (conn: any) => {
+          (connData.connections || []).map(async (conn: Connection) => {
             try {
-              const lookupRes = await fetch(`${AUTH_URL}/api/lookup/${encodeURIComponent(conn.did)}`, {
-                credentials: 'include',
-              });
+              const lookupRes = await fetch(
+                `${AUTH_URL}/api/lookup/${encodeURIComponent(conn.did)}`,
+                { credentials: 'include' }
+              );
               if (lookupRes.ok) {
                 const profile = await lookupRes.json();
                 return { ...conn, handle: profile.handle, name: profile.name };
@@ -60,44 +94,31 @@ export function NewChatModal({ onClose }: { onClose: () => void }) {
     loadConnections();
   }, []);
 
-  async function startConversation(connection: Connection) {
-    setCreating(connection.did);
-    setError(null);
-
-    try {
-      const res = await fetch('/api/conversations', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          type: 'direct',
-          participantDids: [connection.did],
-        }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to create conversation');
-      }
-
-      const data = await res.json();
-      const convId = data.conversation?.id;
-      if (convId) {
-        router.push(`/conversations/${convId}`);
-        onClose();
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to start chat');
-    } finally {
-      setCreating(null);
-    }
+  async function startDm(connection: Connection) {
+    if (!identity) return;
+    setCreatingDm(connection.did);
+    const did = await dmDid(identity.did, connection.did);
+    router.push(`/conversations/${encodeURIComponent(did)}`);
+    onClose();
   }
 
-  const displayName = (conn: Connection) => {
-    if (conn.name) return conn.name;
-    if (conn.handle) return `@${conn.handle}`;
-    return conn.did.slice(0, 24) + '...';
-  };
+  async function createGroup() {
+    if (!identity || selectedDids.size === 0) return;
+    const members = [identity.did, ...Array.from(selectedDids)];
+    const did = await groupDid(members);
+    const params = groupName ? `?name=${encodeURIComponent(groupName)}` : '';
+    router.push(`/conversations/${encodeURIComponent(did)}${params}`);
+    onClose();
+  }
+
+  function toggleMember(did: string) {
+    setSelectedDids((prev) => {
+      const next = new Set(prev);
+      if (next.has(did)) next.delete(did);
+      else next.add(did);
+      return next;
+    });
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
@@ -112,9 +133,29 @@ export function NewChatModal({ onClose }: { onClose: () => void }) {
           </button>
         </div>
 
-        <p className="text-gray-500 dark:text-gray-400 text-sm mb-4">
-          Start a conversation with one of your connections.
-        </p>
+        {/* Tabs */}
+        <div className="flex gap-4 mb-4 border-b border-gray-200 dark:border-gray-700">
+          <button
+            onClick={() => setTab('dm')}
+            className={`pb-2 text-sm font-medium border-b-2 transition ${
+              tab === 'dm'
+                ? 'border-orange-500 text-orange-500'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+          >
+            Direct Message
+          </button>
+          <button
+            onClick={() => setTab('group')}
+            className={`pb-2 text-sm font-medium border-b-2 transition ${
+              tab === 'group'
+                ? 'border-orange-500 text-orange-500'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+          >
+            Create Group
+          </button>
+        </div>
 
         {error && (
           <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 rounded-lg text-sm">
@@ -128,20 +169,17 @@ export function NewChatModal({ onClose }: { onClose: () => void }) {
           ) : connections.length === 0 ? (
             <div className="py-8 text-center">
               <p className="text-gray-500 text-sm mb-3">No connections yet.</p>
-              <a
-                href={CONNECTIONS_URL}
-                className="text-orange-500 hover:underline text-sm"
-              >
+              <a href={CONNECTIONS_URL} className="text-orange-500 hover:underline text-sm">
                 Send an invite →
               </a>
             </div>
-          ) : (
+          ) : tab === 'dm' ? (
             <div className="space-y-1">
               {connections.map((conn) => (
                 <button
                   key={conn.did}
-                  onClick={() => startConversation(conn)}
-                  disabled={creating !== null}
+                  onClick={() => startDm(conn)}
+                  disabled={creatingDm !== null}
                   className="w-full flex items-center justify-between p-3 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg transition text-left"
                 >
                   <div className="min-w-0">
@@ -151,10 +189,56 @@ export function NewChatModal({ onClose }: { onClose: () => void }) {
                     )}
                   </div>
                   <span className="text-sm text-orange-500 font-medium ml-3 shrink-0">
-                    {creating === conn.did ? '...' : 'Chat'}
+                    {creatingDm === conn.did ? '…' : 'Chat'}
                   </span>
                 </button>
               ))}
+            </div>
+          ) : (
+            /* Group tab */
+            <div>
+              <div className="mb-3">
+                <input
+                  type="text"
+                  value={groupName}
+                  onChange={(e) => setGroupName(e.target.value)}
+                  placeholder="Group name (optional)"
+                  className="w-full px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg text-sm outline-none focus:ring-2 focus:ring-orange-500/40"
+                />
+              </div>
+              <p className="text-xs text-gray-500 mb-2 font-medium">Select members:</p>
+              <div className="space-y-1">
+                {connections.map((conn) => (
+                  <label
+                    key={conn.did}
+                    className="flex items-center gap-3 p-3 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedDids.has(conn.did)}
+                      onChange={() => toggleMember(conn.did)}
+                      className="w-4 h-4 rounded accent-orange-500"
+                    />
+                    <div className="min-w-0">
+                      <p className="font-medium truncate">{displayName(conn)}</p>
+                      {conn.handle && conn.name && (
+                        <p className="text-sm text-gray-500">@{conn.handle}</p>
+                      )}
+                    </div>
+                  </label>
+                ))}
+              </div>
+              <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                <button
+                  onClick={createGroup}
+                  disabled={selectedDids.size === 0}
+                  className="w-full py-2.5 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 transition disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {selectedDids.size > 0
+                    ? `Create Group (${selectedDids.size + 1} members)`
+                    : 'Select at least one member'}
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/apps/chat/src/app/conversations/[id]/page.tsx
+++ b/apps/chat/src/app/conversations/[id]/page.tsx
@@ -1,19 +1,141 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { useIdentity, LoginPrompt } from '@/contexts/IdentityContext';
 import { useWebSocket } from '@/hooks/useWebSocket';
-import { MessageBubble } from '@imajin/chat';
+import { MessageBubble, Chat, ChatProvider, VoiceRecorder } from '@imajin/chat';
 import { TypingIndicator } from '@/app/components/TypingIndicator';
 import { FileUpload } from '@/app/components/FileUpload';
-import { MessageMedia } from '@/app/components/MessageMedia';
-import { VoiceRecorder } from '@imajin/chat';
 import { LocationPicker, LocationData } from '@/app/components/LocationPicker';
 import { sendVoiceMessage } from '@/lib/voice';
 
+// Inline DID parser (avoids importing Node.js crypto in client bundle)
+function parseConvDid(did: string): { type: string; slug?: string } {
+  const prefix = 'did:imajin:';
+  if (!did.startsWith(prefix)) return { type: 'unknown' };
+  const rest = did.slice(prefix.length);
+  const idx = rest.indexOf(':');
+  if (idx === -1) return { type: 'unknown' };
+  return { type: rest.slice(0, idx), slug: rest.slice(idx + 1) || undefined };
+}
+
 const MEDIA_URL = process.env.NEXT_PUBLIC_MEDIA_URL ?? '';
+
+// ─── DID-based conversation view ─────────────────────────────────────────────
+
+function DIDConversationView({ did }: { did: string }) {
+  const { identity, loading: authLoading } = useIdentity();
+  const searchParams = useSearchParams();
+  const [convName, setConvName] = useState<string | null>(null);
+  const [nameSet, setNameSet] = useState(false);
+  const parsed = parseConvDid(did);
+
+  // Display name from URL param (e.g., when creating a group)
+  const nameParam = searchParams.get('name');
+
+  // Fetch stored conversation name from v2 API
+  useEffect(() => {
+    if (!identity) return;
+    fetch(`/api/conversations-v2?did=${encodeURIComponent(did)}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        const conv = data?.conversations?.[0];
+        if (conv?.name &&
+          !conv.name.startsWith('dm:') &&
+          !conv.name.startsWith('group:') &&
+          !conv.name.startsWith('event:')
+        ) {
+          setConvName(conv.name);
+          setNameSet(true);
+        }
+      })
+      .catch(() => {});
+  }, [identity, did]);
+
+  // If a name was passed in the URL and we haven't stored a proper name yet,
+  // save it via PATCH once the conversation exists (after the first message creates it).
+  // We use a short delay to give the auto-create time to run.
+  useEffect(() => {
+    if (!identity || !nameParam || nameSet) return;
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch('/api/conversations-v2', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ did, name: nameParam }),
+        });
+        if (res.ok) setNameSet(true);
+      } catch {
+        // Ignore — the name can be set later
+      }
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [identity, nameParam, nameSet, did]);
+
+  const chatUrl = process.env.NEXT_PUBLIC_CHAT_URL || 'http://localhost:3007';
+  const authUrl = process.env.NEXT_PUBLIC_AUTH_URL || 'http://localhost:3002';
+  const inputUrl = process.env.NEXT_PUBLIC_INPUT_URL || 'http://localhost:3008';
+  const mediaUrl = MEDIA_URL;
+
+  const displayName =
+    convName ||
+    nameParam ||
+    (parsed.type === 'dm'
+      ? 'Direct Message'
+      : parsed.type === 'event'
+      ? 'Event Chat'
+      : parsed.type === 'group'
+      ? 'Group Chat'
+      : 'Conversation');
+
+  if (authLoading) {
+    return <div className="max-w-2xl mx-auto mt-20 text-center text-gray-500">Loading...</div>;
+  }
+
+  if (!identity) return <LoginPrompt />;
+
+  return (
+    <div className="max-w-2xl mx-auto flex flex-col h-[calc(100vh-200px)]">
+      {/* Header */}
+      <div className="flex items-center gap-4 pb-4 border-b border-gray-200 dark:border-gray-700">
+        <Link
+          href="/conversations"
+          className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition"
+        >
+          ← Back
+        </Link>
+        <div className="flex-1">
+          <h1 className="font-semibold">{displayName}</h1>
+          {parsed.type === 'group' && (
+            <p className="text-xs text-gray-500 mt-0.5">Group conversation</p>
+          )}
+          {parsed.type === 'event' && (
+            <p className="text-xs text-gray-500 mt-0.5">Event chat</p>
+          )}
+        </div>
+      </div>
+
+      {/* Chat */}
+      <div className="flex-1 overflow-hidden min-h-0">
+        <ChatProvider chatUrl={chatUrl} authUrl={authUrl} inputUrl={inputUrl} mediaUrl={mediaUrl}>
+          <Chat
+            did={did}
+            currentUserDid={identity.did}
+            mediaUrl={mediaUrl}
+            enableVoice
+            enableMedia
+            enableLocation
+            className="h-full"
+          />
+        </ChatProvider>
+      </div>
+    </div>
+  );
+}
+
+// ─── Legacy conversation view (conv_xxx) ─────────────────────────────────────
 
 interface LinkPreview {
   url: string;
@@ -37,7 +159,7 @@ interface Message {
   deletedAt: string | null;
   mediaType?: 'image' | 'file' | null;
   mediaPath?: string | null;
-  mediaMeta?: any;
+  mediaMeta?: unknown;
 }
 
 interface ConversationInfo {
@@ -71,9 +193,7 @@ function formatDateDivider(dateStr: string): string {
   });
 }
 
-export default function MessageThreadPage() {
-  const params = useParams<{ id: string }>();
-  const router = useRouter();
+function LegacyConversationView({ conversationId }: { conversationId: string }) {
   const { identity, loading: authLoading } = useIdentity();
   const [messages, setMessages] = useState<Message[]>([]);
   const [conversation, setConversation] = useState<ConversationInfo | null>(null);
@@ -89,7 +209,7 @@ export default function MessageThreadPage() {
   const [uploadedMedia, setUploadedMedia] = useState<{
     mediaType: 'image' | 'file';
     mediaPath: string;
-    mediaMeta: any;
+    mediaMeta: unknown;
   } | null>(null);
   const [voiceActive, setVoiceActive] = useState(false);
   const [voiceSending, setVoiceSending] = useState(false);
@@ -99,11 +219,14 @@ export default function MessageThreadPage() {
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastTypingSentRef = useRef<number>(0);
   const chatAreaRef = useRef<HTMLDivElement>(null);
-  const { lastMessage: wsMessage, isConnected: wsConnected, subscribe: wsSubscribe, sendTyping, sendStopTyping } = useWebSocket();
+  const {
+    lastMessage: wsMessage,
+    isConnected: wsConnected,
+    subscribe: wsSubscribe,
+    sendTyping,
+    sendStopTyping,
+  } = useWebSocket();
 
-  const conversationId = params.id;
-
-  // Fetch capabilities on mount
   useEffect(() => {
     if (!identity) return;
     async function fetchCapabilities() {
@@ -114,13 +237,12 @@ export default function MessageThreadPage() {
           setCapabilities(new Set(data.capabilities));
         }
       } catch {
-        // Silently fail - default to text-only
+        // Silently fail
       }
     }
     fetchCapabilities();
   }, [identity]);
 
-  // Fetch conversation info and mark as read
   useEffect(() => {
     if (!identity || !conversationId) return;
 
@@ -132,36 +254,31 @@ export default function MessageThreadPage() {
           setConversation(data.conversation || data);
         }
       } catch {
-        // Conversation info is optional for display
+        // Optional
       }
     }
 
     async function markAsRead() {
       try {
-        await fetch(`/api/conversations/${conversationId}/read`, {
-          method: 'POST',
-        });
+        await fetch(`/api/conversations/${conversationId}/read`, { method: 'POST' });
       } catch {
-        // Silently fail - not critical
+        // Silently fail
       }
     }
 
     fetchConversation();
     markAsRead();
 
-    // Mark as read whenever the window gains focus
-    const handleFocus = () => {
-      markAsRead();
-    };
-
+    const handleFocus = () => markAsRead();
     window.addEventListener('focus', handleFocus);
     return () => window.removeEventListener('focus', handleFocus);
   }, [identity, conversationId]);
 
-  // Resolve handles for message senders
   useEffect(() => {
     if (!messages.length) return;
-    const unknownDids = Array.from(new Set(messages.map(m => m.fromDid))).filter(d => !handleMap[d]);
+    const unknownDids = Array.from(new Set(messages.map((m) => m.fromDid))).filter(
+      (d) => !handleMap[d]
+    );
     if (!unknownDids.length) return;
 
     unknownDids.forEach(async (did) => {
@@ -170,18 +287,17 @@ export default function MessageThreadPage() {
         if (res.ok) {
           const data = await res.json();
           const label = data.handle ? `@${data.handle}` : data.name || did.slice(0, 16) + '...';
-          setHandleMap(prev => ({ ...prev, [did]: label }));
+          setHandleMap((prev) => ({ ...prev, [did]: label }));
         } else {
-          setHandleMap(prev => ({ ...prev, [did]: did.slice(0, 16) + '...' }));
+          setHandleMap((prev) => ({ ...prev, [did]: did.slice(0, 16) + '...' }));
         }
       } catch {
-        setHandleMap(prev => ({ ...prev, [did]: did.slice(0, 16) + '...' }));
+        setHandleMap((prev) => ({ ...prev, [did]: did.slice(0, 16) + '...' }));
       }
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages]);
 
-  // Fetch reactions for all messages
   useEffect(() => {
     if (!identity || !messages.length) return;
 
@@ -191,15 +307,14 @@ export default function MessageThreadPage() {
         const res = await fetch(`/api/messages/${msg.id}/reactions`);
         if (res.ok) {
           const data = await res.json();
-          setMessageReactions(prev => ({ ...prev, [msg.id]: data.reactions || [] }));
+          setMessageReactions((prev) => ({ ...prev, [msg.id]: data.reactions || [] }));
         }
       } catch {
-        // Ignore reaction fetch errors
+        // Ignore
       }
     });
   }, [identity, messages]);
 
-  // Fetch messages
   const fetchMessages = useCallback(async () => {
     if (!identity || !conversationId) return;
 
@@ -220,7 +335,6 @@ export default function MessageThreadPage() {
       const msgs = data.messages || [];
       setMessages(msgs);
 
-      // Auto-scroll if new messages arrived
       const lastId = msgs.length > 0 ? msgs[msgs.length - 1].id : null;
       if (lastId && lastId !== lastMessageIdRef.current) {
         lastMessageIdRef.current = lastId;
@@ -233,31 +347,26 @@ export default function MessageThreadPage() {
     } finally {
       setLoadingMessages(false);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [identity, conversationId]);
 
-  // Initial fetch
   useEffect(() => {
     fetchMessages();
   }, [fetchMessages]);
 
-  // Subscribe to WebSocket for this conversation
   useEffect(() => {
     if (!identity || !conversationId) return;
     wsSubscribe(conversationId);
   }, [identity, conversationId, wsSubscribe]);
 
-  // Handle incoming WebSocket messages
   useEffect(() => {
     if (!wsMessage || !wsMessage.type) return;
 
     if (wsMessage.type === 'new_message' && wsMessage.message) {
       const msg = wsMessage.message as Message;
       if (msg.conversationId !== conversationId) return;
-
-      setMessages(prev => {
-        // Deduplicate
-        if (prev.some(m => m.id === msg.id)) return prev;
+      setMessages((prev) => {
+        if (prev.some((m) => m.id === msg.id)) return prev;
         const updated = [...prev, msg];
         setTimeout(() => messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }), 100);
         return updated;
@@ -265,45 +374,45 @@ export default function MessageThreadPage() {
     } else if (wsMessage.type === 'message_edited' && wsMessage.message) {
       const msg = wsMessage.message as Message;
       if (msg.conversationId !== conversationId) return;
-
-      setMessages(prev => prev.map(m => m.id === msg.id ? msg : m));
+      setMessages((prev) => prev.map((m) => (m.id === msg.id ? msg : m)));
     } else if (wsMessage.type === 'message_deleted' && wsMessage.message) {
       const msg = wsMessage.message as Message;
       if (msg.conversationId !== conversationId) return;
-
-      setMessages(prev => prev.map(m => m.id === msg.id ? msg : m));
-    } else if ((wsMessage.type === 'reaction_added' || wsMessage.type === 'reaction_removed') && wsMessage.messageId) {
+      setMessages((prev) => prev.map((m) => (m.id === msg.id ? msg : m)));
+    } else if (
+      (wsMessage.type === 'reaction_added' || wsMessage.type === 'reaction_removed') &&
+      wsMessage.messageId
+    ) {
       if (wsMessage.reactions) {
-        setMessageReactions(prev => ({
+        setMessageReactions((prev) => ({
           ...prev,
           [wsMessage.messageId]: wsMessage.reactions,
         }));
       }
     } else if (wsMessage.type === 'user_typing' && wsMessage.conversationId === conversationId) {
-      setTypingUsers(prev => {
-        // Don't show own typing indicator
+      setTypingUsers((prev) => {
         if (wsMessage.did === identity?.did) return prev;
-        // Deduplicate
-        if (prev.some(u => u.did === wsMessage.did)) return prev;
+        if (prev.some((u) => u.did === wsMessage.did)) return prev;
         return [...prev, { did: wsMessage.did, name: wsMessage.name || null }];
       });
-    } else if (wsMessage.type === 'user_stop_typing' && wsMessage.conversationId === conversationId) {
-      setTypingUsers(prev => prev.filter(u => u.did !== wsMessage.did));
+    } else if (
+      wsMessage.type === 'user_stop_typing' &&
+      wsMessage.conversationId === conversationId
+    ) {
+      setTypingUsers((prev) => prev.filter((u) => u.did !== wsMessage.did));
     }
   }, [wsMessage, conversationId, identity]);
 
-  // Fall back to polling if WebSocket is disconnected
   useEffect(() => {
     if (!identity || !conversationId || wsConnected) return;
     const interval = setInterval(fetchMessages, 3000);
     return () => clearInterval(interval);
   }, [identity, conversationId, fetchMessages, wsConnected]);
 
-  // Handle file upload completion
   const handleUploadComplete = (data: {
     mediaType: 'image' | 'file';
     mediaPath: string;
-    mediaMeta: any;
+    mediaMeta: unknown;
   }) => {
     setUploadedMedia(data);
   };
@@ -357,41 +466,34 @@ export default function MessageThreadPage() {
     }
   };
 
-  // Send or edit message
   const handleSend = async () => {
     if ((!message.trim() && !uploadedMedia) || sending) return;
 
-    // Stop typing indicator
     if (typingTimeoutRef.current) {
       clearTimeout(typingTimeoutRef.current);
       typingTimeoutRef.current = null;
     }
-    if (conversationId) {
-      sendStopTyping(conversationId);
-    }
+    if (conversationId) sendStopTyping(conversationId);
 
     setSending(true);
     try {
       if (editingMessage) {
-        // Edit existing message
-        const res = await fetch(`/api/conversations/${conversationId}/messages/${editingMessage.id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            content: { type: 'text', text: message.trim() },
-          }),
-        });
-
+        const res = await fetch(
+          `/api/conversations/${conversationId}/messages/${editingMessage.id}`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: { type: 'text', text: message.trim() } }),
+          }
+        );
         if (!res.ok) {
           const data = await res.json();
           throw new Error(data.error || 'Failed to edit');
         }
-
         setEditingMessage(null);
         setMessage('');
         await fetchMessages();
       } else {
-        // Send new message
         const res = await fetch(`/api/conversations/${conversationId}/messages`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -405,12 +507,10 @@ export default function MessageThreadPage() {
             }),
           }),
         });
-
         if (!res.ok) {
           const data = await res.json();
           throw new Error(data.error || 'Failed to send');
         }
-
         setReplyToMessage(null);
         setMessage('');
         setUploadedMedia(null);
@@ -423,74 +523,73 @@ export default function MessageThreadPage() {
     }
   };
 
-  // Paste handler for images
-  const handlePaste = useCallback(async (e: ClipboardEvent) => {
-    const items = e.clipboardData?.items;
-    if (!items) return;
+  const handlePaste = useCallback(
+    async (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
 
-    for (const item of Array.from(items)) {
-      if (item.type.startsWith('image/')) {
-        const file = item.getAsFile();
-        if (file) {
-          e.preventDefault();
-          // Upload the file
-          const formData = new FormData();
-          formData.append('file', file);
-
-          try {
-            const res = await fetch(`/api/conversations/${conversationId}/upload`, {
-              method: 'POST',
-              body: formData,
-            });
-
-            if (res.ok) {
-              const data = await res.json();
-              handleUploadComplete(data);
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) {
+            e.preventDefault();
+            const formData = new FormData();
+            formData.append('file', file);
+            try {
+              const res = await fetch(`/api/conversations/${conversationId}/upload`, {
+                method: 'POST',
+                body: formData,
+              });
+              if (res.ok) {
+                const data = await res.json();
+                handleUploadComplete(data);
+              }
+            } catch {
+              handleUploadError('Failed to upload pasted image');
             }
-          } catch (err) {
-            handleUploadError('Failed to upload pasted image');
           }
         }
       }
-    }
-  }, [conversationId]);
+    },
+    [conversationId]
+  );
 
-  // Drag and drop handlers
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
   };
 
-  const handleDrop = useCallback(async (e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const handleDrop = useCallback(
+    async (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
 
-    const files = e.dataTransfer?.files;
-    if (!files || files.length === 0) return;
+      const files = e.dataTransfer?.files;
+      if (!files || files.length === 0) return;
 
-    const file = files[0];
-    const formData = new FormData();
-    formData.append('file', file);
+      const file = files[0];
+      const formData = new FormData();
+      formData.append('file', file);
 
-    try {
-      const res = await fetch(`/api/conversations/${conversationId}/upload`, {
-        method: 'POST',
-        body: formData,
-      });
-
-      if (res.ok) {
-        const data = await res.json();
-        handleUploadComplete(data);
-      } else {
-        const data = await res.json();
-        handleUploadError(data.error || 'Upload failed');
+      try {
+        const res = await fetch(`/api/conversations/${conversationId}/upload`, {
+          method: 'POST',
+          body: formData,
+        });
+        if (res.ok) {
+          const data = await res.json();
+          handleUploadComplete(data);
+        } else {
+          const data = await res.json();
+          handleUploadError(data.error || 'Upload failed');
+        }
+      } catch {
+        handleUploadError('Failed to upload file');
       }
-    } catch (err) {
-      handleUploadError('Failed to upload file');
-    }
-  }, [conversationId]);
+    },
+    [conversationId]
+  );
 
-  // Attach paste handler
   useEffect(() => {
     document.addEventListener('paste', handlePaste);
     return () => document.removeEventListener('paste', handlePaste);
@@ -507,38 +606,25 @@ export default function MessageThreadPage() {
     }
   };
 
-  // Handle typing indicator on input change
   const handleMessageChange = (text: string) => {
     setMessage(text);
-
     if (!text.trim() || !conversationId) return;
 
-    // Debounced typing indicator (max 1 per 2s)
     const now = Date.now();
     if (now - lastTypingSentRef.current > 2000) {
       sendTyping(conversationId, identity?.name || null);
       lastTypingSentRef.current = now;
     }
 
-    // Reset stop typing timer
-    if (typingTimeoutRef.current) {
-      clearTimeout(typingTimeoutRef.current);
-    }
-
-    // Send stop typing after 3s of no input
+    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
     typingTimeoutRef.current = setTimeout(() => {
-      if (conversationId) {
-        sendStopTyping(conversationId);
-      }
+      if (conversationId) sendStopTyping(conversationId);
     }, 3000);
   };
 
-  // Clean up typing timeout on unmount
   useEffect(() => {
     return () => {
-      if (typingTimeoutRef.current) {
-        clearTimeout(typingTimeoutRef.current);
-      }
+      if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
     };
   }, []);
 
@@ -564,12 +650,10 @@ export default function MessageThreadPage() {
       const res = await fetch(`/api/conversations/${conversationId}/messages/${msg.id}`, {
         method: 'DELETE',
       });
-
       if (!res.ok) {
         const data = await res.json();
         throw new Error(data.error || 'Failed to delete');
       }
-
       await fetchMessages();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete');
@@ -584,17 +668,12 @@ export default function MessageThreadPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ emoji }),
       });
-
       if (!res.ok) {
         const data = await res.json();
         throw new Error(data.error || 'Failed to react');
       }
-
       const data = await res.json();
-      setMessageReactions(prev => ({
-        ...prev,
-        [msgId]: data.reactions || [],
-      }));
+      setMessageReactions((prev) => ({ ...prev, [msgId]: data.reactions || [] }));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to react');
     }
@@ -604,7 +683,6 @@ export default function MessageThreadPage() {
     const element = document.getElementById(`msg-${messageId}`);
     if (element) {
       element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      // Highlight briefly
       element.classList.add('bg-yellow-100', 'dark:bg-yellow-900/30');
       setTimeout(() => {
         element.classList.remove('bg-yellow-100', 'dark:bg-yellow-900/30');
@@ -630,21 +708,24 @@ export default function MessageThreadPage() {
         </Link>
         <div className="flex-1">
           <h1 className="font-semibold">
-            {conversation?.name || (conversation?.type === 'direct' ? 'Direct Message' : 'Conversation')}
+            {conversation?.name ||
+              (conversation?.type === 'direct' ? 'Direct Message' : 'Conversation')}
           </h1>
           {conversation?.type === 'group' && conversation?.participantCount && (
             <p className="text-xs text-gray-500 mt-1">
-              {conversation.participantCount} {conversation.participantCount === 1 ? 'member' : 'members'}
+              {conversation.participantCount}{' '}
+              {conversation.participantCount === 1 ? 'member' : 'members'}
             </p>
           )}
         </div>
       </div>
 
-      {/* Error */}
       {error && (
         <div className="my-2 p-3 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 rounded-lg text-sm">
           {error}
-          <button onClick={() => setError(null)} className="ml-2 underline">dismiss</button>
+          <button onClick={() => setError(null)} className="ml-2 underline">
+            dismiss
+          </button>
         </div>
       )}
 
@@ -667,11 +748,11 @@ export default function MessageThreadPage() {
             const prevMsg = messages[index - 1];
             const showDateDivider =
               !prevMsg ||
-              new Date(msg.createdAt).toDateString() !== new Date(prevMsg.createdAt).toDateString();
-
-            const showSenderLabel = !isOwn && (!prevMsg || prevMsg.fromDid !== msg.fromDid || showDateDivider);
-
-            const replyTo = msg.replyTo ? messages.find(m => m.id === msg.replyTo) : null;
+              new Date(msg.createdAt).toDateString() !==
+                new Date(prevMsg.createdAt).toDateString();
+            const showSenderLabel =
+              !isOwn && (!prevMsg || prevMsg.fromDid !== msg.fromDid || showDateDivider);
+            const replyTo = msg.replyTo ? messages.find((m) => m.id === msg.replyTo) : null;
 
             return (
               <div key={msg.id} id={`msg-${msg.id}`}>
@@ -701,7 +782,9 @@ export default function MessageThreadPage() {
                     onEdit={() => handleEdit(msg)}
                     onDelete={() => handleDelete(msg)}
                     reactions={messageReactions[msg.id] || []}
-                    onReactionToggle={(emoji, reacted) => handleReactionToggle(msg.id, emoji, reacted)}
+                    onReactionToggle={(emoji, reacted) =>
+                      handleReactionToggle(msg.id, emoji, reacted)
+                    }
                     replyToMessage={replyTo}
                     onScrollToMessage={scrollToMessage}
                     mediaUrl={MEDIA_URL}
@@ -716,15 +799,15 @@ export default function MessageThreadPage() {
 
       {/* Input */}
       <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-        {/* Typing Indicator */}
         <TypingIndicator typingUsers={typingUsers} />
 
-        {/* Reply preview */}
         {replyToMessage && (
           <div className="mb-2 p-2 bg-gray-100 dark:bg-gray-800 rounded-lg flex items-center justify-between">
             <div className="flex-1 min-w-0">
               <p className="text-xs font-medium text-gray-600 dark:text-gray-400">
-                Replying to {handleMap[replyToMessage.fromDid] || replyToMessage.fromDid.slice(0, 16) + '...'}
+                Replying to{' '}
+                {handleMap[replyToMessage.fromDid] ||
+                  replyToMessage.fromDid.slice(0, 16) + '...'}
               </p>
               <p className="text-sm truncate text-gray-800 dark:text-gray-200">
                 {typeof replyToMessage.content === 'object' && replyToMessage.content?.text
@@ -743,10 +826,11 @@ export default function MessageThreadPage() {
           </div>
         )}
 
-        {/* Edit preview */}
         {editingMessage && (
           <div className="mb-2 p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-between">
-            <p className="text-xs font-medium text-blue-600 dark:text-blue-400">Editing message</p>
+            <p className="text-xs font-medium text-blue-600 dark:text-blue-400">
+              Editing message
+            </p>
             <button
               onClick={() => {
                 setEditingMessage(null);
@@ -759,11 +843,11 @@ export default function MessageThreadPage() {
           </div>
         )}
 
-        {/* Uploaded media preview */}
         {uploadedMedia && (
           <div className="mb-2 flex items-center gap-2 p-2 bg-gray-100 dark:bg-gray-800 rounded-lg">
             <span className="text-sm text-gray-600 dark:text-gray-400">
-              {uploadedMedia.mediaType === 'image' ? '🖼️' : '📎'} {uploadedMedia.mediaMeta.originalName}
+              {uploadedMedia.mediaType === 'image' ? '🖼️' : '📎'}{' '}
+              {(uploadedMedia.mediaMeta as { originalName?: string })?.originalName ?? 'file'}
             </span>
             <button
               onClick={() => setUploadedMedia(null)}
@@ -784,7 +868,9 @@ export default function MessageThreadPage() {
                 disabled={voiceSending}
               />
               {voiceSending && (
-                <span className="text-xs text-gray-400 self-center flex-shrink-0">Sending...</span>
+                <span className="text-xs text-gray-400 self-center flex-shrink-0">
+                  Sending...
+                </span>
               )}
             </>
           ) : (
@@ -852,7 +938,7 @@ export default function MessageThreadPage() {
                     : 'bg-gray-200 dark:bg-gray-700 text-gray-400'
                 }`}
               >
-                {sending ? '...' : editingMessage ? '\u2713' : '\u27A4'}
+                {sending ? '...' : editingMessage ? '✓' : '➤'}
               </button>
             </>
           )}
@@ -861,4 +947,17 @@ export default function MessageThreadPage() {
       </div>
     </div>
   );
+}
+
+// ─── Router: DID vs legacy ────────────────────────────────────────────────────
+
+export default function ConversationPage() {
+  const params = useParams<{ id: string }>();
+  const decoded = decodeURIComponent(params.id);
+
+  if (decoded.startsWith('did:')) {
+    return <DIDConversationView did={decoded} />;
+  }
+
+  return <LegacyConversationView conversationId={params.id} />;
 }

--- a/apps/chat/src/app/conversations/page.tsx
+++ b/apps/chat/src/app/conversations/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import Link from 'next/link';
 import { useIdentity, LoginPrompt } from '@/contexts/IdentityContext';
 import { NewChatModal } from '@/app/components/NewChatModal';
 import { useWebSocket } from '@/hooks/useWebSocket';
 
-interface Conversation {
+interface V1Conversation {
   id: string;
   type: string;
   name: string | null;
@@ -25,6 +25,30 @@ interface Conversation {
   unread?: number;
 }
 
+interface V2Conversation {
+  did: string;
+  name: string | null;
+  type: 'dm' | 'group' | 'event' | 'unknown';
+  slug?: string;
+  createdBy: string;
+  createdAt: string;
+  lastMessageAt: string | null;
+  lastMessagePreview: string;
+  unread: number;
+}
+
+interface DisplayConversation {
+  key: string;
+  href: string;
+  name: string;
+  type: string;
+  lastMessageAt: string | null;
+  createdAt: string;
+  unread: number;
+  subtitle: string;
+  otherParticipantDid?: string;
+}
+
 function formatTime(dateStr: string | null): string {
   if (!dateStr) return '';
   const date = new Date(dateStr);
@@ -41,80 +65,98 @@ function formatTime(dateStr: string | null): string {
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
+function v2DisplayName(conv: V2Conversation): string {
+  if (
+    conv.name &&
+    !conv.name.startsWith('dm:') &&
+    !conv.name.startsWith('group:') &&
+    !conv.name.startsWith('event:')
+  ) {
+    return conv.name;
+  }
+  if (conv.type === 'dm') return 'Direct Message';
+  if (conv.type === 'event') return 'Event Chat';
+  if (conv.type === 'group') return 'Group Chat';
+  return 'Conversation';
+}
+
 export default function ConversationsPage() {
   const { identity, loading } = useIdentity();
-  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [v1Conversations, setV1Conversations] = useState<V1Conversation[]>([]);
+  const [v2Conversations, setV2Conversations] = useState<V2Conversation[]>([]);
   const [loadingConvs, setLoadingConvs] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showNewChat, setShowNewChat] = useState(false);
   const [onlineStatus, setOnlineStatus] = useState<Record<string, boolean>>({});
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const { lastMessage } = useWebSocket();
+
+  // Debounce search
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery), 250);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
 
   const fetchConversations = useCallback(async () => {
     if (!identity) return;
 
     try {
-      const [convsRes, unreadRes] = await Promise.all([
+      const [convsRes, unreadRes, v2Res] = await Promise.all([
         fetch('/api/conversations'),
         fetch('/api/conversations/unread'),
+        fetch('/api/conversations-v2'),
       ]);
 
       if (convsRes.status === 401) {
-        // Session expired — force reload to trigger login prompt
         window.location.reload();
         return;
       }
       if (!convsRes.ok) throw new Error('Failed to load conversations');
 
       const convsData = await convsRes.json();
-      let convs = convsData.conversations || [];
+      let convs: V1Conversation[] = convsData.conversations || [];
 
-      // Add unread counts if available
       if (unreadRes.ok) {
         const unreadData = await unreadRes.json();
         const unreadMap = new Map(
-          unreadData.conversations.map((c: { id: string; unread: number }) => [
-            c.id,
-            c.unread,
-          ])
+          unreadData.conversations.map((c: { id: string; unread: number }) => [c.id, c.unread])
         );
-        convs = convs.map((conv: Conversation) => ({
-          ...conv,
-          unread: unreadMap.get(conv.id) ?? undefined,
-        }));
-
-        // Sort unread conversations to the top
-        convs.sort((a: Conversation, b: Conversation) => {
+        convs = convs.map((conv) => ({ ...conv, unread: (unreadMap.get(conv.id) as number | undefined) ?? undefined }));
+        convs.sort((a, b) => {
           if (a.unread && !b.unread) return -1;
           if (!a.unread && b.unread) return 1;
-          // Both unread or both read - sort by last message time
-          const aTime = new Date(a.lastMessageAt || a.createdAt).getTime();
-          const bTime = new Date(b.lastMessageAt || b.createdAt).getTime();
-          return bTime - aTime;
+          return (
+            new Date(b.lastMessageAt || b.createdAt).getTime() -
+            new Date(a.lastMessageAt || a.createdAt).getTime()
+          );
         });
       }
 
-      setConversations(convs);
+      setV1Conversations(convs);
 
-      // Fetch online status for all participants
+      if (v2Res.ok) {
+        const v2Data = await v2Res.json();
+        setV2Conversations(v2Data.conversations || []);
+      }
+
+      // Fetch online status for v1 DMs
+      const profileUrl = process.env.NEXT_PUBLIC_PROFILE_URL || 'http://localhost:3005';
       const didsToCheck = new Set<string>();
-      convs.forEach((conv: Conversation) => {
+      convs.forEach((conv) => {
         if (conv.type === 'direct' && conv.otherParticipant?.did) {
           didsToCheck.add(conv.otherParticipant.did);
         }
       });
-
-      // Fetch presence for each DID
-      const profileUrl = process.env.NEXT_PUBLIC_PROFILE_URL || 'http://localhost:3005';
       for (const did of Array.from(didsToCheck)) {
         try {
           const presenceRes = await fetch(`${profileUrl}/api/presence/${encodeURIComponent(did)}`);
           if (presenceRes.ok) {
             const presenceData = await presenceRes.json();
-            setOnlineStatus(prev => ({ ...prev, [did]: presenceData.online }));
+            setOnlineStatus((prev) => ({ ...prev, [did]: presenceData.online }));
           }
         } catch {
-          // Ignore presence fetch errors
+          // Ignore presence errors
         }
       }
     } catch (err) {
@@ -128,27 +170,102 @@ export default function ConversationsPage() {
     fetchConversations();
   }, [fetchConversations]);
 
-  // Refetch when new message arrives via WebSocket
   useEffect(() => {
-    if (lastMessage?.type === 'new_message') {
-      fetchConversations();
-    }
+    if (lastMessage?.type === 'new_message') fetchConversations();
   }, [lastMessage, fetchConversations]);
 
-  // Handle presence updates from WebSocket
   useEffect(() => {
     if (!lastMessage || lastMessage.type !== 'user_presence') return;
-    setOnlineStatus(prev => ({
-      ...prev,
-      [lastMessage.did]: lastMessage.online,
-    }));
+    setOnlineStatus((prev) => ({ ...prev, [lastMessage.did]: lastMessage.online }));
   }, [lastMessage]);
+
+  // Build unified display list
+  const allConversations = useMemo((): DisplayConversation[] => {
+    const items: DisplayConversation[] = [];
+
+    // V2 DID-based conversations
+    for (const conv of v2Conversations) {
+      const name = v2DisplayName(conv);
+      const subtitle = conv.lastMessagePreview || (
+        conv.type === 'dm' ? 'Direct message' :
+        conv.type === 'event' ? 'Event chat' :
+        'Group chat'
+      );
+
+      items.push({
+        key: `v2-${conv.did}`,
+        href: `/conversations/${encodeURIComponent(conv.did)}`,
+        name,
+        type: conv.type,
+        lastMessageAt: conv.lastMessageAt,
+        createdAt: conv.createdAt,
+        unread: conv.unread,
+        subtitle,
+      });
+    }
+
+    // V1 legacy conversations
+    for (const conv of v1Conversations) {
+      const name =
+        conv.name ||
+        (conv.type === 'direct' && conv.otherParticipant
+          ? conv.otherParticipant.name ||
+            (conv.otherParticipant.handle
+              ? `@${conv.otherParticipant.handle}`
+              : 'Direct Message')
+          : 'Direct Message');
+
+      const subtitle =
+        conv.type === 'group'
+          ? conv.eventName
+            ? `Event: ${conv.eventName}`
+            : conv.podName
+            ? `Pod: ${conv.podName}`
+            : conv.participantCount
+            ? `${conv.participantCount} members`
+            : 'Group chat'
+          : conv.otherParticipant?.handle
+          ? `@${conv.otherParticipant.handle}`
+          : 'Direct message';
+
+      items.push({
+        key: `v1-${conv.id}`,
+        href: `/conversations/${conv.id}`,
+        name,
+        type: conv.type === 'direct' ? 'dm' : conv.type,
+        lastMessageAt: conv.lastMessageAt,
+        createdAt: conv.createdAt,
+        unread: conv.unread ?? 0,
+        subtitle,
+        otherParticipantDid: conv.otherParticipant?.did,
+      });
+    }
+
+    // Sort: unread first, then by last message time
+    items.sort((a, b) => {
+      if (a.unread && !b.unread) return -1;
+      if (!a.unread && b.unread) return 1;
+      return (
+        new Date(b.lastMessageAt || b.createdAt).getTime() -
+        new Date(a.lastMessageAt || a.createdAt).getTime()
+      );
+    });
+
+    return items;
+  }, [v1Conversations, v2Conversations]);
+
+  // Filter by search
+  const filteredConversations = useMemo(() => {
+    if (!debouncedSearch.trim()) return allConversations;
+    const q = debouncedSearch.toLowerCase();
+    return allConversations.filter(
+      (c) => c.name.toLowerCase().includes(q) || c.subtitle.toLowerCase().includes(q)
+    );
+  }, [allConversations, debouncedSearch]);
 
   if (loading) {
     return (
-      <div className="max-w-2xl mx-auto mt-20 text-center text-gray-500">
-        Loading...
-      </div>
+      <div className="max-w-2xl mx-auto mt-20 text-center text-gray-500">Loading...</div>
     );
   }
 
@@ -156,7 +273,7 @@ export default function ConversationsPage() {
 
   return (
     <div className="max-w-2xl mx-auto">
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-bold">Messages</h1>
         <button
           onClick={() => setShowNewChat(true)}
@@ -164,6 +281,17 @@ export default function ConversationsPage() {
         >
           New Chat
         </button>
+      </div>
+
+      {/* Search bar */}
+      <div className="mb-4">
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search conversations…"
+          className="w-full px-4 py-2 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 text-sm outline-none focus:ring-2 focus:ring-orange-500/40 focus:border-orange-500"
+        />
       </div>
 
       {error && (
@@ -175,88 +303,104 @@ export default function ConversationsPage() {
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg overflow-hidden">
         {loadingConvs ? (
           <div className="p-8 text-center text-gray-500">Loading conversations...</div>
-        ) : conversations.length === 0 ? (
+        ) : filteredConversations.length === 0 ? (
           <div className="p-8 text-center text-gray-500">
-            <p className="mb-4">No conversations yet.</p>
-            <button
-              onClick={() => setShowNewChat(true)}
-              className="text-orange-500 hover:underline"
-            >
-              Start a new chat
-            </button>
+            {debouncedSearch ? (
+              <p>No conversations match &ldquo;{debouncedSearch}&rdquo;.</p>
+            ) : (
+              <>
+                <p className="mb-4">No conversations yet.</p>
+                <button
+                  onClick={() => setShowNewChat(true)}
+                  className="text-orange-500 hover:underline"
+                >
+                  Start a new chat
+                </button>
+              </>
+            )}
           </div>
         ) : (
           <div className="divide-y divide-gray-100 dark:divide-gray-700">
-            {conversations.map((conv) => (
-              <Link
-                key={conv.id}
-                href={`/conversations/${conv.id}`}
-                className="flex items-center gap-4 p-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition"
-              >
-                {/* Avatar */}
-                <div className="relative">
-                  <div
-                    className={`w-12 h-12 rounded-full flex items-center justify-center text-lg font-semibold ${
-                      conv.type === 'group'
-                        ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-600'
-                        : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
-                    }`}
-                  >
-                    {conv.type === 'group' ? '👥' : '💬'}
-                  </div>
-                  {/* Online indicator for direct messages */}
-                  {conv.type === 'direct' && conv.otherParticipant?.did && onlineStatus[conv.otherParticipant.did] && (
-                    <div className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 rounded-full border-2 border-white dark:border-gray-800" />
-                  )}
-                </div>
-
-                {/* Content */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2 min-w-0">
-                      <span className={`truncate text-gray-900 dark:text-white ${conv.unread ? 'font-bold' : 'font-medium'}`}>
-                        {conv.name || (conv.type === 'direct' && conv.otherParticipant
-                          ? (conv.otherParticipant.name || (conv.otherParticipant.handle ? `@${conv.otherParticipant.handle}` : 'Direct Message'))
-                          : 'Direct Message')}
-                      </span>
-                      {conv.unread && conv.unread > 0 && (
-                        <span className="flex-shrink-0 bg-orange-500 text-white text-xs font-bold rounded-full px-2 py-0.5 min-w-[1.25rem] text-center">
-                          {conv.unread}
-                        </span>
-                      )}
-                    </div>
-                    <span className="text-xs text-gray-500 ml-2 flex-shrink-0">
-                      {formatTime(conv.lastMessageAt || conv.createdAt)}
-                    </span>
-                  </div>
-                  <p className="text-sm text-gray-500 truncate mt-1">
-                    {conv.type === 'group'
-                      ? (conv.eventName
-                          ? `Event: ${conv.eventName}`
-                          : conv.podName
-                            ? `Pod: ${conv.podName}`
-                            : conv.participantCount
-                              ? `${conv.participantCount} members`
-                              : 'Group chat')
-                      : conv.otherParticipant?.handle
-                        ? `@${conv.otherParticipant.handle}`
-                        : 'Direct message'}
-                  </p>
-                </div>
-              </Link>
+            {filteredConversations.map((conv) => (
+              <ConversationRow
+                key={conv.key}
+                conv={conv}
+                onlineStatus={onlineStatus}
+              />
             ))}
           </div>
         )}
       </div>
 
-      {/* Encryption notice */}
       <p className="text-center text-sm text-gray-500 mt-6">
         🔒 All messages are end-to-end encrypted
       </p>
 
-      {showNewChat && (
-        <NewChatModal onClose={() => setShowNewChat(false)} />
-      )}
+      {showNewChat && <NewChatModal onClose={() => setShowNewChat(false)} />}
     </div>
+  );
+}
+
+function ConversationRow({
+  conv,
+  onlineStatus,
+}: {
+  conv: DisplayConversation;
+  onlineStatus: Record<string, boolean>;
+}) {
+  const isGroup = conv.type === 'group';
+  const isEvent = conv.type === 'event';
+  const isDm = conv.type === 'dm' || conv.type === 'direct';
+
+  const iconBg = isGroup
+    ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-600'
+    : isEvent
+    ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-600'
+    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
+
+  const icon = isGroup ? '👥' : isEvent ? '📅' : '💬';
+  const isOnline = isDm && conv.otherParticipantDid
+    ? onlineStatus[conv.otherParticipantDid] === true
+    : false;
+
+  return (
+    <Link
+      href={conv.href}
+      className="flex items-center gap-4 p-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition"
+    >
+      <div className="relative flex-shrink-0">
+        <div
+          className={`w-12 h-12 rounded-full flex items-center justify-center text-lg font-semibold ${iconBg}`}
+        >
+          {icon}
+        </div>
+        {isOnline && (
+          <div className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 rounded-full border-2 border-white dark:border-gray-800" />
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 min-w-0">
+            <span
+              className={`truncate text-gray-900 dark:text-white ${
+                conv.unread ? 'font-bold' : 'font-medium'
+              }`}
+            >
+              {conv.name}
+            </span>
+            {conv.unread > 0 && (
+              <span className="flex-shrink-0 bg-orange-500 text-white text-xs font-bold rounded-full px-2 py-0.5 min-w-[1.25rem] text-center">
+                {conv.unread}
+              </span>
+            )}
+          </div>
+          <span className="text-xs text-gray-500 ml-2 flex-shrink-0">
+            {formatTime(conv.lastMessageAt || conv.createdAt)}
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 truncate mt-1">{conv.subtitle}</p>
+      </div>
+    </Link>
   );
 }


### PR DESCRIPTION
Closes #275

## What

### Conversation list (page.tsx)
- **Search bar** — filters by name, handle, DID (debounced, client-side)
- **Visual distinction** — group icon + member count for groups, user icon for DMs, calendar icon for events
- **Groups clickable** — navigate to conversation view same as DMs
- **Dual fetch** — queries both old conversations API and new conversations-v2 for DID-based convos

### New Chat modal
- **Tabs: Direct Message + Create Group**
- DMs now use `dmDid()` — derive deterministic DID, navigate directly (no POST to create)
- Groups: multi-select connections, group name input, derive `groupDid()`, navigate
- First message auto-creates the conversation via DID route

### Conversation view ([id]/page.tsx)
- **DID detection** — if URL param starts with `did:`, uses `<Chat did />` from @imajin/chat
- **Legacy compat** — old `conv_xxx` IDs still work with existing code
- **ChatProvider** wraps the DID view with service URLs
- **Header** shows conversation name, back button, participant info

### New API route
- `GET /api/conversations-v2` — queries conversations_v2 + messages_v2 for the authenticated user
- Returns DID-based conversations with last message preview, unread count, type

+847 / -339 lines