### PR TITLE
feat(ui): PayoutSetupBanner in events + coffee dashboards (#359)

### DIFF
--- a/apps/coffee/app/dashboard/page.tsx
+++ b/apps/coffee/app/dashboard/page.tsx
@@ -2,6 +2,9 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { PayoutSetupBanner } from '@imajin/ui';
+
+const PAY_URL = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
 
 interface Tip {
   id: string;
@@ -151,6 +154,13 @@ export default function DashboardPage() {
   return (
     <main className="min-h-screen bg-gradient-to-b from-amber-50 to-orange-50 dark:from-gray-900 dark:to-gray-800 py-8 px-4">
       <div className="max-w-5xl mx-auto">
+        {userPage?.did && (
+          <PayoutSetupBanner
+            did={userPage.did}
+            payUrl={PAY_URL}
+            message="Connect your bank account to receive tips directly"
+          />
+        )}
         {/* Header */}
         <div className="flex items-start justify-between flex-wrap gap-4 mb-8">
           <div>

--- a/apps/events/app/dashboard/page.tsx
+++ b/apps/events/app/dashboard/page.tsx
@@ -3,6 +3,9 @@ import { getSession } from '@/src/lib/auth';
 import { db, events, ticketTypes } from '@/src/db';
 import { eq, desc } from 'drizzle-orm';
 import Link from 'next/link';
+import { PayoutSetupBanner } from '@imajin/ui';
+
+const PAY_URL = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
 import { EventCard } from './event-card';
 
 interface EventWithStats {
@@ -40,6 +43,11 @@ export default async function DashboardPage() {
 
   return (
     <div className="max-w-7xl mx-auto">
+      <PayoutSetupBanner
+        did={session.id}
+        payUrl={PAY_URL}
+        message="Connect your bank account to receive ticket revenue"
+      />
       {/* Header */}
       <div className="mb-8 flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>

--- a/packages/ui/src/PayoutSetupBanner.tsx
+++ b/packages/ui/src/PayoutSetupBanner.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface PayoutSetupBannerProps {
+  did: string;
+  payUrl: string;
+  message?: string;
+}
+
+/**
+ * Reusable banner nudging users to connect their bank for payouts.
+ * Works cross-service — pass the pay service URL explicitly.
+ *
+ * Checks GET {payUrl}/api/connect/status?did=xxx
+ * If not connected or incomplete → shows dismissible banner linking to {payUrl}/payouts
+ * If connected or on error → renders nothing
+ */
+export function PayoutSetupBanner({
+  did,
+  payUrl,
+  message = 'Set up payouts to receive funds from events, tips, and sales',
+}: PayoutSetupBannerProps) {
+  const [shouldShow, setShouldShow] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const dismissedKey = `payout-banner-dismissed-${did}`;
+    if (typeof window !== 'undefined' && localStorage.getItem(dismissedKey) === 'true') {
+      setLoading(false);
+      return;
+    }
+
+    const check = async () => {
+      try {
+        const res = await fetch(`${payUrl}/api/connect/status?did=${encodeURIComponent(did)}`, {
+          credentials: 'include',
+        });
+
+        if (res.status === 404 || res.status === 403) {
+          setShouldShow(true);
+        } else if (res.ok) {
+          const data = await res.json();
+          setShouldShow(!data.onboardingComplete);
+        }
+      } catch {
+        // Network error / endpoint doesn't exist yet — stay hidden
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (did) check();
+    else setLoading(false);
+  }, [did, payUrl]);
+
+  const handleDismiss = () => {
+    localStorage.setItem(`payout-banner-dismissed-${did}`, 'true');
+    setShouldShow(false);
+  };
+
+  if (loading || !shouldShow) return null;
+
+  return (
+    <div className="bg-orange-900/20 border border-orange-800/50 rounded-xl p-4 mb-6">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-2 h-2 bg-orange-500 rounded-full animate-pulse shrink-0" />
+          <p className="text-sm text-orange-200">{message}</p>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <a
+            href={`${payUrl}/payouts`}
+            className="text-sm text-orange-400 hover:text-orange-300 font-medium transition-colors whitespace-nowrap"
+          >
+            Set up payouts →
+          </a>
+          <button
+            onClick={handleDismiss}
+            className="text-orange-400/60 hover:text-orange-400 text-lg leading-none transition-colors"
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,3 +14,5 @@ export { MarkdownContent } from './MarkdownContent';
 export type { MarkdownContentProps } from './MarkdownContent';
 export { ConnectionPicker } from './connection-picker';
 export type { ConnectionPickerProps } from './connection-picker';
+
+export { PayoutSetupBanner } from './PayoutSetupBanner';


### PR DESCRIPTION
## Summary

Adds the payout setup nudge banner to events and coffee dashboards.

Part of #359.

## What's new

### `@imajin/ui` — PayoutSetupBanner component
Cross-service client component. Props: `did`, `payUrl`, optional `message`.

- Checks `{payUrl}/api/connect/status?did=xxx` on mount
- Shows dismissible banner if not connected or onboarding incomplete
- Hides on connected, error, or network failure (graceful when Connect isn't deployed yet)
- Dismissal persists in localStorage per DID

### Events dashboard (`/dashboard`)
Banner: "Connect your bank account to receive ticket revenue"

### Coffee dashboard (`/dashboard`)
Banner: "Connect your bank account to receive tips directly"
Only renders after user page loads (needs DID from page data).

## Dependencies
- #360 (Connect backend) — banner degrades gracefully without it
- #361 (Connect UI / payouts page) — banner links to `{payUrl}/payouts`

## Files changed
- `packages/ui/src/PayoutSetupBanner.tsx` — new component
- `packages/ui/src/index.ts` — export
- `apps/events/app/dashboard/page.tsx` — added banner
- `apps/coffee/app/dashboard/page.tsx` — added banner