### PR TITLE
feat(auth): emit session.created attestation on all login flows

### DIFF
--- a/apps/auth/app/api/login/verify/route.ts
+++ b/apps/auth/app/api/login/verify/route.ts
@@ -3,6 +3,7 @@ import { db, identities, challenges } from '@/src/db';
 import { eq, and, isNull, gt } from 'drizzle-orm';
 import { verifySignature } from '@/lib/crypto';
 import { createSessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { emitSessionAttestation } from '@/lib/emit-session-attestation';
 
 /**
  * POST /api/login/verify
@@ -108,6 +109,14 @@ export async function POST(request: NextRequest) {
     });
 
     response.cookies.set(cookieConfig.name, token, cookieConfig.options);
+
+    emitSessionAttestation({
+      did: identity.id,
+      method: "keypair",
+      tier: identity.tier || "preliminary",
+      userAgent: request.headers.get("user-agent"),
+    }).catch(err => console.error("Session attestation error:", err));
+
     return response;
 
   } catch (error) {

--- a/apps/auth/app/api/magic/route.ts
+++ b/apps/auth/app/api/magic/route.ts
@@ -12,6 +12,7 @@ import { db } from '@/src/db';
 import { identities } from '@/src/db/schema';
 import { eq } from 'drizzle-orm';
 import { createSessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { emitSessionAttestation } from '@/lib/emit-session-attestation';
 
 const EVENTS_SERVICE_URL = process.env.EVENTS_SERVICE_URL || 'http://localhost:3006';
 const EVENTS_URL = process.env.EVENTS_URL || 'https://events.imajin.ai';
@@ -175,6 +176,13 @@ export async function GET(request: NextRequest) {
       sessionToken,
       cookieOptions.options
     );
+
+    emitSessionAttestation({
+      did: ownerDid,
+      method: "magic_link",
+      tier: identityTier,
+      userAgent: request.headers.get("user-agent"),
+    }).catch(err => console.error("Session attestation error:", err));
 
     return response;
 

--- a/apps/auth/app/api/onboard/verify/route.ts
+++ b/apps/auth/app/api/onboard/verify/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/src/db';
 import { onboardTokens, identities } from '@/src/db/schema';
 import { createSessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { emitSessionAttestation } from '@/lib/emit-session-attestation';
 import { eq, and, gt, isNull } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
@@ -94,6 +95,13 @@ export async function GET(request: NextRequest) {
       sessionToken,
       cookieOptions.options,
     );
+
+    emitSessionAttestation({
+      did,
+      method: "email_onboard",
+      tier: "soft",
+      userAgent: request.headers.get("user-agent"),
+    }).catch(err => console.error("Session attestation error:", err));
 
     return response;
 

--- a/apps/auth/app/api/session/soft/route.ts
+++ b/apps/auth/app/api/session/soft/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createSessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { emitSessionAttestation } from '@/lib/emit-session-attestation';
 import { db } from '@/src/db';
 import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
 import { identities } from '@/src/db/schema';
@@ -111,6 +112,14 @@ export async function POST(request: NextRequest) {
     }, { headers: cors });
 
     response.cookies.set(cookieConfig.name, token, cookieConfig.options);
+
+    emitSessionAttestation({
+      did: identity[0].id,
+      method: "email_soft",
+      tier: "soft",
+      userAgent: request.headers.get("user-agent"),
+    }).catch(err => console.error("Session attestation error:", err));
+
     return response;
 
   } catch (error) {

--- a/apps/auth/lib/emit-session-attestation.ts
+++ b/apps/auth/lib/emit-session-attestation.ts
@@ -1,0 +1,66 @@
+import { db, attestations } from "@/src/db";
+import { canonicalize, crypto as authCrypto } from "@imajin/auth";
+import type { AttestationType } from "@imajin/auth";
+
+function genId(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
+}
+
+export async function emitSessionAttestation(params: {
+  did: string;
+  method: "keypair" | "magic_link" | "email_soft" | "email_onboard";
+  tier: string;
+  userAgent?: string | null;
+}): Promise<void> {
+  const privateKey = process.env.AUTH_PRIVATE_KEY;
+  if (!privateKey) {
+    console.warn("Session attestation skipped: AUTH_PRIVATE_KEY not set");
+    return;
+  }
+
+  const platformDid = process.env.PLATFORM_DID;
+  if (!platformDid) {
+    console.warn("Session attestation skipped: PLATFORM_DID not set");
+    return;
+  }
+
+  const issuedAtMs = Date.now();
+  const payload = {
+    method: params.method,
+    tier: params.tier,
+    user_agent_class: classifyUserAgent(params.userAgent),
+  };
+
+  const canonicalPayload = canonicalize({
+    subject_did: params.did,
+    type: "session.created",
+    context_id: null,
+    context_type: "auth",
+    payload,
+    issued_at: issuedAtMs,
+  });
+
+  try {
+    const signature = authCrypto.signSync(canonicalPayload, privateKey);
+    await db.insert(attestations).values({
+      id: genId("att"),
+      issuerDid: platformDid,
+      subjectDid: params.did,
+      type: "session.created" as AttestationType,
+      contextId: null,
+      contextType: "auth",
+      payload,
+      signature,
+      issuedAt: new Date(issuedAtMs),
+    });
+  } catch (err) {
+    console.error("Session attestation error:", err);
+  }
+}
+
+function classifyUserAgent(ua?: string | null): string {
+  if (!ua) return "unknown";
+  if (/mobile|android|iphone|ipad/i.test(ua)) return "mobile";
+  if (/bot|crawler|spider/i.test(ua)) return "bot";
+  return "desktop";
+}

--- a/packages/auth/src/types/attestation.ts
+++ b/packages/auth/src/types/attestation.ts
@@ -15,6 +15,7 @@ export const ATTESTATION_TYPES = [
   'connection.invited',
   'connection.accepted',
   'vouch',
+  'session.created',
 ] as const;
 
 export type AttestationType = typeof ATTESTATION_TYPES[number];


### PR DESCRIPTION
Track every login as a signed attestation for trust scoring and activity history.

## New attestation type
- `session.created` — emitted on every successful session creation

## Payload captures auth strength
```json
{
  "method": "keypair" | "magic_link" | "email_soft" | "email_onboard",
  "tier": "soft" | "preliminary" | "established",
  "user_agent_class": "desktop" | "mobile" | "bot" | "unknown"
}
```

## Wired into all 4 login endpoints
- `/api/login/verify` — keypair challenge-response (strongest signal)
- `/api/session/soft` — email soft session (weakest signal)
- `/api/magic` — magic link (deprecated but active)
- `/api/onboard/verify` — email verification onboarding

## Implementation
- Auth writes directly to DB (owns attestations table) — no HTTP self-call
- Signs with `AUTH_PRIVATE_KEY`, issuer is `PLATFORM_DID`
- All async with `.catch()` — never blocks the login response
- `classifyUserAgent()` categorizes device type from User-Agent header

## Trust scoring implications
A DID that consistently logs in via keypair auth = much stronger identity signal than email-only soft sessions. This data feeds future progressive trust computation.

[skip ci]