### PR TITLE
feat(pay): auto-issue attestations on transaction settlement (#162)

### DIFF
--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -21,5 +21,8 @@ NEXT_PUBLIC_AUTH_URL=http://localhost:3001
 NEXT_PUBLIC_DOMAIN=imajin.ai
 NEXT_PUBLIC_SERVICE_PREFIX=https://
 
+# Internal service auth
+ATTESTATION_INTERNAL_API_KEY=your-attestation-internal-api-key
+
 # Feature flags
 NEXT_PUBLIC_DISABLE_INVITE_GATE=false

--- a/apps/auth/app/api/attestations/internal/route.ts
+++ b/apps/auth/app/api/attestations/internal/route.ts
@@ -1,0 +1,104 @@
+/**
+ * POST /api/attestations/internal
+ *
+ * Service-to-service endpoint for issuing attestations server-side.
+ * Signs the attestation using the platform keypair (AUTH_PRIVATE_KEY).
+ * Authenticated via Bearer token (ATTESTATION_INTERNAL_API_KEY).
+ *
+ * Body: { issuer_did, subject_did, type, context_id?, context_type?, payload? }
+ * No session cookie required — service-to-service only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, attestations } from '@/src/db';
+import { canonicalize, crypto as authCrypto, ATTESTATION_TYPES } from '@imajin/auth';
+import type { AttestationType } from '@imajin/auth';
+
+function genId(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
+}
+
+export async function POST(request: NextRequest) {
+  // API key auth
+  const apiKey = request.headers.get('authorization')?.replace('Bearer ', '');
+  const expectedKey = process.env.ATTESTATION_INTERNAL_API_KEY;
+
+  if (!expectedKey || apiKey !== expectedKey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const privateKey = process.env.AUTH_PRIVATE_KEY;
+  if (!privateKey) {
+    console.error('AUTH_PRIVATE_KEY not set — cannot sign attestation');
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { issuer_did, subject_did, type, context_id, context_type, payload } = body;
+
+  if (!issuer_did || typeof issuer_did !== 'string') {
+    return NextResponse.json({ error: 'issuer_did required' }, { status: 400 });
+  }
+  if (!subject_did || typeof subject_did !== 'string') {
+    return NextResponse.json({ error: 'subject_did required' }, { status: 400 });
+  }
+  if (!type || typeof type !== 'string') {
+    return NextResponse.json({ error: 'type required' }, { status: 400 });
+  }
+
+  if (!(ATTESTATION_TYPES as readonly string[]).includes(type)) {
+    return NextResponse.json(
+      { error: `Invalid type. Must be one of: ${ATTESTATION_TYPES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  const issuedAtMs = Date.now();
+
+  const canonicalPayload = canonicalize({
+    subject_did,
+    type,
+    context_id: context_id ?? null,
+    context_type: context_type ?? null,
+    payload: payload ?? null,
+    issued_at: issuedAtMs,
+  });
+
+  let signature: string;
+  try {
+    signature = authCrypto.signSync(canonicalPayload, privateKey);
+  } catch (err) {
+    console.error('Failed to sign attestation:', err);
+    return NextResponse.json({ error: 'Signing failed' }, { status: 500 });
+  }
+
+  const id = genId('att');
+
+  try {
+    const [attestation] = await db
+      .insert(attestations)
+      .values({
+        id,
+        issuerDid: issuer_did,
+        subjectDid: subject_did,
+        type: type as AttestationType,
+        contextId: (context_id as string | undefined) ?? null,
+        contextType: (context_type as string | undefined) ?? null,
+        payload: (payload as Record<string, unknown> | undefined) ?? null,
+        signature,
+        issuedAt: new Date(issuedAtMs),
+      })
+      .returning();
+
+    return NextResponse.json(attestation, { status: 201 });
+  } catch (err) {
+    console.error('Failed to insert attestation:', err);
+    return NextResponse.json({ error: 'Failed to store attestation' }, { status: 500 });
+  }
+}

--- a/apps/pay/.env.example
+++ b/apps/pay/.env.example
@@ -20,6 +20,10 @@ COFFEE_WEBHOOK_SECRET=your-coffee-webhook-secret
 
 # API keys
 PAY_SERVICE_API_KEY=your-pay-service-api-key
+AUTH_INTERNAL_API_KEY=your-auth-internal-api-key
+
+# Platform identity
+PLATFORM_DID=did:imajin:platform
 
 # Solana (optional)
 SOLANA_RPC_URL=https://api.mainnet-beta.solana.com

--- a/apps/pay/app/api/settle/route.ts
+++ b/apps/pay/app/api/settle/route.ts
@@ -24,9 +24,106 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { db, balances, transactions } from '@/src/db';
-import { eq, sql } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 import { genId } from '@/src/lib/id';
 import { corsHeaders } from '@/src/lib/cors';
+
+async function emitAttestations(
+  from_did: string,
+  fair_manifest: { chain: Array<{ did: string; amount: number; role: string }> },
+  batchId: string,
+  txIds: string[],
+  total_amount: number,
+  source: string,
+) {
+  const authServiceUrl = process.env.AUTH_SERVICE_URL;
+  const internalApiKey = process.env.AUTH_INTERNAL_API_KEY;
+
+  if (!authServiceUrl || !internalApiKey) {
+    console.warn('Attestation emission skipped: AUTH_SERVICE_URL or AUTH_INTERNAL_API_KEY not set');
+    return;
+  }
+
+  const url = `${authServiceUrl}/api/attestations/internal`;
+
+  const attestationCalls: Promise<void>[] = [];
+
+  // One "customer" attestation per recipient
+  for (const recipient of fair_manifest.chain) {
+    attestationCalls.push(
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${internalApiKey}`,
+        },
+        body: JSON.stringify({
+          issuer_did: recipient.did,
+          subject_did: from_did,
+          type: 'customer',
+          context_id: batchId,
+          context_type: 'service',
+          payload: { role: recipient.role },
+        }),
+      })
+        .then(async (res) => {
+          if (!res.ok) {
+            const text = await res.text().catch(() => '');
+            console.error(`Attestation (customer) failed for ${recipient.did}: ${res.status} ${text}`);
+          }
+        })
+        .catch((err) => {
+          console.error(`Attestation (customer) error for ${recipient.did}:`, err);
+        })
+    );
+  }
+
+  // One "transaction.settled" attestation from the platform
+  const platformDid = process.env.PLATFORM_DID;
+  if (platformDid) {
+    attestationCalls.push(
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${internalApiKey}`,
+        },
+        body: JSON.stringify({
+          issuer_did: platformDid,
+          subject_did: from_did,
+          type: 'transaction.settled',
+          context_id: batchId,
+          context_type: 'service',
+          payload: { total_amount, recipients: fair_manifest.chain.length, source },
+        }),
+      })
+        .then(async (res) => {
+          if (!res.ok) {
+            const text = await res.text().catch(() => '');
+            console.error(`Attestation (transaction.settled) failed: ${res.status} ${text}`);
+          }
+        })
+        .catch((err) => {
+          console.error('Attestation (transaction.settled) error:', err);
+        })
+    );
+  } else {
+    console.warn('Attestation (transaction.settled) skipped: PLATFORM_DID not set');
+  }
+
+  await Promise.all(attestationCalls);
+
+  // Mark transactions as credential_issued
+  if (txIds.length > 0) {
+    await db
+      .update(transactions)
+      .set({ credentialIssued: true })
+      .where(inArray(transactions.id, txIds))
+      .catch((err) => {
+        console.error('Failed to mark credential_issued on transactions:', err);
+      });
+  }
+}
 
 export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
@@ -203,6 +300,11 @@ export async function POST(request: NextRequest) {
             },
           });
       }
+    });
+
+    // Fire attestations asynchronously — don't block settlement response
+    emitAttestations(from_did, fair_manifest, batchId, txIds, total_amount, source).catch((err) => {
+      console.error('Attestation emission error:', err);
     });
 
     return NextResponse.json(

--- a/apps/pay/migrations/0001_add_credential_issued.sql
+++ b/apps/pay/migrations/0001_add_credential_issued.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pay.transactions ADD COLUMN IF NOT EXISTS credential_issued BOOLEAN DEFAULT false;

--- a/apps/pay/src/db/schema.ts
+++ b/apps/pay/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, jsonb, integer, numeric, index, primaryKey, pgSchema } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, jsonb, integer, numeric, boolean, index, primaryKey, pgSchema } from 'drizzle-orm/pg-core';
 
 export const paySchema = pgSchema('pay');
 
@@ -19,6 +19,7 @@ export const transactions = paySchema.table('transactions', {
   metadata: jsonb('metadata').default({}),
   fairManifest: jsonb('fair_manifest'),                  // .fair attribution chain
   batchId: text('batch_id'),                             // for batched settlements
+  credentialIssued: boolean('credential_issued').default(false),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({
   fromDidIdx: index('idx_transactions_from_did').on(table.fromDid),

--- a/packages/auth/src/types/attestation.ts
+++ b/packages/auth/src/types/attestation.ts
@@ -10,6 +10,8 @@ export const ATTESTATION_TYPES = [
   'vouch.received',
   'flag.yellow',
   'flag.cleared',
+  'transaction.settled',
+  'customer',
 ] as const;
 
 export type AttestationType = typeof ATTESTATION_TYPES[number];


### PR DESCRIPTION
## What

After successful settlement, automatically emit signed attestations:
- **`customer`** attestation per recipient (issuer = merchant/creator DID, subject = buyer DID)
- **`transaction.settled`** attestation from platform (issuer = PLATFORM_DID, subject = buyer)

### Changes
- `packages/auth/src/types/attestation.ts` — added `transaction.settled` + `customer` types
- `apps/auth/app/api/attestations/internal/route.ts` — new service-to-service endpoint (API key auth, signs with platform keypair)
- `apps/pay/app/api/settle/route.ts` — `emitAttestations()` fires async after settlement, never blocks payment
- `apps/pay/migrations/0001_add_credential_issued.sql` — tracks attestation issuance per transaction
- `apps/pay/src/db/schema.ts` — `credentialIssued` boolean column
- `.env.example` updates for both services

### Design
- Attestations fire via Promise.all with individual .catch — settlement always succeeds even if attestation fails
- No transaction amounts or purchase details leak into attestations
- Uses existing `@imajin/auth` canonicalize + signSync for server-side signing

Closes #162