### PR TITLE
feat(media,profile): presence bootstrap .imajin folder (#258)

### DIFF
--- a/apps/media/.env.example
+++ b/apps/media/.env.example
@@ -12,5 +12,8 @@ AUTH_SERVICE_URL=http://localhost:3001
 # Storage
 MEDIA_ROOT=/mnt/media
 
+# Internal API keys
+MEDIA_INTERNAL_API_KEY=
+
 # Public URLs (client-side)
 NEXT_PUBLIC_AUTH_URL=http://localhost:3001

--- a/apps/media/app/api/presence/[did]/route.ts
+++ b/apps/media/app/api/presence/[did]/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "fs/promises";
+import { db, assets, folders, assetFolders } from "@/src/db";
+import { eq, and } from "drizzle-orm";
+
+export const dynamic = "force-dynamic";
+
+function requireInternalAuth(request: NextRequest): boolean {
+  const apiKey = request.headers.get("authorization")?.replace("Bearer ", "");
+  const expectedKey = process.env.MEDIA_INTERNAL_API_KEY;
+  return !!(expectedKey && apiKey === expectedKey);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/presence/[did] — read .imajin folder contents for a DID
+// ---------------------------------------------------------------------------
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { did: string } }
+) {
+  if (!requireInternalAuth(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { did } = params;
+  if (!did) {
+    return NextResponse.json({ error: "did is required" }, { status: 400 });
+  }
+
+  // Find .imajin folder for this DID
+  const folder = await db
+    .select()
+    .from(folders)
+    .where(and(eq(folders.ownerDid, did), eq(folders.name, ".imajin"), eq(folders.isSystem, true)))
+    .limit(1);
+
+  if (folder.length === 0) {
+    return NextResponse.json(
+      { did, soul: null, context: null, config: null, seeded: false },
+      { status: 200 }
+    );
+  }
+
+  // Get assets linked to this folder
+  const linkedAssets = await db
+    .select({ asset: assets })
+    .from(assetFolders)
+    .innerJoin(assets, eq(assets.id, assetFolders.assetId))
+    .where(eq(assetFolders.folderId, folder[0].id));
+
+  const assetMap = Object.fromEntries(
+    linkedAssets.map(({ asset }) => [asset.filename, asset])
+  );
+
+  async function readAssetText(filename: string): Promise<string | null> {
+    const asset = assetMap[filename];
+    if (!asset?.storagePath) return null;
+    try {
+      return await readFile(asset.storagePath, "utf8");
+    } catch {
+      return null;
+    }
+  }
+
+  const [soulText, contextText, configText] = await Promise.all([
+    readAssetText("soul.md"),
+    readAssetText("context.md"),
+    readAssetText("config.json"),
+  ]);
+
+  let config: object | null = null;
+  if (configText) {
+    try {
+      config = JSON.parse(configText);
+    } catch {
+      config = null;
+    }
+  }
+
+  return NextResponse.json({
+    did,
+    soul: soulText,
+    context: contextText,
+    config,
+    seeded: true,
+  });
+}

--- a/apps/media/app/api/seed/presence/route.ts
+++ b/apps/media/app/api/seed/presence/route.ts
@@ -1,0 +1,227 @@
+/**
+ * POST /api/seed/presence
+ *
+ * Internal endpoint: seeds a .imajin/ folder with default presence files.
+ * Called by profile service on registration and inference toggle.
+ * Authenticated via Bearer token (MEDIA_INTERNAL_API_KEY).
+ * Idempotent — safe to call multiple times.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { nanoid } from "nanoid";
+import { createHash } from "crypto";
+import { mkdir, writeFile } from "fs/promises";
+import { db, assets, folders, assetFolders } from "@/src/db";
+import { eq, and } from "drizzle-orm";
+
+const MEDIA_ROOT = process.env.MEDIA_ROOT || "/mnt/media";
+
+function didToPath(did: string): string {
+  return did.replace(/:/g, "_").replace(/[^a-zA-Z0-9._@-]/g, "_");
+}
+
+interface SeedFile {
+  filename: string;
+  content: string;
+  mimeType: string;
+}
+
+function getDefaultFiles(handle?: string): SeedFile[] {
+  const who = handle || "your";
+  return [
+    {
+      filename: "soul.md",
+      mimeType: "text/markdown",
+      content: `# I'm ${who}'s presence
+
+Edit this file to define who I am, how I speak, and what I care about.
+
+## Personality
+
+<!-- What's my tone? Formal? Casual? Playful? Direct? -->
+
+## Boundaries
+
+<!-- What topics should I avoid? What should I never do? -->
+`,
+    },
+    {
+      filename: "context.md",
+      mimeType: "text/markdown",
+      content: `# Knowledge & Interests
+
+What topics should I know about? What's my expertise?
+
+## Expertise
+
+<!-- List areas of knowledge, skills, professional background -->
+
+## Interests
+
+<!-- What do I care about? What should I follow? -->
+
+## Sources
+
+<!-- Links, documents, or references I should draw from -->
+`,
+    },
+    {
+      filename: "config.json",
+      mimeType: "application/json",
+      content: JSON.stringify(
+        {
+          model: "default",
+          temperature: 0.7,
+          maxTokens: 2048,
+        },
+        null,
+        2
+      ),
+    },
+  ];
+}
+
+export async function POST(request: NextRequest) {
+  // Internal API key auth
+  const apiKey = request.headers
+    .get("authorization")
+    ?.replace("Bearer ", "");
+  const expectedKey = process.env.MEDIA_INTERNAL_API_KEY;
+
+  if (!expectedKey || apiKey !== expectedKey) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { did?: string; handle?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { did, handle } = body;
+  if (!did || typeof did !== "string") {
+    return NextResponse.json({ error: "did is required" }, { status: 400 });
+  }
+
+  // Check if .imajin folder already exists for this DID
+  const existing = await db
+    .select()
+    .from(folders)
+    .where(
+      and(
+        eq(folders.ownerDid, did),
+        eq(folders.name, ".imajin"),
+        eq(folders.isSystem, true)
+      )
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    // Already seeded — return existing state
+    const folder = existing[0];
+    const existingAssets = await db
+      .select({ assetId: assetFolders.assetId })
+      .from(assetFolders)
+      .where(eq(assetFolders.folderId, folder.id));
+
+    return NextResponse.json({
+      message: "Already seeded",
+      folderId: folder.id,
+      assetIds: existingAssets.map((a) => a.assetId),
+    });
+  }
+
+  // Create .imajin folder
+  const folderId = `folder_${nanoid(16)}`;
+
+  try {
+    await db.insert(folders).values({
+      id: folderId,
+      ownerDid: did,
+      name: ".imajin",
+      icon: "🟠",
+      isSystem: true,
+      sortOrder: -1, // Sort before user folders
+    });
+  } catch (err) {
+    console.error("[Presence] Folder creation failed:", err);
+    return NextResponse.json(
+      { error: "Failed to create folder" },
+      { status: 500 }
+    );
+  }
+
+  // Seed default files
+  const didPath = didToPath(did);
+  const dirPath = `${MEDIA_ROOT}/${didPath}/assets`;
+  const seedFiles = getDefaultFiles(handle);
+  const assetIds: string[] = [];
+
+  try {
+    await mkdir(dirPath, { recursive: true });
+
+    for (const file of seedFiles) {
+      const assetId = `asset_${nanoid(16)}`;
+      const buffer = Buffer.from(file.content, "utf-8");
+      const hash = createHash("sha256").update(buffer).digest("hex");
+      const storagePath = `${dirPath}/${assetId}_${file.filename}`;
+      const fairPath = `${dirPath}/${assetId}.fair.json`;
+
+      const fairManifest = {
+        fair: "1.0",
+        id: assetId,
+        type: file.mimeType,
+        owner: did,
+        created: new Date().toISOString(),
+        source: "presence-seed",
+        access: { type: "private" },
+        attribution: [{ did, role: "creator", share: 1.0 }],
+        transfer: { allowed: false },
+      };
+
+      // Write file + .fair sidecar to disk
+      await writeFile(storagePath, buffer);
+      await writeFile(fairPath, JSON.stringify(fairManifest, null, 2));
+
+      // Insert asset record
+      await db.insert(assets).values({
+        id: assetId,
+        ownerDid: did,
+        filename: file.filename,
+        mimeType: file.mimeType,
+        size: buffer.length,
+        storagePath,
+        hash,
+        fairManifest,
+        fairPath,
+        status: "active",
+        metadata: { context: { app: "presence", feature: "seed" } },
+      });
+
+      // Link to .imajin folder
+      await db
+        .insert(assetFolders)
+        .values({ assetId, folderId })
+        .onConflictDoNothing();
+
+      assetIds.push(assetId);
+    }
+  } catch (err) {
+    console.error("[Presence] File seeding failed:", err);
+    return NextResponse.json(
+      { error: "Failed to seed files", detail: String(err) },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      message: "Presence seeded",
+      folderId,
+      assetIds,
+      files: seedFiles.map((f) => f.filename),
+    },
+    { status: 201 }
+  );
+}

--- a/apps/profile/.env.example
+++ b/apps/profile/.env.example
@@ -7,6 +7,8 @@ DATABASE_URL=postgres://user:password@localhost:5432/imajin_dev
 AUTH_SERVICE_URL=http://localhost:3001
 CONNECTIONS_SERVICE_URL=http://localhost:3003
 LINKS_SERVICE_URL=http://localhost:3102
+MEDIA_SERVICE_URL=http://localhost:3009
+MEDIA_INTERNAL_API_KEY=
 COFFEE_SERVICE_URL=http://localhost:3100
 
 # Public URLs (client-side)

--- a/apps/profile/app/api/profile/inference/route.ts
+++ b/apps/profile/app/api/profile/inference/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from 'next/server';
+import { db, profiles } from '@/db';
+import { requireAuth } from '@/lib/auth';
+import { jsonResponse, errorResponse } from '@/lib/utils';
+import { eq } from 'drizzle-orm';
+
+/**
+ * POST /api/profile/inference - Toggle inference (AI presence) for the authenticated user
+ */
+export async function POST(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status);
+  }
+
+  const { identity } = authResult;
+
+  let body: { enabled?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Invalid JSON body');
+  }
+
+  if (typeof body.enabled !== 'boolean') {
+    return errorResponse('enabled (boolean) is required');
+  }
+
+  const { enabled } = body;
+
+  // Before enabling, fire-and-forget presence seed in media service
+  if (enabled) {
+    const mediaUrl = process.env.MEDIA_SERVICE_URL;
+    const mediaKey = process.env.MEDIA_INTERNAL_API_KEY;
+    if (mediaUrl && mediaKey) {
+      const profile = await db.query.profiles.findFirst({
+        where: (profiles, { eq }) => eq(profiles.did, identity.id),
+      });
+      fetch(`${mediaUrl}/api/seed/presence`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${mediaKey}` },
+        body: JSON.stringify({ did: identity.id, handle: profile?.handle || undefined }),
+      }).catch(err => console.error('[Presence] Seed failed (non-fatal):', err));
+    }
+  }
+
+  // Update inference_enabled on the profile row
+  const result = await db
+    .update(profiles)
+    .set({ inferenceEnabled: enabled })
+    .where(eq(profiles.did, identity.id))
+    .returning();
+
+  const updated = Array.isArray(result) ? result[0] : result;
+  if (!updated) {
+    return errorResponse('Profile not found', 404);
+  }
+
+  return jsonResponse(updated);
+}

--- a/apps/profile/app/api/register/route.ts
+++ b/apps/profile/app/api/register/route.ts
@@ -126,6 +126,17 @@ export async function POST(request: NextRequest) {
 
     const profile = Array.isArray(result) ? result[0] : result;
 
+    // Fire-and-forget presence seed (non-fatal)
+    const mediaUrl = process.env.MEDIA_SERVICE_URL;
+    const mediaKey = process.env.MEDIA_INTERNAL_API_KEY;
+    if (mediaUrl && mediaKey) {
+      fetch(`${mediaUrl}/api/seed/presence`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${mediaKey}` },
+        body: JSON.stringify({ did, handle: handle || undefined }),
+      }).catch(err => console.error('[Presence] Seed failed (non-fatal):', err));
+    }
+
     return jsonResponse({
       did: profile.did,
       handle: profile.handle,

--- a/apps/profile/migrations/0002_add_inference_enabled.sql
+++ b/apps/profile/migrations/0002_add_inference_enabled.sql
@@ -1,0 +1,2 @@
+-- Add inference_enabled to profiles for presence toggle
+ALTER TABLE profile.profiles ADD COLUMN IF NOT EXISTS inference_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/apps/profile/src/db/schema.ts
+++ b/apps/profile/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, jsonb, index, real, pgSchema, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, jsonb, index, real, boolean, pgSchema, uniqueIndex } from 'drizzle-orm/pg-core';
 
 export const profileSchema = pgSchema('profile');
 
@@ -20,6 +20,7 @@ export const profiles = profileSchema.table('profiles', {
   nextInviteAvailableAt: timestamp('next_invite_available_at', { withTimezone: true }), // NULL = can invite now
   metadata: jsonb('metadata').default({}),                    // location, website, etc.
   lastSeenAt: timestamp('last_seen_at', { withTimezone: true }), // Online presence tracking
+  inferenceEnabled: boolean('inference_enabled').notNull().default(false), // Presence queryable
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({


### PR DESCRIPTION
## Summary

Seeds a `.imajin/` folder with default presence files (soul.md, context.md, config.json) into each user's DID-pegged media store. This is the foundation for sovereign inference (#256).

## What's New

### Media Service
- **`POST /api/seed/presence`** — Internal endpoint that creates `.imajin` system folder + seeds 3 default files. Idempotent. Bearer token auth.
- **`GET /api/presence/:did`** — Internal endpoint that reads composed `.imajin/` contents (soul text, context text, config JSON). Used by profile to assemble the full presence payload.

### Profile Service  
- **`inference_enabled`** column on profiles (boolean, default false)
- **`POST /api/profile/inference`** — Toggle endpoint. Seeds `.imajin/` via media before enabling. Checks handle for personalized soul.md.
- **Registration** — Fire-and-forget seed call after profile creation. Every hard DID gets a presence skeleton automatically.

### Default Files
- `soul.md` — Personality, tone, boundaries (personalized with handle)
- `context.md` — Knowledge sources, interests, expertise
- `config.json` — Model preferences (`{ model: 'default', temperature: 0.7, maxTokens: 2048 }`)

## Architecture
- Profile is the orchestrator, media serves files
- Same internal API key pattern as auth attestations (`MEDIA_INTERNAL_API_KEY`)
- .fair manifests created for all seeded files (source: `presence-seed`, access: `private`)

## Migration
```sql
ALTER TABLE profile.profiles ADD COLUMN IF NOT EXISTS inference_enabled BOOLEAN NOT NULL DEFAULT false;
```

Closes #258