### PR TITLE
feat(pay): cryptographic .fair signature verification at settlement

### DIFF
--- a/apps/pay/app/api/settle/route.ts
+++ b/apps/pay/app/api/settle/route.ts
@@ -27,6 +27,8 @@ import { db, balances, transactions } from '@/src/db';
 import { eq, inArray, sql } from 'drizzle-orm';
 import { genId } from '@/src/lib/id';
 import { corsHeaders } from '@/src/lib/cors';
+import { verifyManifest } from '@imajin/fair';
+import { createHttpResolver } from '@imajin/auth';
 
 async function emitAttestations(
   from_did: string,
@@ -181,23 +183,32 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate signature structure if present on non-funded settlements.
-    // TODO: full cryptographic verification once resolvePublicKey is wired.
-    if (!funded && fair_manifest.signature !== undefined) {
-      const sig = fair_manifest.signature;
-      const isValidSig =
-        typeof sig === 'object' &&
-        sig !== null &&
-        sig.algorithm === 'ed25519' &&
-        typeof sig.value === 'string' &&
-        /^[0-9a-f]{128}$/.test(sig.value) &&
-        typeof sig.publicKeyRef === 'string' &&
-        sig.publicKeyRef.startsWith('did:');
-      if (!isValidSig) {
-        return NextResponse.json(
-          { error: 'fair_manifest.signature has invalid structure' },
-          { status: 400, headers: cors }
-        );
+    // Cryptographic signature verification for non-funded settlements.
+    // Funded (external/Stripe) settlements skip verification — manifest came from our own service.
+    let signatureVerified = false;
+
+    if (!funded) {
+      if (fair_manifest.signature !== undefined) {
+        const resolver = createHttpResolver(process.env.AUTH_SERVICE_URL!);
+        const wrappedResolver = async (did: string): Promise<string> => {
+          const identity = await resolver(did);
+          if (!identity) throw new Error(`Could not resolve public key for DID: ${did}`);
+          return identity.publicKey;
+        };
+
+        const result = await verifyManifest(fair_manifest, wrappedResolver);
+        if (result.valid) {
+          signatureVerified = true;
+        } else {
+          // Signed but invalid — reject
+          return NextResponse.json(
+            { error: `fair_manifest signature verification failed: ${result.error}` },
+            { status: 400, headers: cors }
+          );
+        }
+      } else {
+        // Unsigned manifest — allow but warn (transitional period)
+        console.warn(`Settlement received unsigned fair_manifest from ${from_did} (service: ${service})`);
       }
     }
 
@@ -279,6 +290,7 @@ export async function POST(request: NextRequest) {
             ...metadata,
             role: recipient.role,
             ...(funded && { funded: true, funded_provider: funded_provider || 'unknown' }),
+            signature_verified: funded ? false : signatureVerified,
           },
         });
 

--- a/apps/pay/package.json
+++ b/apps/pay/package.json
@@ -11,7 +11,9 @@
     "db:generate": "drizzle-kit generate"
   },
   "dependencies": {
+    "@imajin/auth": "workspace:*",
     "@imajin/config": "workspace:*",
+    "@imajin/fair": "workspace:*",
     "@imajin/db": "workspace:^",
     "@imajin/ui": "workspace:^",
     "@solana/spl-token": "^0.4.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -8,7 +8,12 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@imajin/config": "workspace:*"
+    "@imajin/config": "workspace:*",
+    "@noble/ed25519": "^2.3.0",
+    "@noble/hashes": "^1.3.0"
+  },
+  "devDependencies": {
+    "drizzle-orm": "^0.45.1"
   },
   "peerDependencies": {
     "next": ">=14"

--- a/packages/fair/src/sign.ts
+++ b/packages/fair/src/sign.ts
@@ -1,10 +1,11 @@
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha512';
+import { concatBytes } from '@noble/hashes/utils';
 import type { FairManifest, FairSignature } from './types';
 import { canonicalizeForSigning } from './canonical';
 
 // Provide synchronous sha512 so @noble/ed25519 works in all environments
-ed.etc.sha512Sync = (...m) => sha512(...m);
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(concatBytes(...m));
 
 function hexToBytes(hex: string): Uint8Array {
   const bytes = new Uint8Array(hex.length / 2);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -664,12 +664,18 @@ importers:
 
   apps/pay:
     dependencies:
+      '@imajin/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
       '@imajin/config':
         specifier: workspace:*
         version: link:../../packages/config
       '@imajin/db':
         specifier: workspace:^
         version: link:../../packages/db
+      '@imajin/fair':
+        specifier: workspace:*
+        version: link:../../packages/fair
       '@imajin/ui':
         specifier: workspace:^
         version: link:../../packages/ui
@@ -911,9 +917,19 @@ importers:
       '@imajin/config':
         specifier: workspace:*
         version: link:../config
+      '@noble/ed25519':
+        specifier: ^2.3.0
+        version: 2.3.0
+      '@noble/hashes':
+        specifier: ^1.3.0
+        version: 1.8.0
       next:
         specifier: '>=14'
         version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    devDependencies:
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@neondatabase/serverless@1.0.2)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
 
   packages/chat:
     dependencies:
@@ -962,6 +978,12 @@ importers:
 
   packages/fair:
     dependencies:
+      '@noble/ed25519':
+        specifier: ^2.3.0
+        version: 2.3.0
+      '@noble/hashes':
+        specifier: ^1.3.0
+        version: 1.8.0
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
Replaces structural-only signature check with real Ed25519 verification using `verifyManifest()` from `@imajin/fair` and `createHttpResolver()` from `@imajin/auth`.

## Changes
- Signed manifests: full crypto verification via HTTP resolver → reject on failure (400)
- Unsigned manifests: warn + allow (transitional period)
- Funded/external settlements: skip verification (manifest from our own service)
- Logs `signature_verified: boolean` on each transaction's metadata (audit trail)
- Fixed pre-existing TS spread error in `packages/fair/src/sign.ts`

## Settlement Phase 1 completion
- ✅ Verify .fair signature before settlement
- ✅ Log signature verification result on transaction
- ✅ Emit `transaction.settled` attestation (#329)

[skip ci]