### PR TITLE
feat(events): wire ticket settlement via pay /api/settle

### DIFF
--- a/apps/events/.env.example
+++ b/apps/events/.env.example
@@ -27,8 +27,11 @@ SENDGRID_API_KEY=your-sendgrid-api-key
 SENDGRID_FROM=events@imajin.ai
 
 # Platform
-PLATFORM_DID=did:web:imajin.ai
-PLATFORM_FEE=0.05
+PLATFORM_DID=did:imajin:platform
+PLATFORM_FEE_PERCENT=3
+
+# Service-to-service auth (pay settle endpoint)
+PAY_SERVICE_API_KEY=your-api-key-here
 
 # Public URLs (client-side)
 NEXT_PUBLIC_AUTH_URL=http://localhost:3001

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, events, ticketTypes, tickets } from '@/src/db';
 import { eq, and, sql } from 'drizzle-orm';
 import { sendEmail, ticketConfirmationEmail, generateQRCode } from '@/src/lib/email';
+import { settleTicketPurchase } from '@/src/lib/settle';
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha2.js';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
@@ -330,6 +331,26 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     .where(eq(ticketTypes.id, ticketType.id));
 
   console.log(`Created ${createdTickets.length} ticket(s) for ${customerEmail}`);
+
+  // After ticket creation, trigger .fair settlement (non-fatal)
+  const eventMetadata = (event.metadata || {}) as Record<string, any>;
+  try {
+    await settleTicketPurchase({
+      eventId: event.id,
+      eventDid: event.did,
+      buyerDid: ownerDid,
+      amount: amountTotal, // cents from Stripe
+      currency,
+      fairManifest: eventMetadata.fair || null,
+      metadata: {
+        ticketId: createdTickets[0].id,
+        ticketTypeId: ticketType.id,
+        stripeSessionId: sessionId,
+      },
+    });
+  } catch (settleError) {
+    console.error('[settle] Unexpected settlement error (non-fatal):', settleError);
+  }
 
   // Send confirmation email with onboard verification link
   const eventDate = new Date(event.startsAt);

--- a/apps/events/src/lib/settle.ts
+++ b/apps/events/src/lib/settle.ts
@@ -1,0 +1,106 @@
+/**
+ * settleTicketPurchase
+ *
+ * Calls POST /api/settle on the pay service after a ticket purchase completes.
+ * Settlement failure is non-fatal — the ticket has already been created.
+ */
+
+const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
+const PAY_SERVICE_API_KEY = process.env.PAY_SERVICE_API_KEY!;
+const PLATFORM_DID = process.env.PLATFORM_DID || 'did:imajin:platform';
+const PLATFORM_FEE_PERCENT = parseFloat(process.env.PLATFORM_FEE_PERCENT || '3');
+
+interface FairAttribution {
+  did: string;
+  role: string;
+  share: number; // 0–1 fraction
+}
+
+interface FairManifest {
+  attribution?: FairAttribution[];
+  [key: string]: unknown;
+}
+
+interface SettleTicketPurchaseParams {
+  eventId: string;
+  eventDid: string;
+  buyerDid: string;
+  amount: number;   // cents (from Stripe)
+  currency: string;
+  fairManifest: FairManifest | null;
+  metadata: {
+    ticketId: string;
+    ticketTypeId: string;
+    stripeSessionId: string;
+  };
+}
+
+export async function settleTicketPurchase(params: SettleTicketPurchaseParams): Promise<void> {
+  const { eventId, buyerDid, amount, fairManifest, metadata } = params;
+
+  if (!fairManifest || !fairManifest.attribution?.length) {
+    console.warn(`[settle] No .fair manifest for event ${eventId} — skipping settlement`);
+    return;
+  }
+
+  const totalDollars = amount / 100;
+  const platformAmount = parseFloat((totalDollars * (PLATFORM_FEE_PERCENT / 100)).toFixed(2));
+  const remainingDollars = parseFloat((totalDollars - platformAmount).toFixed(2));
+
+  // Build chain: attribution shares apply to the remaining (non-platform) portion
+  // Use rounding with remainder correction to avoid penny drift
+  const attributionChain = fairManifest.attribution.map((entry) => ({
+    did: entry.did,
+    amount: parseFloat((remainingDollars * entry.share).toFixed(2)),
+    role: entry.role,
+  }));
+
+  // Fix rounding drift: adjust largest recipient so chain sums to totalDollars exactly
+  const attributionSum = attributionChain.reduce((sum, e) => sum + e.amount, 0);
+  const drift = parseFloat((remainingDollars - attributionSum).toFixed(2));
+  if (drift !== 0 && attributionChain.length > 0) {
+    // Give the remainder to the largest recipient
+    const largest = attributionChain.reduce((max, e) => e.amount > max.amount ? e : max, attributionChain[0]);
+    largest.amount = parseFloat((largest.amount + drift).toFixed(2));
+  }
+
+  const chain = [
+    ...attributionChain,
+    { did: PLATFORM_DID, amount: platformAmount, role: 'platform' },
+  ];
+
+  const body = {
+    from_did: buyerDid,
+    total_amount: totalDollars,
+    service: 'events',
+    type: 'ticket_purchase',
+    fair_manifest: { chain },
+    metadata: {
+      ticketId: metadata.ticketId,
+      stripeSessionId: metadata.stripeSessionId,
+      eventId,
+    },
+  };
+
+  try {
+    const response = await fetch(`${PAY_SERVICE_URL}/api/settle`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${PAY_SERVICE_API_KEY}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      console.error(`[settle] pay /api/settle returned ${response.status}: ${text}`);
+      return;
+    }
+
+    const result = await response.json();
+    console.log(`[settle] Settlement complete for ticket ${metadata.ticketId}:`, result);
+  } catch (error) {
+    console.error('[settle] Settlement request failed (non-fatal):', error);
+  }
+}


### PR DESCRIPTION
## Settlement Phase 0 — Wire What Exists

Connects ticket purchases to the existing settlement engine. After a ticket is created via Stripe webhook, the event's `.fair` attribution chain is now sent to `pay /api/settle` for atomic multi-party splitting.

### Changes
- **New: `apps/events/src/lib/settle.ts`** — `settleTicketPurchase()` function
  - Reads `.fair` attribution from event metadata
  - Platform fee (3% default, configurable via `PLATFORM_FEE_PERCENT`)
  - Remaining 97% split per attribution shares
  - Rounding drift correction (penny problem fix)
  - All errors caught and logged — settlement failure never blocks ticket creation
- **Webhook updated** — calls settlement after ticket creation, wrapped in try/catch
- **Env vars:** `PLATFORM_DID`, `PLATFORM_FEE_PERCENT`, `PAY_SERVICE_API_KEY`

### Known gap
The pay service needs to credit the buyer's balance when Stripe confirms payment, before settlement can debit it. If that credit step doesn't exist, settlement will fail gracefully (logged, ticket unaffected).

3 files, 132 insertions, 2 deletions