### PR TITLE
feat(registry): mount DFOS web relay (#452)

### DIFF
--- a/apps/registry/.env.example
+++ b/apps/registry/.env.example
@@ -30,5 +30,9 @@ LEARN_SERVICE_URL=http://localhost:3103
 NEXT_PUBLIC_DOMAIN=imajin.ai
 NEXT_PUBLIC_SERVICE_PREFIX=https://
 
+# DFOS Relay
+RELAY_DID=did:imajin:relay-dev
+RELAY_STORE=postgres
+
 # Runtime
 NODE_ENV=

--- a/apps/registry/app/relay/[[...path]]/route.ts
+++ b/apps/registry/app/relay/[[...path]]/route.ts
@@ -1,0 +1,33 @@
+import { createRelay, MemoryRelayStore } from '@metalabel/dfos-web-relay';
+import { PostgresRelayStore } from '@/src/relay/postgres-store';
+import { db } from '@/src/db';
+
+const RELAY_DID = process.env.RELAY_DID || 'did:imajin:relay-dev';
+
+const store =
+  process.env.RELAY_STORE === 'memory'
+    ? new MemoryRelayStore()
+    : new PostgresRelayStore(db);
+
+const relay = createRelay({ relayDID: RELAY_DID, store });
+
+async function handler(request: Request) {
+  const url = new URL(request.url);
+  const relayPath = url.pathname.replace(/^\/relay/, '') || '/';
+  const relayUrl = new URL(relayPath, url.origin);
+  relayUrl.search = url.search;
+
+  const relayRequest = new Request(relayUrl.toString(), {
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+    // @ts-expect-error duplex needed for streaming body
+    duplex: 'half',
+  });
+
+  return relay.fetch(relayRequest);
+}
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;

--- a/apps/registry/drizzle.config.ts
+++ b/apps/registry/drizzle.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({
-  schema: './src/db/schema.ts',
+  schema: ['./src/db/schema.ts', './src/db/relay-schema.ts'],
   out: './drizzle',
   dialect: 'postgresql',
-  schemaFilter: ['registry'],
+  schemaFilter: ['registry', 'relay'],
   dbCredentials: {
     url: process.env.DATABASE_URL!,
   },

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -15,7 +15,10 @@
   "dependencies": {
     "@imajin/auth": "workspace:*",
     "@imajin/config": "workspace:*",
+    "@metalabel/dfos-protocol": "^0.3.0",
+    "@metalabel/dfos-web-relay": "^0.3.0",
     "drizzle-orm": "^0.45.1",
+    "hono": "^4.12.5",
     "next": "^14.2.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/apps/registry/src/db/index.ts
+++ b/apps/registry/src/db/index.ts
@@ -1,5 +1,7 @@
 import { createDb } from '@imajin/db';
 import * as schema from './schema';
+import * as relaySchema from './relay-schema';
 
-export const db = createDb(schema);
+export const db = createDb({ ...schema, ...relaySchema });
 export * from './schema';
+export * from './relay-schema';

--- a/apps/registry/src/db/relay-schema.ts
+++ b/apps/registry/src/db/relay-schema.ts
@@ -1,0 +1,58 @@
+import { pgSchema, text, timestamp, jsonb, serial, index, primaryKey, customType } from 'drizzle-orm/pg-core';
+
+const bytea = customType<{ data: Buffer; notNull: false; default: false }>({
+  dataType() {
+    return 'bytea';
+  },
+});
+
+export const relaySchema = pgSchema('relay');
+
+export const relayOperations = relaySchema.table('relay_operations', {
+  cid: text('cid').primaryKey(),
+  jwsToken: text('jws_token').notNull(),
+  chainType: text('chain_type').notNull(),
+  chainId: text('chain_id').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});
+
+export const relayIdentityChains = relaySchema.table('relay_identity_chains', {
+  did: text('did').primaryKey(),
+  log: jsonb('log').$type<string[]>().notNull().default([]),
+  state: jsonb('state').notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+});
+
+export const relayContentChains = relaySchema.table('relay_content_chains', {
+  contentId: text('content_id').primaryKey(),
+  genesisCid: text('genesis_cid').notNull(),
+  log: jsonb('log').$type<string[]>().notNull().default([]),
+  state: jsonb('state').notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+});
+
+export const relayBeacons = relaySchema.table('relay_beacons', {
+  did: text('did').primaryKey(),
+  jwsToken: text('jws_token').notNull(),
+  beaconCid: text('beacon_cid').notNull(),
+  state: jsonb('state').notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+});
+
+export const relayBlobs = relaySchema.table('relay_blobs', {
+  creatorDid: text('creator_did').notNull(),
+  documentCid: text('document_cid').notNull(),
+  data: bytea('data').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.creatorDid, table.documentCid] }),
+}));
+
+export const relayCountersignatures = relaySchema.table('relay_countersignatures', {
+  id: serial('id').primaryKey(),
+  operationCid: text('operation_cid').notNull(),
+  jwsToken: text('jws_token').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  operationCidIdx: index('idx_relay_countersignatures_operation_cid').on(table.operationCid),
+}));

--- a/apps/registry/src/relay/postgres-store.ts
+++ b/apps/registry/src/relay/postgres-store.ts
@@ -1,0 +1,191 @@
+import { eq, and } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type {
+  RelayStore,
+  StoredOperation,
+  StoredIdentityChain,
+  StoredContentChain,
+  StoredBeacon,
+  BlobKey,
+} from '@metalabel/dfos-web-relay';
+import {
+  relayOperations,
+  relayIdentityChains,
+  relayContentChains,
+  relayBeacons,
+  relayBlobs,
+  relayCountersignatures,
+} from '../db/relay-schema';
+
+export class PostgresRelayStore implements RelayStore {
+  constructor(private readonly db: PostgresJsDatabase<Record<string, unknown>>) {}
+
+  async getOperation(cid: string): Promise<StoredOperation | undefined> {
+    const rows = await this.db
+      .select()
+      .from(relayOperations)
+      .where(eq(relayOperations.cid, cid));
+    const row = rows[0];
+    if (!row) return undefined;
+    return {
+      cid: row.cid,
+      jwsToken: row.jwsToken,
+      chainType: row.chainType as StoredOperation['chainType'],
+      chainId: row.chainId,
+    };
+  }
+
+  async putOperation(op: StoredOperation): Promise<void> {
+    await this.db
+      .insert(relayOperations)
+      .values({
+        cid: op.cid,
+        jwsToken: op.jwsToken,
+        chainType: op.chainType,
+        chainId: op.chainId,
+      })
+      .onConflictDoNothing();
+  }
+
+  async getIdentityChain(did: string): Promise<StoredIdentityChain | undefined> {
+    const rows = await this.db
+      .select()
+      .from(relayIdentityChains)
+      .where(eq(relayIdentityChains.did, did));
+    const row = rows[0];
+    if (!row) return undefined;
+    return {
+      did: row.did,
+      log: row.log as string[],
+      state: row.state as StoredIdentityChain['state'],
+    };
+  }
+
+  async putIdentityChain(chain: StoredIdentityChain): Promise<void> {
+    await this.db
+      .insert(relayIdentityChains)
+      .values({
+        did: chain.did,
+        log: chain.log,
+        state: chain.state,
+      })
+      .onConflictDoUpdate({
+        target: relayIdentityChains.did,
+        set: {
+          log: chain.log,
+          state: chain.state,
+          updatedAt: new Date(),
+        },
+      });
+  }
+
+  async getContentChain(contentId: string): Promise<StoredContentChain | undefined> {
+    const rows = await this.db
+      .select()
+      .from(relayContentChains)
+      .where(eq(relayContentChains.contentId, contentId));
+    const row = rows[0];
+    if (!row) return undefined;
+    return {
+      contentId: row.contentId,
+      genesisCID: row.genesisCid,
+      log: row.log as string[],
+      state: row.state as StoredContentChain['state'],
+    };
+  }
+
+  async putContentChain(chain: StoredContentChain): Promise<void> {
+    await this.db
+      .insert(relayContentChains)
+      .values({
+        contentId: chain.contentId,
+        genesisCid: chain.genesisCID,
+        log: chain.log,
+        state: chain.state,
+      })
+      .onConflictDoUpdate({
+        target: relayContentChains.contentId,
+        set: {
+          log: chain.log,
+          state: chain.state,
+          updatedAt: new Date(),
+        },
+      });
+  }
+
+  async getBeacon(did: string): Promise<StoredBeacon | undefined> {
+    const rows = await this.db
+      .select()
+      .from(relayBeacons)
+      .where(eq(relayBeacons.did, did));
+    const row = rows[0];
+    if (!row) return undefined;
+    return {
+      did: row.did,
+      jwsToken: row.jwsToken,
+      beaconCID: row.beaconCid,
+      state: row.state as StoredBeacon['state'],
+    };
+  }
+
+  async putBeacon(beacon: StoredBeacon): Promise<void> {
+    await this.db
+      .insert(relayBeacons)
+      .values({
+        did: beacon.did,
+        jwsToken: beacon.jwsToken,
+        beaconCid: beacon.beaconCID,
+        state: beacon.state,
+      })
+      .onConflictDoUpdate({
+        target: relayBeacons.did,
+        set: {
+          jwsToken: beacon.jwsToken,
+          beaconCid: beacon.beaconCID,
+          state: beacon.state,
+          updatedAt: new Date(),
+        },
+      });
+  }
+
+  async getBlob(key: BlobKey): Promise<Uint8Array | undefined> {
+    const rows = await this.db
+      .select()
+      .from(relayBlobs)
+      .where(
+        and(
+          eq(relayBlobs.creatorDid, key.creatorDID),
+          eq(relayBlobs.documentCid, key.documentCID),
+        ),
+      );
+    const row = rows[0];
+    if (!row) return undefined;
+    return row.data as unknown as Uint8Array;
+  }
+
+  async putBlob(key: BlobKey, data: Uint8Array): Promise<void> {
+    await this.db
+      .insert(relayBlobs)
+      .values({
+        creatorDid: key.creatorDID,
+        documentCid: key.documentCID,
+        data: Buffer.from(data),
+      })
+      .onConflictDoNothing();
+  }
+
+  async getCountersignatures(operationCid: string): Promise<string[]> {
+    const rows = await this.db
+      .select()
+      .from(relayCountersignatures)
+      .where(eq(relayCountersignatures.operationCid, operationCid));
+    return rows.map((r) => r.jwsToken);
+  }
+
+  async addCountersignature(operationCid: string, jwsToken: string): Promise<void> {
+    await this.db.insert(relayCountersignatures).values({
+      operationCid,
+      jwsToken,
+    });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -922,9 +922,18 @@ importers:
       '@imajin/ui':
         specifier: workspace:^
         version: link:../../packages/ui
+      '@metalabel/dfos-protocol':
+        specifier: ^0.3.0
+        version: 0.3.0
+      '@metalabel/dfos-web-relay':
+        specifier: ^0.3.0
+        version: 0.3.0(@metalabel/dfos-protocol@0.3.0)
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
+      hono:
+        specifier: ^4.12.5
+        version: 4.12.8
       next:
         specifier: ^14.2.0
         version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2264,6 +2273,14 @@ packages:
 
   '@metalabel/dfos-protocol@0.2.0':
     resolution: {integrity: sha512-8nprwkeIwEbWTSFvhkeA2iF8L8kckAOheaP4cbdlEAy3hr893z+YoMamwZw6U6w3WYNpdo655u9DFNdOI6CsSA==}
+
+  '@metalabel/dfos-protocol@0.3.0':
+    resolution: {integrity: sha512-xg2zvdCN9aSC667MAmgCv9T6pE2eZfEC+0BxI7fhMhqqj9iee+Mysm13bfi+XVJzo4CiKdZgdfAw6EodTUTzQA==}
+
+  '@metalabel/dfos-web-relay@0.3.0':
+    resolution: {integrity: sha512-u4n4lRU58zekJ3/GkI+diXunNpR3XEAcTXlP2KJueRAn6HIBYOHFohuviEQ5UTBED/Uhl2g56z45OfggD2hFIg==}
+    peerDependencies:
+      '@metalabel/dfos-protocol': ^0.3.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -4450,6 +4467,10 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -7457,6 +7478,20 @@ snapshots:
       multiformats: 13.4.2
       zod: 4.3.6
 
+  '@metalabel/dfos-protocol@0.3.0':
+    dependencies:
+      '@ipld/dag-cbor': 9.2.5
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      multiformats: 13.4.2
+      zod: 4.3.6
+
+  '@metalabel/dfos-web-relay@0.3.0(@metalabel/dfos-protocol@0.3.0)':
+    dependencies:
+      '@metalabel/dfos-protocol': 0.3.0
+      hono: 4.12.8
+      zod: 4.3.6
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -9853,6 +9888,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   he@1.2.0: {}
+
+  hono@4.12.8: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## What

Mounts the DFOS web relay (`@metalabel/dfos-web-relay` v0.3.0) inside the registry service. The registry becomes a DFOS relay participant.

### New files
- `apps/registry/app/relay/[[...path]]/route.ts` — catch-all delegating to Hono relay
- `apps/registry/src/db/relay-schema.ts` — 6 tables in `relay` schema
- `apps/registry/src/relay/postgres-store.ts` — full `PostgresRelayStore` implementation

### Routes (all under /relay/)
POST /operations, GET /operations/:cid, GET /identities/:did, GET /content/:contentId, GET /beacons/:did, PUT+GET /content/:contentId/blob

### Deploy
Push relay schema after merge: `cd apps/registry && npx drizzle-kit push --force`

Phase 1 of #452