### PR TITLE
feat(connections): emit attestations on invite, accept, and vouch

### DIFF
--- a/apps/connections/.env.example
+++ b/apps/connections/.env.example
@@ -8,6 +8,7 @@ PORT=3003
 
 # Service URLs (internal)
 AUTH_SERVICE_URL=http://localhost:3001
+AUTH_INTERNAL_API_KEY=
 
 # Email (SendGrid)
 SENDGRID_API_KEY=SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/apps/connections/app/api/invites/[code]/accept/route.ts
+++ b/apps/connections/app/api/invites/[code]/accept/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { eq, sql } from 'drizzle-orm';
 import { db, invites, profiles, pods, podMembers } from '../../../../../src/db/index';
 import { generateId } from '../../../../../src/lib/id';
+import { emitAttestation } from '../../../../../src/lib/attestations';
 
 const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL!;
 const INVITE_COOLDOWN_DAYS = 7;
@@ -118,6 +119,28 @@ export async function POST(
       .set({ nextInviteAvailableAt: cooldownEnd })
       .where(eq(profiles.did, session.did));
   }
+
+  emitAttestation({
+    issuer_did: session.did,
+    subject_did: invite.fromDid,
+    type: 'connection.accepted',
+    context_id: podId,
+    context_type: 'connection',
+    payload: { invite_id: invite.id },
+  }).catch((err: unknown) => {
+    console.error('Attestation (connection.accepted) error:', err);
+  });
+
+  emitAttestation({
+    issuer_did: invite.fromDid,
+    subject_did: session.did,
+    type: 'vouch',
+    context_id: podId,
+    context_type: 'connection',
+    payload: { invite_id: invite.id, delivery: invite.delivery },
+  }).catch((err: unknown) => {
+    console.error('Attestation (vouch) error:', err);
+  });
 
   return NextResponse.json({
     ok: true,

--- a/apps/connections/app/api/invites/route.ts
+++ b/apps/connections/app/api/invites/route.ts
@@ -4,6 +4,7 @@ import { eq, desc, and, sql, isNull } from 'drizzle-orm';
 import { db, invites, profiles, podMembers } from '../../../src/db/index';
 import { generateId } from '../../../src/lib/id';
 import { sendEmail, trustGraphInviteEmail } from '@imajin/email';
+import { emitAttestation } from '../../../src/lib/attestations';
 
 const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL!;
 const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -151,6 +152,17 @@ export async function POST(request: NextRequest) {
       console.error('Failed to send invite email:', err);
     });
 
+    emitAttestation({
+      issuer_did: session.did,
+      subject_did: session.did,
+      type: 'connection.invited',
+      context_id: invite.id,
+      context_type: 'connection',
+      payload: { delivery: invite.delivery },
+    }).catch((err: unknown) => {
+      console.error('Attestation (connection.invited) error:', err);
+    });
+
     return NextResponse.json({ invite, url: inviteUrl }, { status: 201 });
   }
 
@@ -191,6 +203,17 @@ export async function POST(request: NextRequest) {
   }).returning();
 
   const inviteUrl = `${SERVICE_PREFIX}connections.${DOMAIN}/invite/${session.did}/${code}`;
+
+  emitAttestation({
+    issuer_did: session.did,
+    subject_did: session.did,
+    type: 'connection.invited',
+    context_id: invite.id,
+    context_type: 'connection',
+    payload: { delivery: invite.delivery },
+  }).catch((err: unknown) => {
+    console.error('Attestation (connection.invited) error:', err);
+  });
 
   return NextResponse.json({
     invite,

--- a/apps/connections/src/lib/attestations.ts
+++ b/apps/connections/src/lib/attestations.ts
@@ -1,0 +1,31 @@
+export async function emitAttestation(params: {
+  issuer_did: string;
+  subject_did: string;
+  type: string;
+  context_id: string;
+  context_type: string;
+  payload?: Record<string, unknown>;
+}): Promise<void> {
+  const authServiceUrl = process.env.AUTH_SERVICE_URL;
+  const internalApiKey = process.env.AUTH_INTERNAL_API_KEY;
+  if (!authServiceUrl || !internalApiKey) {
+    console.warn('Attestation skipped: AUTH_SERVICE_URL or AUTH_INTERNAL_API_KEY not set');
+    return;
+  }
+  try {
+    const res = await fetch(`${authServiceUrl}/api/attestations/internal`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${internalApiKey}`,
+      },
+      body: JSON.stringify(params),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      console.error(`Attestation (${params.type}) failed: ${res.status} ${text}`);
+    }
+  } catch (err) {
+    console.error(`Attestation (${params.type}) error:`, err);
+  }
+}

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@imajin/config": "workspace:*",
     "@noble/ed25519": "^2.3.0",
-    "@noble/hashes": "^1.3.0"
+    "@noble/hashes": "^1.7.2"
   },
   "devDependencies": {
     "drizzle-orm": "^0.45.1"

--- a/packages/auth/src/types/attestation.ts
+++ b/packages/auth/src/types/attestation.ts
@@ -12,6 +12,9 @@ export const ATTESTATION_TYPES = [
   'flag.cleared',
   'transaction.settled',
   'customer',
+  'connection.invited',
+  'connection.accepted',
+  'vouch',
 ] as const;
 
 export type AttestationType = typeof ATTESTATION_TYPES[number];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -921,7 +921,7 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       '@noble/hashes':
-        specifier: ^1.3.0
+        specifier: ^1.7.2
         version: 1.8.0
       next:
         specifier: '>=14'


### PR DESCRIPTION
Wires attestation emission into the connections service — the trust graph building blocks.

## Attestation types added
- `connection.invited` — emitted when someone sends an invite (both email and link flows)
- `connection.accepted` — emitted when someone accepts an invite
- `vouch` — emitted on accept (inviter implicitly vouches for acceptee)

## Changes
- `apps/connections/src/lib/attestations.ts` — reusable `emitAttestation()` helper (same pattern as pay)
- `apps/connections/app/api/invites/route.ts` — emits `connection.invited` on both email and link invite creation
- `apps/connections/app/api/invites/[code]/accept/route.ts` — emits `connection.accepted` + `vouch` on accept
- `packages/auth/src/types/attestation.ts` — added 3 new types to the union
- `apps/connections/.env.example` — documented `AUTH_INTERNAL_API_KEY`

All attestations fire async (`.catch()`) and never block the API response.

[skip ci]