### PR TITLE
fix(auth): phase 0 — tier migration + security fixes

### DIFF
--- a/apps/auth/app/api/login/verify/route.ts
+++ b/apps/auth/app/api/login/verify/route.ts
@@ -95,7 +95,7 @@ export async function POST(request: NextRequest) {
       handle: identity.handle || undefined,
       type: identity.type,
       name: identity.name || undefined,
-      tier: 'hard', // challenge-response auth is hard DID
+      tier: (identity.tier as 'soft' | 'preliminary' | 'established') || 'preliminary',
     });
 
     // Set cookie and return

--- a/apps/auth/app/api/magic/route.ts
+++ b/apps/auth/app/api/magic/route.ts
@@ -10,7 +10,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/src/db';
 import { identities } from '@/src/db/schema';
-import { eq, sql } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { createSessionToken, getSessionCookieOptions } from '@/lib/jwt';
 
 const EVENTS_SERVICE_URL = process.env.EVENTS_SERVICE_URL || 'http://localhost:3006';
@@ -154,19 +154,7 @@ export async function GET(request: NextRequest) {
         .returning();
     }
 
-    // Check profile tier (profile DB shares same Postgres)
-    let identityTier: 'soft' | 'hard' = 'soft';
-    try {
-      const [profileRow] = await db.execute(
-        sql`SELECT identity_tier FROM profile.profiles WHERE did = ${ownerDid} LIMIT 1`
-      );
-      if (profileRow && (profileRow as any).identity_tier === 'hard') {
-        identityTier = 'hard';
-      }
-    } catch {
-      // Profile table may not exist — fall back to identity metadata
-      if ((identity.metadata as any)?.tier === 'hard') identityTier = 'hard';
-    }
+    const identityTier = (identity.tier || 'soft') as 'soft' | 'preliminary' | 'established';
 
     // Create session token
     const sessionToken = await createSessionToken({

--- a/apps/auth/app/api/register/route.ts
+++ b/apps/auth/app/api/register/route.ts
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
           handle: existing[0].handle || undefined,
           type: existing[0].type,
           name: existing[0].name || undefined,
-          tier: 'hard', // registrations with public keys are hard DIDs
+          tier: 'preliminary', // registrations with public keys are preliminary DIDs
         });
 
         const cookieConfig = getSessionCookieOptions();
@@ -198,7 +198,7 @@ export async function POST(request: NextRequest) {
       handle: identity.handle || undefined,
       type: identity.type,
       name: identity.name || undefined,
-      tier: 'hard', // registrations with public keys are hard DIDs
+      tier: 'preliminary', // registrations with public keys are preliminary DIDs
     });
 
     // Set cookie first so the accept call is authenticated

--- a/apps/auth/app/api/session/route.ts
+++ b/apps/auth/app/api/session/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
 import { db } from '@/src/db';
 import { identities } from '@/src/db/schema';
-import { eq, sql } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { corsHeaders } from '@imajin/config';
 
 export async function OPTIONS(request: NextRequest) {
@@ -45,18 +45,7 @@ export async function GET(request: NextRequest) {
     }
 
     const metadata = identity[0].metadata as Record<string, unknown> || {};
-
-    // Check profile tier as source of truth (profile DB shares same Postgres)
-    let profileTier = session.tier || 'hard';
-    try {
-      const profileRows = await db.execute(
-        sql`SELECT identity_tier FROM profile.profiles WHERE did = ${session.sub} LIMIT 1`
-      );
-      const row = (profileRows as any)?.[0];
-      if (row?.identity_tier) profileTier = row.identity_tier;
-    } catch {
-      // Profile schema may not be available
-    }
+    const tier = (identity[0] as any).tier || 'soft';
 
     return NextResponse.json({
       did: session.sub,
@@ -64,7 +53,7 @@ export async function GET(request: NextRequest) {
       type: identity[0].type || session.type,
       name: identity[0].name || session.name,
       role: metadata.role || 'member',
-      tier: profileTier,
+      tier,
     }, { headers: cors });
 
   } catch (error) {

--- a/apps/auth/lib/jwt.ts
+++ b/apps/auth/lib/jwt.ts
@@ -68,7 +68,7 @@ export interface SessionPayload {
   handle?: string;  // @username
   type: string;     // identity type
   name?: string;
-  tier?: 'soft' | 'hard'; // identity tier
+  tier?: 'soft' | 'preliminary' | 'established'; // identity tier
 }
 
 /**
@@ -81,7 +81,7 @@ export async function createSessionToken(payload: SessionPayload): Promise<strin
     handle: payload.handle,
     type: payload.type,
     name: payload.name,
-    tier: payload.tier || 'hard', // default to 'hard' for existing sessions
+    tier: payload.tier || 'soft',
   })
     .setProtectedHeader({ alg: 'EdDSA' })
     .setSubject(payload.sub)
@@ -104,12 +104,14 @@ export async function verifySessionToken(token: string): Promise<SessionPayload 
       issuer: JWT_ISSUER,
     });
 
+    const rawTier = payload.tier as string || 'soft';
+    const tier = rawTier === 'hard' ? 'preliminary' : rawTier as 'soft' | 'preliminary' | 'established';
     return {
       sub: payload.sub as string,
       handle: payload.handle as string | undefined,
       type: payload.type as string,
       name: payload.name as string | undefined,
-      tier: (payload.tier as 'soft' | 'hard') || 'hard', // default to 'hard' for existing tokens
+      tier,
     };
   } catch (error) {
     console.error('JWT verification failed:', error);

--- a/apps/auth/migrations/0001_add_tier_column.sql
+++ b/apps/auth/migrations/0001_add_tier_column.sql
@@ -1,0 +1,3 @@
+-- Phase 0: Add tier column to auth.identities
+ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS tier TEXT NOT NULL DEFAULT 'soft';
+UPDATE auth.identities SET tier = 'preliminary' WHERE public_key NOT LIKE 'soft_%';

--- a/apps/auth/src/db/schema.ts
+++ b/apps/auth/src/db/schema.ts
@@ -12,6 +12,7 @@ export const identities = authSchema.table('identities', {
   handle: text('handle').unique(),                // @username (unique, optional)
   name: text('name'),                             // Display name
   avatarUrl: text('avatar_url'),
+  tier: text('tier').notNull().default('soft'),
   metadata: jsonb('metadata').default({}),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,3 +3,4 @@ export { requireAuth } from "./require-auth";
 export { optionalAuth } from "./optional-auth";
 export { getSession } from "./session";
 export { requireHardDID } from "./require-hard-did";
+export { requireEstablishedDID } from "./require-established-did";

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -4,8 +4,9 @@
  * Tiers:
  * - none: unauthenticated
  * - soft: soft DID (session-based, no keypair)
- * - hard: hard DID (keypair-based)
- * - hard+graph: hard DID + at least one accepted connection in trust graph
+ * - preliminary: keypair-based DID (registered, not yet established)
+ * - established: established DID (keypair-based, fully onboarded)
+ * - established+graph: established DID + at least one accepted connection in trust graph
  */
 
 export type Action =
@@ -13,34 +14,37 @@ export type Action =
   | 'edit_profile' | 'create_event'
   | 'dm' | 'pod_chat' | 'send_invite' | 'create_pod' | 'connections';
 
-export type Tier = 'none' | 'soft' | 'hard' | 'hard+graph';
+export type Tier = 'none' | 'soft' | 'preliminary' | 'established' | 'established+graph';
 
 /**
  * Returns the minimum tier required for an action
  */
 export function requiredTier(action: Action): Tier {
   switch (action) {
-    // Anyone authenticated (soft or hard DID)
+    // Anyone authenticated (any DID)
     case 'event_lobby_chat':
     case 'view_tickets':
     case 'buy_ticket':
       return 'soft';
 
-    // Hard DID required
+    // Preliminary DID required
     case 'edit_profile':
-    case 'create_event':
-      return 'hard';
+      return 'preliminary';
 
-    // Hard DID + trust graph membership required
+    // Established DID required
+    case 'create_event':
+    case 'send_invite':
+      return 'established';
+
+    // Established DID + trust graph membership required
     case 'dm':
     case 'pod_chat':
-    case 'send_invite':
     case 'create_pod':
     case 'connections':
-      return 'hard+graph';
+      return 'established+graph';
 
     default:
-      return 'hard';
+      return 'established';
   }
 }
 
@@ -49,40 +53,39 @@ export function requiredTier(action: Action): Tier {
  *
  * @param did - The user's DID
  * @param action - The action they want to perform
- * @param currentTier - The user's current identity tier ('soft' | 'hard')
+ * @param currentTier - The user's current identity tier
  * @param connectionsServiceUrl - URL of the connections service (optional, required for graph checks)
  * @returns Promise<boolean> - true if user can perform the action
  */
 export async function canDo(
   did: string,
   action: Action,
-  currentTier: 'soft' | 'hard',
+  currentTier: 'soft' | 'preliminary' | 'established',
   connectionsServiceUrl?: string
 ): Promise<boolean> {
   const required = requiredTier(action);
 
-  // Check tier requirements
   if (required === 'none') {
     return true;
   }
 
   if (required === 'soft') {
-    // Any authenticated user (soft or hard)
-    return currentTier === 'soft' || currentTier === 'hard';
+    return true; // any authenticated user
   }
 
-  if (required === 'hard') {
-    // Hard DID required
-    return currentTier === 'hard';
+  if (required === 'preliminary') {
+    return currentTier === 'preliminary' || currentTier === 'established';
   }
 
-  if (required === 'hard+graph') {
-    // Must be hard DID
-    if (currentTier !== 'hard') {
+  if (required === 'established') {
+    return currentTier === 'established';
+  }
+
+  if (required === 'established+graph') {
+    if (currentTier !== 'established') {
       return false;
     }
 
-    // Must be in trust graph (have at least one connection)
     if (!connectionsServiceUrl) {
       throw new Error('connectionsServiceUrl is required for graph membership checks');
     }
@@ -108,13 +111,14 @@ export async function canDo(
  * Checks if a user has the minimum tier required for an action
  * Does not check graph membership
  */
-export function hasTier(currentTier: 'none' | 'soft' | 'hard', required: Tier): boolean {
-  const tierLevels: Record<Tier, number> = {
+export function hasTier(currentTier: 'none' | 'soft' | 'preliminary' | 'established', required: Tier): boolean {
+  const tierLevels: Record<string, number> = {
     'none': 0,
     'soft': 1,
-    'hard': 2,
-    'hard+graph': 2, // tier check only, graph check is separate
+    'preliminary': 2,
+    'established': 3,
+    'established+graph': 3, // tier check only, graph check is separate
   };
 
-  return tierLevels[currentTier] >= tierLevels[required];
+  return (tierLevels[currentTier] ?? 0) >= (tierLevels[required] ?? 0);
 }

--- a/packages/auth/src/require-auth.ts
+++ b/packages/auth/src/require-auth.ts
@@ -36,7 +36,7 @@ async function validateSessionCookie(
       type: data.type || data.identity?.type || "human",
       name: data.name || data.identity?.name,
       handle: data.handle || data.identity?.handle,
-      tier: data.tier || data.identity?.tier || "hard",
+      tier: data.tier || data.identity?.tier || "soft",
     };
 
     if (!identity.id) {

--- a/packages/auth/src/require-established-did.ts
+++ b/packages/auth/src/require-established-did.ts
@@ -1,0 +1,25 @@
+import type { AuthResult, AuthError } from "./types";
+import { requireAuth } from "./require-auth";
+
+/**
+ * Require established DID authentication (keypair-based, fully onboarded).
+ * Rejects soft and preliminary DIDs.
+ */
+export async function requireEstablishedDID(
+  request: Request
+): Promise<AuthResult | AuthError> {
+  const authResult = await requireAuth(request);
+
+  if ("error" in authResult) {
+    return authResult;
+  }
+
+  if (authResult.identity.tier === "soft" || authResult.identity.tier === "preliminary") {
+    return {
+      error: "This action requires an established identity",
+      status: 403,
+    };
+  }
+
+  return authResult;
+}

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -32,7 +32,7 @@ export async function getSession(): Promise<Identity | null> {
       type: data.type || "human",
       name: data.name,
       handle: data.handle,
-      tier: data.tier || "hard",
+      tier: data.tier || "soft",
     };
   } catch (error) {
     console.error("[AUTH] Session fetch failed:", error);

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -3,7 +3,7 @@ export interface Identity {
   type: "human" | "agent" | "presence";
   name?: string;
   handle?: string;
-  tier?: "soft" | "hard";
+  tier?: "soft" | "preliminary" | "established";
 }
 
 export interface AuthResult {


### PR DESCRIPTION
## Identity Phase 0

Three-tier identity model + security hardening. Addresses #318 and #319.

### Changes
- **Tier column on auth.identities** — source of truth for access control (no more cross-schema profile queries)
- **Three tiers:** `soft` → `preliminary` → `established` (replaces binary soft/hard)
- **Fail-open default fixed:** all defaults now `'soft'` (least privilege)
- **Cross-schema query eliminated** — session route no longer queries `profile.profiles`
- **JWT backward compat:** old `'hard'` tokens mapped to `'preliminary'`
- **New `requireEstablishedDID()`** middleware exported from `@imajin/auth`
- **Permissions updated:** edit_profile=preliminary, create_event/invite=established, dm/pods=established+graph
- **Migration:** `0001_add_tier_column.sql` — adds column, migrates existing data

### 13 files, 77 insertions, 64 deletions

Closes #318, closes #319