### PR TITLE
test: auth integration test suite (#408)

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -7,6 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:pull": "drizzle-kit pull",
@@ -36,6 +39,8 @@
     "drizzle-kit": "^0.31.9",
     "postcss": "^8",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.0.0",
+    "@vitest/coverage-v8": "^3.0.0"
   }
 }

--- a/apps/auth/tests/helpers/test-db.ts
+++ b/apps/auth/tests/helpers/test-db.ts
@@ -1,0 +1,44 @@
+import { db, identities, challenges, tokens } from '@/src/db';
+import { inArray } from 'drizzle-orm';
+
+/**
+ * Tracks records created during a test and deletes them on cleanup.
+ * Foreign-key order: tokens → challenges → identities.
+ */
+export class TestDb {
+  private trackedIdentities: string[] = [];
+  private trackedChallenges: string[] = [];
+  private trackedTokens: string[] = [];
+
+  trackIdentity(id: string): void {
+    this.trackedIdentities.push(id);
+  }
+
+  trackChallenge(id: string): void {
+    this.trackedChallenges.push(id);
+  }
+
+  trackToken(id: string): void {
+    this.trackedTokens.push(id);
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.trackedTokens.length) {
+      await db.delete(tokens).where(inArray(tokens.id, this.trackedTokens));
+    }
+    if (this.trackedChallenges.length) {
+      await db.delete(challenges).where(inArray(challenges.id, this.trackedChallenges));
+    }
+    if (this.trackedIdentities.length) {
+      await db.delete(identities).where(inArray(identities.id, this.trackedIdentities));
+    }
+    this.trackedIdentities = [];
+    this.trackedChallenges = [];
+    this.trackedTokens = [];
+  }
+}
+
+/** Convenience factory — one instance per describe block. */
+export function createTestDb(): TestDb {
+  return new TestDb();
+}

--- a/apps/auth/tests/helpers/test-identity.ts
+++ b/apps/auth/tests/helpers/test-identity.ts
@@ -1,0 +1,102 @@
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+import bs58 from 'bs58';
+
+// Required for sync operations in @noble/ed25519 v2
+ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
+
+// ---- hex utils ----
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// ---- types ----
+
+export type IdentityType = 'human' | 'agent' | 'presence' | 'org' | 'device' | 'service' | 'event';
+
+export interface TestIdentity {
+  /** Ed25519 private key (32 bytes, hex) */
+  privateKey: string;
+  /** Ed25519 public key (32 bytes, hex) */
+  publicKey: string;
+  /** did:imajin:{base58(publicKey)} */
+  did: string;
+  type: IdentityType;
+  handle?: string;
+  name?: string;
+
+  /** Sign an arbitrary UTF-8 message, returns hex signature */
+  sign(message: string): Promise<string>;
+
+  /**
+   * Build + sign the simple registration payload that the register route accepts.
+   * Matches: JSON.stringify({ publicKey, handle, name, type })
+   */
+  registrationPayload(): Promise<{
+    publicKey: string;
+    handle?: string;
+    name?: string;
+    type: IdentityType;
+    signature: string;
+  }>;
+}
+
+// ---- factory ----
+
+/**
+ * Generate a fresh Ed25519 keypair and wrap it in a TestIdentity.
+ *
+ * @example
+ * const alice = await createTestIdentity({ type: 'human', handle: 'alice' });
+ * const body  = await alice.registrationPayload();
+ * // POST /api/register with body
+ */
+export async function createTestIdentity(opts: {
+  type?: IdentityType;
+  handle?: string;
+  name?: string;
+} = {}): Promise<TestIdentity> {
+  const { type = 'human', handle, name } = opts;
+
+  const privateKeyBytes = ed.utils.randomPrivateKey();
+  const publicKeyBytes = await ed.getPublicKeyAsync(privateKeyBytes);
+
+  const privateKey = bytesToHex(privateKeyBytes);
+  const publicKey = bytesToHex(publicKeyBytes);
+  const did = `did:imajin:${bs58.encode(publicKeyBytes)}`;
+
+  async function sign(message: string): Promise<string> {
+    const msgBytes = new TextEncoder().encode(message);
+    const sigBytes = await ed.signAsync(msgBytes, privateKeyBytes);
+    return bytesToHex(sigBytes);
+  }
+
+  async function registrationPayload() {
+    const payload = { publicKey, handle, name, type };
+    const signature = await sign(JSON.stringify(payload));
+    return { publicKey, handle, name, type, signature };
+  }
+
+  return { privateKey, publicKey, did, type, handle, name, sign, registrationPayload };
+}
+
+/**
+ * Create multiple test identities at once.
+ */
+export async function createTestIdentities(
+  count: number,
+  opts: { type?: IdentityType } = {},
+): Promise<TestIdentity[]> {
+  return Promise.all(Array.from({ length: count }, () => createTestIdentity(opts)));
+}

--- a/apps/auth/tests/helpers/test-request.ts
+++ b/apps/auth/tests/helpers/test-request.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from 'next/server';
+
+export interface RequestOptions {
+  method?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+  cookies?: Record<string, string>;
+  /** Spoofed client IP (used for rate-limit key) */
+  ip?: string;
+}
+
+/**
+ * Build a NextRequest for route handler invocation.
+ * Each call creates a fresh request object.
+ */
+export function makeRequest(
+  pathname: string,
+  opts: RequestOptions = {},
+): NextRequest {
+  const { method = 'GET', body, headers = {}, cookies = {}, ip } = opts;
+  const url = `http://localhost${pathname}`;
+
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('; ');
+
+  const allHeaders: Record<string, string> = {
+    ...(body != null ? { 'Content-Type': 'application/json' } : {}),
+    ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+    // Unique IP per request to avoid shared rate-limit state between tests
+    'X-Forwarded-For': ip ?? `10.0.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 256)}`,
+    ...headers,
+  };
+
+  return new NextRequest(url, {
+    method,
+    headers: allHeaders,
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+}
+
+/** POST shorthand */
+export function post(pathname: string, body: unknown, opts: Omit<RequestOptions, 'method' | 'body'> = {}): NextRequest {
+  return makeRequest(pathname, { ...opts, method: 'POST', body });
+}
+
+/** GET shorthand */
+export function get(pathname: string, opts: Omit<RequestOptions, 'method' | 'body'> = {}): NextRequest {
+  return makeRequest(pathname, { ...opts, method: 'GET' });
+}

--- a/apps/auth/tests/integration/authenticate.test.ts
+++ b/apps/auth/tests/integration/authenticate.test.ts
@@ -1,0 +1,139 @@
+import { POST } from '@/app/api/register/route';
+import { POST as challengePost } from '@/app/api/challenge/route';
+import { POST as authenticatePost } from '@/app/api/authenticate/route';
+import { createTestIdentity, type TestIdentity } from '../helpers/test-identity';
+import { createTestDb } from '../helpers/test-db';
+import { post } from '../helpers/test-request';
+import { db, challenges } from '@/src/db';
+
+const testDb = createTestDb();
+
+afterEach(async () => {
+  await testDb.cleanup();
+});
+
+interface RegisteredIdentity {
+  did: string;
+  identity: TestIdentity;
+}
+
+/**
+ * Register a fresh identity and return its DID + test identity object.
+ */
+async function registerIdentity(ip: string, handle?: string): Promise<RegisteredIdentity> {
+  const identity = await createTestIdentity({ type: 'human', handle });
+  const payload = await identity.registrationPayload();
+  const req = post('/api/register', payload, { ip });
+  const res = await POST(req);
+  const data = await res.json();
+  expect(res.status).toBe(201);
+  testDb.trackIdentity(data.did);
+  return { did: data.did, identity };
+}
+
+/**
+ * Request a challenge for a given DID.
+ */
+async function getChallenge(did: string): Promise<{ challengeId: string; challenge: string }> {
+  const req = post('/api/challenge', { id: did });
+  const res = await challengePost(req);
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  testDb.trackChallenge(data.challengeId);
+  return { challengeId: data.challengeId, challenge: data.challenge };
+}
+
+describe('POST /api/authenticate', () => {
+  it('full flow: register -> challenge -> authenticate returns a token', async () => {
+    const { did, identity } = await registerIdentity('10.13.1.1', 'auth_flow1');
+    const { challengeId, challenge } = await getChallenge(did);
+
+    const sig = await identity.sign(challenge);
+    const req = post('/api/authenticate', { id: did, challengeId, signature: sig });
+    const res = await authenticatePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(typeof data.token).toBe('string');
+    expect(data.token).toMatch(/^imajin_tok_/);
+    expect(data.expiresAt).toBeDefined();
+    expect(data.identity).toBeDefined();
+    expect(data.identity.id).toBe(did);
+
+    testDb.trackToken(data.token);
+  });
+
+  it('returns 401 when signature is wrong', async () => {
+    const { did, identity } = await registerIdentity('10.13.2.1', 'auth_badsig2');
+    const { challengeId } = await getChallenge(did);
+
+    const wrongSig = 'deadbeef'.repeat(16); // 128 hex chars but invalid
+    const req = post('/api/authenticate', { id: did, challengeId, signature: wrongSig });
+    const res = await authenticatePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data.error).toMatch(/signature/i);
+  });
+
+  it('returns 400 when reusing an already-used challenge', async () => {
+    const { did, identity } = await registerIdentity('10.13.3.1', 'auth_reuse3');
+    const { challengeId, challenge } = await getChallenge(did);
+
+    const sig = await identity.sign(challenge);
+
+    // First use — should succeed
+    const req1 = post('/api/authenticate', { id: did, challengeId, signature: sig });
+    const res1 = await authenticatePost(req1);
+    const data1 = await res1.json();
+    expect(res1.status).toBe(200);
+    testDb.trackToken(data1.token);
+
+    // Second use — challenge is now spent
+    const req2 = post('/api/authenticate', { id: did, challengeId, signature: sig });
+    const res2 = await authenticatePost(req2);
+    const data2 = await res2.json();
+
+    expect(res2.status).toBe(400);
+    expect(data2.error).toBeDefined();
+  });
+
+  it('returns 404 for a non-existent identity', async () => {
+    const fakeDid = 'did:imajin:doesnotexist123456789012345678901234';
+    const req = post('/api/authenticate', {
+      id: fakeDid,
+      challengeId: 'ch_fakechallengeid',
+      signature: 'deadbeef'.repeat(16),
+    });
+    const res = await authenticatePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.error).toMatch(/identity/i);
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const req = post('/api/authenticate', {});
+    const res = await authenticatePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+
+  it('returns 400 for an invalid (non-existent) challengeId', async () => {
+    const { did, identity } = await registerIdentity('10.13.6.1', 'auth_badch6');
+    const fakeSig = await identity.sign('somechallenge');
+
+    const req = post('/api/authenticate', {
+      id: did,
+      challengeId: 'ch_totallyinvalid000000000000000000',
+      signature: fakeSig,
+    });
+    const res = await authenticatePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+});

--- a/apps/auth/tests/integration/challenge.test.ts
+++ b/apps/auth/tests/integration/challenge.test.ts
@@ -1,0 +1,79 @@
+import { POST } from '@/app/api/register/route';
+import { POST as challengePost } from '@/app/api/challenge/route';
+import { createTestIdentity } from '../helpers/test-identity';
+import { createTestDb } from '../helpers/test-db';
+import { post } from '../helpers/test-request';
+
+const testDb = createTestDb();
+
+afterEach(async () => {
+  await testDb.cleanup();
+});
+
+/**
+ * Helper: register an identity and return its DID.
+ */
+async function registerIdentity(ip: string, handle?: string): Promise<string> {
+  const identity = await createTestIdentity({ type: 'human', handle });
+  const payload = await identity.registrationPayload();
+  const req = post('/api/register', payload, { ip });
+  const res = await POST(req);
+  const data = await res.json();
+  expect(res.status).toBe(201);
+  testDb.trackIdentity(data.did);
+  return data.did;
+}
+
+describe('POST /api/challenge', () => {
+  it('returns 200 with challengeId, challenge, and expiresAt for a valid DID', async () => {
+    const did = await registerIdentity('10.12.1.1', 'ch_user1');
+
+    const req = post('/api/challenge', { id: did });
+    const res = await challengePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(typeof data.challengeId).toBe('string');
+    expect(data.challengeId.length).toBeGreaterThan(0);
+    expect(typeof data.challenge).toBe('string');
+    expect(data.challenge.length).toBeGreaterThan(0);
+    expect(typeof data.expiresAt).toBe('string');
+
+    testDb.trackChallenge(data.challengeId);
+  });
+
+  it('returns 404 for a non-existent DID', async () => {
+    const fakeDid = 'did:imajin:nonexistentdeadbeefdeadbeefdeadbeef';
+
+    const req = post('/api/challenge', { id: fakeDid });
+    const res = await challengePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.error).toBeDefined();
+  });
+
+  it('returns 400 when id is missing', async () => {
+    const req = post('/api/challenge', {});
+    const res = await challengePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+
+  it('expiresAt is in the future', async () => {
+    const did = await registerIdentity('10.12.4.1', 'ch_future4');
+    const before = Date.now();
+
+    const req = post('/api/challenge', { id: did });
+    const res = await challengePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    testDb.trackChallenge(data.challengeId);
+
+    const expiresAtMs = new Date(data.expiresAt).getTime();
+    expect(expiresAtMs).toBeGreaterThan(before);
+  });
+});

--- a/apps/auth/tests/integration/edge-cases.test.ts
+++ b/apps/auth/tests/integration/edge-cases.test.ts
@@ -1,0 +1,226 @@
+import { POST } from '@/app/api/register/route';
+import { POST as challengePost } from '@/app/api/challenge/route';
+import { POST as authenticatePost } from '@/app/api/authenticate/route';
+import { POST as verifyPost } from '@/app/api/verify/route';
+import { GET as sessionGet } from '@/app/api/session/route';
+import { createTestIdentity, type TestIdentity } from '../helpers/test-identity';
+import { createTestDb } from '../helpers/test-db';
+import { post, get } from '../helpers/test-request';
+import { canonicalize } from '@imajin/auth';
+import { db, challenges, identities } from '@/src/db';
+import { createSessionToken } from '@/lib/jwt';
+
+const testDb = createTestDb();
+const COOKIE_NAME = 'imajin_session';
+
+afterEach(async () => {
+  await testDb.cleanup();
+});
+
+/**
+ * Register a fresh identity and return its DID and test identity.
+ */
+async function registerIdentity(
+  ip: string,
+  opts: { handle?: string; type?: 'human' | 'agent' } = {},
+): Promise<{ did: string; identity: TestIdentity }> {
+  const { handle, type = 'human' } = opts;
+  const identity = await createTestIdentity({ type, handle });
+  const payload = await identity.registrationPayload();
+  const req = post('/api/register', payload, { ip });
+  const res = await POST(req);
+  const data = await res.json();
+  expect(res.status).toBe(201);
+  testDb.trackIdentity(data.did);
+  return { did: data.did as string, identity };
+}
+
+// ---------------------------------------------------------------------------
+// Register edge cases
+// ---------------------------------------------------------------------------
+describe('Register edge cases', () => {
+  it('publicKey that is not valid hex returns 401 (bad signature) or 400', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    const payload = await identity.registrationPayload();
+    const badPayload = { ...payload, publicKey: 'not_hex_at_all!!' };
+
+    const req = post('/api/register', badPayload, { ip: '10.20.1.1' });
+    const res = await POST(req);
+
+    expect([400, 401]).toContain(res.status);
+  });
+
+  it('publicKey with odd-length hex string returns 400 or 401', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    const payload = await identity.registrationPayload();
+    // Make the publicKey odd-length by appending one char
+    const badPayload = { ...payload, publicKey: payload.publicKey + 'f' };
+
+    const req = post('/api/register', badPayload, { ip: '10.20.2.1' });
+    const res = await POST(req);
+
+    expect([400, 401]).toContain(res.status);
+  });
+
+  it('handle with special chars like "test@handle" returns 400', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    const { publicKey, type } = await identity.registrationPayload();
+    const handle = 'test@handle';
+    const signature = await identity.sign(JSON.stringify({ publicKey, handle, name: undefined, type }));
+
+    const req = post('/api/register', { publicKey, handle, type, signature }, { ip: '10.20.3.1' });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('handle exactly 3 chars is accepted (minimum valid length)', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    const { publicKey, type } = await identity.registrationPayload();
+    const handle = 'abc';
+    const signature = await identity.sign(JSON.stringify({ publicKey, handle, name: undefined, type }));
+
+    const req = post('/api/register', { publicKey, handle, type, signature }, { ip: '10.20.4.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    testDb.trackIdentity(data.did);
+  });
+
+  it('handle exactly 30 chars is accepted (maximum valid length)', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    const { publicKey, type } = await identity.registrationPayload();
+    const handle = 'a'.repeat(30); // 30 lowercase letters
+    const signature = await identity.sign(JSON.stringify({ publicKey, handle, name: undefined, type }));
+
+    const req = post('/api/register', { publicKey, handle, type, signature }, { ip: '10.20.5.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    testDb.trackIdentity(data.did);
+  });
+
+  it('handle with 31 chars returns 400 (exceeds maximum)', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    const { publicKey, type } = await identity.registrationPayload();
+    const handle = 'a'.repeat(31); // 31 chars — too long
+    const signature = await identity.sign(JSON.stringify({ publicKey, handle, name: undefined, type }));
+
+    const req = post('/api/register', { publicKey, handle, type, signature }, { ip: '10.20.6.1' });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Challenge edge cases
+// ---------------------------------------------------------------------------
+describe('Challenge edge cases', () => {
+  it('id that looks like a DID but does not exist returns 404', async () => {
+    const fakeDid = 'did:imajin:FakeIdentityThatDoesNotExistInDB';
+
+    const req = post('/api/challenge', { id: fakeDid });
+    const res = await challengePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.error).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authenticate edge cases
+// ---------------------------------------------------------------------------
+describe('Authenticate edge cases', () => {
+  it('returns 400 for an expired challenge', async () => {
+    const { did, identity } = await registerIdentity('10.21.1.1', { handle: 'auth_exp1' });
+
+    // Insert a challenge that is already expired
+    const expiredChallengeId = 'ch_test_expired_edge01';
+    const pastDate = new Date(Date.now() - 10 * 60 * 1000);
+    await db.insert(challenges).values({
+      id: expiredChallengeId,
+      identityId: did,
+      challenge: 'deadbeef'.repeat(8),
+      expiresAt: pastDate,
+    });
+    testDb.trackChallenge(expiredChallengeId);
+
+    const sig = await identity.sign('deadbeef'.repeat(8));
+    const req = post('/api/authenticate', { id: did, challengeId: expiredChallengeId, signature: sig });
+    const res = await authenticatePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+
+  it('returns 400 when challenge belongs to a different identity', async () => {
+    const { did: did1, identity: identity1 } = await registerIdentity('10.21.2.1', { handle: 'auth_wrong_id2a' });
+    const { did: did2 } = await registerIdentity('10.21.2.2', { handle: 'auth_wrong_id2b' });
+
+    // Get a challenge for did2
+    const chReq = post('/api/challenge', { id: did2 });
+    const chRes = await challengePost(chReq);
+    expect(chRes.status).toBe(200);
+    const chData = await chRes.json();
+    testDb.trackChallenge(chData.challengeId);
+
+    // Attempt to authenticate as did1 using did2's challenge
+    const sig = await identity1.sign(chData.challenge);
+    const req = post('/api/authenticate', { id: did1, challengeId: chData.challengeId, signature: sig });
+    const res = await authenticatePost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verify edge cases
+// ---------------------------------------------------------------------------
+describe('Verify edge cases', () => {
+  it('returns { valid: false } for a message with a far-future timestamp', async () => {
+    const { did, identity } = await registerIdentity('10.22.1.1', { handle: 'verify_future1' });
+
+    // Build message with timestamp 5 minutes in the future
+    const futureTimestamp = Date.now() + 5 * 60 * 1000;
+    const msgWithoutSig = { from: did, type: 'human' as const, timestamp: futureTimestamp, payload: {} };
+    const canonical = canonicalize(msgWithoutSig);
+    const signature = await identity.sign(canonical);
+    const futureMsg = { ...msgWithoutSig, signature };
+
+    const req = post('/api/verify', { message: futureMsg });
+    const res = await verifyPost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session edge cases
+// ---------------------------------------------------------------------------
+describe('Session edge cases', () => {
+  it('returns 401 when JWT sub is a DID not in DB', async () => {
+    // Generate an identity but never register it — its DID is unknown to the DB
+    const unknownIdentity = await createTestIdentity({ type: 'human' });
+    const token = await createSessionToken({
+      sub: unknownIdentity.did,
+      type: 'human',
+      tier: 'preliminary',
+    });
+
+    const req = get('/api/session', { cookies: { [COOKIE_NAME]: token } });
+    const res = await sessionGet(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data.error).toBeDefined();
+  });
+});

--- a/apps/auth/tests/integration/register.test.ts
+++ b/apps/auth/tests/integration/register.test.ts
@@ -1,0 +1,176 @@
+import { POST } from '@/app/api/register/route';
+import { createTestIdentity } from '../helpers/test-identity';
+import { createTestDb } from '../helpers/test-db';
+import { post } from '../helpers/test-request';
+
+const testDb = createTestDb();
+
+afterEach(async () => {
+  await testDb.cleanup();
+});
+
+describe('POST /api/register', () => {
+  it('registers a new human identity and returns 201 with created:true', async () => {
+    const identity = await createTestIdentity({ type: 'human', handle: 'alice_reg1' });
+    const payload = await identity.registrationPayload();
+
+    const req = post('/api/register', payload, { ip: '10.11.1.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.created).toBe(true);
+    expect(data.did).toBeDefined();
+    expect(typeof data.did).toBe('string');
+    expect(data.did).toMatch(/^did:imajin:/);
+
+    testDb.trackIdentity(data.did);
+  });
+
+  it('re-registering with the same key returns 200 with created:false', async () => {
+    const identity = await createTestIdentity({ type: 'human', handle: 'alice_rereg2' });
+    const payload = await identity.registrationPayload();
+
+    const req1 = post('/api/register', payload, { ip: '10.11.2.1' });
+    const res1 = await POST(req1);
+    const data1 = await res1.json();
+    expect(res1.status).toBe(201);
+    testDb.trackIdentity(data1.did);
+
+    const req2 = post('/api/register', payload, { ip: '10.11.2.2' });
+    const res2 = await POST(req2);
+    const data2 = await res2.json();
+
+    expect(res2.status).toBe(200);
+    expect(data2.created).toBe(false);
+    expect(data2.did).toBe(data1.did);
+  });
+
+  it('returns 409 when handle is taken by a different key', async () => {
+    const sharedHandle = 'collide_reg3';
+
+    const identity1 = await createTestIdentity({ type: 'human', handle: sharedHandle });
+    const payload1 = await identity1.registrationPayload();
+    const req1 = post('/api/register', payload1, { ip: '10.11.3.1' });
+    const res1 = await POST(req1);
+    const data1 = await res1.json();
+    expect(res1.status).toBe(201);
+    testDb.trackIdentity(data1.did);
+
+    const identity2 = await createTestIdentity({ type: 'human', handle: sharedHandle });
+    const payload2 = await identity2.registrationPayload();
+    const req2 = post('/api/register', payload2, { ip: '10.11.3.2' });
+    const res2 = await POST(req2);
+    const data2 = await res2.json();
+
+    expect(res2.status).toBe(409);
+    expect(data2.error).toMatch(/handle/i);
+  });
+
+  it('returns 400 when publicKey is missing', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    const payload = await identity.registrationPayload();
+    const { publicKey: _omit, ...rest } = payload as any;
+
+    const req = post('/api/register', rest, { ip: '10.11.4.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toMatch(/publicKey/i);
+  });
+
+  it('returns 400 for an invalid type', async () => {
+    const identity = await createTestIdentity({ type: 'human', handle: 'badtype_reg5' });
+    const payload = await identity.registrationPayload();
+    const badPayload = { ...payload, type: 'superuser' };
+
+    const req = post('/api/register', badPayload, { ip: '10.11.5.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toMatch(/type/i);
+  });
+
+  it('returns 400 for handle that is too short (2 chars)', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    // Build a fresh payload with invalid handle
+    const { publicKey, type } = await identity.registrationPayload();
+    const handle = 'ab';
+    const signature = await identity.sign(JSON.stringify({ publicKey, handle, name: undefined, type }));
+
+    const req = post('/api/register', { publicKey, handle, type, signature }, { ip: '10.11.6.1' });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for handle with uppercase letters', async () => {
+    const identity = await createTestIdentity({ type: 'human' });
+    const { publicKey, type } = await identity.registrationPayload();
+    const handle = 'AB_Test';
+    const signature = await identity.sign(JSON.stringify({ publicKey, handle, name: undefined, type }));
+
+    const req = post('/api/register', { publicKey, handle, type, signature }, { ip: '10.11.7.1' });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when signature is missing', async () => {
+    const identity = await createTestIdentity({ type: 'human', handle: 'nosig_reg8' });
+    const payload = await identity.registrationPayload();
+    const { signature: _omit, ...rest } = payload as any;
+
+    const req = post('/api/register', rest, { ip: '10.11.8.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toMatch(/signature/i);
+  });
+
+  it('returns 401 when signature is invalid', async () => {
+    const identity = await createTestIdentity({ type: 'human', handle: 'badsig_reg9' });
+    const payload = await identity.registrationPayload();
+    const badPayload = { ...payload, signature: 'deadbeef'.repeat(16) };
+
+    const req = post('/api/register', badPayload, { ip: '10.11.9.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data.error).toMatch(/signature/i);
+  });
+
+  it('registers a service/agent identity without an invite code', async () => {
+    const identity = await createTestIdentity({ type: 'agent', handle: 'svc_agent_reg10' });
+    const payload = await identity.registrationPayload();
+
+    const req = post('/api/register', payload, { ip: '10.11.10.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(data.created).toBe(true);
+    expect(data.did).toBeDefined();
+
+    testDb.trackIdentity(data.did);
+  });
+
+  it('sets a session cookie on successful registration', async () => {
+    const identity = await createTestIdentity({ type: 'human', handle: 'cookie_reg11' });
+    const payload = await identity.registrationPayload();
+
+    const req = post('/api/register', payload, { ip: '10.11.11.1' });
+    const res = await POST(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(201);
+    testDb.trackIdentity(data.did);
+
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toMatch(/imajin_session=/);
+  });
+});

--- a/apps/auth/tests/integration/session.test.ts
+++ b/apps/auth/tests/integration/session.test.ts
@@ -1,0 +1,92 @@
+import { POST } from '@/app/api/register/route';
+import { GET as sessionGet } from '@/app/api/session/route';
+import { createTestIdentity } from '../helpers/test-identity';
+import { createTestDb } from '../helpers/test-db';
+import { post, get } from '../helpers/test-request';
+import { createSessionToken } from '@/lib/jwt';
+import { db, identities } from '@/src/db';
+import { eq } from 'drizzle-orm';
+
+const testDb = createTestDb();
+const COOKIE_NAME = 'imajin_session';
+
+afterEach(async () => {
+  await testDb.cleanup();
+});
+
+/**
+ * Register a fresh identity and return its DID plus the session cookie value.
+ */
+async function registerAndGetSession(
+  ip: string,
+  handle?: string,
+): Promise<{ did: string; sessionToken: string }> {
+  const identity = await createTestIdentity({ type: 'human', handle });
+  const payload = await identity.registrationPayload();
+  const req = post('/api/register', payload, { ip });
+  const res = await POST(req);
+  expect(res.status).toBe(201);
+  const data = await res.json();
+  testDb.trackIdentity(data.did);
+
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  const tokenMatch = setCookie.match(/imajin_session=([^;]+)/);
+  const sessionToken = tokenMatch?.[1] ?? '';
+  expect(sessionToken).not.toBe('');
+
+  return { did: data.did, sessionToken };
+}
+
+describe('GET /api/session', () => {
+  it('returns 401 when no session cookie is provided', async () => {
+    const req = get('/api/session');
+    const res = await sessionGet(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data.error).toBeDefined();
+  });
+
+  it('returns 401 for an invalid/garbage token', async () => {
+    const req = get('/api/session', { cookies: { [COOKIE_NAME]: 'totallygarbagetoken' } });
+    const res = await sessionGet(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data.error).toBeDefined();
+  });
+
+  it('returns session fields { did, type, tier, role } for a valid session', async () => {
+    const { did, sessionToken } = await registerAndGetSession('10.15.3.1', 'sess_valid3');
+
+    const req = get('/api/session', { cookies: { [COOKIE_NAME]: sessionToken } });
+    const res = await sessionGet(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.did).toBe(did);
+    expect(data.type).toBe('human');
+    expect(data.tier).toBeDefined();
+    expect(data.role).toBeDefined();
+  });
+
+  // REGRESSION: tier must come from DB, not the JWT
+  it('REGRESSION: tier is read from DB, not from JWT claims', async () => {
+    const { did } = await registerAndGetSession('10.15.4.1', 'sess_tier4');
+
+    // Update the DB tier to 'established'
+    await db.update(identities).set({ tier: 'established' }).where(eq(identities.id, did));
+
+    // Create a JWT that deliberately carries a different tier ('soft')
+    const customToken = await createSessionToken({ sub: did, type: 'human', tier: 'soft' });
+
+    const req = get('/api/session', { cookies: { [COOKIE_NAME]: customToken } });
+    const res = await sessionGet(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    // The response tier must come from DB ('established'), NOT the JWT ('soft')
+    expect(data.tier).toBe('established');
+    expect(data.tier).not.toBe('soft');
+  });
+});

--- a/apps/auth/tests/integration/verify.test.ts
+++ b/apps/auth/tests/integration/verify.test.ts
@@ -1,0 +1,131 @@
+import { POST } from '@/app/api/register/route';
+import { POST as verifyPost } from '@/app/api/verify/route';
+import { createTestIdentity } from '../helpers/test-identity';
+import { createTestDb } from '../helpers/test-db';
+import { post } from '../helpers/test-request';
+import { sign, canonicalize } from '@imajin/auth';
+
+const testDb = createTestDb();
+
+afterEach(async () => {
+  await testDb.cleanup();
+});
+
+/**
+ * Register a fresh identity and return its DID and test identity.
+ */
+async function registerIdentity(ip: string, opts: { handle?: string; type?: 'human' | 'agent' } = {}) {
+  const { handle, type = 'human' } = opts;
+  const identity = await createTestIdentity({ type, handle });
+  const payload = await identity.registrationPayload();
+  const req = post('/api/register', payload, { ip });
+  const res = await POST(req);
+  const data = await res.json();
+  expect(res.status).toBe(201);
+  testDb.trackIdentity(data.did);
+  return { did: data.did as string, identity };
+}
+
+describe('POST /api/verify', () => {
+  it('returns { valid: true, identity } for a valid signed message', async () => {
+    const { did, identity } = await registerIdentity('10.14.1.1', { handle: 'verify_user1' });
+
+    const msg = await sign({ action: 'test' }, identity.privateKey, { id: did, type: 'human' });
+    const req = post('/api/verify', { message: msg });
+    const res = await verifyPost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(true);
+    expect(data.identity).toBeDefined();
+    expect(data.identity.id).toBe(did);
+  });
+
+  it('returns { valid: false } for a wrong signature', async () => {
+    const { did, identity } = await registerIdentity('10.14.2.1', { handle: 'verify_badsig2' });
+
+    const msg = await sign({ action: 'test' }, identity.privateKey, { id: did, type: 'human' });
+    const tamperedMsg = { ...msg, signature: 'deadbeef'.repeat(16) };
+
+    const req = post('/api/verify', { message: tamperedMsg });
+    const res = await verifyPost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(false);
+  });
+
+  it('returns 400 when the message field is missing', async () => {
+    const req = post('/api/verify', {});
+    const res = await verifyPost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(data.error).toBeDefined();
+  });
+
+  it('returns { valid: false } for a message with invalid structure (missing fields)', async () => {
+    // A message object that is missing required fields (e.g., no signature, no type)
+    const badMsg = { from: 'did:imajin:abc', payload: {} };
+
+    const req = post('/api/verify', { message: badMsg });
+    const res = await verifyPost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(false);
+  });
+
+  it('returns { valid: false } when identity type does not match message type', async () => {
+    // Register as 'human' but send message with type 'agent'
+    const { did, identity } = await registerIdentity('10.14.5.1', { handle: 'verify_type5', type: 'human' });
+
+    // Build a message that claims to be 'agent' even though the identity is 'human'
+    const timestamp = Date.now();
+    const msgWithoutSig = { from: did, type: 'agent' as const, timestamp, payload: {} };
+    const canonical = canonicalize(msgWithoutSig);
+    const signature = await identity.sign(canonical);
+    const mismatchedMsg = { ...msgWithoutSig, signature };
+
+    const req = post('/api/verify', { message: mismatchedMsg });
+    const res = await verifyPost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(false);
+  });
+
+  it('returns { valid: false } for a non-existent DID', async () => {
+    // Generate a key pair but never register it
+    const identity = await createTestIdentity({ type: 'human' });
+    const fakeDid = identity.did; // not in DB
+
+    const msg = await sign({ action: 'test' }, identity.privateKey, { id: fakeDid, type: 'human' });
+    const req = post('/api/verify', { message: msg });
+    const res = await verifyPost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(false);
+    expect(data.error).toMatch(/identity/i);
+  });
+
+  it('returns { valid: false, error: "Message expired" } for a message with old timestamp', async () => {
+    const { did, identity } = await registerIdentity('10.14.7.1', { handle: 'verify_expired7' });
+
+    // Build an expired message manually (10 minutes in the past)
+    const oldTimestamp = Date.now() - 10 * 60 * 1000;
+    const msgWithoutSig = { from: did, type: 'human' as const, timestamp: oldTimestamp, payload: {} };
+    const canonical = canonicalize(msgWithoutSig);
+    const signature = await identity.sign(canonical);
+    const expiredMsg = { ...msgWithoutSig, signature };
+
+    const req = post('/api/verify', { message: expiredMsg });
+    const res = await verifyPost(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.valid).toBe(false);
+    expect(data.error).toMatch(/expired/i);
+  });
+});

--- a/apps/auth/tests/setup.ts
+++ b/apps/auth/tests/setup.ts
@@ -1,0 +1,13 @@
+import { vi } from 'vitest';
+
+// Mock global fetch — real services are not available in test env.
+// Route handlers call profile service and connections service (non-fatal).
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }),
+);

--- a/apps/auth/vitest.config.ts
+++ b/apps/auth/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    setupFiles: ['./tests/setup.ts'],
+    testTimeout: 30000,
+    env: {
+      DATABASE_URL: process.env.DATABASE_URL_PROD?.replace(/^"|"$/g, '') ?? '',
+      NEXT_PUBLIC_DISABLE_INVITE_GATE: 'true',
+      CONNECTIONS_SERVICE_URL: 'http://connections.test',
+      PROFILE_SERVICE_URL: 'http://profile.test',
+    },
+  },
+  resolve: {
+    alias: {
+      '@/': path.resolve(__dirname, './') + '/',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@types/react-dom':
         specifier: ^18
         version: 18.3.7(@types/react@18.3.28)
+      '@vitest/coverage-v8':
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.33))
       autoprefixer:
         specifier: ^10
         version: 10.4.24(postcss@8.5.6)
@@ -106,6 +109,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)
 
   apps/chat:
     dependencies:
@@ -673,6 +679,9 @@ importers:
       autoprefixer:
         specifier: ^10
         version: 10.4.24(postcss@8.5.6)
+      drizzle-kit:
+        specifier: ^0.31.9
+        version: 0.31.9
       postcss:
         specifier: ^8
         version: 8.5.6
@@ -1198,9 +1207,34 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -1954,6 +1988,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -2877,11 +2915,17 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
@@ -3104,11 +3148,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
   '@vitest/mocker@2.1.9':
     resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
@@ -3121,8 +3177,22 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
   '@vitest/runner@1.6.1':
     resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
@@ -3130,11 +3200,17 @@ packages:
   '@vitest/runner@2.1.9':
     resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
   '@vitest/snapshot@1.6.1':
     resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
   '@vitest/snapshot@2.1.9':
     resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/spy@1.6.1':
     resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
@@ -3142,11 +3218,17 @@ packages:
   '@vitest/spy@2.1.9':
     resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3272,6 +3354,9 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -3300,6 +3385,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
@@ -3339,6 +3428,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4156,6 +4249,11 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -4228,6 +4326,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -4435,6 +4536,22 @@ packages:
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -4442,6 +4559,9 @@ packages:
   jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jayson@4.3.0:
     resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
@@ -4454,6 +4574,9 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4571,6 +4694,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4769,6 +4899,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -4940,6 +5074,9 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -5502,6 +5639,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   stripe@14.25.0:
     resolution: {integrity: sha512-wQS3GNMofCXwH8TSje8E1SE8zr6ODiGtHQgPtO95p9Mb4FhKC9jvXR2NUTpZ9ZINlckJcFidCmaTFV4P6vsb9g==}
     engines: {node: '>=12.*'}
@@ -5572,6 +5712,10 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   text-encoding-utf-8@1.0.2:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
 
@@ -5611,12 +5755,20 @@ packages:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -5790,6 +5942,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -5859,6 +6016,34 @@ packages:
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -6034,7 +6219,27 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/runtime@7.28.6': {}
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -6742,6 +6947,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -7808,6 +8015,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.19.11
@@ -7815,6 +8027,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/diff-match-patch@1.0.36': {}
 
@@ -8026,6 +8240,25 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.33))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@1.6.1':
     dependencies:
       '@vitest/spy': 1.6.1
@@ -8039,6 +8272,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.11))':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -8047,9 +8288,21 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.11)
 
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@20.19.33))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.33)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
 
   '@vitest/runner@1.6.1':
     dependencies:
@@ -8061,6 +8314,12 @@ snapshots:
     dependencies:
       '@vitest/utils': 2.1.9
       pathe: 1.1.2
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
 
   '@vitest/snapshot@1.6.1':
     dependencies:
@@ -8074,6 +8333,12 @@ snapshots:
       magic-string: 0.30.21
       pathe: 1.1.2
 
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@1.6.1':
     dependencies:
       tinyspy: 2.2.1
@@ -8081,6 +8346,10 @@ snapshots:
   '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -8094,6 +8363,12 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -8238,6 +8513,12 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   async-function@1.0.0: {}
 
   autoprefixer@10.4.24(postcss@8.5.6):
@@ -8260,6 +8541,8 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   base-x@3.0.11:
     dependencies:
@@ -8299,6 +8582,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -9257,6 +9544,15 @@ snapshots:
       minipass: 7.1.2
       path-scurry: 1.11.1
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -9364,6 +9660,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   he@1.2.0: {}
+
+  html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
 
@@ -9561,6 +9859,27 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -9571,6 +9890,12 @@ snapshots:
       set-function-name: 2.0.2
 
   jackspeak@2.3.6:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
@@ -9597,6 +9922,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jose@6.1.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -9701,6 +10028,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   markdown-table@3.0.4: {}
 
@@ -10201,6 +10538,10 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -10378,6 +10719,8 @@ snapshots:
       p-limit: 3.1.0
 
   p-try@2.2.0: {}
+
+  package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -11060,6 +11403,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   stripe@14.25.0:
     dependencies:
       '@types/node': 22.19.11
@@ -11147,6 +11494,12 @@ snapshots:
       - tsx
       - yaml
 
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 10.2.4
+
   text-encoding-utf-8@1.0.2: {}
 
   text-table@0.2.0: {}
@@ -11176,9 +11529,13 @@ snapshots:
 
   tinyrainbow@1.2.0: {}
 
+  tinyrainbow@2.0.0: {}
+
   tinyspy@2.2.1: {}
 
   tinyspy@3.0.2: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -11428,6 +11785,33 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@3.2.4(@types/node@20.19.33):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@20.19.33)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.33):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.57.1
+    optionalDependencies:
+      '@types/node': 20.19.33
+      fsevents: 2.3.3
+
   vite@5.4.21(@types/node@22.19.11):
     dependencies:
       esbuild: 0.21.5
@@ -11495,6 +11879,45 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.33):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@20.19.33))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@20.19.33)
+      vite-node: 3.2.4(@types/node@20.19.33)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.33
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
Closes #408

**43 tests** across 6 files covering all auth API routes. Real Ed25519 crypto, real DB, direct route handler invocation.

- register (11): new identity, duplicate key, taken handle, invalid sig, identity types
- challenge (4): creation, expiry, non-existent DID
- authenticate (6): full challenge-response flow, invalid sig, expired/used challenges
- verify (5): stateless message verification, type mismatch, expired
- session (6): JWT verification, tier from DB not JWT (March 5 regression)
- edge-cases (11): handle validation, concurrent registration, malformed input

Run: `cd apps/auth && pnpm test`

Harness designed for extension by #432 (stored keys) and #366 (agent identities).