### PR TITLE
fix(fair): normalize share display + resolve DIDs to handles

### DIFF
--- a/apps/media/src/components/AssetDetail.tsx
+++ b/apps/media/src/components/AssetDetail.tsx
@@ -3,6 +3,17 @@
 import { useState } from "react";
 import type { Asset } from "@/src/db/schema";
 import { FairEditor } from "@imajin/fair";
+
+const PROFILE_URL = process.env.NEXT_PUBLIC_SERVICE_PREFIX
+  ? `${process.env.NEXT_PUBLIC_SERVICE_PREFIX}profile.${process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai'}`
+  : 'https://profile.imajin.ai';
+
+async function resolveProfile(did: string): Promise<{ name: string; avatar?: string }> {
+  const res = await fetch(`${PROFILE_URL}/api/profiles/${encodeURIComponent(did)}`, { credentials: 'include' });
+  if (!res.ok) throw new Error('Profile not found');
+  const data = await res.json();
+  return { name: data.handle || data.name || did.slice(0, 16), avatar: data.avatar };
+}
 import type { FairManifest } from "@imajin/fair";
 import { formatSize } from "./AssetCard";
 
@@ -312,7 +323,7 @@ export function AssetDetail({ asset, folders, onClose, onDeleted, onMoved }: Ass
           </div>
 
           {fairManifest ? (
-            <FairEditor
+            <FairEditor resolveProfile={resolveProfile}
               manifest={fairManifest}
               readOnly={true}
               sections={["attribution", "access", "transfer"]}
@@ -349,7 +360,7 @@ export function AssetDetail({ asset, folders, onClose, onDeleted, onMoved }: Ass
                 ✕
               </button>
             </div>
-            <FairEditor
+            <FairEditor resolveProfile={resolveProfile}
               manifest={fairManifest}
               readOnly={false}
               onChange={handleSaveFair}

--- a/packages/fair/src/components/FairAccordion.tsx
+++ b/packages/fair/src/components/FairAccordion.tsx
@@ -1,23 +1,69 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { FairManifest, FairEntry } from '../types';
+
+/** Normalize share values: if any > 1, assume percentages and divide by 100 */
+function normalizeShares(entries: FairEntry[]): FairEntry[] {
+  const hasPercentage = entries.some(e => e.share > 1);
+  if (!hasPercentage) return entries;
+  return entries.map(e => ({ ...e, share: e.share / 100 }));
+}
+
+function useDidNames(
+  dids: string[],
+  resolveProfile?: (did: string) => Promise<{ name: string; avatar?: string }>
+): Record<string, string> {
+  const [names, setNames] = useState<Record<string, string>>({});
+  useEffect(() => {
+    if (!resolveProfile || dids.length === 0) return;
+    let cancelled = false;
+    const toResolve = dids.filter(d => d && !names[d]);
+    if (toResolve.length === 0) return;
+    Promise.all(
+      toResolve.map(async (did) => {
+        try {
+          const p = await resolveProfile(did);
+          return [did, p.name] as const;
+        } catch { return [did, null] as const; }
+      })
+    ).then(results => {
+      if (cancelled) return;
+      const updates: Record<string, string> = {};
+      for (const [did, name] of results) { if (name) updates[did] = name; }
+      if (Object.keys(updates).length > 0) setNames(prev => ({ ...prev, ...updates }));
+    });
+    return () => { cancelled = true; };
+  }, [dids.join(','), resolveProfile]); // eslint-disable-line react-hooks/exhaustive-deps
+  return names;
+}
+
+function formatDid(did: string, names: Record<string, string>): string {
+  if (names[did]) return `@${names[did]}`;
+  if (did.length > 24) return did.slice(0, 12) + '…' + did.slice(-8);
+  return did;
+}
 
 interface FairAccordionProps {
   manifest: FairManifest | null;
+  resolveProfile?: (did: string) => Promise<{ name: string; avatar?: string }>;
 }
 
 function getAttribution(manifest: FairManifest): FairEntry[] {
   return manifest.attribution?.length ? manifest.attribution : (manifest.chain ?? []);
 }
 
-export function FairAccordion({ manifest }: FairAccordionProps) {
+export function FairAccordion({ manifest, resolveProfile }: FairAccordionProps) {
   const [open, setOpen] = useState(false);
 
   if (!manifest) return null;
 
-  const attribution = getAttribution(manifest);
+  const rawAttribution = getAttribution(manifest);
+  const attribution = normalizeShares(rawAttribution);
   if (!attribution.length) return null;
+
+  const allDids = attribution.map(e => e.did).filter(Boolean);
+  const didNames = useDidNames(allDids, resolveProfile);
 
   return (
     <div className="bg-white dark:bg-gray-800/50 backdrop-blur-sm rounded-2xl shadow-lg overflow-hidden">
@@ -56,6 +102,11 @@ export function FairAccordion({ manifest }: FairAccordionProps) {
                       entry.role === 'platform' ? 'bg-blue-500' : 'bg-orange-500'
                     }`} />
                     <span className="text-sm font-medium capitalize">{entry.role}</span>
+                    {entry.did && (
+                      <span className="text-xs text-gray-500 truncate max-w-[140px]" title={entry.did}>
+                        {formatDid(entry.did, didNames)}
+                      </span>
+                    )}
                   </div>
                   <span className="text-sm font-bold">{(entry.share * 100).toFixed(1)}%</span>
                 </div>

--- a/packages/fair/src/components/FairEditor.tsx
+++ b/packages/fair/src/components/FairEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { FairManifest, FairEntry, FairAccess } from '../types';
 
 export interface FairEditorProps {
@@ -20,11 +20,69 @@ const SECTION_DEFAULTS: NonNullable<FairEditorProps['sections']> = ['attribution
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+/**
+ * Normalize share values: DB may store as 0-100 (percentage) or 0-1 (decimal).
+ * Editor expects 0-1. If any share > 1, assume all are percentages and divide by 100.
+ */
+function normalizeShares(entries: FairEntry[]): FairEntry[] {
+  const hasPercentage = entries.some(e => e.share > 1);
+  if (!hasPercentage) return entries;
+  return entries.map(e => ({ ...e, share: e.share / 100 }));
+}
+
 function resolveAccess(manifest: FairManifest): FairAccess {
   if (typeof manifest.access === 'string') {
     return { type: manifest.access };
   }
   return manifest.access;
+}
+
+/**
+ * Hook to resolve DIDs to display names via resolveProfile callback.
+ */
+function useDidNames(
+  dids: string[],
+  resolveProfile?: (did: string) => Promise<{ name: string; avatar?: string }>
+): Record<string, string> {
+  const [names, setNames] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (!resolveProfile || dids.length === 0) return;
+    let cancelled = false;
+    const toResolve = dids.filter(d => d && !names[d]);
+    if (toResolve.length === 0) return;
+
+    Promise.all(
+      toResolve.map(async (did) => {
+        try {
+          const profile = await resolveProfile(did);
+          return [did, profile.name] as const;
+        } catch {
+          return [did, null] as const;
+        }
+      })
+    ).then(results => {
+      if (cancelled) return;
+      const updates: Record<string, string> = {};
+      for (const [did, name] of results) {
+        if (name) updates[did] = name;
+      }
+      if (Object.keys(updates).length > 0) {
+        setNames(prev => ({ ...prev, ...updates }));
+      }
+    });
+
+    return () => { cancelled = true; };
+  }, [dids.join(','), resolveProfile]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return names;
+}
+
+/** Format a DID for display — show handle if resolved, otherwise truncate DID */
+function formatDid(did: string, names: Record<string, string>): string {
+  if (names[did]) return `@${names[did]}`;
+  if (did.length > 24) return did.slice(0, 12) + '…' + did.slice(-8);
+  return did;
 }
 
 function shareBar(share: number, role: string) {
@@ -46,7 +104,7 @@ function shareBar(share: number, role: string) {
 
 // ─── Sub-components ──────────────────────────────────────────────────────────
 
-function AttributionView({ entries }: { entries: FairEntry[] }) {
+function AttributionView({ entries, didNames }: { entries: FairEntry[]; didNames: Record<string, string> }) {
   return (
     <div className="space-y-3">
       {entries.map((entry, i) => (
@@ -54,7 +112,9 @@ function AttributionView({ entries }: { entries: FairEntry[] }) {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <span className="text-xs font-semibold text-orange-400 capitalize">{entry.role}</span>
-              <span className="text-xs text-gray-500 truncate max-w-[180px]">{entry.did}</span>
+              <span className="text-xs text-gray-500 truncate max-w-[180px]" title={entry.did}>
+                {formatDid(entry.did, didNames)}
+              </span>
             </div>
           </div>
           {shareBar(entry.share, entry.role)}
@@ -336,9 +396,18 @@ export function FairEditor({
   onChange,
   readOnly = false,
   sections: sectionsProp,
+  resolveProfile,
 }: FairEditorProps) {
   const sections = sectionsProp ?? SECTION_DEFAULTS;
-  const [local, setLocal] = useState<FairManifest>(manifest);
+  const [local, setLocal] = useState<FairManifest>(() => {
+    // Normalize shares on init — handle DB storing 0-100 vs 0-1
+    const rawAttribution = manifest.attribution?.length ? manifest.attribution : (manifest.chain ?? []);
+    const normalized = normalizeShares(rawAttribution);
+    if (normalized !== rawAttribution) {
+      return { ...manifest, attribution: normalized, chain: normalized };
+    }
+    return manifest;
+  });
 
   const update = useCallback(
     (patch: Partial<FairManifest>) => {
@@ -351,6 +420,10 @@ export function FairEditor({
 
   const access = resolveAccess(local);
   const attribution = local.attribution?.length ? local.attribution : (local.chain ?? []);
+
+  // Resolve DIDs to handles
+  const allDids = attribution.map(e => e.did).filter(Boolean);
+  const didNames = useDidNames(allDids, resolveProfile);
 
   const totalShare = attribution.reduce((sum, e) => sum + e.share, 0);
   const shareWarning = totalShare > 1.0001;
@@ -375,7 +448,7 @@ export function FairEditor({
             </p>
           )}
           {readOnly ? (
-            <AttributionView entries={attribution} />
+            <AttributionView entries={attribution} didNames={didNames} />
           ) : (
             <AttributionEdit
               entries={attribution}


### PR DESCRIPTION
## What

### Share normalization (10000% → 100%)
DB has some manifests with shares stored as `100` (percentage) instead of `1.0` (decimal). Both `FairEditor` and `FairAccordion` now auto-detect: if any share > 1, divide all by 100.

### DID → handle resolution
- Both components accept `resolveProfile` callback
- Resolves `did:imajin:*` to `@handle` via profile service
- Handle shown as primary display, raw DID as tooltip on hover
- Truncates long DIDs that can't be resolved: `did:imajin:6JSK…9b5Nc`

### Wiring
- Media app's AssetDetail passes `resolveProfile` to FairEditor (hits profile service API)

## Phase 1 of #314