### PR TITLE
feat(pay): Stripe Connect onboarding UI (#359)

### DIFF
--- a/apps/pay/app/components/PayoutSetupBanner.tsx
+++ b/apps/pay/app/components/PayoutSetupBanner.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+interface ConnectStatus {
+  did: string;
+  stripeAccountId: string;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+  onboardingComplete: boolean;
+  defaultCurrency: string;
+}
+
+interface PayoutSetupBannerProps {
+  message?: string;
+  did: string;
+}
+
+export function PayoutSetupBanner({
+  message = "Set up payouts to receive funds",
+  did
+}: PayoutSetupBannerProps) {
+  const [shouldShow, setShouldShow] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const checkConnectStatus = async () => {
+      try {
+        // Check if banner was previously dismissed (stored in localStorage)
+        const dismissedKey = `payout-banner-dismissed-${did}`;
+        if (localStorage.getItem(dismissedKey) === 'true') {
+          setIsDismissed(true);
+          setLoading(false);
+          return;
+        }
+
+        const response = await fetch(`/api/connect/status?did=${did}`, {
+          headers: {
+            'Cache-Control': 'no-cache',
+          },
+        });
+
+        if (response.status === 404) {
+          // Not connected - show banner
+          setShouldShow(true);
+        } else if (response.ok) {
+          const status: ConnectStatus = await response.json();
+          // Show banner if onboarding is not complete
+          setShouldShow(!status.onboardingComplete);
+        }
+        // If there's an error or other status, don't show banner
+      } catch (error) {
+        console.error('Error checking connect status for banner:', error);
+        // On error, don't show banner to avoid annoying users
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (did) {
+      checkConnectStatus();
+    } else {
+      setLoading(false);
+    }
+  }, [did]);
+
+  const handleDismiss = () => {
+    const dismissedKey = `payout-banner-dismissed-${did}`;
+    localStorage.setItem(dismissedKey, 'true');
+    setIsDismissed(true);
+  };
+
+  // Don't render anything while loading, if dismissed, or if shouldn't show
+  if (loading || isDismissed || !shouldShow) {
+    return null;
+  }
+
+  return (
+    <div className="bg-orange-900/20 border border-orange-800/50 rounded-xl p-4 mb-6">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="w-2 h-2 bg-orange-500 rounded-full animate-pulse shrink-0"></div>
+          <div className="flex-1">
+            <p className="text-sm text-orange-200">
+              {message}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 shrink-0">
+          <Link
+            href="/payouts"
+            className="text-sm text-orange-400 hover:text-orange-300 font-medium transition-colors"
+          >
+            Set up payouts →
+          </Link>
+          <button
+            onClick={handleDismiss}
+            className="text-orange-400/60 hover:text-orange-400 text-lg leading-none transition-colors"
+            aria-label="Dismiss banner"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/pay/app/page.tsx
+++ b/apps/pay/app/page.tsx
@@ -4,6 +4,7 @@ import { db, balances, transactions } from '@/src/db';
 import { eq, or, desc } from 'drizzle-orm';
 import Link from 'next/link';
 import { BalanceCard } from './components/BalanceCard';
+import { PayoutSetupBanner } from './components/PayoutSetupBanner';
 
 const SERVICE_ICONS: Record<string, string> = {
   coffee: '☕',
@@ -47,6 +48,9 @@ export default async function Home() {
         </p>
       </div>
 
+      {/* Payout Setup Banner */}
+      <PayoutSetupBanner did={session.id} />
+
       {/* Balance */}
       <BalanceCard
         cashAmount={cashAmount}
@@ -54,6 +58,34 @@ export default async function Home() {
         currency={balance?.currency || 'USD'}
         updatedAt={balance?.updatedAt ?? null}
       />
+
+      {/* Quick Navigation */}
+      <div className="flex gap-4">
+        <Link
+          href="/payouts"
+          className="flex-1 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-xl p-4 text-center transition-colors group"
+        >
+          <div className="text-2xl mb-2">💰</div>
+          <div className="text-sm font-medium text-white group-hover:text-orange-400 transition-colors">
+            Payouts
+          </div>
+          <div className="text-xs text-zinc-500 mt-1">
+            Bank account & withdrawals
+          </div>
+        </Link>
+        <Link
+          href="/history"
+          className="flex-1 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-xl p-4 text-center transition-colors group"
+        >
+          <div className="text-2xl mb-2">📊</div>
+          <div className="text-sm font-medium text-white group-hover:text-orange-400 transition-colors">
+            History
+          </div>
+          <div className="text-xs text-zinc-500 mt-1">
+            All transactions
+          </div>
+        </Link>
+      </div>
 
       {/* Recent Transactions */}
       <div>

--- a/apps/pay/app/payouts/PayoutActions.tsx
+++ b/apps/pay/app/payouts/PayoutActions.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+
+interface PayoutActionsProps {
+  status: 'not_connected' | 'incomplete_onboarding' | 'connected';
+  did: string;
+}
+
+export function PayoutActions({ status, did }: PayoutActionsProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleOnboard = async () => {
+    if (loading) return;
+
+    setLoading(true);
+    try {
+      const currentUrl = window.location.href;
+
+      const response = await fetch('/api/connect/onboard', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          return_url: currentUrl,
+          refresh_url: currentUrl,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to create onboarding link: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      // Redirect to Stripe onboarding
+      window.location.href = data.onboardingUrl;
+    } catch (error) {
+      console.error('Error starting onboarding:', error);
+      alert('Failed to start onboarding process. Please try again.');
+      setLoading(false);
+    }
+  };
+
+  const handleDashboard = async () => {
+    if (loading) return;
+
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/connect/dashboard?did=${did}`, {
+        method: 'GET',
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to get dashboard link: ${response.status}`);
+      }
+
+      const data = await response.json();
+
+      // Open Stripe dashboard in new tab
+      window.open(data.url, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      console.error('Error opening dashboard:', error);
+      alert('Failed to open dashboard. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (status === 'not_connected') {
+    return (
+      <button
+        onClick={handleOnboard}
+        disabled={loading}
+        className="px-6 py-3 bg-orange-600 hover:bg-orange-500 disabled:bg-orange-700 disabled:opacity-50 text-white font-medium rounded-lg transition-colors"
+      >
+        {loading ? 'Setting up...' : 'Set up payouts'}
+      </button>
+    );
+  }
+
+  if (status === 'incomplete_onboarding') {
+    return (
+      <button
+        onClick={handleOnboard}
+        disabled={loading}
+        className="px-6 py-3 bg-orange-600 hover:bg-orange-500 disabled:bg-orange-700 disabled:opacity-50 text-white font-medium rounded-lg transition-colors"
+      >
+        {loading ? 'Continuing setup...' : 'Continue setup'}
+      </button>
+    );
+  }
+
+  if (status === 'connected') {
+    return (
+      <button
+        onClick={handleDashboard}
+        disabled={loading}
+        className="px-6 py-3 bg-orange-600 hover:bg-orange-500 disabled:bg-orange-700 disabled:opacity-50 text-white font-medium rounded-lg transition-colors"
+      >
+        {loading ? 'Opening dashboard...' : 'Manage payouts'}
+      </button>
+    );
+  }
+
+  return null;
+}

--- a/apps/pay/app/payouts/page.tsx
+++ b/apps/pay/app/payouts/page.tsx
@@ -1,0 +1,149 @@
+import { redirect } from 'next/navigation';
+import { getSession } from '@imajin/auth';
+import { cookies } from 'next/headers';
+import Link from 'next/link';
+import { PayoutActions } from './PayoutActions';
+
+interface ConnectStatus {
+  did: string;
+  stripeAccountId: string;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  detailsSubmitted: boolean;
+  onboardingComplete: boolean;
+  defaultCurrency: string;
+}
+
+async function getConnectStatus(did: string, cookieHeader: string): Promise<ConnectStatus | null> {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
+    const response = await fetch(`${baseUrl}/api/connect/status?did=${did}`, {
+      headers: {
+        'Cookie': cookieHeader,
+        'Cache-Control': 'no-cache',
+      },
+    });
+
+    if (response.status === 404 || response.status === 403) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch connect status: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching connect status:', error);
+    return null;
+  }
+}
+
+export default async function PayoutsPage() {
+  const session = await getSession();
+
+  if (!session) {
+    const authUrl = process.env.NEXT_PUBLIC_AUTH_URL || 'https://auth.imajin.ai';
+    const payUrl = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
+    redirect(`${authUrl}/login?next=${encodeURIComponent(`${payUrl}/payouts`)}`);
+  }
+
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.getAll().map(c => `${c.name}=${c.value}`).join('; ');
+  const status = await getConnectStatus(session.id, cookieHeader);
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3 flex-wrap">
+        <Link href="/" className="text-zinc-500 hover:text-zinc-300 text-sm transition-colors">
+          ← Dashboard
+        </Link>
+        <h1 className="text-3xl font-bold text-white">Payouts</h1>
+      </div>
+
+      {/* Payout Status Card */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+        {!status ? (
+          // State A - Not connected
+          <div className="text-center space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold text-white mb-2">Set up payouts</h2>
+              <p className="text-zinc-400 max-w-2xl mx-auto">
+                Connect your bank account to receive payouts from events, tips, and sales.
+              </p>
+            </div>
+            <PayoutActions
+              status="not_connected"
+              did={session.id}
+            />
+          </div>
+        ) : !status.onboardingComplete ? (
+          // State B - Onboarding incomplete
+          <div className="space-y-6">
+            <div>
+              <h2 className="text-xl font-semibold text-white mb-2">Complete your setup</h2>
+              <p className="text-zinc-400">
+                Your payout account needs more information to start receiving funds.
+              </p>
+            </div>
+
+            {/* Capabilities Status */}
+            <div className="grid gap-3">
+              <div className="flex items-center gap-3">
+                <span className={`text-lg ${status.chargesEnabled ? 'text-green-400' : 'text-red-400'}`}>
+                  {status.chargesEnabled ? '✅' : '❌'}
+                </span>
+                <span className="text-sm text-zinc-300">
+                  Charges enabled
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className={`text-lg ${status.payoutsEnabled ? 'text-green-400' : 'text-red-400'}`}>
+                  {status.payoutsEnabled ? '✅' : '❌'}
+                </span>
+                <span className="text-sm text-zinc-300">
+                  Payouts enabled
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className={`text-lg ${status.detailsSubmitted ? 'text-green-400' : 'text-red-400'}`}>
+                  {status.detailsSubmitted ? '✅' : '❌'}
+                </span>
+                <span className="text-sm text-zinc-300">
+                  Details submitted
+                </span>
+              </div>
+            </div>
+
+            <PayoutActions
+              status="incomplete_onboarding"
+              did={session.id}
+            />
+          </div>
+        ) : (
+          // State C - Connected
+          <div className="space-y-6">
+            <div className="text-center">
+              <div className="text-green-400 text-4xl mb-3">✅</div>
+              <h2 className="text-xl font-semibold text-white mb-2">Payouts enabled</h2>
+              <p className="text-zinc-400">
+                Default currency: {status.defaultCurrency}
+              </p>
+            </div>
+
+            <div className="text-center">
+              <PayoutActions
+                status="connected"
+                did={session.id}
+              />
+              <p className="text-xs text-zinc-500 mt-3">
+                View payout schedule, bank details, and transaction history in the Stripe Dashboard
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the frontend for Stripe Connect onboarding and payout management in the pay app. Backend is PR #360 (#142).

Closes #359

## What's new

### Payouts page (`/payouts`)
Three-state UI based on Connect account status:
- **Not connected** — explanation + "Set up payouts" button → redirects to Stripe Express onboarding
- **Onboarding incomplete** — capability checklist (charges/payouts/details) + "Continue setup" button
- **Connected** — success state + "Manage payouts" button → opens Stripe Express Dashboard

### PayoutSetupBanner component
Reusable dismissible banner for cross-app nudging. Checks Connect status on mount, shows nudge if not connected/incomplete. Dismissal persists in localStorage. Added to pay dashboard.

### Dashboard updates
- PayoutSetupBanner integrated on main `/` page
- Navigation cards for Payouts and History

## Technical notes
- Server component forwards session cookie for ownership-gated status endpoint
- Gracefully handles missing Connect endpoints (returns null on 404/403/network error)
- Follows existing pay app patterns (dark theme, orange accents, auth redirect)

## Dependencies
- #360 (Stripe Connect backend) must merge first — this PR's pages will show "not connected" state until those endpoints exist

## Files
- `apps/pay/app/payouts/page.tsx` — server component, three-state payouts page
- `apps/pay/app/payouts/PayoutActions.tsx` — client component for onboard/dashboard actions
- `apps/pay/app/components/PayoutSetupBanner.tsx` — reusable nudge banner
- `apps/pay/app/page.tsx` — dashboard updates (banner + nav cards)