### PR TITLE
feat(fair): portable attribution with chain-backed creator proof (#418)

### DIFF
--- a/apps/media/app/api/assets/route.ts
+++ b/apps/media/app/api/assets/route.ts
@@ -172,6 +172,9 @@ export async function POST(request: NextRequest) {
 
   // .fair manifest — allow context to override access (public only)
   const accessLevel = context?.access === "public" ? "public" : "private";
+  const chainProof = identity.chainVerified
+    ? { verified: true, verifiedAt: new Date().toISOString() }
+    : undefined;
   const fairManifest = {
     fair: "1.0",
     id: assetId,
@@ -180,7 +183,7 @@ export async function POST(request: NextRequest) {
     created: new Date().toISOString(),
     source: "upload",
     access: { type: accessLevel },
-    attribution: [{ did: ownerDid, role: "creator", share: 1.0 }],
+    attribution: [{ did: ownerDid, role: "creator", share: 1.0, chainProof }],
     transfer: { allowed: false },
   };
 

--- a/packages/fair/src/components/FairAccordion.tsx
+++ b/packages/fair/src/components/FairAccordion.tsx
@@ -107,6 +107,11 @@ export function FairAccordion({ manifest, resolveProfile }: FairAccordionProps) 
                         {formatDid(entry.did, didNames)}
                       </span>
                     )}
+                    {entry.chainProof?.verified && (
+                      <span className="inline-flex items-center px-1.5 py-0.5 bg-emerald-900/30 border border-emerald-700/50 rounded-full text-[10px] text-emerald-400">
+                        ⛓ verified
+                      </span>
+                    )}
                   </div>
                   <span className="text-sm font-bold">{(entry.share * 100).toFixed(1)}%</span>
                 </div>

--- a/packages/fair/src/components/FairEditor.tsx
+++ b/packages/fair/src/components/FairEditor.tsx
@@ -119,6 +119,11 @@ function AttributionView({ entries, didNames }: { entries: FairEntry[]; didNames
               <span className="text-xs text-gray-500 truncate max-w-[180px]" title={entry.did}>
                 {formatDid(entry.did, didNames)}
               </span>
+              {entry.chainProof?.verified && (
+                <span className="inline-flex items-center px-1.5 py-0.5 bg-emerald-900/30 border border-emerald-700/50 rounded-full text-[10px] text-emerald-400">
+                  ⛓ verified
+                </span>
+              )}
             </div>
           </div>
           {shareBar(entry.share, entry.role)}

--- a/packages/fair/src/types.ts
+++ b/packages/fair/src/types.ts
@@ -9,6 +9,10 @@ export interface FairEntry {
   role: string; // creator, collaborator, producer, performer, platform, venue, etc.
   share: number; // 0.0 to 1.0
   note?: string;
+  chainProof?: {            // present when contributor has chain identity
+    verified: boolean;      // was chain verified at manifest creation time?
+    verifiedAt?: string;    // ISO timestamp
+  };
 }
 
 export interface FairTransfer {


### PR DESCRIPTION
## Portable Attribution with Chain-Backed Creator Proof

Part of Batch 2 (Trust Boundaries) under Epic #415.

### Changes
- **@imajin/fair:** `chainProof` field on `FairContributor` type (verified boolean + timestamp)
- **Media:** Populates `chainProof` on upload when uploader has chain verification
- **FairEditor:** Verification badge next to chain-verified contributors
- **FairAccordion:** Same badge in read-only view

### Design
- No chain DID in manifests — `did:imajin` resolves through registry/auth (substrate-agnostic)
- No chain library imports in media or fair packages
- Verification status is a snapshot at creation time

Closes #418