### PR TITLE
feat(auth): DFOS chain resolution endpoints (#398)

### DIFF
--- a/apps/auth/app/api/identity/[did]/chain/route.ts
+++ b/apps/auth/app/api/identity/[did]/chain/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders } from '@imajin/config';
+import { getChainByImajinDid } from '@/lib/dfos';
+import { verifyChain } from '@imajin/dfos';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * GET /api/identity/:did/chain
+ * Public endpoint — serve the DFOS identity chain for a DID.
+ * The log is a portable, self-verifying artifact.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const cors = corsHeaders(request);
+  try {
+    const { did } = await params;
+    const decodedDid = decodeURIComponent(did);
+
+    const chain = await getChainByImajinDid(decodedDid);
+    if (!chain) {
+      return NextResponse.json(
+        { error: 'No DFOS chain found for this identity' },
+        { status: 404, headers: cors }
+      );
+    }
+
+    // Verify chain integrity before serving
+    const verified = await verifyChain(chain.log as string[]);
+
+    return NextResponse.json({
+      did: decodedDid,
+      dfosDid: chain.dfosDid,
+      log: chain.log,
+      headCid: chain.headCid,
+      keyCount: chain.keyCount,
+      isDeleted: verified.isDeleted,
+    }, { headers: cors });
+  } catch (err) {
+    console.error('[chain] Error serving chain:', err);
+    return NextResponse.json(
+      { error: 'Internal error' },
+      { status: 500, headers: cors }
+    );
+  }
+}

--- a/apps/auth/app/api/identity/[did]/route.ts
+++ b/apps/auth/app/api/identity/[did]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, identities } from '@/src/db';
 import { eq } from 'drizzle-orm';
 import { corsHeaders } from '@imajin/config';
+import { getChainByImajinDid } from '@/lib/dfos';
 
 export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
@@ -39,12 +40,15 @@ export async function GET(
       );
     }
 
+    const chain = await getChainByImajinDid(decodedDid);
+
     return NextResponse.json(
       {
         did: identity.id,
         publicKey: identity.publicKey,
         type: identity.type,
         tier: identity.tier,
+        ...(chain ? { dfosDid: chain.dfosDid } : {}),
       },
       { headers: cors }
     );

--- a/apps/auth/app/api/resolve/dfos/[dfosDid]/route.ts
+++ b/apps/auth/app/api/resolve/dfos/[dfosDid]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders } from '@imajin/config';
+import { getIdentityByDfosDid } from '@/lib/dfos';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * GET /api/resolve/dfos/:dfosDid
+ * Public endpoint — resolve a did:dfos to its linked did:imajin identity.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ dfosDid: string }> }
+) {
+  const cors = corsHeaders(request);
+  try {
+    const { dfosDid } = await params;
+    const decodedDid = decodeURIComponent(dfosDid);
+
+    const identity = await getIdentityByDfosDid(decodedDid);
+    if (!identity) {
+      return NextResponse.json(
+        { error: 'No Imajin identity linked to this DFOS DID' },
+        { status: 404, headers: cors }
+      );
+    }
+
+    return NextResponse.json(identity, { headers: cors });
+  } catch (err) {
+    console.error('[resolve] Error resolving DFOS DID:', err);
+    return NextResponse.json(
+      { error: 'Internal error' },
+      { status: 500, headers: cors }
+    );
+  }
+}

--- a/apps/auth/lib/dfos.ts
+++ b/apps/auth/lib/dfos.ts
@@ -1,6 +1,6 @@
 import { verifyChain } from '@imajin/dfos';
 import { hexToMultibase } from '@imajin/auth';
-import { db, identityChains, credentials } from '@/src/db';
+import { db, identities, identityChains, credentials } from '@/src/db';
 import { eq } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
 
@@ -94,4 +94,50 @@ export async function storeDfosChain(
   });
 
   return true;
+}
+
+/**
+ * Look up a DFOS chain by Imajin DID.
+ * Returns the full chain record or null.
+ */
+export async function getChainByImajinDid(imajinDid: string) {
+  const [chain] = await db
+    .select()
+    .from(identityChains)
+    .where(eq(identityChains.did, imajinDid))
+    .limit(1);
+  return chain ?? null;
+}
+
+/**
+ * Look up an Imajin identity by its DFOS DID.
+ * Returns { imajinDid, dfosDid, type, tier } or null.
+ */
+export async function getIdentityByDfosDid(dfosDid: string) {
+  const [chain] = await db
+    .select()
+    .from(identityChains)
+    .where(eq(identityChains.dfosDid, dfosDid))
+    .limit(1);
+
+  if (!chain) return null;
+
+  const [identity] = await db
+    .select({
+      id: identities.id,
+      type: identities.type,
+      tier: identities.tier,
+    })
+    .from(identities)
+    .where(eq(identities.id, chain.did))
+    .limit(1);
+
+  if (!identity) return null;
+
+  return {
+    imajinDid: identity.id,
+    dfosDid: chain.dfosDid,
+    type: identity.type,
+    tier: identity.tier,
+  };
 }


### PR DESCRIPTION
Closes #398

## New endpoints
- `GET /api/identity/:did/chain` — portable chain log with integrity verification
- `GET /api/resolve/dfos/:dfosDid` — DFOS→Imajin DID lookup
- `GET /api/identity/:did` — now includes `dfosDid` when chain exists

## Implementation
- `getChainByImajinDid()` + `getIdentityByDfosDid()` shared lookups in `lib/dfos.ts`
- All public, no auth required (self-certifying identity is discoverable)
- Proper CORS headers on all endpoints