### PR TITLE
feat(ui): shared Toast component + replace 48 alert() calls (#373)

### DIFF
--- a/apps/coffee/app/[handle]/tip-form.tsx
+++ b/apps/coffee/app/[handle]/tip-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useToast } from '@imajin/ui';
 
 interface FundDirection {
   id: string;
@@ -24,6 +25,7 @@ interface TipFormProps {
 }
 
 export default function TipForm({ page, primaryColor }: TipFormProps) {
+  const { toast } = useToast();
   const [selectedAmount, setSelectedAmount] = useState<number | null>(page.presets?.[1] || 500);
   const [customAmount, setCustomAmount] = useState('');
   const [message, setMessage] = useState('');
@@ -92,7 +94,7 @@ export default function TipForm({ page, primaryColor }: TipFormProps) {
         window.location.href = data.url;
       } else if (paymentMethod === 'solana' && data.solanaAddress) {
         // Show Solana address for payment
-        alert(`Send ${amount / 100} USD worth of SOL to:\n${data.solanaAddress}`);
+        toast.info(`Send ${amount / 100} USD worth of SOL to: ${data.solanaAddress}`);
       }
     } catch (err: any) {
       setError(err.message);

--- a/apps/coffee/app/layout.tsx
+++ b/apps/coffee/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { NavBar } from '@imajin/ui';
 import './globals.css';
+import { Providers } from './providers';
 
 export const metadata: Metadata = {
   title: 'Coffee | Imajin',
@@ -23,7 +24,7 @@ export default function RootLayout({
           servicePrefix={servicePrefix}
           domain={domain}
         />
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/coffee/app/providers.tsx
+++ b/apps/coffee/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ToastProvider } from '@imajin/ui';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/apps/connections/app/invitations-tab.tsx
+++ b/apps/connections/app/invitations-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
+import { useToast } from '@imajin/ui';
 
 const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
 const SERVICE_PREFIX = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
@@ -61,6 +62,7 @@ function statusBadge(status: string) {
 }
 
 export default function InvitationsTab({ onCountUpdate }: { onCountUpdate?: (pending: number, remaining: number | null) => void }) {
+  const { toast } = useToast();
   const [invitedBy, setInvitedBy] = useState<InvitedBy | null | 'loading'>('loading');
   const [sentInvites, setSentInvites] = useState<SentInvite[]>([]);
   const [quota, setQuota] = useState<Quota | null>(null);
@@ -132,7 +134,7 @@ export default function InvitationsTab({ onCountUpdate }: { onCountUpdate?: (pen
         fetchSentInvites();
       } else {
         const err = await res.json();
-        alert(err.error || 'Failed to generate invite');
+        toast.error(err.error || 'Failed to generate invite');
       }
     } catch {} finally {
       setGenerating(false);

--- a/apps/connections/app/layout.tsx
+++ b/apps/connections/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { NavBar } from '@imajin/ui';
 import { IdentityProvider } from './context/IdentityContext';
 import './globals.css';
+import { Providers } from './providers';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -18,11 +19,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className="dark">
       <body className="min-h-screen bg-[#0a0a0a] text-white">
         <NavBar currentService="Connections" servicePrefix={prefix} domain={domain} />
-        <IdentityProvider>
-          <main className="container mx-auto px-4 py-8">
-            {children}
-          </main>
-        </IdentityProvider>
+        <Providers>
+          <IdentityProvider>
+            <main className="container mx-auto px-4 py-8">
+              {children}
+            </main>
+          </IdentityProvider>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/connections/app/pods/[id]/page.tsx
+++ b/apps/connections/app/pods/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useIdentity } from '../../context/IdentityContext';
-import { ConnectionPicker } from '@imajin/ui';
+import { ConnectionPicker, useToast } from '@imajin/ui';
 
 const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
 const SERVICE_PREFIX = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
@@ -35,6 +35,7 @@ interface Pod {
 export default function PodDetailPage({ params }: { params: { id: string } }) {
   const { id } = params;
   const { did, isLoggedIn, loading } = useIdentity();
+  const { toast } = useToast();
   const [pod, setPod] = useState<Pod | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
   const [loadingPod, setLoadingPod] = useState(true);
@@ -102,7 +103,7 @@ export default function PodDetailPage({ params }: { params: { id: string } }) {
         fetchPod();
       } else {
         const data = await res.json();
-        alert(data.error || 'Failed to add member');
+        toast.error(data.error || 'Failed to add member');
       }
     } catch {} finally {
       setAdding(false);
@@ -124,7 +125,7 @@ export default function PodDetailPage({ params }: { params: { id: string } }) {
         fetchPod();
       } else {
         const data = await res.json();
-        alert(data.error || 'Failed to remove member');
+        toast.error(data.error || 'Failed to remove member');
       }
     } catch {}
   }
@@ -136,7 +137,7 @@ export default function PodDetailPage({ params }: { params: { id: string } }) {
       if (res.ok) {
         window.location.href = '/?tab=groups';
       } else {
-        alert('Failed to delete group.');
+        toast.error('Failed to delete group');
       }
     } catch {}
   }

--- a/apps/connections/app/providers.tsx
+++ b/apps/connections/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ToastProvider } from '@imajin/ui';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/apps/dykil/app/(chrome)/[handle]/[surveyId]/page.tsx
+++ b/apps/dykil/app/(chrome)/[handle]/[surveyId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useToast } from '@imajin/ui';
 import { Model } from 'survey-core';
 import { Survey } from 'survey-react-ui';
 import 'survey-core/survey-core.min.css';
@@ -17,6 +18,7 @@ interface SurveyData {
 export default function SurveyResponsePage() {
   const params = useParams();
   const router = useRouter();
+  const { toast } = useToast();
   const { handle, surveyId } = params;
 
   const [loading, setLoading] = useState(true);
@@ -55,12 +57,12 @@ export default function SurveyResponsePage() {
 
         setSurveyModel(model);
       } else {
-        alert('Survey not found');
+        toast.error('Survey not found');
         router.push('/');
       }
     } catch (error) {
       console.error('Failed to fetch survey:', error);
-      alert('Failed to load survey');
+      toast.error('Failed to load survey');
     } finally {
       setLoading(false);
     }
@@ -80,12 +82,12 @@ export default function SurveyResponsePage() {
         setSubmitted(true);
       } else {
         const error = await res.json();
-        alert(error.error || 'Failed to submit response');
+        toast.error(error.error || 'Failed to submit response');
         setSubmitting(false);
       }
     } catch (error) {
       console.error('Failed to submit response:', error);
-      alert('Failed to submit response');
+      toast.error('Failed to submit response');
       setSubmitting(false);
     }
   };

--- a/apps/dykil/app/(chrome)/create/page.tsx
+++ b/apps/dykil/app/(chrome)/create/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useToast } from '@imajin/ui';
 import { Model } from 'survey-core';
 import { Survey } from 'survey-react-ui';
 import 'survey-core/survey-core.min.css';
@@ -162,6 +163,7 @@ function FieldFormPanel({
 function CreateSurveyContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { toast } = useToast();
   const editId = searchParams.get('id');
 
   const [loading, setLoading] = useState(!!editId);
@@ -216,12 +218,12 @@ function CreateSurveyContent() {
           fields: { elements }
         });
       } else {
-        alert('Failed to load survey');
+        toast.error('Failed to load survey');
         router.push('/dashboard');
       }
     } catch (error) {
       console.error('Failed to fetch survey:', error);
-      alert('Failed to load survey');
+      toast.error('Failed to load survey');
     } finally {
       setLoading(false);
     }
@@ -262,13 +264,13 @@ function CreateSurveyContent() {
 
   const saveField = () => {
     if (!fieldForm.title.trim()) {
-      alert('Question title is required');
+      toast.warning('Question title is required');
       return;
     }
 
     if ((fieldForm.type === 'radiogroup' || fieldForm.type === 'checkbox' || fieldForm.type === 'dropdown') &&
         (!fieldForm.choices || fieldForm.choices.length === 0 || !fieldForm.choices.some(c => typeof c === 'string' ? c.trim() : c.text?.trim()))) {
-      alert('Multiple choice questions must have at least one option');
+      toast.warning('Multiple choice questions must have at least one option');
       return;
     }
 
@@ -307,12 +309,12 @@ function CreateSurveyContent() {
 
   const saveSurvey = async (publish: boolean = false) => {
     if (!survey.title.trim()) {
-      alert('Survey title is required');
+      toast.warning('Survey title is required');
       return;
     }
 
     if (survey.fields.elements.length === 0) {
-      alert('Survey must have at least one question');
+      toast.warning('Survey must have at least one question');
       return;
     }
 
@@ -337,11 +339,11 @@ function CreateSurveyContent() {
         router.push('/dashboard');
       } else {
         const error = await res.json();
-        alert(error.error || 'Failed to save survey');
+        toast.error(error.error || 'Failed to save survey');
       }
     } catch (error) {
       console.error('Failed to save survey:', error);
-      alert('Failed to save survey');
+      toast.error('Failed to save survey');
     } finally {
       setSaving(false);
     }

--- a/apps/dykil/app/(chrome)/dashboard/page.tsx
+++ b/apps/dykil/app/(chrome)/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useToast } from '@imajin/ui';
 
 interface Survey {
   id: string;
@@ -16,6 +17,7 @@ interface Survey {
 
 export default function DashboardPage() {
   const router = useRouter();
+  const { toast } = useToast();
   const [loading, setLoading] = useState(true);
   const [surveys, setSurveys] = useState<Survey[]>([]);
 
@@ -74,11 +76,11 @@ export default function DashboardPage() {
         await fetchSurveys();
       } else {
         const error = await res.json();
-        alert(error.error || 'Failed to delete survey');
+        toast.error(error.error || 'Failed to delete survey');
       }
     } catch (error) {
       console.error('Failed to delete survey:', error);
-      alert('Failed to delete survey');
+      toast.error('Failed to delete survey');
     }
   };
 
@@ -175,7 +177,7 @@ export default function DashboardPage() {
                           const handle = survey.handle || 'survey';
                           const url = `${window.location.origin}/${handle}/${survey.id}`;
                           navigator.clipboard.writeText(url);
-                          alert('Survey link copied to clipboard!');
+                          toast.success('Survey link copied!');
                         }}
                         className="px-4 py-2 border border-gray-300 dark:border-gray-700 rounded-lg text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-700 transition"
                         title="Copy survey link"

--- a/apps/dykil/app/(chrome)/survey/[id]/results/page.tsx
+++ b/apps/dykil/app/(chrome)/survey/[id]/results/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useToast } from '@imajin/ui';
 import type { SurveyJSElement } from '@/db/schema';
 
 interface SurveyData {
@@ -33,6 +34,7 @@ interface Aggregation {
 export default function ResultsPage() {
   const params = useParams();
   const router = useRouter();
+  const { toast } = useToast();
   const surveyId = params.id as string;
 
   const [loading, setLoading] = useState(true);
@@ -71,12 +73,12 @@ export default function ResultsPage() {
         const agg = aggregateResponses(normalizedSurvey.fields.elements, responsesData.responses || []);
         setAggregation(agg);
       } else {
-        alert('Failed to load survey results');
+        toast.error('Failed to load survey results');
         router.push('/dashboard');
       }
     } catch (error) {
       console.error('Failed to fetch data:', error);
-      alert('Failed to load results');
+      toast.error('Failed to load results');
     } finally {
       setLoading(false);
     }

--- a/apps/dykil/app/layout.tsx
+++ b/apps/dykil/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import { Providers } from './providers';
 
 export const metadata: Metadata = {
   title: 'Dykil | Imajin',
@@ -14,7 +15,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100">
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/dykil/app/providers.tsx
+++ b/apps/dykil/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ToastProvider } from '@imajin/ui';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { useToast } from '@imajin/ui';
 
 interface Profile {
   name: string | null;
@@ -118,6 +119,7 @@ function ProfileCell({ ownerDid, profile, paymentMethod, paymentId }: {
 type FilterKey = 'type' | 'status' | null;
 
 export function GuestList({ eventId, isOwner }: GuestListProps) {
+  const { toast } = useToast();
   const [guests, setGuests] = useState<Guest[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -154,14 +156,14 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
       const res = await fetch(`/api/events/${eventId}/tickets/${ticketId}/check-in`, { method: 'POST' });
       const data = await res.json();
       if (!res.ok) {
-        alert(data.error || 'Check-in failed');
+        toast.error(data.error || 'Check-in failed');
         return;
       }
       setGuests(prev => prev.map(g =>
         g.id === ticketId ? { ...g, usedAt: data.ticket.usedAt } : g
       ));
     } catch {
-      alert('Check-in failed');
+      toast.error('Check-in failed');
     } finally {
       setActionLoading(null);
     }
@@ -174,14 +176,14 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
       const res = await fetch(`/api/tickets/${ticketId}/confirm-payment`, { method: 'POST' });
       const data = await res.json();
       if (!res.ok) {
-        alert(data.error || 'Confirmation failed');
+        toast.error(data.error || 'Confirmation failed');
         return;
       }
       setGuests(prev => prev.map(g =>
         g.id === ticketId ? { ...g, status: 'valid', purchasedAt: data.ticket.purchasedAt } : g
       ));
     } catch {
-      alert('Confirmation failed');
+      toast.error('Confirmation failed');
     } finally {
       setActionLoading(null);
     }
@@ -197,7 +199,7 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
       ]);
       const data = await res.json();
       if (!res.ok) {
-        alert(data.error || 'Failed to resend email');
+        toast.error(data.error || 'Failed to resend email');
         setResendState(prev => { const n = { ...prev }; delete n[ticketId]; return n; });
         return;
       }
@@ -209,7 +211,7 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
       setResendToast({ email: data.email });
       setTimeout(() => setResendToast(null), 4000);
     } catch {
-      alert('Failed to resend email');
+      toast.error('Failed to resend email');
       setResendState(prev => { const n = { ...prev }; delete n[ticketId]; return n; });
     }
   };
@@ -238,14 +240,14 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
       const res = await fetch(`/api/events/${eventId}/tickets/${ticketId}/refund`, { method: 'POST' });
       const data = await res.json();
       if (!res.ok) {
-        alert(data.error || 'Refund failed');
+        toast.error(data.error || 'Refund failed');
         return;
       }
       setGuests(prev => prev.map(g =>
         g.id === ticketId ? { ...g, status: 'refunded' } : g
       ));
     } catch {
-      alert('Refund failed');
+      toast.error('Refund failed');
     } finally {
       setActionLoading(null);
     }

--- a/apps/events/app/layout.tsx
+++ b/apps/events/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { NavBar } from './components/NavBar';
+import { Providers } from './providers';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -43,9 +44,11 @@ export default function RootLayout({
     <html lang="en" className="dark">
       <body className="min-h-screen bg-[#0a0a0a] text-white">
         <NavBar currentService="Events" />
-        <main className="container mx-auto px-4 py-8">
-          {children}
-        </main>
+        <Providers>
+          <main className="container mx-auto px-4 py-8">
+            {children}
+          </main>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/events/app/providers.tsx
+++ b/apps/events/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ToastProvider } from '@imajin/ui';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/apps/learn/app/course/[slug]/page.tsx
+++ b/apps/learn/app/course/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { OnboardGate } from '@imajin/onboard';
+import { useToast } from '@imajin/ui';
 
 interface Lesson {
   id: string;
@@ -60,6 +61,7 @@ const contentTypeIcons: Record<string, string> = {
 export default function CourseDetailPage() {
   const params = useParams();
   const router = useRouter();
+  const { toast } = useToast();
   const slug = params.slug as string;
 
   const [course, setCourse] = useState<Course | null>(null);
@@ -131,7 +133,7 @@ export default function CourseDetailPage() {
 
       if (!res.ok) {
         const err = await res.json();
-        alert(err.error || 'Enrollment failed');
+        toast.error(err.error || 'Enrollment failed');
         return;
       }
 
@@ -146,7 +148,7 @@ export default function CourseDetailPage() {
         window.location.reload();
       }
     } catch (e) {
-      alert('Enrollment failed');
+      toast.error('Enrollment failed');
     } finally {
       setEnrolling(false);
     }

--- a/apps/learn/app/dashboard/[slug]/page.tsx
+++ b/apps/learn/app/dashboard/[slug]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useToast } from '@imajin/ui';
 
 interface Lesson {
   id: string;
@@ -37,6 +38,7 @@ interface Course {
 export default function CourseEditorPage() {
   const params = useParams();
   const router = useRouter();
+  const { toast } = useToast();
   const slug = params.slug as string;
 
   const [course, setCourse] = useState<Course | null>(null);
@@ -97,7 +99,7 @@ export default function CourseEditorPage() {
       });
       await loadCourse();
     } catch (e) {
-      alert('Failed to save');
+      toast.error('Failed to save');
     } finally {
       setSaving(false);
     }

--- a/apps/learn/app/dashboard/page.tsx
+++ b/apps/learn/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useToast } from '@imajin/ui';
 
 interface Course {
   id: string;
@@ -23,6 +24,7 @@ const statusColors: Record<string, string> = {
 };
 
 export default function DashboardPage() {
+  const { toast } = useToast();
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -68,10 +70,10 @@ export default function DashboardPage() {
         window.location.href = `/dashboard/${course.slug}`;
       } else {
         const err = await res.json();
-        alert(err.error || 'Failed to create course');
+        toast.error(err.error || 'Failed to create course');
       }
     } catch (e) {
-      alert('Failed to create course');
+      toast.error('Failed to create course');
     } finally {
       setCreating(false);
     }

--- a/apps/learn/app/layout.tsx
+++ b/apps/learn/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { NavBar } from '@imajin/ui';
 import './globals.css';
+import { Providers } from './providers';
 
 export const metadata: Metadata = {
   title: 'Learn | Imajin',
@@ -23,7 +24,7 @@ export default function RootLayout({
           servicePrefix={servicePrefix}
           domain={domain}
         />
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/learn/app/providers.tsx
+++ b/apps/learn/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ToastProvider } from '@imajin/ui';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/apps/links/app/dashboard/page.tsx
+++ b/apps/links/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useToast } from '@imajin/ui';
 
 interface LinkStats {
   id: string;
@@ -29,6 +30,7 @@ interface Stats {
 
 export default function DashboardPage() {
   const router = useRouter();
+  const { toast } = useToast();
   const [loading, setLoading] = useState(true);
   const [stats, setStats] = useState<Stats | null>(null);
   const [handle, setHandle] = useState<string>('');
@@ -125,7 +127,7 @@ export default function DashboardPage() {
             <button
               onClick={() => {
                 navigator.clipboard.writeText(`${window.location.origin}/${handle}`);
-                alert('Link copied!');
+                toast.success('Link copied!');
               }}
               className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-700 transition"
             >

--- a/apps/links/app/edit/page.tsx
+++ b/apps/links/app/edit/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useToast } from '@imajin/ui';
 
 interface Link {
   id: string;
@@ -70,6 +71,7 @@ const THEME_PRESETS = {
 };
 
 export default function EditPage() {
+  const { toast } = useToast();
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState<LinkPage | null>(null);
   const [autoCreateError, setAutoCreateError] = useState(false);
@@ -162,11 +164,11 @@ export default function EditPage() {
         setShowEditForm(false);
       } else {
         const error = await res.json();
-        alert(error.error || 'Failed to update page');
+        toast.error(error.error || 'Failed to update page');
       }
     } catch (error) {
       console.error('Failed to update page:', error);
-      alert('Failed to update page');
+      toast.error('Failed to update page');
     }
   };
 
@@ -196,11 +198,11 @@ export default function EditPage() {
         setLinkFormData({ title: '', url: '', icon: '', visibility: 'public', isActive: true });
       } else {
         const error = await res.json();
-        alert(error.error || 'Failed to add link');
+        toast.error(error.error || 'Failed to add link');
       }
     } catch (error) {
       console.error('Failed to add link:', error);
-      alert('Failed to add link');
+      toast.error('Failed to add link');
     }
   };
 
@@ -228,11 +230,11 @@ export default function EditPage() {
         setLinkFormData({ title: '', url: '', icon: '', visibility: 'public', isActive: true });
       } else {
         const error = await res.json();
-        alert(error.error || 'Failed to update link');
+        toast.error(error.error || 'Failed to update link');
       }
     } catch (error) {
       console.error('Failed to update link:', error);
-      alert('Failed to update link');
+      toast.error('Failed to update link');
     }
   };
 
@@ -249,11 +251,11 @@ export default function EditPage() {
         await fetchPage();
       } else {
         const error = await res.json();
-        alert(error.error || 'Failed to delete link');
+        toast.error(error.error || 'Failed to delete link');
       }
     } catch (error) {
       console.error('Failed to delete link:', error);
-      alert('Failed to delete link');
+      toast.error('Failed to delete link');
     }
   };
 
@@ -287,7 +289,7 @@ export default function EditPage() {
       await fetchPage();
     } catch (error) {
       console.error('Failed to reorder links:', error);
-      alert('Failed to reorder links');
+      toast.error('Failed to reorder links');
     }
   };
 

--- a/apps/links/app/layout.tsx
+++ b/apps/links/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { NavBar } from '@imajin/ui';
 import { LayoutWrapper } from '@/components/LayoutWrapper';
 import './globals.css';
+import { Providers } from './providers';
 
 export const metadata: Metadata = {
   title: 'Links | Imajin',
@@ -24,9 +25,11 @@ export default function RootLayout({
           servicePrefix={servicePrefix}
           domain={domain}
         />
-        <LayoutWrapper>
-          {children}
-        </LayoutWrapper>
+        <Providers>
+          <LayoutWrapper>
+            {children}
+          </LayoutWrapper>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/links/app/providers.tsx
+++ b/apps/links/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ToastProvider } from '@imajin/ui';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/apps/pay/app/layout.tsx
+++ b/apps/pay/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { NavBar } from './components/NavBar';
+import { Providers } from './providers';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -34,9 +35,11 @@ export default function RootLayout({
     <html lang="en" className="dark">
       <body className="min-h-screen bg-[#0a0a0a] text-white">
         <NavBar currentService="Pay" />
-        <main className="container mx-auto px-4 py-8">
-          {children}
-        </main>
+        <Providers>
+          <main className="container mx-auto px-4 py-8">
+            {children}
+          </main>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/pay/app/payouts/PayoutActions.tsx
+++ b/apps/pay/app/payouts/PayoutActions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useToast } from '@imajin/ui';
 
 interface PayoutActionsProps {
   status: 'not_connected' | 'incomplete_onboarding' | 'connected';
@@ -8,6 +9,7 @@ interface PayoutActionsProps {
 }
 
 export function PayoutActions({ status, did }: PayoutActionsProps) {
+  const { toast } = useToast();
   const [loading, setLoading] = useState(false);
 
   const handleOnboard = async () => {
@@ -38,7 +40,7 @@ export function PayoutActions({ status, did }: PayoutActionsProps) {
       window.location.href = data.onboardingUrl;
     } catch (error) {
       console.error('Error starting onboarding:', error);
-      alert('Failed to start onboarding process. Please try again.');
+      toast.error('Failed to start onboarding process. Please try again.');
       setLoading(false);
     }
   };
@@ -62,7 +64,7 @@ export function PayoutActions({ status, did }: PayoutActionsProps) {
       window.open(data.url, '_blank', 'noopener,noreferrer');
     } catch (error) {
       console.error('Error opening dashboard:', error);
-      alert('Failed to open dashboard. Please try again.');
+      toast.error('Failed to open dashboard. Please try again.');
     } finally {
       setLoading(false);
     }

--- a/apps/pay/app/providers.tsx
+++ b/apps/pay/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ToastProvider } from '@imajin/ui';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/apps/www/app/bugs/admin/page.tsx
+++ b/apps/www/app/bugs/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useToast } from '@imajin/ui';
 import type { BugReport } from '@/db/schema';
 
 const STATUSES = ['all', 'new', 'reviewed', 'imported', 'ignored', 'duplicate'] as const;
@@ -39,6 +40,7 @@ interface DuplicateState {
 }
 
 export default function AdminBugsPage() {
+  const { toast } = useToast();
   const [reports, setReports] = useState<BugReport[]>([]);
   const [filter, setFilter] = useState<StatusFilter>('new');
   const [loading, setLoading] = useState(true);
@@ -78,7 +80,7 @@ export default function AdminBugsPage() {
       }
       await fetchReports(filter);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Import failed');
+      toast.error(err instanceof Error ? err.message : 'Import failed');
     } finally {
       setActionLoading(null);
     }
@@ -98,7 +100,7 @@ export default function AdminBugsPage() {
       }
       await fetchReports(filter);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Update failed');
+      toast.error(err instanceof Error ? err.message : 'Update failed');
     } finally {
       setActionLoading(null);
       setIgnoreState(null);

--- a/apps/www/app/bugs/page.tsx
+++ b/apps/www/app/bugs/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { db, bugReports } from '@/db';
 import type { BugReport } from '@/db/schema';
 import { eq, desc } from 'drizzle-orm';
+import { BugReporterOpenButton } from '@/components/BugReporterOpenButton';
 
 const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
 import { SESSION_COOKIE_NAME as SESSION_COOKIE } from '@imajin/config';
@@ -126,22 +127,8 @@ export default async function BugsPage() {
             {allReports.length} total report{allReports.length !== 1 ? 's' : ''}
           </p>
         </div>
-        <button
-          id="open-bug-reporter"
-          className="px-4 py-2 bg-orange-500 hover:bg-orange-600 text-white text-sm font-medium rounded-lg transition-colors"
-        >
-          🐛 Report a Bug
-        </button>
+        <BugReporterOpenButton />
       </div>
-
-      {/* Script to trigger the floating bug reporter */}
-      <script dangerouslySetInnerHTML={{ __html: `
-        document.getElementById('open-bug-reporter')?.addEventListener('click', function() {
-          var btn = document.querySelector('[data-bug-reporter-trigger]');
-          if (btn) btn.click();
-          else alert('Bug reporter is loading — try again in a moment.');
-        });
-      `}} />
 
       {/* My Reports */}
       <section className="mb-10">

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { NavBar } from './components/NavBar';
 import { BugReportButton } from '@/components/bug-report-button';
+import { Providers } from './providers';
 
 const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
 import { SESSION_COOKIE_NAME as SESSION_COOKIE } from '@imajin/config';
@@ -74,7 +75,7 @@ export default function RootLayout({
     <html lang="en" className="dark">
       <body className="min-h-screen antialiased bg-[#0a0a0a] text-white">
         <NavBar currentService="Home" />
-        {children}
+        <Providers>{children}</Providers>
         <BugReportWidget />
       </body>
     </html>

--- a/apps/www/app/providers.tsx
+++ b/apps/www/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ToastProvider } from '@imajin/ui';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/apps/www/components/BugReporterOpenButton.tsx
+++ b/apps/www/components/BugReporterOpenButton.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useToast } from '@imajin/ui';
+
+export function BugReporterOpenButton() {
+  const { toast } = useToast();
+
+  const handleClick = () => {
+    const btn = document.querySelector('[data-bug-reporter-trigger]') as HTMLElement | null;
+    if (btn) {
+      btn.click();
+    } else {
+      toast.warning('Bug reporter is loading — try again in a moment.');
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="px-4 py-2 bg-orange-500 hover:bg-orange-600 text-white text-sm font-medium rounded-lg transition-colors"
+    >
+      🐛 Report a Bug
+    </button>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,3 +16,6 @@ export { ConnectionPicker } from './connection-picker';
 export type { ConnectionPickerProps } from './connection-picker';
 
 export { PayoutSetupBanner } from './PayoutSetupBanner';
+
+export { ToastProvider, useToast } from './toast';
+export type { ToastType } from './toast';

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import React, { createContext, useContext, useReducer, useCallback, useEffect } from 'react';
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+interface Toast {
+  id: string;
+  type: ToastType;
+  message: string;
+  sticky: boolean;
+}
+
+type Action =
+  | { type: 'ADD'; toast: Toast }
+  | { type: 'REMOVE'; id: string };
+
+function reducer(state: Toast[], action: Action): Toast[] {
+  switch (action.type) {
+    case 'ADD':
+      return [...state, action.toast].slice(-5);
+    case 'REMOVE':
+      return state.filter((t) => t.id !== action.id);
+    default:
+      return state;
+  }
+}
+
+interface ToastContextValue {
+  toast: {
+    success: (message: string) => void;
+    error: (message: string) => void;
+    warning: (message: string) => void;
+    info: (message: string) => void;
+  };
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const BORDER_COLORS: Record<ToastType, string> = {
+  success: 'border-l-green-500',
+  error: 'border-l-red-500',
+  warning: 'border-l-amber-500',
+  info: 'border-l-blue-500',
+};
+
+const DURATIONS: Record<ToastType, number> = {
+  success: 4000,
+  error: 0,
+  warning: 6000,
+  info: 4000,
+};
+
+function AutoDismiss({
+  id,
+  duration,
+  onDismiss,
+}: {
+  id: string;
+  duration: number;
+  onDismiss: (id: string) => void;
+}) {
+  useEffect(() => {
+    const timer = setTimeout(() => onDismiss(id), duration);
+    return () => clearTimeout(timer);
+  }, [id, duration, onDismiss]);
+  return null;
+}
+
+function ToastItem({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      className={`flex items-start gap-3 bg-gray-900 text-white px-4 py-3 rounded-lg shadow-lg border-l-4 ${BORDER_COLORS[toast.type]} min-w-[280px] max-w-sm`}
+      style={{ animation: 'toastSlideIn 0.2s ease-out' }}
+    >
+      <p className="flex-1 text-sm">{toast.message}</p>
+      <button
+        onClick={onDismiss}
+        className="text-gray-400 hover:text-white transition-colors shrink-0 text-lg leading-none"
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, dispatch] = useReducer(reducer, []);
+
+  const dismiss = useCallback((id: string) => {
+    dispatch({ type: 'REMOVE', id });
+  }, []);
+
+  const add = useCallback((type: ToastType, message: string) => {
+    const id =
+      typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : String(Date.now() + Math.random());
+    const sticky = type === 'error';
+    dispatch({ type: 'ADD', toast: { id, type, message, sticky } });
+  }, []);
+
+  const toast = {
+    success: (message: string) => add('success', message),
+    error: (message: string) => add('error', message),
+    warning: (message: string) => add('warning', message),
+    info: (message: string) => add('info', message),
+  };
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <div
+        className="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 items-end"
+        aria-live="polite"
+      >
+        <style>{`
+          @keyframes toastSlideIn {
+            from { transform: translateX(calc(100% + 1rem)); opacity: 0; }
+            to { transform: translateX(0); opacity: 1; }
+          }
+        `}</style>
+        {toasts.map((t) => (
+          <React.Fragment key={t.id}>
+            {!t.sticky && DURATIONS[t.type] > 0 && (
+              <AutoDismiss id={t.id} duration={DURATIONS[t.type]} onDismiss={dismiss} />
+            )}
+            <ToastItem toast={t} onDismiss={() => dismiss(t.id)} />
+          </React.Fragment>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within a ToastProvider');
+  return ctx;
+}


### PR DESCRIPTION
Adds `ToastProvider` + `useToast()` to `@imajin/ui` and replaces every `alert()` call in the monorepo.

**Toast component** (`packages/ui/src/toast.tsx`):
- `toast.success(msg)` — green, auto-dismiss 4s
- `toast.error(msg)` — red, sticky (manual dismiss)
- `toast.warning(msg)` — amber, auto-dismiss 6s
- `toast.info(msg)` — blue, auto-dismiss 4s
- Fixed bottom-right, stacks up to 5, slide-in animation, dark theme

**48 alert() calls replaced across 9 apps:**
| App | Count |
|-----|-------|
| dykil | 17 |
| links | 9 |
| events | 8 |
| connections | 4 |
| learn | 4 |
| www/bugs | 3 |
| pay | 2 |
| coffee | 1 |

Each app gets a `providers.tsx` client wrapper for `ToastProvider` (since root layouts are Server Components).

Closes #373