### PR TITLE
fix(media): rename files, fix move-to-folder, allow subfolders in system folders

### DIFF
--- a/apps/media/app/api/assets/[id]/folders/route.ts
+++ b/apps/media/app/api/assets/[id]/folders/route.ts
@@ -66,6 +66,9 @@ export async function PUT(
       }
     });
 
+    // Update the direct folderId column too (UI reads this for filtering)
+    await db.update(assets).set({ folderId: folderIds.length > 0 ? (folderIds as string[])[0] : null }).where(eq(assets.id, id));
+
     return NextResponse.json({ assetId: id, folderIds });
   } catch (err) {
     console.error("DB transaction failed:", err);

--- a/apps/media/app/api/assets/[id]/route.ts
+++ b/apps/media/app/api/assets/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { readFile, unlink } from "fs/promises";
+import { readFile, unlink, rename } from "fs/promises";
+import path from "path";
 import { db, assets } from "@/src/db";
 import { requireAuth } from "@/src/lib/auth";
 import { eq } from "drizzle-orm";
@@ -201,4 +202,62 @@ export async function DELETE(
   await db.delete(assets).where(eq(assets.id, id));
 
   return NextResponse.json({ ok: true });
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/assets/[id] — rename asset filename (owner only)
+// ---------------------------------------------------------------------------
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const authResult = await requireAuth(request);
+  if ("error" in authResult) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+  const requesterDid = authResult.identity.id;
+
+  let body: { filename?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { filename } = body;
+  if (!filename || typeof filename !== "string" || !filename.trim()) {
+    return NextResponse.json({ error: "filename is required" }, { status: 400 });
+  }
+
+  let asset;
+  try {
+    [asset] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  } catch (err) {
+    console.error("DB lookup failed:", err);
+    return NextResponse.json({ error: "Database failure" }, { status: 500 });
+  }
+
+  if (!asset || asset.status !== "active") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (asset.ownerDid !== requesterDid) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const newFilename = filename.trim();
+  const newStoragePath = path.join(path.dirname(asset.storagePath), newFilename);
+
+  try {
+    await rename(asset.storagePath, newStoragePath);
+  } catch (err) {
+    console.error("File rename failed:", err);
+    return NextResponse.json({ error: "File rename failed" }, { status: 500 });
+  }
+
+  await db.update(assets).set({ filename: newFilename, storagePath: newStoragePath }).where(eq(assets.id, id));
+
+  return NextResponse.json({ ok: true, filename: newFilename });
 }

--- a/apps/media/src/components/AssetDetail.tsx
+++ b/apps/media/src/components/AssetDetail.tsx
@@ -40,6 +40,9 @@ export function AssetDetail({ asset, folders, onClose, onDeleted, onMoved }: Ass
   });
   const [movingTo, setMovingTo] = useState(false);
   const [shareLabel, setShareLabel] = useState("Copy URL");
+  const [savedFilename, setSavedFilename] = useState(asset.filename);
+  const [editingFilename, setEditingFilename] = useState(false);
+  const [filenameInput, setFilenameInput] = useState("");
 
   const isImage = asset.mimeType.startsWith("image/");
   const isAudio = asset.mimeType.startsWith("audio/");
@@ -61,6 +64,24 @@ export function AssetDetail({ asset, folders, onClose, onDeleted, onMoved }: Ass
     navigator.clipboard.writeText(url).catch(() => {});
     setShareLabel("Copied!");
     setTimeout(() => setShareLabel("Copy URL"), 2000);
+  };
+
+  const handleRenameFile = async () => {
+    const trimmed = filenameInput.trim();
+    if (!trimmed || trimmed === savedFilename) {
+      setEditingFilename(false);
+      return;
+    }
+    const res = await fetch(`/api/assets/${asset.id}`, {
+      method: "PATCH",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filename: trimmed }),
+    });
+    if (res.ok) {
+      setSavedFilename(trimmed);
+    }
+    setEditingFilename(false);
   };
 
   const handleSaveFair = async (manifest: FairManifest) => {
@@ -102,7 +123,27 @@ export function AssetDetail({ asset, folders, onClose, onDeleted, onMoved }: Ass
             ← Back
           </button>
           <span className="text-gray-700">/</span>
-          <span className="text-sm text-gray-200 truncate flex-1 min-w-0">{asset.filename}</span>
+          {editingFilename ? (
+            <input
+              className="flex-1 min-w-0 text-sm bg-[#252525] border border-orange-500 rounded px-1 py-0.5 text-gray-100 outline-none"
+              value={filenameInput}
+              onChange={(e) => setFilenameInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleRenameFile();
+                if (e.key === "Escape") setEditingFilename(false);
+              }}
+              onBlur={handleRenameFile}
+              autoFocus
+            />
+          ) : (
+            <span
+              className="text-sm text-gray-200 truncate flex-1 min-w-0 cursor-pointer hover:text-white"
+              onClick={() => { setFilenameInput(savedFilename); setEditingFilename(true); }}
+              title="Click to rename"
+            >
+              {savedFilename}
+            </span>
+          )}
         </div>
 
         {/* Preview */}

--- a/apps/media/src/components/FolderTree.tsx
+++ b/apps/media/src/components/FolderTree.tsx
@@ -106,20 +106,18 @@ function FolderRow({
             {count}
           </span>
         )}
-        {!node.isSystem && (
-          <button
-            className={`opacity-0 group-hover:opacity-100 p-0.5 rounded text-xs transition-opacity ${
-              isSelected ? "text-white hover:bg-white/20" : "text-gray-400 hover:bg-white/10"
-            }`}
-            onClick={(e) => {
-              e.stopPropagation();
-              onContextMenu(e as unknown as React.MouseEvent, node);
-            }}
-            title="Folder options"
-          >
-            ···
-          </button>
-        )}
+        <button
+          className={`opacity-0 group-hover:opacity-100 p-0.5 rounded text-xs transition-opacity ${
+            isSelected ? "text-white hover:bg-white/20" : "text-gray-400 hover:bg-white/10"
+          }`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onContextMenu(e as unknown as React.MouseEvent, node);
+          }}
+          title="Folder options"
+        >
+          ···
+        </button>
       </div>
       {isExpanded &&
         node.children.map((child) => (
@@ -275,7 +273,7 @@ export function FolderTree({
       )}
 
       {/* Context menu */}
-      {contextMenu && !contextMenu.isSystem && (
+      {contextMenu && (
         <div
           ref={menuRef}
           className="fixed z-50 min-w-36 bg-[#2a2a2a] border border-white/10 rounded-lg shadow-xl py-1"
@@ -289,7 +287,7 @@ export function FolderTree({
               New Subfolder
             </button>
           )}
-          {onRenameFolder && (
+          {!contextMenu.isSystem && onRenameFolder && (
             <button
               className="w-full text-left px-3 py-1.5 text-sm text-gray-200 hover:bg-white/10 transition-colors"
               onClick={() => startRename(contextMenu.folderId)}
@@ -297,7 +295,7 @@ export function FolderTree({
               Rename
             </button>
           )}
-          {onDeleteFolder && (
+          {!contextMenu.isSystem && onDeleteFolder && (
             <button
               className="w-full text-left px-3 py-1.5 text-sm text-red-400 hover:bg-white/10 transition-colors"
               onClick={() => handleDelete(contextMenu.folderId)}


### PR DESCRIPTION
## What

### 1. Rename files
- `PATCH /api/assets/{id}` — updates filename + renames file on disk
- Click-to-edit filename in AssetDetail header (Enter to save, Escape to cancel)

### 2. Fix move-to-folder
- Move was writing to `assetFolders` junction table but UI filtered by `assets.folderId` direct column
- Now syncs both: junction table + `assets.folderId` column

### 3. Subfolders in system folders
- Context menu now shows "New Subfolder" on system folders (Photos, Audio, Videos, Documents)
- Rename/Delete still hidden for system folders