### PR TITLE
fix(www): add market to health check + homepage (#382)

### DIFF
--- a/apps/www/app/api/health/route.ts
+++ b/apps/www/app/api/health/route.ts
@@ -30,6 +30,7 @@ const SERVICES = [
   { name: 'dykil', label: 'Surveys' },
   { name: 'links', label: 'Links' },
   { name: 'learn', label: 'Learn' },
+  { name: 'market', label: 'Market' },
 ];
 
 async function checkService(service: { name: string; label: string }): Promise<ServiceCheck> {

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -190,6 +190,10 @@ export default async function Home() {
             <span>API Docs</span>
             <span className="text-gray-700">→</span>
           </a>
+          <a href={`${PREFIX}market.${DOMAIN}`} className="flex justify-between items-center text-gray-400 hover:text-amber-400 transition-colors py-1 border-b border-gray-900">
+            <span>Market</span>
+            <span className="text-gray-700">→</span>
+          </a>
         </div>
       </section>
 


### PR DESCRIPTION
Adds market service to:
- `apps/www/app/api/health/route.ts` SERVICES array
- Homepage Explore links section

The `/apps` launcher page already picks up market from `@imajin/config` SERVICES — just needs a www rebuild.

Closes #382