### PR TITLE
feat: @imajin/llm provider abstraction package (#34)

### DIFF
--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@imajin/llm",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.0"
+  }
+}

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -1,0 +1,3 @@
+export type { Message, CompletionRequest, CompletionResponse, LLMProvider } from './types';
+export { AnthropicProvider, LLMError } from './providers/anthropic';
+export { createProvider, getDefaultProvider } from './registry';

--- a/packages/llm/src/providers/anthropic.ts
+++ b/packages/llm/src/providers/anthropic.ts
@@ -1,0 +1,67 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { CompletionRequest, CompletionResponse, LLMProvider } from '../types';
+
+// Rates in USD per million tokens
+const MODEL_RATES: Record<string, { input: number; output: number }> = {
+  'claude-sonnet-4-20250514': { input: 3, output: 15 },
+  'claude-haiku-3-20250307': { input: 0.25, output: 1.25 },
+  'claude-opus-4-20250514': { input: 15, output: 75 },
+};
+
+const DEFAULT_RATES = MODEL_RATES['claude-sonnet-4-20250514'];
+
+export class LLMError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'LLMError';
+  }
+}
+
+export class AnthropicProvider implements LLMProvider {
+  readonly name = 'anthropic';
+  private client: Anthropic;
+
+  constructor({ apiKey }: { apiKey: string }) {
+    this.client = new Anthropic({ apiKey });
+  }
+
+  estimateCost(model: string, promptTokens: number, completionTokens: number): number {
+    const rates = MODEL_RATES[model] ?? DEFAULT_RATES;
+    return (promptTokens * rates.input + completionTokens * rates.output) / 1_000_000;
+  }
+
+  async complete(request: CompletionRequest): Promise<CompletionResponse> {
+    try {
+      const response = await this.client.messages.create({
+        model: request.model,
+        max_tokens: request.maxTokens ?? 1024,
+        system: request.system,
+        messages: request.messages,
+        ...(request.temperature !== undefined && { temperature: request.temperature }),
+      });
+
+      const content = response.content
+        .filter((block) => block.type === 'text')
+        .map((block) => (block as { type: 'text'; text: string }).text)
+        .join('');
+
+      const promptTokens = response.usage.input_tokens;
+      const completionTokens = response.usage.output_tokens;
+
+      return {
+        content,
+        usage: { promptTokens, completionTokens },
+        model: response.model,
+        cost: this.estimateCost(response.model, promptTokens, completionTokens),
+      };
+    } catch (err) {
+      if (err instanceof Anthropic.APIError) {
+        throw new LLMError(`Anthropic API error ${err.status}: ${err.message}`, err);
+      }
+      throw new LLMError('Unexpected error calling Anthropic API', err);
+    }
+  }
+}

--- a/packages/llm/src/registry.ts
+++ b/packages/llm/src/registry.ts
@@ -1,0 +1,17 @@
+import { AnthropicProvider } from './providers/anthropic';
+import type { LLMProvider } from './types';
+
+export function createProvider(config: { provider: string; apiKey: string }): LLMProvider {
+  switch (config.provider) {
+    case 'anthropic':
+      return new AnthropicProvider({ apiKey: config.apiKey });
+    default:
+      throw new Error(`Unknown provider: ${config.provider}`);
+  }
+}
+
+export function getDefaultProvider(): LLMProvider {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not set');
+  return new AnthropicProvider({ apiKey });
+}

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -1,0 +1,28 @@
+export interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface CompletionRequest {
+  model: string;
+  system: string;
+  messages: Message[];
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface CompletionResponse {
+  content: string;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+  };
+  model: string;
+  cost: number; // USD, calculated from token rates
+}
+
+export interface LLMProvider {
+  name: string;
+  complete(request: CompletionRequest): Promise<CompletionResponse>;
+  estimateCost(model: string, promptTokens: number, completionTokens: number): number;
+}

--- a/packages/llm/tsconfig.json
+++ b/packages/llm/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

New shared package `@imajin/llm` at `packages/llm/` — pluggable LLM provider abstraction for sovereign inference.

## What's In It

- **Types** — `LLMProvider`, `CompletionRequest`, `CompletionResponse`, `Message`
- **AnthropicProvider** — Full implementation using `@anthropic-ai/sdk`. Handles messages API, token counting, cost calculation from known per-model rates (Sonnet/Haiku/Opus).
- **Registry** — `createProvider()` factory + `getDefaultProvider()` (reads `ANTHROPIC_API_KEY` from env)
- **LLMError** — Standard error wrapper for provider errors

## Cost Rates

| Model | Input | Output |
|-------|-------|--------|
| claude-sonnet-4 | $3/MTok | $15/MTok |
| claude-haiku-3 | $0.25/MTok | $1.25/MTok |
| claude-opus-4 | $15/MTok | $75/MTok |

## Usage

```typescript
import { getDefaultProvider } from '@imajin/llm';

const llm = getDefaultProvider();
const response = await llm.complete({
  model: 'claude-sonnet-4-20250514',
  system: 'You are Ryan'\''s presence...',
  messages: [{ role: 'user', content: 'What does Ryan think about sovereignty?' }],
});
// response.content, response.usage, response.cost
```

## 144 lines, 6 files. No new service — just a package.

Closes #34