### PR TITLE
feat(connections): chain-recorded pod membership attestations (#421)

### DIFF
--- a/apps/connections/app/api/groups/[id]/members/route.ts
+++ b/apps/connections/app/api/groups/[id]/members/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, pods, podMembers } from '../../../../../src/db/index';
+import { emitAttestation } from '../../../../../src/lib/attestations';
 import { eq, and, isNull } from 'drizzle-orm';
 
 const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL!;
@@ -48,7 +49,59 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
     joinedAt: new Date(),
   }).returning();
 
+  if (session.chainVerified) {
+    emitAttestation({
+      issuer_did: session.did,
+      subject_did: body.did,
+      type: 'pod.member.added',
+      context_id: params.id,
+      context_type: 'pod',
+      payload: { role: member.role },
+    }).catch((err: unknown) => {
+      console.error('Attestation (pod.member.added) error:', err);
+    });
+  }
+
   return NextResponse.json({ member }, { status: 201 });
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const session = await getSession(request);
+  if (!session?.did) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const [pod] = await db.select().from(pods).where(eq(pods.id, params.id));
+  if (!pod) return NextResponse.json({ error: 'Pod not found' }, { status: 404 });
+  if (pod.ownerDid !== session.did) return NextResponse.json({ error: 'Only the owner can change roles' }, { status: 403 });
+  if (pod.type === 'event') return NextResponse.json({ error: 'Event pods are read-only' }, { status: 403 });
+
+  const body = await request.json();
+  if (!body.did) return NextResponse.json({ error: 'did is required' }, { status: 400 });
+  if (!body.role) return NextResponse.json({ error: 'role is required' }, { status: 400 });
+
+  const [updated] = await db
+    .update(podMembers)
+    .set({ role: body.role })
+    .where(and(eq(podMembers.podId, params.id), eq(podMembers.did, body.did), isNull(podMembers.removedAt)))
+    .returning();
+
+  if (!updated) return NextResponse.json({ error: 'Member not found' }, { status: 404 });
+
+  if (session.chainVerified) {
+    emitAttestation({
+      issuer_did: session.did,
+      subject_did: body.did,
+      type: 'pod.role.changed',
+      context_id: params.id,
+      context_type: 'pod',
+      payload: { role: body.role },
+    }).catch((err: unknown) => {
+      console.error('Attestation (pod.role.changed) error:', err);
+    });
+  }
+
+  return NextResponse.json({ member: updated });
 }
 
 export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
@@ -73,5 +126,19 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     .returning();
 
   if (!removed) return NextResponse.json({ error: 'Member not found' }, { status: 404 });
+
+  if (session.chainVerified) {
+    emitAttestation({
+      issuer_did: session.did,
+      subject_did: body.did,
+      type: 'pod.member.removed',
+      context_id: params.id,
+      context_type: 'pod',
+      payload: {},
+    }).catch((err: unknown) => {
+      console.error('Attestation (pod.member.removed) error:', err);
+    });
+  }
+
   return NextResponse.json({ removed: true });
 }

--- a/apps/connections/app/api/pods/[id]/members/route.ts
+++ b/apps/connections/app/api/pods/[id]/members/route.ts
@@ -1,13 +1,19 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth';
-import { db, podMembers } from '@/db';
-import { eq, and } from 'drizzle-orm';
+import { emitAttestation } from '@/lib/attestations';
+import { db, pods, podMembers } from '@/db';
+import { eq, and, isNull } from 'drizzle-orm';
 
 export async function POST(request: Request, { params }: { params: { id: string } }) {
-  const auth = await requireAuth(request);
+  const auth = await requireAuth(request, { verifyChain: true });
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
+  const [pod] = await db.select().from(pods).where(eq(pods.id, params.id));
+  if (!pod) return NextResponse.json({ error: 'Pod not found' }, { status: 404 });
+  if (pod.ownerDid !== auth.identity.id) return NextResponse.json({ error: 'Only the owner can add members' }, { status: 403 });
+
   const body = await request.json();
+  if (!body.did) return NextResponse.json({ error: 'did is required' }, { status: 400 });
 
   const [member] = await db.insert(podMembers).values({
     podId: params.id,
@@ -17,14 +23,68 @@ export async function POST(request: Request, { params }: { params: { id: string 
     joinedAt: new Date(),
   }).returning();
 
+  if (auth.identity.chainVerified) {
+    emitAttestation({
+      issuer_did: auth.identity.id,
+      subject_did: body.did,
+      type: 'pod.member.added',
+      context_id: params.id,
+      context_type: 'pod',
+      payload: { role: member.role },
+    }).catch((err: unknown) => {
+      console.error('Attestation (pod.member.added) error:', err);
+    });
+  }
+
   return NextResponse.json({ member }, { status: 201 });
 }
 
-export async function DELETE(request: Request, { params }: { params: { id: string } }) {
-  const auth = await requireAuth(request);
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  const auth = await requireAuth(request, { verifyChain: true });
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
+  const [pod] = await db.select().from(pods).where(eq(pods.id, params.id));
+  if (!pod) return NextResponse.json({ error: 'Pod not found' }, { status: 404 });
+  if (pod.ownerDid !== auth.identity.id) return NextResponse.json({ error: 'Only the owner can change roles' }, { status: 403 });
+
   const body = await request.json();
+  if (!body.did) return NextResponse.json({ error: 'did is required' }, { status: 400 });
+  if (!body.role) return NextResponse.json({ error: 'role is required' }, { status: 400 });
+
+  const [updated] = await db
+    .update(podMembers)
+    .set({ role: body.role })
+    .where(and(eq(podMembers.podId, params.id), eq(podMembers.did, body.did), isNull(podMembers.removedAt)))
+    .returning();
+
+  if (!updated) return NextResponse.json({ error: 'Member not found' }, { status: 404 });
+
+  if (auth.identity.chainVerified) {
+    emitAttestation({
+      issuer_did: auth.identity.id,
+      subject_did: body.did,
+      type: 'pod.role.changed',
+      context_id: params.id,
+      context_type: 'pod',
+      payload: { role: body.role },
+    }).catch((err: unknown) => {
+      console.error('Attestation (pod.role.changed) error:', err);
+    });
+  }
+
+  return NextResponse.json({ member: updated });
+}
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const auth = await requireAuth(request, { verifyChain: true });
+  if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const [pod] = await db.select().from(pods).where(eq(pods.id, params.id));
+  if (!pod) return NextResponse.json({ error: 'Pod not found' }, { status: 404 });
+  if (pod.ownerDid !== auth.identity.id) return NextResponse.json({ error: 'Only the owner can remove members' }, { status: 403 });
+
+  const body = await request.json();
+  if (!body.did) return NextResponse.json({ error: 'did is required' }, { status: 400 });
 
   const [removed] = await db
     .update(podMembers)
@@ -33,5 +93,19 @@ export async function DELETE(request: Request, { params }: { params: { id: strin
     .returning();
 
   if (!removed) return NextResponse.json({ error: 'Member not found' }, { status: 404 });
+
+  if (auth.identity.chainVerified) {
+    emitAttestation({
+      issuer_did: auth.identity.id,
+      subject_did: body.did,
+      type: 'pod.member.removed',
+      context_id: params.id,
+      context_type: 'pod',
+      payload: {},
+    }).catch((err: unknown) => {
+      console.error('Attestation (pod.member.removed) error:', err);
+    });
+  }
+
   return NextResponse.json({ removed: true });
 }

--- a/packages/auth/src/types/attestation.ts
+++ b/packages/auth/src/types/attestation.ts
@@ -17,6 +17,9 @@ export const ATTESTATION_TYPES = [
   'connection.accepted',
   'vouch',
   'session.created',
+  'pod.member.added',
+  'pod.member.removed',
+  'pod.role.changed',
 ] as const;
 
 export type AttestationType = typeof ATTESTATION_TYPES[number];


### PR DESCRIPTION
## Phase A: Chain-Recorded Pod Membership

Part of Batch 3 (Federation) under Epic #415.

### Changes
- Pod member add/remove/role-change emit attestations: `pod.member.added`, `pod.member.removed`, `pod.role.changed`
- Attestation types added to `@imajin/auth`
- Same pattern as events check-in attestations

Phase B (Cultural DID / collective chains) blocked on DFOS upstream support.

Closes #421