### PR TITLE
chore: consolidate all RFCs into docs/rfcs/ with canonical numbering (01-16)

### DIFF
--- a/docs/rfcs/INDEX.md
+++ b/docs/rfcs/INDEX.md
@@ -1,0 +1,22 @@
+# Imajin RFCs
+
+Canonical location for all Imajin protocol and architecture RFCs. Each RFC has a corresponding [GitHub Discussion](https://github.com/ima-jin/imajin-ai/discussions) for community input.
+
+| RFC | Title | Status | Discussion |
+|-----|-------|--------|------------|
+| [01](./RFC-01-fair-attribution.md) | .fair Attribution from Commit History | Draft | [#15](https://github.com/ima-jin/imajin-ai/discussions/15) |
+| [02](./RFC-02-distribution-contracts.md) | Programmable Distribution Contracts | Draft | [#16](https://github.com/ima-jin/imajin-ai/discussions/16) |
+| [03](./RFC-03-memory-attribution.md) | Memory Attribution (HRPOS) | Stub | — |
+| [04](./RFC-04-settlement-protocol.md) | Settlement Protocol | Stub | — |
+| [05](./RFC-05-intent-bearing-transactions.md) | Intent-Bearing Transactions | Draft | — |
+| [06](./RFC-06-identity-portability.md) | Identity Portability & Backup Nodes | Draft | — |
+| [07](./RFC-07-cultural-did.md) | Cultural DID | Draft | [#252](https://github.com/ima-jin/imajin-ai/discussions/252) |
+| [08](./RFC-08-org-did.md) | Org DID | Draft | [#253](https://github.com/ima-jin/imajin-ai/discussions/253) |
+| [09](./RFC-09-application-plugin-architecture.md) | Application Plugin Architecture | Draft | [#254](https://github.com/ima-jin/imajin-ai/discussions/254) |
+| [10](./RFC-10-sovereign-user-data.md) | Sovereign User Data | Draft | [#255](https://github.com/ima-jin/imajin-ai/discussions/255) |
+| [11](./RFC-11-embedded-wallet.md) | Embedded Wallet | Draft | [#268](https://github.com/ima-jin/imajin-ai/discussions/268) |
+| [12](./RFC-12-mjn-token-economics.md) | MJN Token Economics | Draft | [#269](https://github.com/ima-jin/imajin-ai/discussions/269) |
+| [13](./RFC-13-progressive-trust-model.md) | Progressive Trust Model | Draft | [#271](https://github.com/ima-jin/imajin-ai/discussions/271) |
+| [14](./RFC-14-community-issuance-network.md) | Community Issuance Network | Draft | [#272](https://github.com/ima-jin/imajin-ai/discussions/272) |
+| [15](./RFC-15-trust-accountability-framework.md) | Trust Accountability Framework | Draft | [#273](https://github.com/ima-jin/imajin-ai/discussions/273) |
+| [16](./RFC-16-jin-workspace-agent.md) | Jin Workspace Agent Architecture | Draft | — |

--- a/docs/rfcs/RFC-01-fair-attribution.md
+++ b/docs/rfcs/RFC-01-fair-attribution.md
@@ -1,7 +1,10 @@
-# RFC: .fair Attribution from Commit History
+# RFC-01: .fair Attribution from Commit History
 
-**Category:** RFC / Architecture  
-**Status:** Open for discussion  
+**Status:** Open for discussion
+**Authors:** TBD
+**Created:** TBD
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/15
+**Category:** RFC / Architecture
 **Related:** [Bounty: imajin Syndication Service](#) *(link when live)*
 
 ---

--- a/docs/rfcs/RFC-02-distribution-contracts.md
+++ b/docs/rfcs/RFC-02-distribution-contracts.md
@@ -1,8 +1,11 @@
-# RFC + Bounty: Programmable Distribution Contracts
+# RFC-02: Programmable Distribution Contracts
 
-**Category:** RFC / Architecture / Bounty  
-**Status:** Open for discussion  
-**Related:** [RFC: .fair Attribution from Commit History](#) *(link when live)*  
+**Status:** Open for discussion
+**Authors:** TBD
+**Created:** TBD
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/16
+**Category:** RFC / Architecture / Bounty
+**Related:** [RFC-01: .fair Attribution from Commit History](./RFC-01-fair-attribution.md)
 **Attribution:** Financial contributors to this bounty are logged in the .fair chain. When the network generates value, the chain pays back.
 
 ---

--- a/docs/rfcs/RFC-03-memory-attribution.md
+++ b/docs/rfcs/RFC-03-memory-attribution.md
@@ -1,0 +1,22 @@
+# RFC-03: Memory Attribution (HRPOS)
+
+**Status:** Stub — referenced in RFC-05 but not yet written
+**Authors:** TBD
+**Created:** TBD
+**Discussion:** none
+
+---
+
+## Summary
+
+This RFC will define how memory and learned context (HRPOS — Human-Readable Proof of State) gets attributed in the .fair chain. When an AI presence accumulates understanding through interactions, how is that accumulated knowledge attributed?
+
+## Status
+
+This RFC is a placeholder. It was referenced in [RFC-05: Intent-Bearing Transactions](./RFC-05-intent-bearing-transactions.md) as a dependency but has not been authored yet.
+
+## Related
+- RFC-01: .fair Attribution
+- RFC-05: Intent-Bearing Transactions (depends on this)
+- Issue #139: ZERR Integration
+- Issue #153: ZERR keypair exchange

--- a/docs/rfcs/RFC-04-settlement-protocol.md
+++ b/docs/rfcs/RFC-04-settlement-protocol.md
@@ -1,0 +1,22 @@
+# RFC-04: Settlement Protocol
+
+**Status:** Stub — referenced in RFC-05 but not yet written
+**Authors:** TBD
+**Created:** TBD
+**Discussion:** none
+
+---
+
+## Summary
+
+This RFC will define the settlement protocol — how transactions are finalized, recorded, and distributed across the Imajin network. Covers the mechanics of payment routing, .fair-attributed settlements, and the bridge between fiat and on-chain settlement.
+
+## Status
+
+This RFC is a placeholder. It was referenced in [RFC-05: Intent-Bearing Transactions](./RFC-05-intent-bearing-transactions.md) as a dependency but has not been authored yet.
+
+## Related
+- RFC-02: Programmable Distribution Contracts
+- RFC-05: Intent-Bearing Transactions (depends on this)
+- Issue #111: Inference cost flow
+- Issue #143: Two-bucket balance model

--- a/docs/rfcs/RFC-05-intent-bearing-transactions.md
+++ b/docs/rfcs/RFC-05-intent-bearing-transactions.md
@@ -1,8 +1,9 @@
 # RFC-05: Intent-Bearing Transactions and Contribution Pools
 
-**Status:** Draft  
-**Authors:** Ryan Veteze, Jin  
-**Created:** 2026-03-03  
+**Status:** Draft
+**Authors:** Ryan Veteze, Jin
+**Created:** 2026-03-03
+**Discussion:** none
 **Requires:** RFC-01 (.fair attribution), RFC-02 (runtime modules), RFC-04 (settlement protocol)
 
 ---

--- a/docs/rfcs/RFC-06-identity-portability.md
+++ b/docs/rfcs/RFC-06-identity-portability.md
@@ -1,8 +1,9 @@
-# RFC-001: Identity Portability & Backup Nodes
+# RFC-06: Identity Portability & Backup Nodes
 
-**Status:** Draft  
-**Author:** Ryan Veteze, Jin  
-**Date:** 2026-03-05  
+**Status:** Draft
+**Author:** Ryan Veteze, Jin
+**Date:** 2026-03-05
+**Discussion:** none
 **Related:** Federation (#registry), MJN Token, Network of Souls
 
 ---

--- a/docs/rfcs/RFC-07-cultural-did.md
+++ b/docs/rfcs/RFC-07-cultural-did.md
@@ -1,0 +1,119 @@
+# RFC-07: Cultural DID — Identity Primitive for Collectives, Scenes, and Communities of Practice
+
+**Status:** Discussion
+**Authors:** Greg ([@anonymous_observer](https://github.com/anonymous_observer))
+**Created:** 2026-03-09
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/252
+
+---
+
+*Migrated from #247*
+
+---
+
+## Author
+Greg ([@anonymous_observer](https://github.com/anonymous_observer)) — March 9, 2026
+
+## Summary
+
+A fourth identity primitive for entities defined by shared practice rather than legal structure or commercial purpose: art collectives, music scenes, mutual aid networks, festival communities, open-source creative projects.
+
+Neither Person DID nor Org DID captures these. They have no legal incorporation, no single founder, fluid membership, collective creative output, and identity that persists across membership changes.
+
+## Formation Requirements
+
+### Minimum Founding Membership
+- Requires **5–7 founding Person DIDs**
+- Each founding member must meet a **token context threshold** — trust graph depth, .fair contribution history, attestation count, activity recency
+- This is a **performance qualifier, not a financial barrier** — rewards real participation, not capital
+
+### Formation Process
+1. Qualifying Person DIDs submit a formation proposal: collective name, declared cultural domain, statement of alignment with network covenant
+2. Founding members attest to each other and to the collective identity — each attestation carries the attesting DID's trust weight
+3. Combined trust weight of founding members must meet a network-defined threshold
+4. Cultural DID is issued — publicly visible identity, privately held membership roster
+
+## Governance Model
+
+### Trust-Weighted Participation
+Governance authority is a living reflection of who is actually carrying the collective — measured by contribution history (.fair), activity recency, and trust graph weight within the group.
+
+- Decisions require attestation from members whose combined internal trust weight crosses a **quorum threshold**
+- Voting weight is proportional to demonstrated contribution — not one-person-one-vote
+- Members with higher token context and .fair contribution records hold greater governance weight
+- Stronger Person DIDs can elevate other members into governance positions as membership evolves
+
+### Entry and Removal
+- A member enters governance when their token context and contribution weight crosses the governance threshold — not by appointment alone
+- A member is removed from governance if they fall below the activity and token context threshold — inactivity is a natural disqualifier
+- A member can be removed by weighted quorum if they display behaviour misaligned with the collective's declared values
+- **No single Person DID can hold unilateral control** — any action concentrating authority beyond the quorum threshold is structurally blocked
+- **Anti-abuse safeguard:** if one Person DID accumulates governance weight beyond a defined ceiling, redistribution is triggered automatically
+
+## Membership Tiers
+
+| Tier | Description |
+|------|-------------|
+| **Governing Member** | Meets governance threshold. Holds weighted vote on collective decisions. Visible to other governing members. |
+| **Active Member** | Meets formation threshold. Full participation in collective activity and .fair splits. Not yet at governance weight. |
+| **Participant** | Below formation threshold. Can contribute to collective work and receive .fair attribution. No governance access. |
+| **Observer** | Connected via trust graph. Sees public identity and output. No internal access. |
+
+## Membership Privacy
+
+### Public
+- Cultural DID identity — name, declared domain, covenant alignment status
+- Creative output and .fair attribution records on published work
+- Transaction history at the collective level (aggregate, not individual)
+- Governance quorum results — decisions reached, not deliberation content
+
+### Private
+- Membership roster — who belongs is not publicly visible
+- Individual member contribution weights — visible only to governing members
+- Internal deliberation and governance activity
+- Participant-tier membership — not disclosed externally
+
+### Tiered Visibility
+- Full roster: governing members only
+- Active member list: active members and above
+- External Person DIDs — even trusted ones — see only public identity and published output
+- Visibility gates enforced by trust graph and token context level, not manual permissions
+
+## Structural Properties
+
+| Property | Person DID | Org DID | Cultural DID | Agent DID |
+|----------|-----------|---------|-------------|-----------|
+| Default visibility | Private | Public | Public face, private interior | Scoped to parent |
+| Governance | Individual | Anchored founders | Trust-weighted quorum | Parent DID |
+| Entry condition | Invite | Vetting + covenant | Quorum + token threshold | Parent authorization |
+| Profit motive | N/A | Possible | Structurally excluded | N/A |
+| Membership | Individual | Fixed (founders) | Fluid, tiered | Scoped |
+
+## Representative Use Cases
+- Art and music collectives producing work under a shared identity
+- Intentional festival communities with recurring events and evolving organizers
+- Sound healing, meditation, or wellness communities with shared lineage
+- Neighbourhood mutual aid networks with rotating coordination
+- Open-source creative projects with multiple contributors over time
+- Community venues governed by changing stewards
+- Local scenes — music, food, craft — wanting shared infrastructure without incorporation
+
+## Open Questions
+- Minimum founding member count: 5 or 7? What about legitimate small collectives (trio of artists)?
+- Token context threshold values — what counts as 'enough' participation?
+- Dissolution mechanics — what happens when active membership drops below formation threshold?
+- Treasury management — who signs for collective funds? Quorum-based multi-sig?
+- Relationship to pods — Cultural DID as a pod with public identity + governance layer?
+- .fair attribution splits within the collective — per-work or standing ratio?
+- Cross-node Cultural DIDs — can a collective span multiple nodes?
+- Dispute resolution between governing members at quorum deadlock
+
+## Relationship to Existing Primitives
+The Cultural DID likely builds on top of the existing **pod** primitive in connections. A pod already has membership and shared context. The Cultural DID adds: public identity, governance model, formation threshold, tiered membership, and treasury capability.
+
+## References
+- Current DID types: human, event, service, presence
+- Pods: connections.imajin.ai
+- .fair attribution: packages/fair
+- #114: Declared-Intent Marketplace (Cultural DIDs as economic entities)
+- #246: Check-ins (Cultural DIDs as location-associated scenes)

--- a/docs/rfcs/RFC-08-org-did.md
+++ b/docs/rfcs/RFC-08-org-did.md
@@ -1,0 +1,94 @@
+# RFC-08: Org DID — Businesses and Legal Entities
+
+**Status:** Discussion
+**Authors:** TBD
+**Created:** TBD
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/253
+
+---
+
+*Migrated from #248*
+
+---
+
+## Summary
+
+A DID primitive for legally incorporated entities: businesses, nonprofits, cooperatives, registered organizations. Distinct from Cultural DID (#247) in that it has legal structure, fixed founders, and optionally a profit motive.
+
+## Why Separate from Cultural DID
+
+| | Org DID | Cultural DID |
+|-|---------|-------------|
+| Legal entity | Yes — incorporated or registered | No — exists by participation |
+| Founders | Named, with binding authority | Quorum-based, no single authority |
+| Profit motive | Allowed | Structurally excluded |
+| Membership | Fixed (employees, partners) | Fluid, tiered |
+| Governance | Founder-anchored hierarchy | Trust-weighted quorum |
+| Entry | Vetting + covenant | Formation threshold + token context |
+
+## Formation
+
+### Requirements
+- At least **1 founding Person DID** (the business owner/operator)
+- Business declaration: name, category, location (optional), description
+- Covenant alignment attestation
+- Optional: legal entity reference (business number, incorporation ID)
+
+### Soft Loading (#246)
+Org DIDs can be **soft-loaded** via check-in data from users:
+- Users check in at a location and record transactions
+- A soft Org DID is created — unclaimed, community-built
+- When the business owner claims it, they inherit: verified customer count, transaction volume, reviews
+- Claiming requires verification (location proof, phone, or existing DID attestation)
+
+## Capabilities
+
+### What an Org DID Can Do
+- Appear in trust graphs as a business entity (typed, transparent)
+- Receive reviews and check-ins from Person DIDs
+- Post commercial messages to trust-graph connections (Tier 1 in #114 — free/low cost)
+- Participate in declared-intent marketplace (#114) as a business
+- Issue .fair manifests on products and services
+- Hold a balance and transact via pay.imajin.ai
+- Run an "Ask [Business]" presence (#117 — trust graph queries)
+
+### What an Org DID Cannot Do
+- Impersonate a Person DID — typed and labeled as org
+- Buy trust-graph position — connections earned, not purchased
+- Access private membership of Cultural DIDs
+- Bypass gas costs for extended reach
+
+## Governance
+
+- **Founder-anchored** — founding Person DID(s) have administrative control
+- **Delegated roles** — founders can add employees/partners with scoped permissions
+- **Succession** — founders can transfer ownership to another Person DID
+- **Revocation** — founding DID can revoke employee access
+
+## Visibility
+
+- **Public by default** — business name, category, location, .fair records
+- **Transaction aggregates** — public (total volume, not individual transactions)
+- **Customer list** — private (only the business sees who their customers are)
+- **Reviews** — public, tied to reviewer's DID
+
+## Open Questions
+- Soft → claimed transition: what verification is sufficient?
+- Multi-location businesses — one Org DID or one per location?
+- Franchise model — parent Org DID with child locations?
+- Employee DID scoping — what can an employee do on behalf of the org?
+- Org DID in Cultural DID trust graph — can a business be an observer of a scene?
+- Tax/compliance implications of on-network revenue tracking
+
+## Dependencies
+- Trust graph (exists)
+- Identity tiers (exists)
+- Check-in system (#246) for soft loading
+- Declared-intent marketplace (#114) for commercial reach
+- .fair attribution (exists)
+
+## References
+- #246: Check-ins — soft business onboarding
+- #247: Cultural DID — the non-commercial counterpart
+- #114: Declared-Intent Marketplace
+- #112: Revenue streams overview

--- a/docs/rfcs/RFC-09-application-plugin-architecture.md
+++ b/docs/rfcs/RFC-09-application-plugin-architecture.md
@@ -1,0 +1,110 @@
+# RFC-09: Application Plugin Architecture — Third-Party Apps, Launcher Dock, and Dev Bounties
+
+**Status:** Discussion
+**Authors:** TBD
+**Created:** TBD
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/254
+
+---
+
+*Migrated from #249*
+
+---
+
+## Parent: #244
+
+## Summary
+
+An open application ecosystem where developers build apps that plug into the Imajin stack. Users choose which apps appear in their launcher/dock. Apps authenticate through delegated sessions (#244), settle through pay, and attribute through .fair.
+
+This extends #244 (delegated app sessions) from "apps can use Imajin auth" to "apps are first-class citizens of the network."
+
+## How It Works
+
+### For Users
+1. Browse available apps in the registry (registry.imajin.ai already exists)
+2. Add an app to their launcher/dock
+3. Agree to the app's usage policy and data scope (granular consent from #244)
+4. App appears in their nav alongside core services
+5. Revoke anytime — app loses access, disappears from launcher
+
+### For Developers
+1. Build an app to the delegated session spec (#244)
+2. Register it in the Imajin registry with: name, description, required scopes, hosting model
+3. App is discoverable by all users (or tier-gated)
+4. Earn revenue through settlement fees on transactions within the app
+5. .fair attribution on the app itself — if someone forks/extends your app, you get attributed
+
+### Hosting Models
+- **Remote** — developer hosts the app on their own infrastructure, authenticates via delegated session
+- **Node-hosted** — app package installable on a community node (like a WordPress plugin)
+- **Hybrid** — light frontend on node, heavy compute remote
+
+## App Ideas (Third-Party Bounties)
+
+### Music & Creative
+- **Label management** — release scheduling, royalty splits (.fair native), catalog
+- **Digital distribution** — push to DSPs, reporting, .fair revenue tracking
+- **Gallery/portfolio** — curated media showcase with .fair attribution
+
+### Business & Commerce
+- **Booking/scheduling** — trust-graph-scoped availability, appointment management
+- **Inventory/POS** — for Org DIDs (#248) running physical locations
+- **Accounting** — transaction reporting from pay.imajin.ai settlement data
+- **Invoicing** — DID-to-DID billing with .fair attribution
+
+### Community
+- **Email/newsletter** — trust-graph-scoped broadcasts (sovereign, not Mailchimp)
+- **Surveys/polls** — community decision-making, DYKIL-adjacent
+- **Governance tools** — for Cultural DIDs (#247), weighted voting UI
+- **Ticketing extensions** — season passes, memberships, recurring events
+
+### Infrastructure
+- **Cloud hosting** — node infrastructure as a service
+- **Analytics** — node operator dashboard, traffic, settlement volume
+- **Backup/export** — sovereignty insurance, portable data packages
+- **Monitoring** — health checks, uptime, alerting for node operators
+
+## Bounty Model
+
+Apps specced as GitHub issues with:
+- `bounty` label
+- Clear spec + required scopes + data model
+- Settlement-fee-sharing model (app developer earns ongoing % from usage)
+- Acceptance criteria
+
+Developer picks up the bounty → builds to spec → submits for review → ships to registry → earns from usage.
+
+This is not a one-time payment. The developer earns settlement fees for as long as their app generates transactions. Aligned incentives.
+
+## Registry Integration
+
+The app launcher already exists and is registry-driven. Extensions needed:
+
+- [ ] App listing with install/uninstall per user
+- [ ] Per-user launcher customization (which apps appear in your dock)
+- [ ] Usage policy display and consent flow
+- [ ] App review/rating system (trust-graph-scoped reviews, like #246 for places)
+- [ ] Developer dashboard — installs, usage, revenue
+
+## Dependencies
+- Delegated app sessions (#244) — the auth foundation
+- Registry (exists — needs app listing extensions)
+- App launcher (exists — needs per-user customization)
+- Pay service (exists — needs app-scoped settlement)
+- .fair (exists — app attribution)
+
+## Open Questions
+- App review/vetting process before appearing in registry? Or open and community-moderated?
+- Sandboxing for node-hosted apps — what can a plugin access on the node?
+- App versioning and update mechanism
+- Revenue share model — what % goes to app dev vs node operator vs protocol?
+- Can an app require specific DID tiers? (e.g., "only available to Org DIDs")
+- Plugin dependency management — can apps depend on other apps?
+
+## References
+- #244: Delegated App Sessions
+- #247: Cultural DID (governance tools as app)
+- #248: Org DID (business tools as apps)
+- #246: Check-ins
+- #114: Declared-Intent Marketplace

--- a/docs/rfcs/RFC-10-sovereign-user-data.md
+++ b/docs/rfcs/RFC-10-sovereign-user-data.md
@@ -1,0 +1,131 @@
+# RFC-10: Sovereign User Data — Portable Identity Bundles and Federated User Operations
+
+**Status:** Discussion
+**Authors:** TBD
+**Created:** TBD
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/255
+
+---
+
+*Migrated from #251*
+
+---
+
+## Summary
+
+An architectural RFC for how user data is stored, owned, and operated on across the Imajin platform. Defines the relationship between service-owned tables (runtime model) and user-owned portable data bundles (canonical truth).
+
+## Problem
+
+Today, a user's data is scattered across 13+ service databases, organized by what each service needs. The user's identity is sovereign (DID, keypair, portable) but their data is not — it's shaped by services, not owned by users. This is structurally the same model as every platform, just self-hosted instead of cloud-hosted.
+
+For Imajin to deliver on sovereignty, users need to be able to:
+- **Export** — pull a complete, portable data object at any time
+- **Delete** — coordinated removal across all services, with proof
+- **Transfer** — move to another node with full data continuity
+- **Backup** — user-controlled, user-stored copies
+
+## Architectural Position
+
+### Service tables are the runtime model
+
+Postgres stays. Services query shared indexes for performance — loading an event chat with 400 attendees can't fan out to 400 per-user databases. Relational tables are the right choice for coordinated reads.
+
+### The user's data bundle is canonical truth
+
+The exportable, signed, portable data object is the *source of truth* for what belongs to a user. If the node disappears, the bundle is what survives. Postgres is effectively a cache of user-owned data.
+
+## Design: Append Log per DID
+
+Every mutation that touches a user's data appends to a per-DID event log:
+
+```
+did:imajin:ryan → [
+  { t: 1709000001, service: "auth",    op: "identity.create", ... },
+  { t: 1709000045, service: "profile", op: "profile.create", ... },
+  { t: 1709000200, service: "events",  op: "ticket.purchase", ref: "tkt_xxx", ... },
+  { t: 1709000300, service: "chat",    op: "message.send", ref: "msg_xxx", ... },
+  { t: 1709000400, service: "media",   op: "asset.upload", ref: "ast_xxx", context: "personal", ... },
+]
+```
+
+### Why append log over dynamic export
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Dynamic export (query on demand) | Always current, no extra storage | Slow, all services must be up, no audit trail |
+| Continuous append log | Instant export, audit trail for free, transfer = log replay | Parallel data structure to maintain |
+
+The append log wins because it also provides:
+- **Audit trail** — every change to your data, when, by which service
+- **Transfer** — ship the log to a new node, replay it, rehydrate
+- **Verifiable delete** — cryptographic proof that every append was reversed
+- **Backup** — the log *is* the backup, continuously updated
+
+## Federated User Operations
+
+Each service implements a standard interface:
+
+### `exportForDid(did)`
+Returns all data owned by this DID from this service, in a portable format.
+
+### `deleteForDid(did)`
+Removes all data for this DID. Returns a signed deletion receipt. Open questions:
+- **Tombstone vs hard-delete?** A .fair chain with a deleted creator has a hole in provenance
+- **Shared data?** Chat messages in group conversations, co-authored .fair manifests
+- **Retention windows?** Legal/financial records may require minimum retention
+
+### `transferForDid(did, targetNode)`
+Coordinates with target node to migrate data. Verify DID ownership on both ends.
+
+### `countForDid(did)`
+Returns data footprint — useful for pre-delete review ("you have 47 assets, 312 messages, 3 tickets").
+
+### Orchestrator
+
+Auth service (as identity authority) fans out operations to all registered services. The service manifest (#227) provides the map of "who has data for this DID."
+
+## The Data Bundle
+
+A user's portable data object, assembled from the append log or dynamic export:
+
+```json
+{
+  "did": "did:imajin:ryan",
+  "exported_at": "2026-03-09T16:45:00Z",
+  "node": "jin.imajin.ai",
+  "signature": "...",
+  "sections": {
+    "identity": { "attestations": [...], "tier": "hard" },
+    "profile": { "handle": "ryan", "display_name": "...", ... },
+    "media": { "assets": [...], "contexts": [...] },
+    "events": { "tickets": [...] },
+    "chat": { "messages": [...] },
+    "connections": { "graph": [...] },
+    "learn": { "enrollments": [...], "progress": [...] },
+    "fair": { "manifests": [...] }
+  }
+}
+```
+
+Signed by the user's DID keypair. Verifiable by any node.
+
+## Open Questions
+
+1. **Log storage** — per-DID append logs in postgres? Separate event store? Filesystem?
+2. **Log compaction** — do we compact over time, or keep full history?
+3. **Shared data semantics** — when you delete, what happens to your messages in group chats? Your name on .fair manifests others reference?
+4. **Plugin data** — third-party apps (#249) that store user data need to implement the same interface. How do we enforce this?
+5. **Media binaries** — the log tracks metadata, but asset files need their own export/transfer path (could be large)
+6. **Encryption at rest** — should the append log be encrypted with the user's key?
+
+## Related
+
+- #3 — First node registration
+- #24 — Node registry certification and heartbeat
+- #155 — DID-to-endpoint resolution
+- #156-#160 — Federated chat sequence
+- #227 — Shared service manifest
+- #244 — Delegated app sessions
+- #249 — Plugin architecture
+- #250 — Media context routing

--- a/docs/rfcs/RFC-11-embedded-wallet.md
+++ b/docs/rfcs/RFC-11-embedded-wallet.md
@@ -1,0 +1,170 @@
+# RFC-11: RFC: Embedded Wallet — DID keypair as MJN-scoped Solana wallet with hierarchical key derivation
+
+**Status:** Draft
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/268
+
+---
+
+## The Realization
+
+We did not design a wallet. We discovered one.
+
+Imajin chose Ed25519 for DID keypairs because it was the right cryptographic primitive for sovereign identity. Solana uses Ed25519 for wallet addresses. The choice was made for identity, not settlement. Solana's use of Ed25519 was already a fact of the world — but nobody was thinking about wallets when the first keypair was generated.
+
+On March 9, 2026, during a conversation about whether users would need to connect external wallet apps to trade MJN, we realized: they already have wallets. Every DID keypair generated at registration is a valid Solana keypair. Every backup file already contains a wallet private key. Every registered identity — ~25 hard DIDs, ~48 soft DIDs — is one derivation away from holding MJN tokens.
+
+Nobody planned this. The architecture planned itself. When you build from the right primitives — sovereign keypairs, typed identity, trust graphs, embedded attribution — the late decisions make themselves. The settlement layer was already inside the identity layer, waiting to be noticed.
+
+This is what happens when the architecture is honest.
+
+---
+
+## Summary
+
+Every Imajin DID keypair (Ed25519) is already a valid Solana keypair. This RFC proposes making that explicit: every identity is a wallet by default, scoped to MJN token settlement, with hierarchical key derivation for purpose-scoped child keys.
+
+## Design Principles
+
+### MJN-Scoped Only
+The embedded wallet transacts MJN tokens only. Not general-purpose Solana. Not SPL tokens. Not DeFi. This is a settlement instrument, not a trading platform.
+
+**Security consequence:** A compromised key can only affect the MJN balance in that wallet. No bridge exploits, no token approvals, no DeFi drainage. The blast radius is structurally contained.
+
+**And it gets safer with scope.** Generate child keys for different purposes — a spending key, a delegation key, an app session key. Each one is revocable by the master. Compromise one and the damage is limited to that key's scope. This is the opposite of general-purpose wallets where one leaked seed phrase means everything is gone.
+
+### Identity IS the Wallet
+- Registration generates a keypair → DID + wallet address in one step
+- The backup file already contains the private key
+- No external wallet app required
+- Client-side signing — private key never touches the server
+
+### Gas Subsidization
+Solana transactions cost ~$0.001. The MJN Foundation operates a gas pool that covers transaction fees for MJN settlements. Users never think about SOL or gas.
+
+## Hierarchical Key Derivation
+
+The master DID keypair is the root identity. Child keys are derived for scoped purposes:
+
+### Key Types
+
+| Key | Scope | Revocable | Example |
+|-----|-------|-----------|---------|
+| **Master** | Full identity + wallet | No (IS the identity) | `did:imajin:ryan` |
+| **Spending** | Daily transactions, capped balance | Yes, by master | `did:imajin:ryan/spending` |
+| **Savings** | Long-term holdings, cold | Yes, by master | `did:imajin:ryan/savings` |
+| **Delegation** | Agent/service can spend within limits | Yes, by master | `did:imajin:ryan/delegate/jin` |
+| **App Session** | Scoped to one service, time-limited | Yes, by master or expiry | `did:imajin:ryan/session/events` |
+
+### Per-Primitive Wallet Behavior
+
+The wallet capability exists on every identity primitive, but governance follows the identity type:
+
+**Individual**
+- Personal wallet hierarchy (spending, savings, delegation)
+- Full autonomy — the individual controls all derived keys
+- Lose a spending key → revoke from master, generate new one, identity survives
+
+**Family**
+- Shared treasury — multi-sig between family member DIDs
+- Allowance keys for dependents (spending caps, category restrictions)
+- Custodial authority for minor family members
+- Emergency access patterns for healthcare/legal scenarios
+
+**Cultural**
+- Quorum-signed treasury — governed by trust-weighted membership
+- Contribution payouts follow .fair governance weights
+- No single member can unilaterally move funds (structural anti-capture)
+- Payout proposals require quorum attestation before settlement executes
+
+**Org**
+- Corporate spending authority with delegation hierarchy
+- Employee expense keys with per-transaction and per-period limits
+- Departmental budget keys
+- Founder can revoke any delegated key
+
+## Settlement Integration
+
+### .fair → On-Chain Settlement
+When a .fair manifest triggers a payment:
+1. Consumer's spending key signs the transaction
+2. Transaction splits per .fair contributor shares
+3. Each contributor's wallet receives their share directly
+4. Settlement is atomic — all splits execute or none do
+5. The .fair manifest hash is recorded on-chain as provenance
+
+### Trust-Gated Inference Payments
+When someone queries a presence through the trust graph:
+1. Querier's spending key signs inference fee
+2. Fee routes to knowledge leader's wallet
+3. If the leader is part of a Cultural DID, the fee splits per governance weight
+4. All on-chain, all auditable, all following the identity graph
+
+## Implementation Phases
+
+### Phase 1: Surface the Wallet
+- Derive Solana address from existing DID keypair
+- Display wallet address and MJN balance on profile
+- No transactions yet — just visibility
+- Update backup file to note wallet address
+
+### Phase 2: Receive MJN
+- Wallet can receive MJN tokens
+- Balance display in pay service
+- Transaction history view
+
+### Phase 3: On-Chain Settlement
+- Client-side transaction signing in pay service
+- .fair settlements execute on Solana
+- Gas subsidized by Foundation pool
+- Spending key derivation for daily transactions
+
+### Phase 4: Hierarchical Keys
+- Key derivation UI — generate spending/savings/delegation keys
+- Per-primitive governance (Family multi-sig, Cultural quorum, Org delegation)
+- Revocation and rotation
+- Optional export to external wallets (Phantom, Solflare) for users who want it
+
+## Security Model
+
+### Blast Radius Containment
+| Scenario | General Wallet | MJN-Scoped Wallet |
+|----------|---------------|-------------------|
+| Key compromised | All tokens, NFTs, approvals, DeFi positions | MJN balance only |
+| With child keys | N/A | Only the scope of that child key |
+| Revocation | Impossible (seed phrase) | Parent DID revokes child key |
+| Social recovery | None (unless set up externally) | Trust graph can attest to identity for key rotation |
+
+### Key Rotation
+If a master key is compromised, the trust graph provides social recovery:
+- N trusted connections attest to a new keypair
+- Attestations carry the weight of the attesting DIDs
+- Once threshold is met, the new keypair inherits the DID
+- Old key is revoked network-wide
+- MJN balance transfers to new wallet address
+
+## Open Questions
+
+1. **Key derivation scheme** — BIP-44 style paths or custom derivation? HD wallet standards exist but are Bitcoin/Ethereum-centric.
+2. **Soft DIDs** — do `did:email:` soft DIDs get wallet addresses? Probably not until upgrade to hard DID.
+3. **Multi-device** — spending key on phone, master key in cold storage. How does the UX work?
+4. **Regulatory** — does an embedded wallet trigger money transmitter requirements? MJN-scoped + Foundation-governed may help.
+5. **Gas pool economics** — how is the Foundation gas pool funded? Token allocation? Transaction micro-fees?
+6. **Social recovery threshold** — how many attestations, at what trust weight, to rotate a master key?
+7. **Child key limits** — how are spending caps enforced? On-chain program or client-side?
+
+## Dependencies
+
+- MJN token on Solana mainnet (exists: `12rXuUVzC71zoLrqVa3JYGRiXkKrezQLXB7gKkfq9AjK`)
+- Pay service pluggable backend architecture (exists)
+- Ed25519 keypair generation (exists: `@imajin/auth`)
+- Trust graph for social recovery (exists: connections service)
+- .fair attribution manifests (exists: `@imajin/fair`)
+
+## References
+
+- MJN Whitepaper v0.2: `docs/mjn-whitepaper.md`
+- #256: Sovereign Inference (inference fee settlement)
+- #257: Profile Secrets Vault (encrypted key storage)
+- Discussion #252: Cultural DID (quorum treasury governance)
+- Discussion #253: Org DID (delegated spending authority)
+- Discussion #255: Sovereign User Data (portable wallet state)

--- a/docs/rfcs/RFC-12-mjn-token-economics.md
+++ b/docs/rfcs/RFC-12-mjn-token-economics.md
@@ -1,0 +1,271 @@
+# RFC-12: RFC: MJN Token Economics — reserve-backed utility token with fiat bridge
+
+**Status:** Draft
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/269
+
+---
+
+## Summary
+
+MJN is a reserve-backed utility token that serves as the settlement currency for the Imajin protocol. Users can freely convert between fiat and MJN through the Foundation clearinghouse. The token starts at a fixed exchange rate and evolves to a managed float as network volume grows.
+
+This is not a speculative asset. This is a settlement instrument that happens to live on Solana.
+
+## Core Model
+
+### Dual-Currency Network
+
+Every transaction on the Imajin network can settle in **fiat OR MJN**. Nobody is forced into crypto. The network works either way.
+
+| Rail | Mechanism | Fees | Settlement Speed |
+|------|-----------|------|-----------------|
+| **Fiat** | Stripe / e-transfer | 2.9% + 30¢ (Stripe) | 2-day payout |
+| **MJN** | Solana on-chain | ~$0.001 (gas, subsidized) | Instant |
+
+MJN is better — lower fees, instant settlement, atomic .fair splits — but not required. The user chooses. Over time, the economic advantage of MJN drives organic adoption.
+
+### Mint/Burn Reserve Model
+
+```
+Fiat in  → Foundation mints MJN → user's wallet
+MJN in   → Foundation burns MJN → fiat to user's bank
+                    ↕
+         Foundation holds fiat reserves
+         backing outstanding MJN supply
+```
+
+- **Mint on deposit:** User sends fiat (Stripe or e-transfer), Foundation mints equivalent MJN to their embedded wallet
+- **Burn on withdrawal:** User redeems MJN, Foundation burns tokens and sends fiat to their bank
+- **Reserves are auditable:** Outstanding MJN supply always backed by fiat reserves held by the Foundation
+- **No fractional reserve:** 1:1 backing. Every MJN in circulation has fiat behind it.
+
+### Exchange Rate Strategy
+
+**Phase 1 — Fixed rate (launch)**
+- 1 MJN = fixed USD value (e.g., $0.01 or $0.10 — TBD)
+- Maximum stability. Merchants know exactly what they're accepting.
+- Settlement currency should be boring. This is intentionally boring.
+- Foundation revenue: spread on mint/burn + transaction micro-fees
+
+**Phase 2 — Managed float (maturity)**
+- Foundation adjusts rate gradually based on network economics
+- Not pegged, not wild — like a central bank managing currency
+- Rate adjustments are published transparently
+- Reflects real network utility, not speculation
+- Transition happens when network volume makes price discovery meaningful
+
+**The rule:** The rate never moves fast enough to matter for a single transaction. If you're buying coffee with MJN, you don't check the exchange rate first. That's the target.
+
+## How MJN Enters Circulation
+
+### Primary: Earned Through Participation
+- **.fair royalties** — your creative work earns MJN when consumed
+- **Inference fees** — your presence earns MJN when queried
+- **Contribution rewards** — active participation in Cultural DIDs
+- **Network rewards** — node operators earn for infrastructure
+
+### Secondary: Fiat Top-Up
+- Users buy MJN directly through pay.imajin.ai
+- Stripe charges their card, Foundation mints MJN
+- Familiar UX — like loading a transit card or buying game credits
+
+### Tertiary: DEX Liquidity (future)
+- Foundation seeds SOL/MJN pool on Jupiter/Raydium
+- Only after sufficient circulation exists
+- Provides an additional on/off ramp, not the primary one
+
+## Where MJN Gets Spent
+
+### On-Network Settlement
+- **Event tickets** — pay in MJN for lower fees, instant confirmation
+- **Inference queries** — trust-gated presence queries cost MJN
+- **.fair settlements** — attribution chain splits execute on-chain
+- **Course enrollment** — learn.imajin.ai accepts MJN
+- **Tipping** — coffee.imajin.ai micropayments
+
+### Participating Businesses (Org DIDs)
+- Org DIDs in your trust graph accept MJN at their businesses
+- Coffee shop, bookstore, service provider — real-world commerce
+- Merchant receives MJN, cashes out to fiat whenever they want
+- Lower fees than credit card processing (no Stripe 2.9%)
+- Instant settlement (no 2-day wait)
+
+### Declared-Intent Marketplace (#114)
+- Users spend MJN balance to access declared-intent categories
+- Businesses burn MJN gas to reach opted-in users
+- Signal strength (intent + conversion history) determines gas cost
+- The marketplace runs on MJN natively
+
+## Foundation Clearinghouse Role
+
+The MJN Foundation operates as a **protocol clearinghouse**, not a bank.
+
+### What the Foundation Does
+- Holds fiat reserves backing outstanding MJN supply
+- Mints MJN on fiat deposit
+- Burns MJN on fiat withdrawal
+- Sets and publishes exchange rate
+- Operates gas subsidy pool for transaction fees
+- Publishes reserve audits (quarterly minimum)
+
+### What the Foundation Does NOT Do
+- Hold user funds (MJN is in user's sovereign wallet)
+- Control who can transact (permissionless within protocol rules)
+- Lend against reserves (no fractional reserve, ever)
+- Speculate on MJN price
+- Restrict fiat withdrawal (always redeemable)
+
+### Revenue Model
+- **Mint/burn spread** — small percentage on fiat ↔ MJN conversion
+- **Transaction micro-fees** — fraction of a cent per on-chain settlement
+- **Gas pool margin** — Foundation subsidizes gas but retains small margin
+- Transparent, published, auditable
+
+## Regulatory Position
+
+### Swiss Foundation (FINMA)
+- MJN Foundation is a Swiss Stiftung — FINMA has clear frameworks for utility tokens
+- Reserve-backed + non-speculative + clearinghouse model = favorable classification
+- Not a deposit-taking institution (user funds in sovereign wallets)
+- Not a money transmitter (protocol clearinghouse with published rates)
+- The MJN-scoped wallet decision helps here — general-purpose Solana wallet would trigger broader regulations
+
+### Why This Model Works
+- **Full reserve:** No fractional lending, no systemic risk
+- **Redeemable:** Always convertible back to fiat at published rate
+- **Transparent:** Supply, reserves, and rate are all auditable
+- **Non-speculative:** Fixed rate at launch, managed float later — not a trading vehicle
+- **Protocol-specific:** MJN settles Imajin protocol transactions, not general-purpose payments
+
+## Token Supply Mechanics
+
+### Current State
+- Token: `12rXuUVzC71zoLrqVa3JYGRiXkKrezQLXB7gKkfq9AjK`
+- Network: Solana Mainnet
+- Supply: 0 (nothing minted)
+- Mint authority: Ryan (transfers to Foundation)
+
+### At Launch
+- Foundation receives mint authority
+- Initial mint for gas subsidy pool
+- Fixed rate published
+- Fiat bridge activated via pay.imajin.ai
+
+### Growth
+- Supply increases as fiat flows in (mint on deposit)
+- Supply decreases as fiat flows out (burn on withdrawal)
+- Net supply reflects the real economic value locked in the MJN network
+- No arbitrary inflation, no emission schedule — supply follows demand
+
+## Open Questions
+
+1. **Fixed rate value** — $0.01? $0.10? $1.00? Lower = more tokens in circulation, feels like micropayments. Higher = fewer tokens, feels like real money.
+2. **Managed float trigger** — what network volume or user count triggers the transition from fixed to managed?
+3. **Reserve auditing** — self-published or third-party audit? Frequency?
+4. **Multi-currency fiat** — USD only at launch, or CAD/EUR/GBP from the start?
+5. **Withdrawal limits** — any minimum/maximum for fiat redemption?
+6. **Tax implications** — how do users report MJN earnings? Is the fiat ↔ MJN conversion a taxable event?
+7. **Foundation capitalization** — initial fiat reserves to seed the gas pool and mint/burn operations
+8. **Merchant settlement** — do Org DIDs receive MJN and convert themselves, or can they opt for automatic fiat conversion?
+
+## Dependencies
+
+- MJN token on Solana mainnet (exists)
+- Embedded wallet (Discussion #268)
+- Pay service fiat rails (exists: Stripe, e-transfer)
+- Foundation incorporation (planned: Q1 2026)
+- .fair attribution for royalty settlement (exists)
+- Declared-intent marketplace (#114) for gas economics
+- Org DID (Discussion #253) for merchant participation
+
+## References
+
+- MJN Whitepaper v0.2: `docs/mjn-whitepaper.md`
+- Discussion #268: Embedded Wallet
+- Discussion #252: Cultural DID (quorum treasury)
+- Discussion #253: Org DID (merchant participation)
+- #114: Declared-Intent Marketplace
+- #256: Sovereign Inference (inference fee settlement)
+
+---
+
+## MJN Foundation — Formation Roadmap
+
+The Foundation is a Swiss Stiftung (non-profit foundation under Swiss Civil Code Art. 80-89). This is the same vehicle used by Ethereum, Solana, Cardano, and Polkadot. Switzerland has the clearest regulatory framework for protocol foundations with token economics.
+
+### Step 1: Formation (~CHF 30-50K, 4-8 weeks)
+
+- Draft foundation deed (Stiftungsurkunde) — purpose, governance, initial board
+- Minimum endowment: CHF 50,000 (~$55K USD)
+- Notarize the deed with a Swiss notary
+- Register with the Commercial Registry (canton of Zug or Zurich)
+- Appoint initial Foundation Board (minimum 1 member, typically 3)
+- Requires at least one Swiss-resident board member (can be a service provider)
+
+### Step 2: FINMA Token Classification (1-3 months)
+
+- Submit formal token classification request to FINMA
+- FINMA categorizes tokens as: **utility**, **payment**, or **asset**
+- MJN target classification: **utility token** (settlement currency for a specific protocol)
+- Arguments in our favor: reserve-backed, non-speculative, MJN-scoped, fixed rate at launch, clear protocol utility
+- If classified as payment token: heavier regulation but still workable under Swiss framework
+- Deliverable: formal no-action letter or classification ruling from FINMA
+
+### Step 3: Operational Setup
+
+- Open Swiss bank account for the Foundation (crypto-friendly banks: SEBA, Sygnum, Hypothekarbank Lenzburg)
+- Appoint statutory auditor (required for supervised foundations)
+- Establish AML/KYC procedures for the fiat bridge
+- Transfer MJN mint authority from Ryan to Foundation
+- Set up Foundation governance: board meetings, decision protocols, transparency requirements
+
+### Cost Estimate
+
+| Item | Cost (CHF) |
+|------|------------|
+| Legal setup (Swiss blockchain law firm) | 20,000 - 40,000 |
+| Foundation endowment (minimum) | 50,000 |
+| FINMA classification (legal fees) | 10,000 - 20,000 |
+| Ongoing compliance + audit (annual) | 10,000 - 20,000 |
+| Swiss-resident board member service (annual) | 5,000 - 10,000 |
+| **Total to launch** | **~CHF 100,000 - 150,000 (~$110-165K USD)** |
+
+### Recommended Law Firms (Blockchain Specialization)
+
+- **MME** (Zurich/Zug) — represented Ethereum Foundation, deep FINMA experience
+- **Lenz & Staehelin** (Zurich/Geneva) — largest Swiss firm, strong regulatory practice
+- **Walder Wyss** (Zurich) — crypto and fintech specialization
+- **LEXR** (Zurich) — startup-focused, more accessible pricing
+
+### Corporate Structure
+
+```
+MJN Foundation (Swiss Stiftung)
+├── Owns: protocol spec, token treasury, mint authority
+├── Governs: RFC process, token economics, rate adjustments
+├── Contracts: Imajin Inc. for protocol development
+│
+Imajin Inc. (Canadian corporation)
+├── Operates: imajin.ai (reference implementation, first node)
+├── Builds: platform services, SDK, developer tools
+├── Ryan Veteze — founder
+├── Revenue: settlement fees, mint/burn spread, gas pool margin
+```
+
+### Timeline
+
+| Milestone | Target |
+|-----------|--------|
+| Engage Swiss law firm | Q2 2026 |
+| Foundation deed drafted | Q2 2026 |
+| FINMA classification submitted | Q2-Q3 2026 |
+| Foundation registered | Q3 2026 |
+| Mint authority transferred | Q3 2026 |
+| Fiat bridge operational | Q3-Q4 2026 |
+
+### Why Switzerland
+
+- **FINMA has clear token frameworks** — utility, payment, and asset classifications are published and tested
+- **Neutrality** — Foundation cannot be captured by US or Chinese regulatory pressure
+- **Precedent** — Ethereum, Solana, Cardano, Polkadot all chose Swiss Stiftung for the same reasons
+- **The name draws from Japanese, built by a Canadian, governed from Switzerland** — sovereign infrastructure has no nationality

--- a/docs/rfcs/RFC-13-progressive-trust-model.md
+++ b/docs/rfcs/RFC-13-progressive-trust-model.md
@@ -1,0 +1,89 @@
+# RFC-13: RFC: Progressive Trust Model — graduated permissions on hard DIDs
+
+**Status:** Draft
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/271
+
+---
+
+## Context
+
+Greg Mulholland drafted a tiered onboarding model (March 2026) that proposes separating **entry** from **full participation**. After discussion with Ryan, the model was refined to use graduated permissions on existing DID types rather than introducing new DID types.
+
+Related: #247 (Cultural DID), #248 (Org DID), #244 (Delegated App Sessions)
+
+## Current State
+
+Two identity tiers:
+- **Soft DID** (`did:email:*`) — created via email verification or event magic links. Can attend events, hold tickets, enroll in courses. No profile, no apps, no wallet.
+- **Hard DID** (`did:imajin:*`) — keypair-based. Full profile, full access, can do everything.
+
+The gap between soft and hard is binary. You either have full access or almost none.
+
+## Proposal: Three Permission Levels, Two DID Types
+
+Same keypair throughout. Same `did:imajin:*`. What changes is your **standing**, computed from attestation history.
+
+### Soft DID — Visitor
+- Attend events, hold tickets, enroll in courses
+- No profile, no apps, no wallet
+- Created via email/magic link or event check-in
+
+### Hard DID (Preliminary) — Resident
+- Full profile (avatar, bio, handle)
+- Connect payment rails (wallet active, can transact)
+- Use apps (coffee, links, learn, dykil, etc.)
+- Message direct connections
+- See markets/offers within immediate trust graph
+- Browse Cultural DID lobbies, apply to join
+- ❌ Cannot vouch for or invite others
+- ❌ Cannot create events, Cultural DIDs, or Org DIDs
+- ❌ Cannot see extended trust graph (direct connections only)
+
+### Hard DID (Established) — Host
+- Everything above, plus:
+- Vouch for preliminary DIDs (starts their onboarding period)
+- Create events, Cultural DIDs, Org DIDs
+- See extended trust graph
+- Eligible for governance weight in communities
+- Standing visible to the network
+
+## How Progression Works
+
+### Soft → Preliminary
+Generate a keypair. Register. You're a preliminary hard DID.
+
+### Preliminary → Established
+Requires **both**:
+1. **A vouch from an established DID** — someone in good standing sponsors your onboarding
+2. **Milestone completion during onboarding period** — the vouch starts a probation window, not instant graduation
+
+### Onboarding Milestones (examples, governance-configurable)
+- N verified interactions with established DIDs
+- N event attendances (verified physical presence)
+- N days on the network (time-gating prevents rush)
+- Zero unresolved flags
+
+### Accelerated Path
+An established DID can manually vouch and accelerate — but their standing is on the line. Reckless vouching has consequences (see Trust Accountability Framework).
+
+### Automated Path
+If no one vouches but a preliminary DID accumulates sufficient attestations organically (through events, check-ins, interactions), the system can surface them to governance bodies for evaluation. The network doesn't require a personal relationship with an existing member — just demonstrated relational behavior.
+
+## Implementation Notes
+
+- **Standing is computed, not assigned.** It's a query over attestation history on `auth.identities`.
+- **Attestations are the mechanism.** "Attended event X", "vouched by DID Y", "checked in at Org Z" — typed, signed, verifiable.
+- **No new DID type needed.** `did:imajin:*` with a `standing` field derived from attestations.
+- **Permission checks** happen at the service level — each API checks the caller's standing tier.
+- **Greg's \"context tokens\"** map to attestation count + diversity. Not a new token primitive — just a query shape.
+
+## Open Questions
+
+1. What are the right milestone thresholds? Should they be network-wide defaults or per-Cultural-DID configurable?
+2. How long is the onboarding period? Fixed or variable based on activity velocity?
+3. Should preliminary DIDs see that they're in an onboarding phase, or is it invisible until they try to do something they can't?
+4. Can an established DID be **demoted** back to preliminary? (See Trust Accountability Framework)
+
+## Credit
+
+Core concept from Greg Mulholland's \"Entering the Network\" (March 2026). Architectural grounding by Ryan and Jin.

--- a/docs/rfcs/RFC-14-community-issuance-network.md
+++ b/docs/rfcs/RFC-14-community-issuance-network.md
@@ -1,0 +1,77 @@
+# RFC-14: RFC: Community Issuance Network — trusted institutions as identity entry points
+
+**Status:** Draft
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/272
+
+---
+
+## Context
+
+Greg Mulholland's "Commons Layer" proposal (March 2026) argues that Imajin's identity architecture has implications beyond the product — it's a prototype for **public digital identity infrastructure**. The key insight: any trusted institution can be an identity issuance point.
+
+Related: #271 (Progressive Trust Model), #247 (Cultural DID), #249 (Plugin Architecture), Discussion #269 (MJN Token Economics / Foundation)
+
+## The Insight
+
+Imajin's EventDID check-in model is, structurally, a **community-anchored identity issuance network**. A person scans a ticket, passes an ID check, receives a DID. The physical body is the proof of work.
+
+This generalizes. The gate is any **verifiable in-person interaction** at a trusted institution:
+
+| Institution | Issuance Context |
+|---|---|
+| Imajin events | EventDID check-in (exists today) |
+| Libraries | Library card issuance → DID |
+| Credit unions | Account opening → DID |
+| Community orgs | Membership verification → DID |
+| Medical practices | Patient verification → DID |
+| Schools/universities | Student verification → DID |
+
+Each institution becomes an **issuance point** on the network. The DID they issue carries an attestation: "verified in-person by [institution DID] on [date]."
+
+## How This Maps to Existing Architecture
+
+### What already exists
+- **Ed25519 keypair identity** — no platform issues it, no platform can revoke it
+- **EventDID** — events as first-class identity-issuing entities
+- **Federated nodes** — anyone can run a node (registry.imajin.ai)
+- **MJN Foundation** (planned) — protocol stewardship separate from Imajin Inc.
+
+### What this adds
+- **Institutional DID type** — a new DID category for trusted issuance points (or an Org DID with issuance attestation rights)
+- **Issuance attestations** — "DID X was verified in-person by Institution Y" as a first-class attestation type
+- **Issuance point registry** — how institutions register as trusted issuers (probably through the federated node model)
+- **Cross-institution trust** — a DID issued at a library carries weight at a credit union because both are on the same trust network
+
+## Imajin Product vs. Imajin Protocol
+
+Greg's framing (and Ryan's existing architecture) separates these cleanly:
+
+| | Imajin Protocol (Foundation) | Imajin Product (Inc.) |
+|---|---|---|
+| **Owns** | DID spec, trust primitives, settlement protocol | Reference implementation, UX, community tools |
+| **Governed by** | Foundation board, weighted by community contribution | Imajin Inc. (Canadian corp) |
+| **Revenue** | Protocol fees (mint/burn spread, settlement micro-fees) | Operator excellence, premium features, node hosting |
+| **Analogy** | HTML/HTTP | Netscape/Chrome |
+
+The protocol is a public good. The product competes on operator excellence. Open protocol makes the product *more* valuable because the network is larger.
+
+## Why This Matters
+
+There is currently **no public option** for digital identity. Every major system (Google, Apple, Meta) extracts value from the identity it holds hostage. Government IDs have no digital native form in most jurisdictions.
+
+A community-anchored issuance network means:
+- Identity doesn't require a smartphone with a proprietary OS
+- Identity doesn't require an advertising account
+- Identity doesn't require a government to issue it
+- Identity requires a **trusted human to verify that a body exists** — and cryptographically record that verification
+
+## Open Questions
+
+1. How do institutions register as issuance points? Through the federated node model, or a separate registration path?
+2. What level of verification is required? Government ID check? Or is institutional trust sufficient (library card, membership roll)?
+3. How does this interact with the MJN Foundation governance? Does the Foundation certify issuance points?
+4. Timeline: is this Year 1 (product), Year 2 (protocol), or Year 3 (public infrastructure)?
+
+## Credit
+
+Core concept from Greg Mulholland's "The Commons Layer" (March 2026). Architectural grounding from Imajin's existing federated node model and MJN Foundation plans.

--- a/docs/rfcs/RFC-15-trust-accountability-framework.md
+++ b/docs/rfcs/RFC-15-trust-accountability-framework.md
@@ -1,0 +1,113 @@
+# RFC-15: RFC: Trust Accountability Framework — bad actor detection, consequences, and vouch chain responsibility
+
+**Status:** Draft
+**Discussion:** https://github.com/ima-jin/imajin-ai/discussions/273
+
+---
+
+## Context
+
+Greg Mulholland's onboarding proposal (March 2026) includes a detailed bad actor model that's currently missing from the Imajin architecture. The existing system has connections and trust graph queries but **no formalized consequence model** for bad behavior.
+
+Related: #271 (Progressive Trust Model), #247 (Cultural DID), #248 (Org DID)
+
+## The Gap
+
+Currently, if someone behaves badly on the network, the only recourse is:
+- Manual intervention by Ryan (doesn't scale)
+- Removing connections (informal, no network-wide effect)
+- Nothing
+
+There's no flagging system, no consequence tiers, no vouch chain accountability, and no path for rehabilitation.
+
+## Behavioral Categories (not ideological)
+
+Imajin is not in the business of ideological policing. The model is **behavioral**, defining patterns that undermine trust, accountability, and non-extraction.
+
+### Category A — Extraction and Exploitation
+- Commercial solicitation in non-commercial community spaces
+- Using trust graph access to harvest contact or behavioral data
+- Manufacturing fake vouches or coordinated identity deception
+- Sockpuppet or Sybil behavior to manipulate governance weight
+
+### Category B — Relational Harm
+- Harassment, sustained unwanted contact, boundary violation
+- Behavior that causes a member to disengage or feel unsafe
+- Abuse of the flagging system as a weapon against legitimate participants
+
+### Category C — Network Integrity
+- Circumventing physical attendance gates (ticket fraud, ID fraud)
+- Coordinated manipulation of attestation accumulation
+- Bad actor behavior by a vouched person that the voucher had reasonable cause to anticipate
+
+## Detection Sources
+
+No automated content moderation. Detection comes from three sources:
+
+1. **Peer flagging** — by established DIDs, Cultural DID governance bodies, or EventDID operators. The flagger's trust weight is attached to the flag.
+2. **Systemic anomaly detection** — unusual patterns in connection requests, attestation velocity, or check-in behavior that diverge from baseline.
+3. **Vouch chain accountability** — if a vouched person exhibits bad behavior, the voucher is notified and their standing is reviewed.
+
+All flags are initially **private** — visible only to the flagging party, the flagged party's direct trust graph, and governance. The flagged DID is not publicly identified.
+
+> Imajin does not issue public verdicts. The trust graph renders judgment structurally. Exclusion comes through irrelevance, not public shaming.
+
+## Consequence Tiers
+
+### Level 1 — Yellow Flag
+First incident or low-severity flag.
+- DID is notified privately
+- Standing adjusts marginally
+- Cultural DID governance bodies are alerted with summary
+- No access changes
+
+### Level 2 — Amber Flag
+Repeated or moderate-severity flags.
+- Attestation accrual rate is throttled
+- Applications to new Cultural DIDs surfaced with flag history visible to evaluators
+- Direct messaging to non-connected DIDs suspended
+- Established DID may be **demoted to preliminary** standing
+
+### Level 3 — Red Flag
+Sustained pattern or severe single incident.
+- DID is demoted to preliminary (or soft) standing
+- EventDID and Cultural DID operators notified
+- Vouching DID takes a standing reduction
+- Recovery path exists but requires formal review by a governance body
+
+### Permanent Removal
+Reserved for Category C violations or uncontested pattern of Category A + B.
+- Cryptographic DID is blacklisted across the network
+- Vouching DID takes significant standing penalty
+- Threshold is intentionally high — over-punishment erodes trust as surely as under-punishment
+
+## Vouch Chain Accountability
+
+When you vouch for someone, you're not just saying "I know them." You're saying **"I'm sponsoring their onboarding, and my standing reflects how that goes."**
+
+If your vouched person:
+- Completes onboarding successfully → your standing gets a small positive attestation
+- Gets flagged during onboarding → you're notified, your standing is reviewed
+- Gets permanently removed → you take a significant standing hit
+
+This makes vouching a **considered act** with real consequences. The social pressure is architectural, not performative.
+
+## Implementation Notes
+
+- **Flags are attestations** — typed, signed, attached to the flagged DID's identity record
+- **Standing computation** incorporates flag history alongside positive attestations
+- **Governance weight** for flag evaluation follows the Cultural DID model — weighted by contribution, corrected by inactivity
+- **Privacy by default** — flags don't leak beyond the relevant governance scope
+- **Appeals process** — flagged DID can request review by a higher-standing governance body
+
+## Open Questions
+
+1. Who has flagging rights? Only established DIDs? Or can preliminary DIDs flag too (with lower weight)?
+2. How does cross-community flagging work? A flag in Cultural DID A — does it affect standing in Cultural DID B?
+3. What's the decay rate on flags? Do yellow flags expire after N months of clean behavior?
+4. How do we prevent coordinated flagging attacks (brigading)?
+5. Should there be a "voucher score" — a visible track record of how your vouched people have performed?
+
+## Credit
+
+Bad actor model from Greg Mulholland's "Entering the Network" (March 2026). Vouch chain accountability refined in discussion with Ryan.

--- a/docs/rfcs/RFC-16-jin-workspace-agent.md
+++ b/docs/rfcs/RFC-16-jin-workspace-agent.md
@@ -1,8 +1,9 @@
-# RFC-002: Jin Workspace Agent Architecture
+# RFC-16: Jin Workspace Agent Architecture
 
-**Author:** Ryan Veteze + Jin  
-**Date:** March 15, 2026  
-**Status:** Draft  
+**Author:** Ryan Veteze + Jin
+**Date:** March 15, 2026
+**Status:** Draft
+**Discussion:** none
 **Scope:** Presence system, workspace UI, agent runtime, memory, identity
 
 ---


### PR DESCRIPTION
Consolidates all RFCs from three scattered locations into `docs/rfcs/` with a single numbering scheme.

## What changed
- **Moved** 3 RFCs from `apps/www/articles/` → `docs/rfcs/`
- **Renumbered** RFC-001 → RFC-06, RFC-002 → RFC-16
- **Created stubs** for RFC-03 (Memory Attribution) and RFC-04 (Settlement Protocol)
- **Created repo files** for 9 discussion-only RFCs (07-15), pulled from GitHub Discussions
- **Added** `INDEX.md` with full table and discussion links

## RFC Index

| # | Title | Discussion |
|---|-------|------------|
| 01 | .fair Attribution | #15 |
| 02 | Distribution Contracts | #16 |
| 03 | Memory Attribution (HRPOS) | stub |
| 04 | Settlement Protocol | stub |
| 05 | Intent-Bearing Transactions | — |
| 06 | Identity Portability | — |
| 07 | Cultural DID | #252 |
| 08 | Org DID | #253 |
| 09 | Plugin Architecture | #254 |
| 10 | Sovereign User Data | #255 |
| 11 | Embedded Wallet | #268 |
| 12 | MJN Token Economics | #269 |
| 13 | Progressive Trust Model | #271 |
| 14 | Community Issuance Network | #272 |
| 15 | Trust Accountability | #273 |
| 16 | Jin Workspace Agent | — |