### PR TITLE
feat(llm): media-aware sovereign inference — searchAssets + readAsset tools (#350)

### DIFF
--- a/apps/media/app/api/assets/[id]/content/route.ts
+++ b/apps/media/app/api/assets/[id]/content/route.ts
@@ -1,9 +1,84 @@
 import { NextRequest, NextResponse } from "next/server";
-import { writeFile } from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import { createHash } from "crypto";
 import { db, assets } from "@/src/db";
 import { requireAuth } from "@/src/lib/auth";
 import { eq } from "drizzle-orm";
+import type { FairManifest } from "@imajin/fair";
+
+function getAccessType(access: FairManifest["access"]): string {
+  if (!access) return "private";
+  if (typeof access === "string") return access;
+  return access.type ?? "private";
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/assets/[id]/content — read text content of a file
+// ---------------------------------------------------------------------------
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  let asset;
+  try {
+    [asset] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  } catch (err) {
+    console.error("DB lookup failed:", err);
+    return NextResponse.json({ error: "Database failure" }, { status: 500 });
+  }
+
+  if (!asset || asset.status !== "active") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Only serve text/* and application/json
+  const isReadable =
+    asset.mimeType.startsWith("text/") || asset.mimeType === "application/json";
+  if (!isReadable) {
+    return NextResponse.json(
+      { error: "Not a text file", mimeType: asset.mimeType },
+      { status: 415 }
+    );
+  }
+
+  // Determine .fair access level
+  const manifest = asset.fairManifest as FairManifest | null;
+  const accessType = getAccessType(manifest?.access ?? "private");
+
+  // Internal API key auth: allow read for public/trust-graph assets
+  const internalApiKey = process.env.MEDIA_INTERNAL_API_KEY;
+  const authHeader = request.headers.get("Authorization");
+  const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+  if (bearerToken && internalApiKey && bearerToken === internalApiKey) {
+    if (accessType !== "public" && accessType !== "trust-graph") {
+      return NextResponse.json(
+        { error: "Access denied", reason: "Asset is private" },
+        { status: 403 }
+      );
+    }
+  } else {
+    // Fall through to cookie auth — owner always allowed
+    const authResult = await requireAuth(request);
+    if ("error" in authResult) {
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+    if (authResult.identity.id !== asset.ownerDid) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+
+  let content: string;
+  try {
+    content = await readFile(asset.storagePath, "utf-8");
+  } catch {
+    return NextResponse.json({ error: "File not found on storage" }, { status: 404 });
+  }
+
+  return NextResponse.json({ content, filename: asset.filename });
+}
 
 // ---------------------------------------------------------------------------
 // PUT /api/assets/[id]/content — overwrite text file content (owner only)

--- a/apps/media/app/api/assets/route.ts
+++ b/apps/media/app/api/assets/route.ts
@@ -264,19 +264,34 @@ export async function POST(request: NextRequest) {
 }
 
 // ---------------------------------------------------------------------------
-// GET /api/assets — list assets for authenticated user
+// GET /api/assets — list assets for authenticated user (or via internal API key)
 // ---------------------------------------------------------------------------
 export async function GET(request: NextRequest) {
   const cors = corsHeaders(request);
-  const authResult = await requireAuth(request);
-  if ("error" in authResult) {
-    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+
+  // Internal API key auth: Bearer token + X-Owner-DID header
+  const internalApiKey = process.env.MEDIA_INTERNAL_API_KEY;
+  const authHeader = request.headers.get("Authorization");
+  const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+  let ownerDid: string;
+  if (bearerToken && internalApiKey && bearerToken === internalApiKey) {
+    const ownerDidHeader = request.headers.get("X-Owner-DID");
+    if (!ownerDidHeader) {
+      return NextResponse.json({ error: "X-Owner-DID header required" }, { status: 400, headers: cors });
+    }
+    ownerDid = ownerDidHeader;
+  } else {
+    const authResult = await requireAuth(request);
+    if ("error" in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+    }
+    ownerDid = authResult.identity.id;
   }
-  const { identity } = authResult;
-  const ownerDid = identity.id;
 
   const { searchParams } = new URL(request.url);
-  const type = searchParams.get("type");         // e.g. "image"
+  const search = searchParams.get("search");      // filename search
+  const type = searchParams.get("type");          // e.g. "image"
   const sort = searchParams.get("sort") || "created";
   const order = searchParams.get("order") || "desc";
   const limit = Math.min(parseInt(searchParams.get("limit") || "50", 10), 200);
@@ -288,7 +303,6 @@ export async function GET(request: NextRequest) {
     // Build where conditions
     const conditions = [eq(assets.ownerDid, ownerDid), eq(assets.status, "active")];
 
-    // Type filter (mime prefix match)
     let rows = await db
       .select()
       .from(assets)
@@ -301,9 +315,15 @@ export async function GET(request: NextRequest) {
       .limit(limit)
       .offset(offset);
 
-    // Post-filter by MIME prefix (simple; can be pushed to DB if needed)
+    // Post-filter by MIME prefix
     if (type) {
       rows = rows.filter((r) => r.mimeType.startsWith(`${type}/`));
+    }
+
+    // Post-filter by filename search
+    if (search) {
+      const q = search.toLowerCase();
+      rows = rows.filter((r) => r.filename.toLowerCase().includes(q));
     }
 
     return NextResponse.json({ assets: rows, limit, offset, count: rows.length }, { headers: cors });

--- a/apps/profile/app/api/profile/[id]/stream/route.ts
+++ b/apps/profile/app/api/profile/[id]/stream/route.ts
@@ -97,8 +97,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   // 6. System prompt
   const soulMd = presenceData.soul ?? '';
   const contextMd = presenceData.context ?? '';
-  const systemPrompt = [soulMd, contextMd].filter(Boolean).join('\n\n') ||
-    `You are the presence of ${profile.displayName}. Answer questions helpfully and authentically.`;
+  const bootstrap = '\n\n## Available Tools\nYou have tools to interact with the Imajin platform. When someone asks about essays, documents, or files — use searchAssets to find them, then readAsset to read their content. Do not say you lack access without searching first.\n\nAvailable: searchAssets (find files by name), readAsset (read text file content), getProfile, getEvents, getConnections, getAttestations.';
+  const systemPrompt = ([soulMd, contextMd].filter(Boolean).join('\n\n') ||
+    `You are the presence of ${profile.displayName}. Answer questions helpfully and authentically.`) + bootstrap;
 
   // 7. Parse body — convert useChat format to plain messages for streamText
   //    useChat sends messages with toolInvocations[] on assistant messages.
@@ -130,6 +131,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     payUrl: process.env.PAY_SERVICE_URL ?? '',
     profileUrl: process.env.NEXT_PUBLIC_PROFILE_URL ?? '',
     learnUrl: process.env.LEARN_SERVICE_URL ?? '',
+    mediaUrl: MEDIA_URL,
+    mediaApiKey: MEDIA_INTERNAL_API_KEY,
     targetDid: resolvedTargetDid,
     requesterDid,
     trustDistance,

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -24,5 +24,5 @@ export { generateText, streamText } from 'ai';
 export type { LanguageModelV1 } from 'ai';
 
 // Presence tools
-export { createPresenceTools, createEventTools, createConnectionTools, createAttestationTools, createProfileTools, createPayTools, createLearnTools } from './tools/index';
+export { createPresenceTools, createEventTools, createConnectionTools, createAttestationTools, createProfileTools, createPayTools, createLearnTools, createMediaTools } from './tools/index';
 export type { ToolConfig } from './tools/index';

--- a/packages/llm/src/tools/index.ts
+++ b/packages/llm/src/tools/index.ts
@@ -4,6 +4,7 @@ import { createAttestationTools } from './attestations';
 import { createProfileTools } from './profile';
 import { createPayTools } from './pay';
 import { createLearnTools } from './learn';
+import { createMediaTools } from './media';
 
 export { createEventTools } from './events';
 export { createConnectionTools } from './connections';
@@ -11,6 +12,7 @@ export { createAttestationTools } from './attestations';
 export { createProfileTools } from './profile';
 export { createPayTools } from './pay';
 export { createLearnTools } from './learn';
+export { createMediaTools } from './media';
 
 export interface ToolConfig {
   // Service URLs
@@ -20,6 +22,8 @@ export interface ToolConfig {
   payUrl: string;
   profileUrl: string;
   learnUrl: string;
+  mediaUrl?: string;
+  mediaApiKey?: string;
   // Conversation scope — every tool is bounded to these two participants
   targetDid: string;
   requesterDid: string;
@@ -52,6 +56,9 @@ export function createPresenceTools(config: ToolConfig) {
     Object.assign(tools, createConnectionTools({ connectionsUrl: config.connectionsUrl, ...scope, apiKey: config.internalApiKey }));
     Object.assign(tools, createAttestationTools({ authUrl: config.authUrl, ...scope, apiKey: config.internalApiKey }));
     Object.assign(tools, createLearnTools({ learnUrl: config.learnUrl, ...scope, apiKey: config.internalApiKey }));
+    if (config.mediaUrl && config.mediaApiKey) {
+      Object.assign(tools, createMediaTools({ mediaUrl: config.mediaUrl, apiKey: config.mediaApiKey, ...scope }));
+    }
   }
 
   // Self-query: full access (still scoped to self)

--- a/packages/llm/src/tools/media.ts
+++ b/packages/llm/src/tools/media.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { tool } from 'ai';
+import { safeFetch } from './utils';
+
+export function createMediaTools(config: {
+  mediaUrl: string;
+  apiKey: string;
+  targetDid: string;
+  requesterDid: string;
+}) {
+  const authHeaders: Record<string, string> = {
+    Authorization: `Bearer ${config.apiKey}`,
+    'X-Owner-DID': config.targetDid,
+  };
+
+  return {
+    searchAssets: tool({
+      description: 'Search the media library for files by name. Use this to find essays, documents, images, and other uploaded files.',
+      parameters: z.object({
+        query: z.string().describe('Search query — filename or keyword to match'),
+        type: z.string().optional().describe('Optional MIME prefix filter, e.g. "text" or "image"'),
+      }),
+      execute: async ({ query, type }) => {
+        const url = new URL('/api/assets', config.mediaUrl);
+        url.searchParams.set('search', query);
+        if (type) url.searchParams.set('type', type);
+        const result = await safeFetch(url.toString(), authHeaders) as any;
+        if (result?.assets) {
+          return result.assets.map((a: any) => ({
+            id: a.id,
+            filename: a.filename,
+            mimeType: a.mimeType,
+            size: a.size,
+            createdAt: a.createdAt,
+          }));
+        }
+        return result;
+      },
+    }),
+
+    readAsset: tool({
+      description: 'Read the text content of a file. Use this after searchAssets to retrieve essay content, documents, or configuration files.',
+      parameters: z.object({
+        id: z.string().describe('The asset ID from searchAssets'),
+      }),
+      execute: async ({ id }) => {
+        return safeFetch(
+          `${config.mediaUrl}/api/assets/${encodeURIComponent(id)}/content`,
+          authHeaders,
+        );
+      },
+    }),
+  };
+}


### PR DESCRIPTION
Adds `searchAssets` and `readAsset` tools to the sovereign inference system so presences can search and read files from the media library.

## What changed
- **`packages/llm/src/tools/media.ts`** — new `createMediaTools` with `searchAssets` + `readAsset`
- **`apps/media/app/api/assets/route.ts`** — internal API key auth path + `search` query param
- **`apps/media/app/api/assets/[id]/content/route.ts`** — GET handler for text file content with .fair access control
- **`apps/profile/app/api/profile/[id]/stream/route.ts`** — wires mediaUrl/mediaApiKey into tool config
- **`packages/llm/src/tools/index.ts`** — registers createMediaTools
- **`packages/llm/src/index.ts`** — exports createMediaTools

## Known issues
Tracked in #351 (priority:high):
- Post-filter search should be DB-level ILIKE
- API key comparison should use timingSafeEqual
- Tool bootstrap prompt should be auto-generated

Closes #350