### PR TITLE
feat(fair): phase 0 — schema hardening

### DIFF
--- a/packages/fair/src/components/FairEditor.tsx
+++ b/packages/fair/src/components/FairEditor.tsx
@@ -2,12 +2,15 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import type { FairManifest, FairEntry, FairAccess } from '../types';
+import type { FairTemplate } from '../templates';
+import { templates } from '../templates';
 
 export interface FairEditorProps {
   manifest: FairManifest;
   onChange?: (manifest: FairManifest) => void;
   readOnly?: boolean;
-  sections?: ('attribution' | 'access' | 'transfer' | 'integrity')[];
+  sections?: ('attribution' | 'access' | 'transfer' | 'integrity' | 'intent' | 'terms' | 'distributions')[];
+  template?: FairTemplate;
   resolveProfile?: (did: string) => Promise<{ name: string; avatar?: string }>;
 }
 
@@ -16,6 +19,7 @@ const ROLE_OPTIONS = [
   'platform', 'venue', 'distributor', 'label', 'other',
 ];
 
+const ALL_SECTIONS = ['attribution', 'access', 'transfer', 'integrity', 'intent', 'terms', 'distributions'] as const;
 const SECTION_DEFAULTS: NonNullable<FairEditorProps['sections']> = ['attribution', 'access', 'transfer', 'integrity'];
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -222,7 +226,7 @@ function AccessSection({
   readOnly: boolean;
   onChange?: (access: FairAccess) => void;
 }) {
-  const types = ['public', 'private', 'trust-graph'] as const;
+  const types = ['public', 'private', 'trust-graph', 'conversation'] as const;
 
   return (
     <div className="space-y-3">
@@ -242,6 +246,23 @@ function AccessSection({
           </button>
         ))}
       </div>
+
+      {access.type === 'conversation' && (
+        <div className="space-y-2">
+          <p className="text-xs text-gray-500">Conversation DID</p>
+          {readOnly ? (
+            <span className="text-xs text-gray-400 truncate block">{access.conversationDid ?? '—'}</span>
+          ) : (
+            <input
+              type="text"
+              value={access.conversationDid ?? ''}
+              onChange={e => onChange?.({ ...access, conversationDid: e.target.value || undefined })}
+              placeholder="did:key:... (conversation)"
+              className="w-full bg-[#252525] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 placeholder-gray-600 focus:outline-none focus:border-orange-500"
+            />
+          )}
+        </div>
+      )}
 
       {(access.type === 'private' || access.type === 'trust-graph') && (
         <div className="space-y-2">
@@ -396,9 +417,14 @@ export function FairEditor({
   onChange,
   readOnly = false,
   sections: sectionsProp,
+  template,
   resolveProfile,
 }: FairEditorProps) {
-  const sections = sectionsProp ?? SECTION_DEFAULTS;
+  // Derive active sections: explicit prop > template config > defaults
+  const sections: NonNullable<FairEditorProps['sections']> = sectionsProp
+    ?? (template
+      ? ALL_SECTIONS.filter(s => templates[template].sections[s])
+      : SECTION_DEFAULTS);
   const [local, setLocal] = useState<FairManifest>(() => {
     // Normalize shares on init — handle DB storing 0-100 vs 0-1
     const rawAttribution = manifest.attribution?.length ? manifest.attribution : (manifest.chain ?? []);

--- a/packages/fair/src/index.ts
+++ b/packages/fair/src/index.ts
@@ -3,8 +3,12 @@ export type {
   FairTransfer,
   FairAccess,
   FairIntegrity,
+  FairIntent,
   FairManifest,
 } from './types';
+
+export type { FairTemplate, TemplateConfig } from './templates';
+export { templates } from './templates';
 
 export { validateManifest, isValidManifest } from './validate';
 export { createManifest } from './create';

--- a/packages/fair/src/templates.ts
+++ b/packages/fair/src/templates.ts
@@ -1,0 +1,108 @@
+import type { FairManifest } from './types';
+
+export type FairTemplate = "media" | "ticket" | "course" | "module" | "document" | "custom";
+
+export interface TemplateConfig {
+  name: string;
+  description: string;
+  sections: {
+    attribution: boolean;
+    access: boolean;
+    transfer: boolean;
+    integrity: boolean;
+    intent: boolean;
+    terms: boolean;
+    distributions: boolean;
+  };
+  defaults?: Partial<FairManifest>;
+}
+
+export const templates: Record<FairTemplate, TemplateConfig> = {
+  media: {
+    name: "Media",
+    description: "Audio, video, or image content with transfer and integrity tracking.",
+    sections: {
+      attribution: true,
+      access: true,
+      transfer: true,
+      integrity: true,
+      intent: false,
+      terms: true,
+      distributions: false,
+    },
+    defaults: {
+      transfer: { allowed: true, resaleRoyalty: 0.1 },
+    },
+  },
+  ticket: {
+    name: "Ticket",
+    description: "Event or access ticket with transfer controls and stated purpose.",
+    sections: {
+      attribution: true,
+      access: true,
+      transfer: true,
+      integrity: false,
+      intent: true,
+      terms: true,
+      distributions: false,
+    },
+    defaults: {
+      transfer: { allowed: true, faceValueCap: true },
+    },
+  },
+  course: {
+    name: "Course",
+    description: "Educational course with distribution splits and stated learning intent.",
+    sections: {
+      attribution: true,
+      access: true,
+      transfer: false,
+      integrity: false,
+      intent: true,
+      terms: true,
+      distributions: true,
+    },
+    defaults: {
+      access: { type: "private" },
+    },
+  },
+  module: {
+    name: "Module",
+    description: "Standalone content module or lesson, minimal configuration.",
+    sections: {
+      attribution: true,
+      access: true,
+      transfer: false,
+      integrity: false,
+      intent: false,
+      terms: true,
+      distributions: false,
+    },
+  },
+  document: {
+    name: "Document",
+    description: "Written document or file with integrity verification.",
+    sections: {
+      attribution: true,
+      access: true,
+      transfer: false,
+      integrity: true,
+      intent: false,
+      terms: true,
+      distributions: false,
+    },
+  },
+  custom: {
+    name: "Custom",
+    description: "Fully custom manifest — all sections visible.",
+    sections: {
+      attribution: true,
+      access: true,
+      transfer: true,
+      integrity: true,
+      intent: true,
+      terms: true,
+      distributions: true,
+    },
+  },
+};

--- a/packages/fair/src/types.ts
+++ b/packages/fair/src/types.ts
@@ -13,13 +13,19 @@ export interface FairTransfer {
 }
 
 export interface FairAccess {
-  type: "public" | "private" | "trust-graph";
+  type: "public" | "private" | "trust-graph" | "conversation";
   allowedDids?: string[]; // for private access
+  conversationDid?: string; // for conversation-scoped access
 }
 
 export interface FairIntegrity {
   hash: string; // sha256:...
   size: number; // bytes
+}
+
+export interface FairIntent {
+  purpose: string;
+  constraints?: Record<string, unknown>;
 }
 
 export interface FairManifest {
@@ -35,6 +41,9 @@ export interface FairManifest {
   distributions?: FairEntry[];
   integrity?: FairIntegrity;
   terms?: string; // license URL or text
+  intent?: FairIntent; // stated purpose and optional constraints
+  signature?: string; // creator signature (required in Phase 1)
+  platformSignature?: string; // platform endorsement signature
   // backward compat with existing events code
   version?: string;
   chain?: FairEntry[]; // alias for attribution

--- a/packages/fair/src/validate.ts
+++ b/packages/fair/src/validate.ts
@@ -25,9 +25,14 @@ export function validateManifest(manifest: unknown): { valid: boolean; errors: s
     }
   } else if (typeof m.access === "object") {
     const access = m.access as Record<string, unknown>;
-    const validTypes = ["public", "private", "trust-graph"];
+    const validTypes = ["public", "private", "trust-graph", "conversation"];
     if (!validTypes.includes(access.type as string)) {
-      errors.push('access.type must be "public", "private", or "trust-graph"');
+      errors.push('access.type must be "public", "private", "trust-graph", or "conversation"');
+    }
+    if (access.type === "conversation") {
+      if (typeof access.conversationDid !== "string" || !access.conversationDid) {
+        errors.push('access.conversationDid must be a non-empty string when access.type is "conversation"');
+      }
     }
     if (access.allowedDids !== undefined) {
       if (!Array.isArray(access.allowedDids)) {
@@ -76,6 +81,22 @@ export function validateManifest(manifest: unknown): { valid: boolean; errors: s
       if (typeof t.resaleRoyalty !== "number" || t.resaleRoyalty < 0 || t.resaleRoyalty > 1) {
         errors.push("transfer.resaleRoyalty must be a number between 0 and 1");
       }
+    }
+  }
+
+  // Signature validation (optional fields — will be required in Phase 1)
+  if (m.signature !== undefined && typeof m.signature !== "string") {
+    errors.push("signature must be a string");
+  }
+  if (m.platformSignature !== undefined && typeof m.platformSignature !== "string") {
+    errors.push("platformSignature must be a string");
+  }
+
+  // Intent validation (optional)
+  if (m.intent !== undefined) {
+    const intent = m.intent as Record<string, unknown>;
+    if (typeof intent.purpose !== "string" || !intent.purpose) {
+      errors.push("intent.purpose must be a non-empty string");
     }
   }
 


### PR DESCRIPTION
## .fair Phase 0 — Schema Hardening

Extends `FairManifest` types for Phase 1 signing, adds template system, adds conversation access type.

### Changes
- **Types:** `signature?`, `platformSignature?`, `intent?` fields on FairManifest
- **Conversation access:** `"conversation"` type + `conversationDid` on FairAccess (#305)
- **Templates:** `media`, `ticket`, `course`, `module`, `document`, `custom` — each defines which editor sections to show (#314)
- **FairEditor:** accepts `template` prop, conditionally renders sections per template config
- **Validation:** handles new fields (conversation, signature, intent)

No crypto. All new fields optional. Fully backward compatible.

5 files, 174 insertions, 6 deletions