### PR TITLE
docs: regenerate OpenAPI specs for all 15 services (#455)

### DIFF
--- a/apps/auth/api-spec/openapi.yaml
+++ b/apps/auth/api-spec/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.1.0"
 info:
   title: imajin auth
   version: "1.0.0"
-  description: Identity registration, DID-based challenge-response authentication, session management, and magic-link flows.
+  description: Identity registration, DID-based challenge-response authentication, session management, magic-link flows, attestations, and DFOS chain identity.
 servers:
   - url: https://auth.imajin.ai
     description: production
@@ -11,12 +11,20 @@ servers:
   - url: http://localhost:7001
     description: local
 
+tags:
+  - name: auth
+    description: imajin auth service
+
 components:
   securitySchemes:
     cookieAuth:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: "Bearer token (imajin_tok_* API token)"
   schemas:
     Identity:
       type: object
@@ -24,9 +32,14 @@ components:
         did: { type: string, example: "did:imajin:abc123" }
         handle: { type: string }
         name: { type: string }
-        type: { type: string, enum: [hard, soft] }
+        type:
+          type: string
+          enum: [human, agent, presence, org, device, service, event]
+        tier:
+          type: string
+          enum: [soft, preliminary, established]
         role: { type: string }
-        tier: { type: string, enum: [hard, soft] }
+        chainVerified: { type: boolean }
     Error:
       type: object
       required: [error]
@@ -34,10 +47,29 @@ components:
         error: { type: string }
 
 paths:
+  /api/health:
+    get:
+      tags: [auth]
+      operationId: healthCheck
+      summary: Service health check
+      responses:
+        "200":
+          description: Service healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  service: { type: string }
+                  timestamp: { type: string, format: date-time }
+
   /api/challenge:
     post:
+      tags: [auth]
       operationId: createChallenge
-      summary: Create a signing challenge
+      summary: Create a signing challenge (API token flow)
+      description: Request a random challenge to be signed by the identity's private key. Part of the low-level token-based auth flow.
       requestBody:
         required: true
         content:
@@ -46,7 +78,7 @@ paths:
               type: object
               required: [id]
               properties:
-                id: { type: string, description: "DID or public key" }
+                id: { type: string, description: "DID of the identity requesting the challenge" }
       responses:
         "200":
           description: Challenge created
@@ -57,12 +89,24 @@ paths:
                 properties:
                   challengeId: { type: string }
                   challenge: { type: string }
-                  expiresAt: { type: number }
+                  expiresAt: { type: string, format: date-time }
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Identity not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/authenticate:
     post:
+      tags: [auth]
       operationId: authenticate
-      summary: Submit signed challenge and receive a token
+      summary: Submit signed challenge and receive an API token
+      description: Verify an Ed25519 signature over the challenge string and issue an imajin_tok_* API token with expiry.
       requestBody:
         required: true
         content:
@@ -71,20 +115,25 @@ paths:
               type: object
               required: [id, challengeId, signature]
               properties:
-                id: { type: string }
+                id: { type: string, description: "DID" }
                 challengeId: { type: string }
-                signature: { type: string }
+                signature: { type: string, description: "Ed25519 signature of challenge bytes (hex)" }
       responses:
         "200":
-          description: Authenticated
+          description: Authenticated — returns API token
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  token: { type: string }
-                  expiresAt: { type: number }
+                  token: { type: string, example: "imajin_tok_..." }
+                  expiresAt: { type: string, format: date-time }
                   identity: { $ref: "#/components/schemas/Identity" }
+        "400":
+          description: Invalid or expired challenge
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "401":
           description: Invalid signature
           content:
@@ -93,8 +142,10 @@ paths:
 
   /api/login/challenge:
     post:
+      tags: [auth]
       operationId: createLoginChallenge
-      summary: Create a login challenge by handle or DID
+      summary: Create a login challenge by handle or DID (session cookie flow)
+      description: Request a challenge for the cookie-based login flow. Rate-limited to 10 req/min per IP.
       requestBody:
         required: true
         content:
@@ -114,12 +165,31 @@ paths:
                 properties:
                   challengeId: { type: string }
                   challenge: { type: string }
-                  expiresAt: { type: number }
+                  expiresAt: { type: string, format: date-time }
+        "400":
+          description: handle or did required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Identity not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Too many requests
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/login/verify:
     post:
+      tags: [auth]
       operationId: verifyLogin
       summary: Verify signed challenge and set session cookie
+      description: |
+        Verify Ed25519 signature over the challenge. On success, sets the `imajin_session` HttpOnly cookie.
+        Optionally bridges a DFOS chain on login by passing `dfosChain`.
       requestBody:
         required: true
         content:
@@ -129,7 +199,8 @@ paths:
               required: [challengeId, signature]
               properties:
                 challengeId: { type: string }
-                signature: { type: string }
+                signature: { type: string, description: "Ed25519 signature of the challenge (hex)" }
+                dfosChain: { type: array, items: { type: string }, description: "Optional DFOS chain log to bridge at login" }
       responses:
         "200":
           description: Login successful — sets imajin_session cookie
@@ -147,6 +218,11 @@ paths:
                   handle: { type: string }
                   type: { type: string }
                   name: { type: string }
+        "400":
+          description: Invalid challenge
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "401":
           description: Invalid signature
           content:
@@ -155,6 +231,7 @@ paths:
 
   /api/logout:
     post:
+      tags: [auth]
       operationId: logout
       summary: Clear session cookie
       responses:
@@ -169,8 +246,10 @@ paths:
 
   /api/session:
     get:
+      tags: [auth]
       operationId: getSession
       summary: Get current session from cookie
+      description: Reads the imajin_session cookie, verifies the JWT, and returns the full identity record including tier and chain status.
       security:
         - cookieAuth: []
       responses:
@@ -187,8 +266,12 @@ paths:
 
   /api/session/soft:
     post:
+      tags: [auth]
       operationId: createSoftSession
-      summary: Create a soft DID session from email
+      summary: Create or retrieve a soft DID session from email
+      description: |
+        Mints a stable `did:imajin:*` for the email (or retrieves existing) and sets a session cookie.
+        Soft DIDs have no keypair — email is the credential. Rate-limited to 10 req/min per IP.
       requestBody:
         required: true
         content:
@@ -201,7 +284,7 @@ paths:
                 name: { type: string }
       responses:
         "200":
-          description: Soft session created
+          description: Soft session created — sets imajin_session cookie
           content:
             application/json:
               schema:
@@ -209,14 +292,30 @@ paths:
                 properties:
                   did: { type: string }
                   handle: { type: string }
-                  type: { type: string, enum: [soft] }
+                  type: { type: string }
                   name: { type: string }
                   tier: { type: string, enum: [soft] }
+        "400":
+          description: Invalid email
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Too many requests
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/register:
     post:
+      tags: [auth]
       operationId: register
-      summary: Register a new hard DID identity
+      summary: Register a new keypair-backed DID identity
+      description: |
+        Register a new identity with an Ed25519 public key. Requires an invite code for human
+        registrations (unless NEXT_PUBLIC_DISABLE_INVITE_GATE=true). Non-human types bypass the
+        invite gate. If the public key already exists, returns the existing identity (login-via-register).
+        Rate-limited to 5 req/min per IP.
       requestBody:
         required: true
         content:
@@ -225,15 +324,21 @@ paths:
               type: object
               required: [publicKey, type, signature]
               properties:
-                publicKey: { type: string, description: "Ed25519 public key (base64)" }
-                handle: { type: string }
+                publicKey: { type: string, description: "Ed25519 public key (hex)" }
+                handle: { type: string, description: "3-30 chars: lowercase letters, numbers, underscores" }
                 name: { type: string }
-                type: { type: string, enum: [hard] }
-                signature: { type: string }
-                inviteCode: { type: string }
+                type:
+                  type: string
+                  enum: [human, agent, presence, org, device, service, event]
+                signature: { type: string, description: "Ed25519 signature of the registration payload (hex)" }
+                inviteCode: { type: string, description: "Required for human type when invite gate is enabled" }
+                email: { type: string, format: email }
+                phone: { type: string }
+                optInUpdates: { type: boolean }
+                dfosChain: { type: array, items: { type: string }, description: "Optional DFOS chain to bridge at registration" }
       responses:
         "201":
-          description: Identity registered
+          description: Identity registered — sets imajin_session cookie
           content:
             application/json:
               schema:
@@ -244,16 +349,49 @@ paths:
                   type: { type: string }
                   created: { type: boolean }
                   inviteAccepted: { type: boolean }
+        "200":
+          description: Public key already registered — returns existing identity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  did: { type: string }
+                  handle: { type: string }
+                  type: { type: string }
+                  created: { type: boolean }
         "400":
           description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Invalid signature
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Invite required or invalid
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: Handle already taken by a different key
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Too many requests
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
 
   /api/magic:
     get:
+      tags: [auth]
       operationId: magicLink
-      summary: Authenticate via magic link token and redirect
+      summary: Authenticate via magic link token (deprecated — use /api/onboard/verify)
+      description: Verifies a ticket magic-link token via the events service, sets a session cookie, and redirects. Returns HTML on error.
       parameters:
         - name: token
           in: query
@@ -263,21 +401,112 @@ paths:
         "302":
           description: Redirects to event or destination after setting session cookie
         "400":
-          description: Invalid or expired token
+          description: Missing or invalid token (returns HTML error page)
+
+  /api/magic/send:
+    post:
+      tags: [auth]
+      operationId: sendMagicLink
+      summary: Send a magic link email for re-authentication
+      description: |
+        Sends a magic link to the email associated with a soft or hard DID. Always returns
+        `{ sent: true }` to prevent email enumeration. Rate-limited to 5 req/min per IP.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email: { type: string, format: email }
+                redirectUrl: { type: string }
+      responses:
+        "200":
+          description: Magic link sent (or silently suppressed — always 200 to prevent enumeration)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sent: { type: boolean }
+        "429":
+          description: Too many requests
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
 
+  /api/onboard:
+    post:
+      tags: [auth]
+      operationId: initiateOnboard
+      summary: Initiate email-based onboarding — sends verification email
+      description: |
+        Sends a verification email with a magic link. The link calls `/api/onboard/verify` to
+        complete onboarding and mint a soft DID. Rate-limited to 5 req/min per IP.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email: { type: string, format: email }
+                name: { type: string }
+                redirectUrl: { type: string }
+                context: { type: string, description: "Context label shown in email (e.g. event name)" }
+      responses:
+        "200":
+          description: Verification email sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sent: { type: boolean }
+        "400":
+          description: Invalid email
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Too many requests
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/onboard/verify:
+    get:
+      tags: [auth]
+      operationId: verifyOnboard
+      summary: Complete email verification — mints soft DID and sets session cookie
+      description: |
+        Consumes the one-time onboard token from the email link. Mints or retrieves a soft DID,
+        sets the imajin_session cookie, and redirects to the configured redirectUrl.
+      parameters:
+        - name: token
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "302":
+          description: Redirects to redirectUrl (or default) after setting session cookie
+        "400":
+          description: Missing or expired token (returns HTML error page)
+
   /api/lookup/{id}:
     get:
+      tags: [auth]
       operationId: lookupIdentity
       summary: Look up identity by DID
+      description: Public endpoint returning public identity fields by DID.
       parameters:
         - name: id
           in: path
           required: true
           schema: { type: string }
-          description: "DID (e.g., did:imajin:abc123)"
+          description: "DID (URL-encoded, e.g. did%3Aimajin%3Aabc123)"
       responses:
         "200":
           description: Identity found
@@ -290,6 +519,7 @@ paths:
                   handle: { type: string }
                   name: { type: string }
                   type: { type: string }
+                  tier: { type: string }
                   avatarUrl: { type: string }
                   metadata: { type: object }
                   createdAt: { type: string, format: date-time }
@@ -301,8 +531,10 @@ paths:
 
   /api/validate:
     post:
+      tags: [auth]
       operationId: validateToken
-      summary: Validate an API token
+      summary: Validate an API token and return identity
+      description: Validates an imajin_tok_* token, updates its last-used timestamp, and returns the associated identity.
       requestBody:
         required: true
         content:
@@ -322,11 +554,14 @@ paths:
                 properties:
                   valid: { type: boolean }
                   identity: { $ref: "#/components/schemas/Identity" }
+                  error: { type: string }
 
   /api/verify:
     post:
-      operationId: verifySignature
+      tags: [auth]
+      operationId: verifySignedMessage
       summary: Stateless verification of a signed message
+      description: Resolves the signer's public key from DB and verifies an imajin SignedMessage envelope.
       requestBody:
         required: true
         content:
@@ -339,7 +574,7 @@ paths:
                   type: object
                   required: [from, type, timestamp, payload, signature]
                   properties:
-                    from: { type: string }
+                    from: { type: string, description: "DID of signer" }
                     type: { type: string }
                     timestamp: { type: number }
                     payload: { type: object }
@@ -354,3 +589,673 @@ paths:
                 properties:
                   valid: { type: boolean }
                   identity: { $ref: "#/components/schemas/Identity" }
+                  error: { type: string }
+
+  /api/access/{did}:
+    get:
+      tags: [auth]
+      operationId: checkAccess
+      summary: Check whether the authenticated requester has access to a resource DID
+      description: |
+        Supports three DID namespaces:
+        - `did:imajin:event:*` / `did:imajin:evt_*` — ticket-holder or organizer check
+        - `did:imajin:dm:*` — deterministic DM membership check
+        - `did:imajin:group:*` — group participant check
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+          description: "URL-encoded resource DID"
+      responses:
+        "200":
+          description: Access result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  allowed: { type: boolean }
+                  role: { type: string, description: "attendee | organizer | participant | <pod role>" }
+                  governance: { type: string, description: "ticket | owner | dm | group" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/identity/{did}:
+    get:
+      tags: [auth]
+      operationId: resolveIdentity
+      summary: Resolve a DID to its public key and metadata
+      description: Public endpoint. Returns did, publicKey, type, tier, and dfosDid (if chain exists).
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Identity resolved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  did: { type: string }
+                  publicKey: { type: string, description: "Ed25519 public key (hex)" }
+                  type: { type: string }
+                  tier: { type: string }
+                  dfosDid: { type: string }
+        "404":
+          description: Identity not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/identity/{did}/chain:
+    get:
+      tags: [auth]
+      operationId: getIdentityChain
+      summary: Get the DFOS identity chain for a DID
+      description: Public endpoint. Returns the portable, self-verifying chain log and integrity metadata.
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Chain log
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  did: { type: string }
+                  dfosDid: { type: string }
+                  log: { type: array, items: { type: string } }
+                  headCid: { type: string }
+                  keyCount: { type: number }
+                  isDeleted: { type: boolean }
+        "404":
+          description: No DFOS chain found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/identity/{did}/keys:
+    get:
+      tags: [auth]
+      operationId: getIdentityKeys
+      summary: Get current key state for the authenticated identity
+      description: Authenticated — returns multi-role key state (auth/assert/controller) from the DFOS chain, or single-key state if no chain.
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Key state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  did: { type: string }
+                  dfosDid: { type: string }
+                  singleKey: { type: boolean }
+                  keyCount: { type: number }
+                  chainLength: { type: number }
+                  authKeys: { type: array, items: { type: string } }
+                  assertKeys: { type: array, items: { type: string } }
+                  controllerKeys: { type: array, items: { type: string } }
+                  lastRotated: { type: string, format: date-time }
+        "401":
+          description: Unauthorized (must be the DID owner)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/identity/{did}/rotate:
+    post:
+      tags: [auth]
+      operationId: rotateKeys
+      summary: Rotate keys by submitting an updated DFOS chain log
+      description: |
+        Accepts a client-signed chain update (signed with the controller key) and stores the
+        updated chain. Invalidates all existing sessions/tokens for this DID.
+        Rate-limited to 1 rotation per hour.
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [log]
+              properties:
+                log:
+                  type: array
+                  items: { type: string }
+                  description: "Full updated chain log (existing entries + new rotation entry)"
+      responses:
+        "200":
+          description: Keys rotated — all sessions invalidated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  did: { type: string }
+                  keyCount: { type: number }
+                  headCid: { type: string }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: No existing chain found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Rate limit — max 1 rotation per hour
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/identity/{did}/sign:
+    post:
+      tags: [auth]
+      operationId: nodeSignPayload
+      summary: Internal — node signs a payload on behalf of a chain-verified identity
+      description: |
+        Service-to-service endpoint (INTERNAL_API_KEY required). Signs a canonical payload using
+        AUTH_PRIVATE_KEY as node witness. Only signs for identities with a valid DFOS chain.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [payload]
+              properties:
+                payload: { type: string }
+      responses:
+        "200":
+          description: Signature result
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      signature: { type: string }
+                  - type: object
+                    properties:
+                      signed: { type: boolean, enum: [false] }
+                      reason: { type: string }
+        "401":
+          description: Unauthorized (invalid INTERNAL_API_KEY)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/identity/{did}/verify:
+    get:
+      tags: [auth]
+      operationId: verifyIdentityChain
+      summary: Verify DFOS chain and check DB consistency for a DID
+      description: Public endpoint. Verifies chain cryptographic integrity and checks that the DB public key matches the chain.
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  did: { type: string }
+                  hasDfosChain: { type: boolean }
+                  chain:
+                    type: object
+                    properties:
+                      valid: { type: boolean }
+                      keyCount: { type: number }
+                      isDeleted: { type: boolean }
+                      publicKeyMatches: { type: boolean }
+        "404":
+          description: Identity not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/identity/present-chain:
+    post:
+      tags: [auth]
+      operationId: presentChain
+      summary: External onboarding — present a DFOS chain log to create or retrieve a did:imajin alias
+      description: |
+        An external user presents their chain log. Auth verifies it cryptographically, creates a
+        `did:imajin:*` alias (or returns existing), and sets a session cookie.
+        Trust tier: `preliminary` — chain proves keypair ownership, not standing on this network.
+        Rate-limited to 10 req/min per IP.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [chainLog]
+              properties:
+                chainLog:
+                  type: array
+                  items: { type: string }
+                  description: "Non-empty DFOS chain log"
+                provider: { type: string, description: "Chain provider hint (e.g. dfos)" }
+      responses:
+        "200":
+          description: Identity resolved or created — sets imajin_session cookie
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  identity:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      tier: { type: string, enum: [preliminary] }
+                      chainVerified: { type: boolean, enum: [true] }
+                  created: { type: boolean }
+        "400":
+          description: chainLog must be a non-empty array
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "422":
+          description: Chain verification failed
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Too many requests
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/identity/verify-chain:
+    post:
+      tags: [auth]
+      operationId: verifyChain
+      summary: Internal — verify a DFOS chain log and resolve identity
+      description: |
+        Chain abstraction endpoint used by registry and other services. Verifies chain integrity
+        and resolves a `did:imajin` alias if one exists.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [chainLog]
+              properties:
+                chainLog:
+                  type: array
+                  items: { type: string }
+      responses:
+        "200":
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  valid: { type: boolean }
+                  did: { type: string, description: "Canonical DID (did:imajin alias or chain DID)" }
+                  chainDid: { type: string }
+                  publicKey: { type: string }
+                  keyCount: { type: number }
+                  error: { type: string }
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/resolve/dfos/{dfosDid}:
+    get:
+      tags: [auth]
+      operationId: resolveDfosDid
+      summary: Resolve a did:dfos to its linked did:imajin identity
+      description: Public endpoint.
+      parameters:
+        - name: dfosDid
+          in: path
+          required: true
+          schema: { type: string }
+          description: "URL-encoded did:dfos:... identifier"
+      responses:
+        "200":
+          description: Identity found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  imajinDid: { type: string }
+                  dfosDid: { type: string }
+                  type: { type: string }
+                  tier: { type: string }
+        "404":
+          description: No Imajin identity linked to this DFOS DID
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/attestations:
+    post:
+      tags: [auth]
+      operationId: createAttestation
+      summary: Issue a new attestation
+      description: |
+        Caller must be the issuer (session cookie or Bearer token). The signature must be an
+        Ed25519 signature over the canonical JSON of `{subject_did, type, context_id, context_type, payload, issued_at}`.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [issuer_did, subject_did, type, signature]
+              properties:
+                issuer_did: { type: string }
+                subject_did: { type: string }
+                type: { type: string, description: "Attestation type (from ATTESTATION_TYPES registry)" }
+                context_id: { type: string }
+                context_type: { type: string }
+                payload: { type: object }
+                signature: { type: string, description: "Ed25519 signature over canonical payload (hex)" }
+                issued_at: { type: number, description: "Unix timestamp ms (defaults to now)" }
+                author_jws: { type: string, description: "Optional JWS for bilateral attestation flow" }
+      responses:
+        "201":
+          description: Attestation created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  cid: { type: string }
+                  issuerDid: { type: string }
+                  subjectDid: { type: string }
+                  type: { type: string }
+                  attestationStatus: { type: string, enum: [pending, bilateral, declined, "null"] }
+                  issuedAt: { type: string, format: date-time }
+        "400":
+          description: Invalid request or signature
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    get:
+      tags: [auth]
+      operationId: listAttestations
+      summary: List non-revoked attestations for a subject DID
+      description: Returns attestations newest first. subject_did is required.
+      parameters:
+        - name: subject_did
+          in: query
+          required: true
+          schema: { type: string }
+        - name: type
+          in: query
+          schema: { type: string }
+        - name: issuer_did
+          in: query
+          schema: { type: string }
+        - name: status
+          in: query
+          schema: { type: string, enum: [pending, bilateral, declined] }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20, maximum: 100 }
+      responses:
+        "200":
+          description: Attestation list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: { type: string }
+                    cid: { type: string }
+                    issuerDid: { type: string }
+                    subjectDid: { type: string }
+                    type: { type: string }
+                    contextId: { type: string }
+                    contextType: { type: string }
+                    payload: { type: object }
+                    attestationStatus: { type: string }
+                    issuedAt: { type: string, format: date-time }
+        "400":
+          description: subject_did required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/attestations/{did}:
+    get:
+      tags: [auth]
+      operationId: getAttestationsByDid
+      summary: Shorthand — list attestations for a subject DID (path param)
+      description: Equivalent to GET /api/attestations?subject_did={did}
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Attestation list
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: object }
+
+  /api/attestations/countersign:
+    post:
+      tags: [auth]
+      operationId: countersignAttestation
+      summary: Countersign a pending attestation (witness/subject signs to make it bilateral)
+      description: Only the attestation subject can countersign. Transitions status from `pending` to `bilateral`.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [attestationId, witnessJws]
+              properties:
+                attestationId: { type: string }
+                witnessJws: { type: string, description: "JWS from the subject's chain key" }
+      responses:
+        "200":
+          description: Attestation is now bilateral
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  cid: { type: string }
+                  status: { type: string, enum: [bilateral] }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Only the subject can countersign
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Attestation not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: Attestation is not in pending state
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/attestations/decline:
+    post:
+      tags: [auth]
+      operationId: declineAttestation
+      summary: Decline a pending attestation
+      description: Only the attestation subject can decline. Transitions status from `pending` to `declined`.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [attestationId]
+              properties:
+                attestationId: { type: string }
+      responses:
+        "200":
+          description: Attestation declined
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  status: { type: string, enum: [declined] }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Only the subject can decline
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Attestation not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: Attestation is not in pending state
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/attestations/internal:
+    post:
+      tags: [auth]
+      operationId: issueAttestationInternal
+      summary: Internal — issue a platform-signed attestation (service-to-service)
+      description: |
+        Signs the attestation using the platform keypair (AUTH_PRIVATE_KEY).
+        Requires `ATTESTATION_INTERNAL_API_KEY` as Bearer token. No session cookie.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [issuer_did, subject_did, type]
+              properties:
+                issuer_did: { type: string }
+                subject_did: { type: string }
+                type: { type: string }
+                context_id: { type: string }
+                context_type: { type: string }
+                payload: { type: object }
+      responses:
+        "201":
+          description: Attestation issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  cid: { type: string }
+                  issuerDid: { type: string }
+                  subjectDid: { type: string }
+                  type: { type: string }
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized (invalid API key)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/spec:
+    get:
+      tags: [auth]
+      operationId: getSpec
+      summary: Serve the OpenAPI spec YAML
+      responses:
+        "200":
+          description: OpenAPI YAML
+          content:
+            text/yaml:
+              schema: { type: string }

--- a/apps/chat/api-spec/openapi.yaml
+++ b/apps/chat/api-spec/openapi.yaml
@@ -8,7 +8,7 @@ servers:
     description: production
   - url: https://dev-chat.imajin.ai
     description: dev
-  - url: http://localhost:7007
+  - url: http://localhost:7006
     description: local
 
 components:
@@ -17,28 +17,63 @@ components:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
   schemas:
-    Conversation:
+    ConversationV2:
       type: object
       properties:
-        id: { type: string }
-        type: { type: string }
+        did: { type: string, description: "Conversation DID (stable identifier)" }
         name: { type: string }
-        description: { type: string }
-        visibility: { type: string, enum: [public, private] }
+        type: { type: string, enum: [dm, group, event, unknown] }
+        slug: { type: string }
+        createdBy: { type: string }
         createdAt: { type: string, format: date-time }
-    Message:
+        lastMessageAt: { type: string, format: date-time }
+        lastMessagePreview: { type: string }
+        unread: { type: integer }
+        otherParticipant:
+          type: object
+          nullable: true
+          properties:
+            did: { type: string }
+            handle: { type: string, nullable: true }
+            name: { type: string, nullable: true }
+    MessageV2:
       type: object
       properties:
         id: { type: string }
-        conversationId: { type: string }
-        authorDid: { type: string }
-        content: { type: string }
-        replyTo: { type: string }
-        mediaType: { type: string }
-        mediaPath: { type: string }
-        mediaMeta: { type: object }
+        conversationDid: { type: string }
+        fromDid: { type: string }
+        content:
+          type: object
+          description: "Structured content object. For text messages: {type: 'text', text: string}. For media: {type: 'media'}. For voice: {type: 'voice'}. For location: {type: 'location'}."
+        contentType: { type: string, enum: [text, system, media, voice, location] }
+        replyToMessageId: { type: string, nullable: true }
+        mediaType: { type: string, nullable: true }
+        mediaPath: { type: string, nullable: true }
+        mediaAssetId: { type: string, nullable: true }
+        mediaMeta: { type: object, nullable: true }
+        signature: { type: string, nullable: true, description: "Node chain signature (best-effort, may be null)" }
+        editedAt: { type: string, format: date-time, nullable: true }
+        deletedAt: { type: string, format: date-time, nullable: true }
         createdAt: { type: string, format: date-time }
+        reactions:
+          type: array
+          items: { $ref: "#/components/schemas/Reaction" }
+    Reaction:
+      type: object
+      properties:
+        messageId: { type: string }
+        did: { type: string }
+        emoji: { type: string }
+    ReactionSummary:
+      type: object
+      properties:
+        emoji: { type: string }
+        count: { type: integer }
+        reacted: { type: boolean, description: "Whether the current user has added this reaction" }
     KeyBundle:
       type: object
       properties:
@@ -46,18 +81,59 @@ components:
         identityKey: { type: string }
         signedPreKey: { type: string }
         signature: { type: string }
-        oneTimePreKey: { type: string }
+        oneTimePreKey: { type: string, nullable: true }
+    ChatInvite:
+      type: object
+      properties:
+        id: { type: string }
+        conversationId: { type: string, description: "Conversation DID or legacy ID" }
+        createdBy: { type: string }
+        forDid: { type: string, nullable: true }
+        maxUses: { type: string, nullable: true }
+        usedCount: { type: string }
+        expiresAt: { type: string, format: date-time, nullable: true }
+        revokedAt: { type: string, format: date-time, nullable: true }
+        createdAt: { type: string, format: date-time }
+    Member:
+      type: object
+      properties:
+        did: { type: string }
+        role: { type: string }
+        name: { type: string, nullable: true }
+        handle: { type: string, nullable: true }
     Error:
       type: object
       required: [error]
       properties:
         error: { type: string }
 
+tags:
+  - name: chat
+    description: imajin chat service
+
 paths:
+  /api/health:
+    get:
+      tags: [chat]
+      operationId: chatHealthCheck
+      summary: Service health check
+      responses:
+        "200":
+          description: Service healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  service: { type: string }
+                  timestamp: { type: string, format: date-time }
+
   /api/session:
     get:
+      tags: [chat]
       operationId: getChatSession
-      summary: Get current chat session
+      summary: Get current chat session — verifies JWT and returns enriched identity with profile
       security:
         - cookieAuth: []
       responses:
@@ -75,11 +151,60 @@ paths:
                       handle: { type: string }
                       name: { type: string }
                       type: { type: string }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/capabilities:
+    get:
+      tags: [chat]
+      operationId: getChatCapabilities
+      summary: Get current user's capabilities based on identity tier
+      security:
+        - cookieAuth: []
+      responses:
+        "200":
+          description: Capabilities
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tier: { type: string }
+                  inGraph: { type: boolean }
+                  capabilities: { type: array, items: { type: string } }
+        "401":
+          description: Not authenticated
+
+  /api/access/{did}:
+    get:
+      tags: [chat]
+      operationId: proxyAccessCheck
+      summary: Proxy access check to auth service — forwards session cookie server-to-server
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+          description: URL-encoded DID to check access for
+      responses:
+        "200":
+          description: Access check result
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/conversations:
     get:
+      tags: [chat]
       operationId: listConversations
-      summary: List conversations for authenticated user
+      summary: List v2 conversations for authenticated user — includes unread counts and DM participant enrichment
       security:
         - cookieAuth: []
       responses:
@@ -92,10 +217,13 @@ paths:
                 properties:
                   conversations:
                     type: array
-                    items: { $ref: "#/components/schemas/Conversation" }
+                    items: { $ref: "#/components/schemas/ConversationV2" }
+        "401":
+          description: Not authenticated
     post:
+      tags: [chat]
       operationId: createConversation
-      summary: Create a new conversation
+      summary: Create a new v2 conversation — direct type requires trust graph membership
       security:
         - cookieAuth: []
       requestBody:
@@ -106,22 +234,46 @@ paths:
               type: object
               required: [type, participantDids]
               properties:
-                type: { type: string }
-                name: { type: string }
-                description: { type: string }
-                participantDids: { type: array, items: { type: string } }
-                visibility: { type: string, enum: [public, private], default: private }
+                type:
+                  type: string
+                  enum: [direct, group]
+                  description: "direct = DM (requires graph membership); group = multi-person"
+                name:
+                  type: string
+                  description: "Required for group conversations"
+                participantDids:
+                  type: array
+                  items: { type: string }
+                  description: "Exactly 1 DID for direct; 1+ for group"
       responses:
         "201":
           description: Conversation created
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Conversation" }
+              schema:
+                type: object
+                properties:
+                  conversation: { $ref: "#/components/schemas/ConversationV2" }
+        "200":
+          description: Conversation already exists (idempotent)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversation: { $ref: "#/components/schemas/ConversationV2" }
+                  existing: { type: boolean }
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/conversations/unread:
     get:
+      tags: [chat]
       operationId: getUnreadCounts
-      summary: Get unread message counts
+      summary: Get unread message counts — returns total and per-conversation breakdown
       security:
         - cookieAuth: []
       responses:
@@ -143,8 +295,9 @@ paths:
 
   /api/conversations/{id}:
     get:
+      tags: [chat]
       operationId: getConversation
-      summary: Get conversation by ID
+      summary: Get v2 conversation by URL-encoded DID — verifies access via auth service
       security:
         - cookieAuth: []
       parameters:
@@ -152,17 +305,22 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
       responses:
         "200":
           description: Conversation
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Conversation" }
+              schema:
+                type: object
+                properties:
+                  conversation: { $ref: "#/components/schemas/ConversationV2" }
         "404":
-          description: Not found
+          description: Not found or access denied
     patch:
+      tags: [chat]
       operationId: updateConversation
-      summary: Update conversation metadata
+      summary: Update conversation name — only the creator can update; auto-creates if not exists
       security:
         - cookieAuth: []
       parameters:
@@ -170,6 +328,7 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
       requestBody:
         required: true
         content:
@@ -178,14 +337,21 @@ paths:
               type: object
               properties:
                 name: { type: string }
-                description: { type: string }
-                visibility: { type: string, enum: [public, private] }
       responses:
         "200":
           description: Updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+        "403":
+          description: Only the creator can update
     delete:
+      tags: [chat]
       operationId: deleteConversation
-      summary: Delete conversation
+      summary: Delete conversation (creator only) — cascades to messages, reactions, and read records
       security:
         - cookieAuth: []
       parameters:
@@ -193,14 +359,26 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
       responses:
         "200":
           description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+        "403":
+          description: Only the creator can delete
+        "404":
+          description: Not found
 
   /api/conversations/{id}/messages:
     get:
+      tags: [chat]
       operationId: getMessages
-      summary: Get messages in a conversation
+      summary: Get paginated messages for a conversation — includes inline reactions
       security:
         - cookieAuth: []
       parameters:
@@ -208,9 +386,10 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
         - name: limit
           in: query
-          schema: { type: integer, default: 50 }
+          schema: { type: integer, default: 50, maximum: 100 }
         - name: before
           in: query
           schema: { type: string }
@@ -225,10 +404,14 @@ paths:
                 properties:
                   messages:
                     type: array
-                    items: { $ref: "#/components/schemas/Message" }
+                    items: { $ref: "#/components/schemas/MessageV2" }
+                  hasMore: { type: boolean }
+        "404":
+          description: Not found or access denied
     post:
+      tags: [chat]
       operationId: sendMessage
-      summary: Send a message
+      summary: Send a message — soft DIDs blocked; content must be an object; auto-creates conversation if missing
       security:
         - cookieAuth: []
       parameters:
@@ -236,6 +419,7 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
       requestBody:
         required: true
         content:
@@ -244,22 +428,44 @@ paths:
               type: object
               required: [content]
               properties:
-                content: { type: string }
-                replyTo: { type: string }
+                content:
+                  type: object
+                  description: "Structured content object, e.g. {type: 'text', text: 'hello'}"
+                contentType:
+                  type: string
+                  enum: [text, system, media, voice, location]
+                  default: text
+                replyToMessageId: { type: string }
                 mediaType: { type: string }
                 mediaPath: { type: string }
+                mediaAssetId: { type: string }
                 mediaMeta: { type: object }
+                conversationName: { type: string, description: "Optional name hint for auto-creation" }
       responses:
         "201":
           description: Message sent
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Message" }
+              schema:
+                type: object
+                properties:
+                  message: { $ref: "#/components/schemas/MessageV2" }
+        "403":
+          description: Soft DID or capability denied
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  code: { type: string }
+                  required: { type: string }
 
   /api/conversations/{id}/messages/{msgId}:
     put:
+      tags: [chat]
       operationId: editMessage
-      summary: Edit a message
+      summary: Edit a message (author only) — content must be an object
       security:
         - cookieAuth: []
       parameters:
@@ -267,6 +473,7 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
         - name: msgId
           in: path
           required: true
@@ -279,13 +486,26 @@ paths:
               type: object
               required: [content]
               properties:
-                content: { type: string }
+                content:
+                  type: object
+                  description: "Structured content object"
       responses:
         "200":
           description: Message updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { $ref: "#/components/schemas/MessageV2" }
+        "403":
+          description: Not the author
+        "404":
+          description: Message not found
     delete:
+      tags: [chat]
       operationId: deleteMessage
-      summary: Delete a message
+      summary: Soft delete a message — author can always delete; others need conversation access
       security:
         - cookieAuth: []
       parameters:
@@ -293,18 +513,30 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
         - name: msgId
           in: path
           required: true
           schema: { type: string }
       responses:
         "200":
-          description: Message deleted
+          description: Message soft-deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { $ref: "#/components/schemas/MessageV2" }
+        "403":
+          description: No permission
+        "404":
+          description: Message not found
 
   /api/conversations/{id}/participants:
     get:
+      tags: [chat]
       operationId: listParticipants
-      summary: List conversation participants
+      summary: List conversation participants — proxies to auth service members endpoint
       security:
         - cookieAuth: []
       parameters:
@@ -312,12 +544,24 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
       responses:
         "200":
           description: Participants list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  participants:
+                    type: array
+                    items: { type: object }
+        "404":
+          description: Not found or access denied
     post:
+      tags: [chat]
       operationId: addParticipant
-      summary: Add a participant
+      summary: Add a participant — delegates to auth service
       security:
         - cookieAuth: []
       parameters:
@@ -325,6 +569,7 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
       requestBody:
         required: true
         content:
@@ -337,50 +582,12 @@ paths:
       responses:
         "201":
           description: Participant added
-    patch:
-      operationId: updateParticipant
-      summary: Update participant role
-      security:
-        - cookieAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema: { type: string }
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                did: { type: string }
-                role: { type: string }
-      responses:
-        "200":
-          description: Updated
-    delete:
-      operationId: removeParticipant
-      summary: Remove a participant
-      security:
-        - cookieAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema: { type: string }
-        - name: did
-          in: query
-          required: true
-          schema: { type: string }
-      responses:
-        "200":
-          description: Removed
 
   /api/conversations/{id}/read:
     post:
+      tags: [chat]
       operationId: markRead
-      summary: Mark conversation as read
+      summary: Mark a v2 conversation as read — upserts last-read timestamp
       security:
         - cookieAuth: []
       parameters:
@@ -388,14 +595,22 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
       responses:
         "200":
           description: Marked as read
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
 
   /api/conversations/{id}/upload:
     post:
+      tags: [chat]
       operationId: uploadMedia
-      summary: Upload media to a conversation
+      summary: Upload media to a conversation (25 MB max) — images are auto-resized and thumbnailed
       security:
         - cookieAuth: []
       parameters:
@@ -403,6 +618,7 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: URL-encoded conversation DID
       requestBody:
         required: true
         content:
@@ -414,6 +630,7 @@ paths:
                 file:
                   type: string
                   format: binary
+                  description: "Allowed: image/jpeg, image/png, image/gif, image/webp, application/pdf, application/zip, text/plain, application/msword, xlsx"
       responses:
         "200":
           description: Media uploaded
@@ -422,175 +639,65 @@ paths:
               schema:
                 type: object
                 properties:
-                  mediaType: { type: string }
+                  mediaType: { type: string, enum: [image, file] }
                   mediaPath: { type: string }
-                  mediaMeta: { type: object }
-
-  /api/invites:
-    get:
-      operationId: listInvites
-      summary: List conversation invites
-      security:
-        - cookieAuth: []
-      parameters:
-        - name: conversationId
-          in: query
-          schema: { type: string }
-      responses:
-        "200":
-          description: Invites list
-    post:
-      operationId: createInvite
-      summary: Create a conversation invite
-      security:
-        - cookieAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                conversationId: { type: string }
-      responses:
-        "201":
-          description: Invite created
-
-  /api/invites/{id}:
-    get:
-      operationId: getInvite
-      summary: Get invite by ID (public)
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema: { type: string }
-      responses:
-        "200":
-          description: Invite details
-    post:
-      operationId: acceptInvite
-      summary: Accept a conversation invite
-      security:
-        - cookieAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema: { type: string }
-      responses:
-        "200":
-          description: Invite accepted
-    delete:
-      operationId: revokeInvite
-      summary: Revoke a conversation invite
-      security:
-        - cookieAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema: { type: string }
-      responses:
-        "200":
-          description: Invite revoked
-
-  /api/keys:
-    get:
-      operationId: getKeyBundle
-      summary: Get own E2EE key bundle
-      security:
-        - cookieAuth: []
-      responses:
-        "200":
-          description: Key bundle
+                  mediaMeta:
+                    type: object
+                    properties:
+                      originalName: { type: string }
+                      mimeType: { type: string }
+                      size: { type: integer }
+                      width: { type: integer }
+                      height: { type: integer }
+                      thumbnailPath: { type: string }
+        "400":
+          description: Missing file or invalid type
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/KeyBundle" }
-    post:
-      operationId: uploadKeyBundle
-      summary: Upload E2EE key bundle (X3DH-style)
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/d/{did}/messages:
+    get:
+      tags: [chat]
+      operationId: getDMessages
+      summary: Get paginated messages for a DID-keyed conversation — includes inline reactions
       security:
         - cookieAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [identityKey, signedPreKey, signature]
-              properties:
-                identityKey: { type: string }
-                signedPreKey: { type: string }
-                signature: { type: string }
-                oneTimePreKeys: { type: array, items: { type: string } }
-      responses:
-        "200":
-          description: Key bundle stored
-
-  /api/keys/{did}:
-    get:
-      operationId: getPublicKeys
-      summary: Get public keys for a DID (public)
       parameters:
         - name: did
           in: path
           required: true
           schema: { type: string }
-      responses:
-        "200":
-          description: Public key bundle
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/KeyBundle" }
-
-  /api/lobby/{eventId}:
-    get:
-      operationId: getLobby
-      summary: Get lobby conversation for an event (requires ticket)
-      security:
-        - cookieAuth: []
-      parameters:
-        - name: eventId
-          in: path
-          required: true
-          schema: { type: string }
-      responses:
-        "200":
-          description: Lobby conversation
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/Conversation" }
-        "403":
-          description: No ticket
-
-  /api/lobby/{eventId}/messages:
-    get:
-      operationId: getLobbyMessages
-      summary: Get lobby messages (requires ticket)
-      security:
-        - cookieAuth: []
-      parameters:
-        - name: eventId
-          in: path
-          required: true
-          schema: { type: string }
+          description: Conversation DID (not URL-encoded in this path)
         - name: limit
           in: query
-          schema: { type: integer, default: 50 }
+          schema: { type: integer, default: 50, maximum: 100 }
         - name: before
           in: query
           schema: { type: string }
+          description: "Cursor for pagination (message ID)"
       responses:
         "200":
-          description: Lobby messages
+          description: Messages
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    items: { $ref: "#/components/schemas/MessageV2" }
+                  hasMore: { type: boolean }
+        "403":
+          description: Access denied
     post:
-      operationId: sendLobbyMessage
-      summary: Send a lobby message (requires ticket)
+      tags: [chat]
+      operationId: sendDMessage
+      summary: Send a message to a DID-keyed conversation — soft DIDs blocked; auto-creates conversation; node signs payload
       security:
         - cookieAuth: []
       parameters:
-        - name: eventId
+        - name: did
           in: path
           required: true
           schema: { type: string }
@@ -602,44 +709,105 @@ paths:
               type: object
               required: [content]
               properties:
-                content: { type: string }
+                content:
+                  type: object
+                  description: "Structured content object, e.g. {type: 'text', text: 'hello'}"
+                contentType:
+                  type: string
+                  enum: [text, system, media, voice, location]
+                replyToMessageId: { type: string }
+                mediaType: { type: string }
+                mediaPath: { type: string }
+                mediaAssetId: { type: string }
+                mediaMeta: { type: object }
+                conversationName: { type: string }
       responses:
         "201":
           description: Message sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { $ref: "#/components/schemas/MessageV2" }
+        "403":
+          description: Soft DID or access denied
 
-  /api/lookup/{did}:
-    get:
-      operationId: lookupDid
-      summary: Resolve DID to handle and name (proxies to auth service)
+  /api/d/{did}/messages/{msgId}:
+    patch:
+      tags: [chat]
+      operationId: editDMessage
+      summary: Edit a DID-keyed message (author only)
+      security:
+        - cookieAuth: []
       parameters:
         - name: did
           in: path
           required: true
           schema: { type: string }
+        - name: msgId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [content]
+              properties:
+                content:
+                  type: object
+                  description: "Structured content object"
       responses:
         "200":
-          description: Identity info
-
-  /api/messages/{msgId}/reactions:
-    get:
-      operationId: listReactions
-      summary: List reactions on a message
+          description: Message updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { $ref: "#/components/schemas/MessageV2" }
+        "403":
+          description: Not the author
+        "404":
+          description: Message not found
+    delete:
+      tags: [chat]
+      operationId: deleteDMessage
+      summary: Soft delete a DID-keyed message (author only)
       security:
         - cookieAuth: []
       parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
         - name: msgId
           in: path
           required: true
           schema: { type: string }
       responses:
-        "200":
-          description: Reactions
+        "204":
+          description: Message deleted
+        "403":
+          description: Not the author
+        "404":
+          description: Message not found
+
+  /api/d/{did}/messages/{msgId}/reactions:
     post:
-      operationId: addReaction
-      summary: Add a reaction to a message
+      tags: [chat]
+      operationId: addDReaction
+      summary: Add a reaction to a DID-keyed message
       security:
         - cookieAuth: []
       parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
         - name: msgId
           in: path
           required: true
@@ -656,9 +824,120 @@ paths:
       responses:
         "201":
           description: Reaction added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+        "400":
+          description: emoji required
+        "404":
+          description: Message not found
     delete:
-      operationId: removeReaction
-      summary: Remove a reaction from a message
+      tags: [chat]
+      operationId: removeDReaction
+      summary: Remove a reaction from a DID-keyed message
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+        - name: msgId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [emoji]
+              properties:
+                emoji: { type: string }
+      responses:
+        "204":
+          description: Reaction removed
+
+  /api/d/{did}/members:
+    get:
+      tags: [chat]
+      operationId: getDConversationMembers
+      summary: Get members of a DID-keyed conversation via pod membership — resolves names from auth service
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Members list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  members:
+                    type: array
+                    items: { $ref: "#/components/schemas/Member" }
+                  count: { type: integer }
+
+  /api/d/{did}/read:
+    post:
+      tags: [chat]
+      operationId: markDRead
+      summary: Mark a DID-keyed conversation as read
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Marked as read
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+
+  /api/messages/{msgId}/reactions:
+    get:
+      tags: [chat]
+      operationId: listReactions
+      summary: List grouped reactions on a v2 message — returns per-emoji counts with current user's react status
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: msgId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Reactions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reactions:
+                    type: array
+                    items: { $ref: "#/components/schemas/ReactionSummary" }
+        "404":
+          description: Message not found
+    post:
+      tags: [chat]
+      operationId: addReaction
+      summary: Add a reaction to a v2 message — idempotent; returns updated reaction counts
       security:
         - cookieAuth: []
       parameters:
@@ -677,38 +956,240 @@ paths:
                 emoji: { type: string }
       responses:
         "200":
-          description: Reaction removed
-
-  /api/participants/migrate:
-    post:
-      operationId: migrateParticipants
-      summary: Migrate chat data between DIDs (e.g. soft → hard DID)
+          description: Reaction added; updated counts returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reactions:
+                    type: array
+                    items: { $ref: "#/components/schemas/ReactionSummary" }
+    delete:
+      tags: [chat]
+      operationId: removeReaction
+      summary: Remove a reaction from a v2 message — returns updated reaction counts
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: msgId
+          in: path
+          required: true
+          schema: { type: string }
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [fromDid, toDid]
+              required: [emoji]
               properties:
-                fromDid: { type: string }
-                toDid: { type: string }
+                emoji: { type: string }
       responses:
         "200":
-          description: Migration result
+          description: Reaction removed; updated counts returned
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  migrated: { type: boolean }
-                  participants: { type: integer }
-                  messages: { type: integer }
+                  reactions:
+                    type: array
+                    items: { $ref: "#/components/schemas/ReactionSummary" }
 
-  /api/participants/{did}/conversations:
+  /api/invites:
     get:
-      operationId: getParticipantConversations
-      summary: Get conversation IDs for a DID (public)
+      tags: [chat]
+      operationId: listInvites
+      summary: List active (non-revoked) invites for a conversation
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: conversationId
+          in: query
+          required: true
+          schema: { type: string }
+          description: Conversation DID or legacy ID
+      responses:
+        "200":
+          description: Invites list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invites:
+                    type: array
+                    items: { $ref: "#/components/schemas/ChatInvite" }
+        "403":
+          description: Permission denied
+    post:
+      tags: [chat]
+      operationId: createInvite
+      summary: Create an invite link for a conversation
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [conversationId]
+              properties:
+                conversationId: { type: string }
+                forDid: { type: string, description: "Restrict invite to specific DID" }
+                maxUses: { type: integer }
+                expiresInHours: { type: integer }
+      responses:
+        "201":
+          description: Invite created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invite: { $ref: "#/components/schemas/ChatInvite" }
+                  link: { type: string }
+
+  /api/invites/{id}:
+    get:
+      tags: [chat]
+      operationId: getInvite
+      summary: Get invite info (public — for preview before joining)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Invite details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invite:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      conversationId: { type: string }
+                      forDid: { type: string, nullable: true }
+                      expiresAt: { type: string, format: date-time, nullable: true }
+        "404":
+          description: Invite not found
+        "410":
+          description: Invite expired, revoked, or max uses reached
+    post:
+      tags: [chat]
+      operationId: acceptInvite
+      summary: Accept a conversation invite — increments use count and returns conversation DID
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Invite accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId: { type: string }
+                  joined: { type: boolean }
+        "403":
+          description: Invite is for a different user
+        "410":
+          description: Invite expired, revoked, or max uses reached
+    delete:
+      tags: [chat]
+      operationId: revokeInvite
+      summary: Revoke a conversation invite (creator or conversation member)
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Invite revoked
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  revoked: { type: boolean }
+        "403":
+          description: Permission denied
+        "404":
+          description: Invite not found
+
+  /api/keys:
+    get:
+      tags: [chat]
+      operationId: getKeyBundle
+      summary: Get own E2EE key bundle with unused pre-key count
+      security:
+        - cookieAuth: []
+      responses:
+        "200":
+          description: Key bundle
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/KeyBundle"
+                  - type: object
+                    properties:
+                      unusedPreKeyCount: { type: integer }
+        "404":
+          description: No keys uploaded
+    post:
+      tags: [chat]
+      operationId: uploadKeyBundle
+      summary: Upload or update E2EE key bundle (X3DH-style) — signature is verified server-side
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [identityKey, signedPreKey, signature]
+              properties:
+                identityKey: { type: string, description: "Base64-encoded Ed25519 public key" }
+                signedPreKey: { type: string, description: "Base64-encoded signed pre-key" }
+                signature: { type: string, description: "Base64-encoded Ed25519 signature of signedPreKey" }
+                oneTimePreKeys: { type: array, items: { type: string } }
+      responses:
+        "200":
+          description: Key bundle stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+                  preKeysAdded: { type: integer }
+        "400":
+          description: Invalid signature
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/keys/{did}:
+    get:
+      tags: [chat]
+      operationId: getPublicKeys
+      summary: Get public keys for a DID (public endpoint) — consumes one one-time pre-key if available
       parameters:
         - name: did
           in: path
@@ -716,18 +1197,41 @@ paths:
           schema: { type: string }
       responses:
         "200":
-          description: Conversation IDs
+          description: Public key bundle
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/KeyBundle" }
+        "404":
+          description: No keys found for DID
+
+  /api/lookup/{did}:
+    get:
+      tags: [chat]
+      operationId: lookupDid
+      summary: Resolve DID to handle and name (proxies to auth service)
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Identity info (graceful on lookup failure)
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  conversationIds: { type: array, items: { type: string } }
+                  did: { type: string }
+                  handle: { type: string, nullable: true }
+                  name: { type: string, nullable: true }
+                  tier: { type: string, nullable: true }
 
   /api/profile:
     get:
+      tags: [chat]
       operationId: getChatProfile
-      summary: Proxy profile lookup by handle
+      summary: Proxy profile lookup by handle to profile service
       parameters:
         - name: handle
           in: query
@@ -736,16 +1240,75 @@ paths:
       responses:
         "200":
           description: Profile data
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
-  /api/media/chat/{path}:
+  /api/ws-token:
     get:
-      operationId: serveChatMedia
-      summary: Serve chat media files (public)
-      parameters:
-        - name: path
-          in: path
-          required: true
-          schema: { type: string }
+      tags: [chat]
+      operationId: getWsToken
+      summary: Get a short-lived token for WebSocket authentication — exchanges session cookie for token
+      security:
+        - cookieAuth: []
       responses:
         "200":
-          description: Media file
+          description: WS token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token: { type: string }
+        "401":
+          description: Not authenticated
+
+  /api/ws-token/validate:
+    post:
+      tags: [chat]
+      operationId: validateWsToken
+      summary: Validate a WS auth token (internal — used by ws-server)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token]
+              properties:
+                token: { type: string }
+      responses:
+        "200":
+          description: Token valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  did: { type: string }
+        "401":
+          description: Invalid or expired token
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /start:
+    get:
+      tags: [chat]
+      operationId: startConversation
+      summary: Find or create a DM conversation then redirect to it — used by chat open deep-link
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: query
+          required: true
+          schema: { type: string }
+          description: DID of the person to start a conversation with
+      responses:
+        "302":
+          description: Redirect to /conversations/{encodedConvDid}
+        "307":
+          description: Redirect (unauthenticated falls back to /conversations)

--- a/apps/coffee/api-spec/openapi.yaml
+++ b/apps/coffee/api-spec/openapi.yaml
@@ -3,6 +3,7 @@ info:
   title: imajin coffee
   version: "1.0.0"
   description: Tip pages and one-time or recurring support payments via Stripe Checkout and Solana.
+
 servers:
   - url: https://coffee.imajin.ai
     description: production
@@ -11,12 +12,18 @@ servers:
   - url: http://localhost:7100
     description: local
 
+tags:
+  - name: coffee
+
 components:
   securitySchemes:
     cookieAuth:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
     webhookSecret:
       type: http
       scheme: bearer
@@ -31,6 +38,7 @@ components:
         title: { type: string }
         bio: { type: string }
         avatar: { type: string }
+        avatarAssetId: { type: string, nullable: true, description: "Media service asset ID for the avatar" }
         theme: { type: object }
         paymentMethods:
           type: object
@@ -47,8 +55,10 @@ components:
         presets: { type: array, items: { type: integer }, description: "Preset amounts in cents" }
         allowCustomAmount: { type: boolean }
         allowMessages: { type: boolean }
+        thankYouContent: { type: string, nullable: true }
         isPublic: { type: boolean }
         createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
     Tip:
       type: object
       properties:
@@ -70,12 +80,31 @@ components:
         error: { type: string }
 
 paths:
+  /api/health:
+    get:
+      operationId: getCoffeeHealth
+      summary: Health check
+      tags: [coffee]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: coffee }
+                  timestamp: { type: string, format: date-time }
+
   /api/pages:
     post:
       operationId: createCoffeePage
       summary: Create a tip page — one per DID
+      tags: [coffee]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -88,39 +117,65 @@ paths:
                 title: { type: string }
                 bio: { type: string }
                 avatar: { type: string }
+                avatarAssetId: { type: string, description: "Media service asset ID for the avatar" }
                 theme: { type: object }
                 paymentMethods: { type: object }
                 presets: { type: array, items: { type: integer } }
                 allowCustomAmount: { type: boolean }
                 allowMessages: { type: boolean }
+                thankYouContent: { type: string }
       responses:
         "201":
           description: Page created
           content:
             application/json:
               schema: { $ref: "#/components/schemas/CoffeePage" }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "409":
           description: Page or handle already exists
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/pages/mine:
     get:
       operationId: getMyCoffeePage
       summary: Get authenticated user's tip page
+      tags: [coffee]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       responses:
         "200":
           description: User's coffee page
           content:
             application/json:
               schema: { $ref: "#/components/schemas/CoffeePage" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "404":
           description: No page found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/pages/{handle}:
     get:
       operationId: getCoffeePage
       summary: Get a public tip page by handle
+      tags: [coffee]
       parameters:
         - name: handle
           in: path
@@ -134,13 +189,21 @@ paths:
               schema: { $ref: "#/components/schemas/CoffeePage" }
         "403":
           description: Page is private
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "404":
           description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     put:
       operationId: updateCoffeePage
       summary: Update tip page (owner only)
+      tags: [coffee]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: handle
           in: path
@@ -156,23 +219,42 @@ paths:
                 title: { type: string }
                 bio: { type: string }
                 avatar: { type: string }
+                avatarAssetId: { type: string }
                 theme: { type: object }
                 paymentMethods: { type: object }
                 presets: { type: array, items: { type: integer } }
                 allowCustomAmount: { type: boolean }
                 allowMessages: { type: boolean }
                 isPublic: { type: boolean }
+                thankYouContent: { type: string }
       responses:
         "200":
           description: Page updated
           content:
             application/json:
               schema: { $ref: "#/components/schemas/CoffeePage" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the page owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
       operationId: deleteCoffeePage
       summary: Delete tip page (owner only)
+      tags: [coffee]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: handle
           in: path
@@ -181,13 +263,37 @@ paths:
       responses:
         "200":
           description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the page owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/tip:
     post:
       operationId: sendTip
       summary: Send a tip via Stripe Checkout (redirect) or Solana (address return)
+      tags: [coffee]
       security:
         - cookieAuth: []
+        - bearerAuth: []
+        - {}
       requestBody:
         required: true
         content:
@@ -226,13 +332,33 @@ paths:
                       paymentMethod: { type: string, enum: [solana] }
         "400":
           description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "403":
           description: Page not accepting tips or payment method disabled
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Coffee page not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Too many requests
+          headers:
+            Retry-After:
+              schema: { type: integer }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/checkout:
     post:
       operationId: coffeeCheckout
       summary: Create Stripe checkout for one-time or recurring support (no specific page)
+      tags: [coffee]
       requestBody:
         required: true
         content:
@@ -253,13 +379,33 @@ paths:
                 type: object
                 properties:
                   url: { type: string }
+        "400":
+          description: Amount below minimum
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Too many requests
+          headers:
+            Retry-After:
+              schema: { type: integer }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          description: Failed to create checkout
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/tips/{did}:
     get:
       operationId: getTipsReceived
       summary: Get tips received by a DID (owner only)
+      tags: [coffee]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: did
           in: path
@@ -298,11 +444,27 @@ paths:
                     properties:
                       limit: { type: integer }
                       offset: { type: integer }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized to view these tips
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: No coffee page found for this DID
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/webhook/payment:
     post:
       operationId: coffeePaymentWebhook
       summary: Receive payment callbacks from pay service
+      tags: [coffee]
       security:
         - webhookSecret: []
       requestBody:
@@ -315,9 +477,15 @@ paths:
                 type: { type: string, enum: [payment.succeeded, payment.failed, checkout.completed] }
                 tipId: { type: string }
                 pageId: { type: string }
+                pageHandle: { type: string }
                 amount: { type: number }
                 paymentId: { type: string }
-                status: { type: string }
+                fromDid: { type: string }
+                fromName: { type: string }
+                fromEmail: { type: string }
+                to_did: { type: string }
+                message: { type: string }
+                stripeSessionId: { type: string }
       responses:
         "200":
           description: Received
@@ -327,3 +495,25 @@ paths:
                 type: object
                 properties:
                   received: { type: boolean }
+        "401":
+          description: Invalid or missing webhook secret
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          description: Webhook handler failed
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/spec:
+    get:
+      operationId: getCoffeeSpec
+      summary: Serve this OpenAPI spec
+      tags: [coffee]
+      responses:
+        "200":
+          description: OpenAPI YAML
+          content:
+            text/yaml:
+              schema: { type: string }

--- a/apps/connections/api-spec/openapi.yaml
+++ b/apps/connections/api-spec/openapi.yaml
@@ -17,6 +17,9 @@ components:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
   schemas:
     Pod:
       type: object
@@ -25,40 +28,73 @@ components:
         name: { type: string }
         description: { type: string }
         ownerDid: { type: string }
-        type: { type: string, enum: [personal, group, community] }
+        type: { type: string, enum: [personal, shared, event] }
         visibility: { type: string, enum: [public, private] }
-        avatar: { type: string }
+        avatar: { type: string, nullable: true }
+        conversationDid: { type: string, nullable: true }
         createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+    PodMember:
+      type: object
+      properties:
+        podId: { type: string }
+        did: { type: string }
+        role: { type: string, enum: [owner, member] }
+        addedBy: { type: string }
+        joinedAt: { type: string, format: date-time }
+        removedAt: { type: string, format: date-time, nullable: true }
+        handle: { type: string, nullable: true }
+        name: { type: string, nullable: true }
     Invite:
       type: object
       properties:
         id: { type: string }
         code: { type: string }
         fromDid: { type: string }
-        fromHandle: { type: string }
-        note: { type: string }
-        used: { type: boolean }
-        createdAt: { type: string, format: date-time }
-    TrustInvite:
-      type: object
-      properties:
-        id: { type: string }
-        inviterDid: { type: string }
-        inviteeDid: { type: string }
-        inviteeEmail: { type: string }
+        fromHandle: { type: string, nullable: true }
+        toEmail: { type: string, nullable: true }
+        toDid: { type: string, nullable: true }
+        note: { type: string, nullable: true }
+        delivery: { type: string, enum: [link, email] }
         status: { type: string, enum: [pending, accepted, revoked, expired] }
-        expiresAt: { type: string, format: date-time }
+        maxUses: { type: integer }
+        usedCount: { type: integer }
+        expiresAt: { type: string, format: date-time, nullable: true }
+        acceptedAt: { type: string, format: date-time, nullable: true }
+        createdAt: { type: string, format: date-time }
     Error:
       type: object
       required: [error]
       properties:
         error: { type: string }
 
+tags:
+  - name: connections
+    description: imajin connections service
+
 paths:
+  /api/health:
+    get:
+      tags: [connections]
+      operationId: connectionsHealthCheck
+      summary: Service health check
+      responses:
+        "200":
+          description: Service healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  service: { type: string }
+                  timestamp: { type: string, format: date-time }
+
   /api/connections:
     get:
+      tags: [connections]
       operationId: listConnections
-      summary: List 2-person connection pods for authenticated user
+      summary: List 2-person connection pods for authenticated user — resolves handles from auth service
       security:
         - cookieAuth: []
       responses:
@@ -78,13 +114,14 @@ paths:
                         podId: { type: string }
                         joinedAt: { type: string, format: date-time }
                         podName: { type: string }
-                        handle: { type: string }
-                        name: { type: string }
+                        handle: { type: string, nullable: true }
+                        name: { type: string, nullable: true }
 
   /api/connections/{podId}:
     delete:
+      tags: [connections]
       operationId: disconnect
-      summary: Disconnect from a pod (leave 2-person connection)
+      summary: Disconnect from a 2-person connection pod — removes user from pod; deletes pod if empty
       security:
         - cookieAuth: []
       parameters:
@@ -95,11 +132,20 @@ paths:
       responses:
         "200":
           description: Disconnected
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  disconnected: { type: boolean }
+        "404":
+          description: Not a member of this connection
 
   /api/connections/status/{did}:
     get:
+      tags: [connections]
       operationId: checkGraphMembership
-      summary: Check if a DID is in the trust graph
+      summary: Check if a DID is in the trust graph — inGraph = has at least one accepted 2-person connection
       parameters:
         - name: did
           in: path
@@ -118,13 +164,14 @@ paths:
 
   /api/invites:
     get:
+      tags: [connections]
       operationId: listConnectionInvites
-      summary: List connection invites (sent by user)
+      summary: List all invites sent by authenticated user — includes quota info per role
       security:
         - cookieAuth: []
       responses:
         "200":
-          description: Invites list
+          description: Invites list with quota
           content:
             application/json:
               schema:
@@ -133,9 +180,14 @@ paths:
                   invites:
                     type: array
                     items: { $ref: "#/components/schemas/Invite" }
+                  role: { type: string }
+                  limit: { type: integer, nullable: true }
+                  pending: { type: integer }
+                  remaining: { type: integer, nullable: true }
     post:
+      tags: [connections]
       operationId: createConnectionInvite
-      summary: Create a connection invite
+      summary: Create a connection invite — link or email delivery; email requires hard DID + trust graph; 7-day cooldown
       security:
         - cookieAuth: []
       requestBody:
@@ -145,10 +197,16 @@ paths:
             schema:
               type: object
               properties:
-                toEmail: { type: string, format: email }
-                toPhone: { type: string }
+                delivery:
+                  type: string
+                  enum: [link, email]
+                  default: link
+                toEmail:
+                  type: string
+                  format: email
+                  description: "Required when delivery=email"
                 note: { type: string }
-                maxUses: { type: integer }
+                maxUses: { type: integer, default: 1 }
       responses:
         "201":
           description: Invite created
@@ -159,12 +217,54 @@ paths:
                 properties:
                   invite: { $ref: "#/components/schemas/Invite" }
                   url: { type: string }
-                  remaining: { type: integer }
+                  remaining: { type: integer, nullable: true }
+        "403":
+          description: Not in trust graph or not hard DID (email delivery)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Cooldown active, pending invite exists, or invite limit reached
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  nextAvailableAt: { type: string, format: date-time }
+                  limit: { type: integer }
+                  pending: { type: integer }
+
+  /api/invites/invited-by:
+    get:
+      tags: [connections]
+      operationId: getInvitedBy
+      summary: Get who invited the current user — null for founding members
+      security:
+        - cookieAuth: []
+      responses:
+        "200":
+          description: Inviter info or null
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invitedBy:
+                    nullable: true
+                    type: object
+                    properties:
+                      did: { type: string }
+                      handle: { type: string, nullable: true }
+                      name: { type: string, nullable: true }
+                      avatar: { type: string, nullable: true }
+                      date: { type: string, format: date-time, nullable: true }
 
   /api/invites/{code}:
     get:
+      tags: [connections]
       operationId: getConnectionInvite
-      summary: Get invite by code (public, CORS-enabled)
+      summary: Get invite by code (public, CORS-enabled — for preview before accepting)
       parameters:
         - name: code
           in: path
@@ -175,12 +275,25 @@ paths:
           description: Invite details
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Invite" }
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  code: { type: string }
+                  fromDid: { type: string }
+                  fromHandle: { type: string, nullable: true }
+                  note: { type: string, nullable: true }
+                  used: { type: boolean }
+                  createdAt: { type: string, format: date-time }
         "404":
           description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
+      tags: [connections]
       operationId: deleteConnectionInvite
-      summary: Delete an invite
+      summary: Revoke (soft-delete) an invite — only the creator can revoke; email invite clears cooldown
       security:
         - cookieAuth: []
       parameters:
@@ -190,12 +303,23 @@ paths:
           schema: { type: string }
       responses:
         "200":
-          description: Deleted
+          description: Revoked
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+        "400":
+          description: Cannot revoke non-pending invite
+        "403":
+          description: Not authorized
 
   /api/invites/{code}/accept:
     post:
+      tags: [connections]
       operationId: acceptConnectionInvite
-      summary: Accept an invite — creates a 2-person connection pod
+      summary: Accept an invite — creates a 2-person personal pod; emits connection.accepted and vouch attestations
       security:
         - cookieAuth: []
       parameters:
@@ -205,7 +329,7 @@ paths:
           schema: { type: string }
       responses:
         "201":
-          description: Connected
+          description: Connected — 2-person pod created
           content:
             application/json:
               schema:
@@ -217,11 +341,272 @@ paths:
                     properties:
                       id: { type: string }
                       name: { type: string }
+        "400":
+          description: Cannot accept own invite
+        "403":
+          description: Email invite is not for this user
+        "404":
+          description: Invite not found
+        "410":
+          description: Invite expired, already used, or revoked
+
+  /api/groups:
+    get:
+      tags: [connections]
+      operationId: listGroups
+      summary: List non-personal (shared/event) pods the user is a member of — includes member counts
+      security:
+        - cookieAuth: []
+      responses:
+        "200":
+          description: Groups list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pods:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: "#/components/schemas/Pod"
+                        - type: object
+                          properties:
+                            memberCount: { type: integer }
+    post:
+      tags: [connections]
+      operationId: createGroup
+      summary: Create a shared group pod — creator becomes owner; optionally add initial members
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                description: { type: string }
+                conversationDid: { type: string }
+                memberDids:
+                  type: array
+                  items: { type: string }
+      responses:
+        "201":
+          description: Group pod created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pod:
+                    allOf:
+                      - $ref: "#/components/schemas/Pod"
+                      - type: object
+                        properties:
+                          memberCount: { type: integer }
+        "400":
+          description: Name is required
+
+  /api/groups/{id}:
+    get:
+      tags: [connections]
+      operationId: getGroup
+      summary: Get a group pod with members (requester must be a member) — resolves member profiles
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Pod with members
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pod:
+                    allOf:
+                      - $ref: "#/components/schemas/Pod"
+                      - type: object
+                        properties:
+                          memberCount: { type: integer }
+                  members:
+                    type: array
+                    items: { $ref: "#/components/schemas/PodMember" }
+        "403":
+          description: Not a member
+        "404":
+          description: Pod not found
+    patch:
+      tags: [connections]
+      operationId: updateGroup
+      summary: Update group pod — conversationDid update requires only membership (first-write wins); all other updates require ownership
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                description: { type: string }
+                conversationDid: { type: string }
+      responses:
+        "200":
+          description: Pod updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pod: { $ref: "#/components/schemas/Pod" }
+        "404":
+          description: Pod not found or unauthorized
+    delete:
+      tags: [connections]
+      operationId: deleteGroup
+      summary: Delete a group pod (owner only)
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+        "404":
+          description: Pod not found or unauthorized
+
+  /api/groups/{id}/members:
+    post:
+      tags: [connections]
+      operationId: addGroupMember
+      summary: Add a member to a group pod (owner only) — emits pod.member.added attestation if chain-verified
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [did]
+              properties:
+                did: { type: string }
+      responses:
+        "201":
+          description: Member added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member: { $ref: "#/components/schemas/PodMember" }
+        "403":
+          description: Only the owner can add members
+        "409":
+          description: Already a member
+    patch:
+      tags: [connections]
+      operationId: updateGroupMemberRole
+      summary: Change a member's role (owner only) — emits pod.role.changed attestation
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [did, role]
+              properties:
+                did: { type: string }
+                role: { type: string }
+      responses:
+        "200":
+          description: Role updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member: { $ref: "#/components/schemas/PodMember" }
+        "403":
+          description: Only the owner can change roles
+        "404":
+          description: Member not found
+    delete:
+      tags: [connections]
+      operationId: removeGroupMember
+      summary: Remove a member from a group pod (owner only) — emits pod.member.removed attestation
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [did]
+              properties:
+                did: { type: string }
+      responses:
+        "200":
+          description: Member removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removed: { type: boolean }
+        "400":
+          description: Cannot remove yourself as owner
+        "403":
+          description: Only the owner can remove members
+        "404":
+          description: Member not found
 
   /api/pods:
     get:
+      tags: [connections]
       operationId: listPods
-      summary: List pods for authenticated user
+      summary: List all pods for authenticated user (all types)
       security:
         - cookieAuth: []
       responses:
@@ -236,6 +621,7 @@ paths:
                     type: array
                     items: { $ref: "#/components/schemas/Pod" }
     post:
+      tags: [connections]
       operationId: createPod
       summary: Create a pod — requires trust graph membership
       security:
@@ -251,19 +637,23 @@ paths:
                 name: { type: string }
                 description: { type: string }
                 avatar: { type: string }
-                type: { type: string, enum: [personal, group, community] }
-                visibility: { type: string, enum: [public, private] }
+                type: { type: string, enum: [personal, shared, event], default: personal }
+                visibility: { type: string, enum: [public, private], default: private }
       responses:
         "201":
           description: Pod created
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Pod" }
+              schema:
+                type: object
+                properties:
+                  pod: { $ref: "#/components/schemas/Pod" }
 
   /api/pods/{id}:
     get:
+      tags: [connections]
       operationId: getPod
-      summary: Get pod by ID
+      summary: Get pod by ID with current members
       security:
         - cookieAuth: []
       parameters:
@@ -273,13 +663,22 @@ paths:
           schema: { type: string }
       responses:
         "200":
-          description: Pod
+          description: Pod with members
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Pod" }
+              schema:
+                type: object
+                properties:
+                  pod: { $ref: "#/components/schemas/Pod" }
+                  members:
+                    type: array
+                    items: { $ref: "#/components/schemas/PodMember" }
+        "404":
+          description: Pod not found
     patch:
+      tags: [connections]
       operationId: updatePod
-      summary: Update pod
+      summary: Update pod (owner only)
       security:
         - cookieAuth: []
       parameters:
@@ -291,13 +690,28 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: "#/components/schemas/Pod" }
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                description: { type: string }
+                avatar: { type: string }
+                visibility: { type: string, enum: [public, private] }
       responses:
         "200":
           description: Pod updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pod: { $ref: "#/components/schemas/Pod" }
+        "404":
+          description: Pod not found or unauthorized
     delete:
+      tags: [connections]
       operationId: deletePod
-      summary: Delete pod
+      summary: Delete pod (owner only)
       security:
         - cookieAuth: []
       parameters:
@@ -308,11 +722,20 @@ paths:
       responses:
         "200":
           description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+        "404":
+          description: Pod not found or unauthorized
 
   /api/pods/{id}/members:
     post:
+      tags: [connections]
       operationId: addPodMember
-      summary: Add a member to a pod
+      summary: Add a member to a pod (owner only, chain verification required) — emits pod.member.added attestation
       security:
         - cookieAuth: []
       parameters:
@@ -333,9 +756,52 @@ paths:
       responses:
         "201":
           description: Member added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member: { $ref: "#/components/schemas/PodMember" }
+        "403":
+          description: Only the owner can add members
+    patch:
+      tags: [connections]
+      operationId: updatePodMemberRole
+      summary: Change a pod member's role (owner only, chain verification required)
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [did, role]
+              properties:
+                did: { type: string }
+                role: { type: string }
+      responses:
+        "200":
+          description: Role updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member: { $ref: "#/components/schemas/PodMember" }
+        "403":
+          description: Only the owner can change roles
+        "404":
+          description: Member not found
     delete:
+      tags: [connections]
       operationId: removePodMember
-      summary: Remove a member from a pod
+      summary: Remove a member from a pod (owner only, chain verification required)
       security:
         - cookieAuth: []
       parameters:
@@ -355,9 +821,20 @@ paths:
       responses:
         "200":
           description: Member removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removed: { type: boolean }
+        "403":
+          description: Only the owner can remove members
+        "404":
+          description: Member not found
 
   /api/pods/{id}/links:
     post:
+      tags: [connections]
       operationId: linkPod
       summary: Link a child pod to this pod
       security:
@@ -379,9 +856,16 @@ paths:
       responses:
         "201":
           description: Pod linked
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  link: { type: object }
     delete:
+      tags: [connections]
       operationId: unlinkPod
-      summary: Unlink a child pod
+      summary: Unlink a child pod (soft delete)
       security:
         - cookieAuth: []
       parameters:
@@ -401,9 +885,18 @@ paths:
       responses:
         "200":
           description: Pod unlinked
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  unlinked: { type: boolean }
+        "404":
+          description: Link not found
 
   /api/pods/{id}/resolve:
     get:
+      tags: [connections]
       operationId: resolvePodMembers
       summary: Resolve full recursive member set via trust graph
       security:
@@ -424,101 +917,42 @@ paths:
                   podId: { type: string }
                   members: { type: array, items: { type: string } }
 
-  /api/trust-invites:
+  /api/trust/distance:
     get:
-      operationId: listTrustInvites
-      summary: List sent and received trust graph invites
+      tags: [connections]
+      operationId: getTrustDistance
+      summary: Get trust distance between two DIDs (internal — requires Bearer TRUST_INTERNAL_API_KEY)
       security:
-        - cookieAuth: []
-      responses:
-        "200":
-          description: Trust invites
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  sent:
-                    type: array
-                    items: { $ref: "#/components/schemas/TrustInvite" }
-                  received:
-                    type: array
-                    items: { $ref: "#/components/schemas/TrustInvite" }
-    post:
-      operationId: createTrustInvite
-      summary: Create a trust graph invite — requires hard DID and trust graph membership. 7-day cooldown per invite.
-      security:
-        - cookieAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                email: { type: string, format: email }
-                did: { type: string }
-      responses:
-        "201":
-          description: Invite created
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  invite: { $ref: "#/components/schemas/TrustInvite" }
-                  message: { type: string }
-        "403":
-          description: Not in trust graph or not hard DID
-        "429":
-          description: Cooldown active or pending invite exists
-
-  /api/trust-invites/{id}:
-    delete:
-      operationId: revokeTrustInvite
-      summary: Revoke a pending trust invite
-      security:
-        - cookieAuth: []
+        - bearerAuth: []
       parameters:
-        - name: id
-          in: path
+        - name: from
+          in: query
+          required: true
+          schema: { type: string }
+        - name: to
+          in: query
           required: true
           schema: { type: string }
       responses:
         "200":
-          description: Invite revoked
-
-  /api/trust-invites/{id}/accept:
-    post:
-      operationId: acceptTrustInvite
-      summary: Accept a trust graph invite — creates bilateral connection pod
-      security:
-        - cookieAuth: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema: { type: string }
-      responses:
-        "200":
-          description: Invite accepted, pod created
+          description: Trust distance result
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  success: { type: boolean }
-                  pod:
-                    type: object
-                    properties:
-                      id: { type: string }
-                      name: { type: string }
-                  message: { type: string }
-        "410":
-          description: Invite expired or already accepted/revoked
+                  from: { type: string }
+                  to: { type: string }
+                  distance: { type: integer, description: "-1 if not connected" }
+                  connected: { type: boolean }
+        "400":
+          description: Missing from or to params
+        "401":
+          description: Unauthorized
 
   /api/auth/session:
     get:
+      tags: [connections]
       operationId: getAuthSession
       summary: Proxy to auth service session
       security:
@@ -526,11 +960,20 @@ paths:
       responses:
         "200":
           description: Session data
+        "401":
+          description: Not authenticated
 
   /api/auth/logout:
     post:
+      tags: [connections]
       operationId: authLogout
-      summary: Proxy logout to auth service
+      summary: Proxy logout to auth service — forwards Set-Cookie header to clear session
       responses:
         "200":
           description: Logged out
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }

--- a/apps/dykil/api-spec/openapi.yaml
+++ b/apps/dykil/api-spec/openapi.yaml
@@ -8,8 +8,11 @@ servers:
     description: production
   - url: https://dev-dykil.imajin.ai
     description: dev
-  - url: http://localhost:7101
+  - url: http://localhost:7013
     description: local
+
+tags:
+  - name: dykil
 
 components:
   securitySchemes:
@@ -17,6 +20,9 @@ components:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
   schemas:
     Survey:
       type: object
@@ -36,16 +42,16 @@ components:
               description: "Legacy format: array of field objects"
               items: { type: object }
         settings: { type: object }
-        eventId: { type: string }
         type: { type: string, enum: [survey, poll, quiz] }
         status: { type: string, enum: [draft, published, closed] }
         createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
     SurveyResponse:
       type: object
       properties:
         id: { type: string }
         surveyId: { type: string }
-        respondentDid: { type: string }
+        respondentDid: { type: string, nullable: true }
         answers: { type: object }
         createdAt: { type: string, format: date-time }
     Error:
@@ -55,12 +61,31 @@ components:
         error: { type: string }
 
 paths:
+  /api/health:
+    get:
+      operationId: healthCheck
+      summary: Service health check
+      tags: [dykil]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: dykil }
+                  timestamp: { type: string, format: date-time }
+
   /api/surveys:
     post:
       operationId: createSurvey
       summary: Create a new survey
+      tags: [dykil]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -82,7 +107,6 @@ paths:
                       description: "Legacy format — will be wrapped into SurveyJS structure"
                       items: { type: object }
                 settings: { type: object }
-                eventId: { type: string }
                 type: { type: string, enum: [survey, poll, quiz], default: survey }
                 status: { type: string, enum: [draft, published], default: draft }
       responses:
@@ -91,11 +115,23 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Survey" }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     get:
       operationId: listMySurveys
       summary: List authenticated user's surveys
+      tags: [dykil]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       responses:
         "200":
           description: Surveys list
@@ -107,13 +143,20 @@ paths:
                   surveys:
                     type: array
                     items: { $ref: "#/components/schemas/Survey" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/surveys/mine:
     get:
       operationId: getMySurveys
       summary: List authenticated user's surveys (explicit route)
+      tags: [dykil]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       responses:
         "200":
           description: Surveys list
@@ -125,40 +168,17 @@ paths:
                   surveys:
                     type: array
                     items: { $ref: "#/components/schemas/Survey" }
-
-  /api/surveys/event/{eventId}:
-    get:
-      operationId: getEventSurveys
-      summary: Get published surveys linked to an event (public, CORS-enabled)
-      parameters:
-        - name: eventId
-          in: path
-          required: true
-          schema: { type: string }
-      responses:
-        "200":
-          description: Event surveys with response counts
+        "401":
+          description: Unauthorized
           content:
             application/json:
-              schema:
-                type: object
-                properties:
-                  surveys:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id: { type: string }
-                        title: { type: string }
-                        description: { type: string }
-                        type: { type: string }
-                        handle: { type: string }
-                        responseCount: { type: integer }
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/surveys/handle/{handle}:
     get:
       operationId: getSurveysByHandle
       summary: Get published surveys by user handle (public)
+      tags: [dykil]
       parameters:
         - name: handle
           in: path
@@ -181,6 +201,7 @@ paths:
     get:
       operationId: getSurvey
       summary: Get survey by ID. Published surveys are public; draft surveys require ownership.
+      tags: [dykil]
       parameters:
         - name: id
           in: path
@@ -188,6 +209,7 @@ paths:
           schema: { type: string }
       security:
         - cookieAuth: []
+        - bearerAuth: []
         - {}
       responses:
         "200":
@@ -197,11 +219,16 @@ paths:
               schema: { $ref: "#/components/schemas/Survey" }
         "404":
           description: Not found (or unpublished and not owner)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     put:
       operationId: updateSurvey
       summary: Update survey (owner only)
+      tags: [dykil]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -218,7 +245,6 @@ paths:
                 description: { type: string }
                 fields: { type: object }
                 settings: { type: object }
-                eventId: { type: string }
                 type: { type: string }
                 status: { type: string, enum: [draft, published, closed] }
       responses:
@@ -227,11 +253,28 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Survey" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the survey owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Survey not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
       operationId: deleteSurvey
       summary: Delete survey (owner only)
+      tags: [dykil]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -240,11 +283,33 @@ paths:
       responses:
         "200":
           description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the survey owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Survey not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/surveys/{id}/respond:
     post:
       operationId: submitSurveyResponse
       summary: Submit a response to a published survey. Optional auth — anonymous responses allowed.
+      tags: [dykil]
       parameters:
         - name: id
           in: path
@@ -252,6 +317,7 @@ paths:
           schema: { type: string }
       security:
         - cookieAuth: []
+        - bearerAuth: []
         - {}
       requestBody:
         required: true
@@ -264,7 +330,19 @@ paths:
                 answers:
                   type: object
                   description: "Key-value pairs matching field names (SurveyJS: field.name; legacy: field.id)"
+                forceNew:
+                  type: boolean
+                  description: "When true, always creates a new response instead of upserting (used for ticket-scoped responses)"
       responses:
+        "200":
+          description: Response updated (upsert — authenticated user already responded)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  response: { $ref: "#/components/schemas/SurveyResponse" }
         "201":
           description: Response submitted
           content:
@@ -275,18 +353,29 @@ paths:
                   message: { type: string }
                   response: { $ref: "#/components/schemas/SurveyResponse" }
         "400":
-          description: Missing required fields
+          description: Missing required fields or validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "403":
           description: Survey not accepting responses (not published)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "404":
           description: Survey not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/surveys/{id}/responses:
     get:
       operationId: getSurveyResponses
       summary: Get all responses for a survey (owner only, CORS-enabled)
+      tags: [dykil]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -304,5 +393,81 @@ paths:
                     type: array
                     items: { $ref: "#/components/schemas/SurveyResponse" }
                   total: { type: integer }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "403":
           description: Not the survey owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Survey not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/surveys/{id}/responses/check:
+    get:
+      operationId: checkSurveyResponse
+      summary: Check if the current user has already responded to a survey. Supports session cookie, DID param, or responseId param.
+      tags: [dykil]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: did
+          in: query
+          required: false
+          schema: { type: string }
+          description: "Explicit DID lookup — used server-to-server by the events service"
+        - name: responseId
+          in: query
+          required: false
+          schema: { type: string }
+          description: "Response ID for anonymous users who stored it in localStorage"
+        - name: include
+          in: query
+          required: false
+          schema: { type: string, enum: [answers] }
+          description: "Pass 'answers' to also return the submitted answer payload"
+        - name: skipDid
+          in: query
+          required: false
+          schema: { type: boolean }
+          description: "When true, skips session-cookie DID lookup (for ticket-scoped checks)"
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+        - {}
+      responses:
+        "200":
+          description: Response check result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  completed: { type: boolean }
+                  answers:
+                    type: object
+                    description: "Only present when include=answers and the user has responded"
+                  responseId:
+                    type: string
+                    description: "Only present when include=answers and the user has responded"
+
+  /api/spec:
+    get:
+      operationId: getSpec
+      summary: Serve the OpenAPI spec YAML
+      tags: [dykil]
+      responses:
+        "200":
+          description: OpenAPI YAML document
+          content:
+            text/yaml:
+              schema:
+                type: string

--- a/apps/events/api-spec/openapi.yaml
+++ b/apps/events/api-spec/openapi.yaml
@@ -8,8 +8,11 @@ servers:
     description: production
   - url: https://dev-events.imajin.ai
     description: dev
-  - url: http://localhost:7006
+  - url: http://localhost:7008
     description: local
+
+tags:
+  - name: events
 
 components:
   securitySchemes:
@@ -17,6 +20,9 @@ components:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
     webhookSecret:
       type: http
       scheme: bearer
@@ -26,9 +32,21 @@ components:
       type: object
       properties:
         id: { type: string }
+        did: { type: string }
         title: { type: string }
         description: { type: string }
-        status: { type: string }
+        status: { type: string, enum: [draft, published, paused, cancelled, completed] }
+        startsAt: { type: string, format: date-time }
+        endsAt: { type: string, format: date-time, nullable: true }
+        timezone: { type: string, nullable: true }
+        isVirtual: { type: boolean }
+        virtualUrl: { type: string, nullable: true }
+        venue: { type: string, nullable: true }
+        address: { type: string, nullable: true }
+        city: { type: string, nullable: true }
+        country: { type: string, nullable: true }
+        imageUrl: { type: string, nullable: true }
+        tags: { type: array, items: { type: string } }
         fairManifest: { type: object }
         createdAt: { type: string, format: date-time }
     TicketTier:
@@ -38,8 +56,12 @@ components:
         name: { type: string }
         description: { type: string }
         price: { type: number }
-        quantity: { type: integer }
+        currency: { type: string }
+        quantity: { type: integer, nullable: true }
+        sold: { type: integer }
+        available: { type: integer, nullable: true }
         perks: { type: array, items: { type: string } }
+        requiresRegistration: { type: boolean }
     Error:
       type: object
       required: [error]
@@ -47,17 +69,54 @@ components:
         error: { type: string }
 
 paths:
+  /api/health:
+    get:
+      tags: [events]
+      operationId: healthCheck
+      summary: Service health check
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  service: { type: string }
+                  timestamp: { type: string, format: date-time }
+
+  /api/spec:
+    get:
+      tags: [events]
+      operationId: getSpec
+      summary: Serve OpenAPI spec (YAML)
+      responses:
+        "200":
+          description: OpenAPI YAML spec
+          content:
+            text/yaml:
+              schema: { type: string }
+
   /api/events:
     get:
+      tags: [events]
       operationId: listEvents
       summary: List events
       parameters:
         - name: status
           in: query
-          schema: { type: string }
+          schema: { type: string, default: published }
         - name: limit
           in: query
           schema: { type: integer, default: 20 }
+        - name: courseSlug
+          in: query
+          schema: { type: string }
+        - name: upcoming
+          in: query
+          schema: { type: boolean }
+          description: "Filter to events that haven't started yet"
       responses:
         "200":
           description: Events list
@@ -70,6 +129,7 @@ paths:
                     type: array
                     items: { $ref: "#/components/schemas/Event" }
     post:
+      tags: [events]
       operationId: createEvent
       summary: Create an event — requires hard DID
       security:
@@ -80,33 +140,78 @@ paths:
           application/json:
             schema:
               type: object
-              required: [title]
+              required: [title, startsAt]
               properties:
                 title: { type: string }
                 description: { type: string }
                 startsAt: { type: string, format: date-time }
                 endsAt: { type: string, format: date-time }
-                location: { type: string }
-                coverImage: { type: string }
-                fairManifest: { type: object }
+                timezone: { type: string }
+                isVirtual: { type: boolean }
+                virtualUrl: { type: string }
+                venue: { type: string }
+                address: { type: string }
+                city: { type: string }
+                country: { type: string }
+                imageUrl: { type: string }
+                imageAssetId: { type: string }
+                tags: { type: array, items: { type: string } }
+                courseSlug: { type: string }
+                emtEmail: { type: string }
+                tickets:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name: { type: string }
+                      description: { type: string }
+                      price: { type: number }
+                      currency: { type: string }
+                      quantity: { type: integer }
+                      perks: { type: array, items: { type: string } }
       responses:
         "201":
           description: Event created
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Event" }
+              schema:
+                type: object
+                properties:
+                  event: { $ref: "#/components/schemas/Event" }
+                  ticketTypes:
+                    type: array
+                    items: { $ref: "#/components/schemas/TicketTier" }
+                  eventKeypair:
+                    type: object
+                    properties:
+                      publicKey: { type: string }
+                      privateKey: { type: string }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "403":
           description: Requires hard DID
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/events/mine:
     get:
+      tags: [events]
       operationId: listMyEvents
       summary: List authenticated user's events with stats
       security:
         - cookieAuth: []
       responses:
         "200":
-          description: User's events
+          description: User's events with ticket stats
           content:
             application/json:
               schema:
@@ -114,12 +219,58 @@ paths:
                 properties:
                   events:
                     type: array
-                    items: { $ref: "#/components/schemas/Event" }
+                    items:
+                      allOf:
+                        - { $ref: "#/components/schemas/Event" }
+                        - type: object
+                          properties:
+                            ticketsSold: { type: integer }
+                            revenue: { type: number }
+                            statusBadge: { type: string }
+                            ticketTypes:
+                              type: array
+                              items: { $ref: "#/components/schemas/TicketTier" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/events/by-did/{did}:
+    get:
+      tags: [events]
+      operationId: getEventByDid
+      summary: Look up an event by its DID
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Event found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      title: { type: string }
+                      did: { type: string }
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/events/{id}:
     get:
+      tags: [events]
       operationId: getEvent
-      summary: Get event by ID
+      summary: Get event by ID with ticket types and admins
       parameters:
         - name: id
           in: path
@@ -127,18 +278,26 @@ paths:
           schema: { type: string }
       responses:
         "200":
-          description: Event
+          description: Event details
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Event" }
+              schema:
+                type: object
+                properties:
+                  event: { $ref: "#/components/schemas/Event" }
+                  ticketTypes:
+                    type: array
+                    items: { $ref: "#/components/schemas/TicketTier" }
+                  admins: { type: array, items: { type: object } }
         "404":
           description: Not found
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
     put:
+      tags: [events]
       operationId: updateEvent
-      summary: Update event
+      summary: Update event fields — requires creator, admin, or cohost
       security:
         - cookieAuth: []
       parameters:
@@ -150,16 +309,105 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: "#/components/schemas/Event" }
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                description: { type: string }
+                startsAt: { type: string, format: date-time }
+                endsAt: { type: string, format: date-time }
+                timezone: { type: string }
+                isVirtual: { type: boolean }
+                virtualUrl: { type: string }
+                venue: { type: string }
+                address: { type: string }
+                city: { type: string }
+                country: { type: string }
+                imageUrl: { type: string }
+                imageAssetId: { type: string }
+                tags: { type: array, items: { type: string } }
+                status: { type: string }
+                metadata: { type: object }
+                nameDisplayPolicy:
+                  type: string
+                  enum: [real_name, handle, anonymous, attendee_choice]
+                accessMode: { type: string }
+                courseSlug: { type: string }
+                emtEmail: { type: string }
       responses:
         "200":
           description: Event updated
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Event" }
+              schema:
+                type: object
+                properties:
+                  event: { $ref: "#/components/schemas/Event" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    patch:
+      tags: [events]
+      operationId: updateEventStatus
+      summary: Update event status — creator only; follows allowed status transitions
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [draft, published, paused, cancelled, completed]
+      responses:
+        "200":
+          description: Status updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event: { $ref: "#/components/schemas/Event" }
+        "400":
+          description: Invalid or disallowed status transition
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Only creator can change status
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/events/{id}/admins:
     get:
+      tags: [events]
       operationId: listEventAdmins
       summary: List event admins
       security:
@@ -172,7 +420,15 @@ paths:
       responses:
         "200":
           description: Admin list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  creator: { type: string }
+                  admins: { type: array, items: { type: object } }
     post:
+      tags: [events]
       operationId: addEventAdmin
       summary: Add an admin to an event
       security:
@@ -194,7 +450,18 @@ paths:
       responses:
         "201":
           description: Admin added
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
+      tags: [events]
       operationId: removeEventAdmin
       summary: Remove an admin from an event
       security:
@@ -211,11 +478,56 @@ paths:
       responses:
         "200":
           description: Admin removed
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
-  /api/events/{id}/my-ticket:
+  /api/events/{id}/cohosts:
     get:
-      operationId: getMyTicket
-      summary: Check if authenticated user has a ticket for this event
+      tags: [events]
+      operationId: listEventCohosts
+      summary: List cohosts for an event (via pod membership)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Cohost list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cohosts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        did: { type: string }
+                        name: { type: string, nullable: true }
+                        handle: { type: string, nullable: true }
+                        avatar: { type: string, nullable: true }
+                        role: { type: string }
+        "404":
+          description: Event not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/events/{id}/guests:
+    get:
+      tags: [events]
+      operationId: listEventGuests
+      summary: List all ticket holders with profile info — organizer only
       security:
         - cookieAuth: []
       parameters:
@@ -225,13 +537,190 @@ paths:
           schema: { type: string }
       responses:
         "200":
-          description: Ticket ownership status
+          description: Guest/ticket list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  guests:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        status: { type: string }
+                        ownerDid: { type: string }
+                        pricePaid: { type: number }
+                        currency: { type: string }
+                        purchasedAt: { type: string, format: date-time }
+                        usedAt: { type: string, format: date-time, nullable: true }
+                        paymentMethod: { type: string }
+                        ticketType: { type: string }
+                        attendeeName: { type: string, nullable: true }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/events/{id}/invites:
+    get:
+      tags: [events]
+      operationId: listEventInvites
+      summary: List invite links — organizer only
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Invite list with URLs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invites:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        token: { type: string }
+                        label: { type: string }
+                        maxUses: { type: integer, nullable: true }
+                        useCount: { type: integer }
+                        expiresAt: { type: string, format: date-time, nullable: true }
+                        url: { type: string }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    post:
+      tags: [events]
+      operationId: createEventInvite
+      summary: Create an invite link — organizer only
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                label: { type: string }
+                maxUses: { type: integer }
+                expiresAt: { type: string, format: date-time }
+      responses:
+        "201":
+          description: Invite created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invite:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      token: { type: string }
+                      url: { type: string }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/events/{id}/invites/{inviteId}:
+    delete:
+      tags: [events]
+      operationId: revokeEventInvite
+      summary: Revoke an invite link — organizer only
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: inviteId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Invite revoked
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Invite not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/events/{id}/my-ticket:
+    get:
+      tags: [events]
+      operationId: getMyTicket
+      summary: Check if authenticated user has a ticket or organizer access for this event
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Ticket ownership and access status
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   hasTicket: { type: boolean }
+                  hasAccess: { type: boolean }
+                  isOrganizer: { type: boolean }
                   tickets: { type: array, items: { type: object } }
                   ticketId: { type: string }
                   conversationId: { type: string }
@@ -239,6 +728,7 @@ paths:
 
   /api/events/{id}/fair:
     patch:
+      tags: [events]
       operationId: updateEventFair
       summary: Update .fair manifest for an event
       security:
@@ -260,11 +750,34 @@ paths:
       responses:
         "200":
           description: Manifest updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event: { $ref: "#/components/schemas/Event" }
+                  manifest: { type: object }
+        "400":
+          description: Invalid .fair manifest
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/events/{id}/queue:
     get:
+      tags: [events]
       operationId: getQueue
-      summary: Get queue for a ticket type
+      summary: Get queue position for a ticket type
       security:
         - cookieAuth: []
       parameters:
@@ -274,11 +787,22 @@ paths:
           schema: { type: string }
         - name: ticketTypeId
           in: query
+          required: true
           schema: { type: string }
       responses:
         "200":
           description: Queue info
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inQueue: { type: boolean }
+                  position: { type: integer }
+                  totalAhead: { type: integer }
+                  message: { type: string }
     post:
+      tags: [events]
       operationId: joinQueue
       summary: Join the ticket queue
       security:
@@ -299,7 +823,13 @@ paths:
       responses:
         "200":
           description: Joined queue
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
+      tags: [events]
       operationId: leaveQueue
       summary: Leave the ticket queue
       security:
@@ -315,9 +845,15 @@ paths:
       responses:
         "200":
           description: Left queue
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/events/{id}/hold:
     post:
+      tags: [events]
       operationId: holdTicket
       summary: Place a hold on a ticket
       security:
@@ -336,11 +872,27 @@ paths:
               required: [ticketTypeId]
               properties:
                 ticketTypeId: { type: string }
-                holdHours: { type: number, default: 24 }
+                holdHours: { type: number, default: 72 }
       responses:
         "200":
           description: Hold placed
+        "400":
+          description: Validation error or existing hold
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Ticket type not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
+      tags: [events]
       operationId: releaseHold
       summary: Release a ticket hold
       security:
@@ -357,9 +909,15 @@ paths:
       responses:
         "200":
           description: Hold released
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/events/{id}/tiers:
     get:
+      tags: [events]
       operationId: listTicketTiers
       summary: List ticket tiers for an event
       parameters:
@@ -379,6 +937,7 @@ paths:
                     type: array
                     items: { $ref: "#/components/schemas/TicketTier" }
     post:
+      tags: [events]
       operationId: createTicketTier
       summary: Create a ticket tier
       security:
@@ -392,14 +951,37 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: "#/components/schemas/TicketTier" }
+            schema:
+              type: object
+              required: [name, price]
+              properties:
+                name: { type: string }
+                description: { type: string }
+                price: { type: number }
+                currency: { type: string, default: USD }
+                quantity: { type: integer }
+                perks: { type: array, items: { type: string } }
+                sortOrder: { type: integer }
+                requiresRegistration: { type: boolean }
+                registrationFormId: { type: string }
       responses:
         "201":
           description: Tier created
           content:
             application/json:
               schema: { $ref: "#/components/schemas/TicketTier" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     put:
+      tags: [events]
       operationId: updateTicketTier
       summary: Update a ticket tier
       security:
@@ -426,9 +1008,354 @@ paths:
       responses:
         "200":
           description: Tier updated
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/events/{id}/tickets/{ticketId}/check-in:
+    post:
+      tags: [events]
+      operationId: checkInTicket
+      summary: Check in a ticket holder — sets used_at timestamp; organizer only
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: ticketId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Checked in
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ticket:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      usedAt: { type: string, format: date-time }
+        "400":
+          description: Ticket not valid or already checked in
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Ticket not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/events/{id}/tickets/{ticketId}/refund:
+    post:
+      tags: [events]
+      operationId: refundTicket
+      summary: Mark a ticket as refunded — event owner only
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: ticketId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Ticket refunded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ticket:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      status: { type: string }
+        "400":
+          description: Ticket not in refundable state
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Only event owner can issue refunds
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Ticket or event not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/events/{id}/tickets/{ticketId}/resend-email:
+    post:
+      tags: [events]
+      operationId: resendTicketEmail
+      summary: Resend ticket confirmation email — organizer only; 3-day cooldown
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: ticketId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Email resent
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Ticket not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Email cooldown not elapsed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  lastEmailSentAt: { type: string, format: date-time }
+
+  /api/events/{id}/tickets/{ticketId}/registration:
+    get:
+      tags: [events]
+      operationId: getTicketRegistration
+      summary: Get registration answers for a ticket — organizer only
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: ticketId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Registration data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  registration: { type: object, nullable: true }
+                  questions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        question: { type: string }
+                        answer: {}
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Ticket not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/tickets/{id}/qr:
+    get:
+      tags: [events]
+      operationId: getTicketQr
+      summary: Generate QR code data URI for a ticket
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: QR code data URI
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  qrCodeDataUri: { type: string }
+        "500":
+          description: QR generation failed
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/tickets/{id}/confirm-payment:
+    post:
+      tags: [events]
+      operationId: confirmTicketPayment
+      summary: Confirm e-Transfer payment for a held ticket — organizer only
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Payment confirmed, ticket activated
+        "400":
+          description: Ticket not in held state or not an e-Transfer hold
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Ticket not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/register/{ticketId}:
+    get:
+      tags: [events]
+      operationId: getTicketRegistrationByTicket
+      summary: Get registration for a specific ticket
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Registration data
+          content:
+            application/json:
+              schema: { type: object }
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    post:
+      tags: [events]
+      operationId: submitTicketRegistration
+      summary: Submit registration details for a ticket
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [formId]
+              properties:
+                name: { type: string }
+                email: { type: string, format: email }
+                formId: { type: string }
+                responseId: { type: string, description: "Dykil survey response ID" }
+                registeredByDid: { type: string }
+      responses:
+        "200":
+          description: Registration submitted, confirmation email sent
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Ticket not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/access/{did}:
+    get:
+      tags: [events]
+      operationId: checkAccess
+      summary: Proxy access check to auth service for a given DID
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Access check result from auth service
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/checkout:
     post:
+      tags: [events]
       operationId: eventCheckout
       summary: Create checkout session via pay service
       requestBody:
@@ -443,6 +1370,7 @@ paths:
                 ticketTypeId: { type: string }
                 quantity: { type: integer, default: 1 }
                 email: { type: string, format: email }
+                invite: { type: string, description: "Invite token for restricted events" }
       responses:
         "200":
           description: Checkout URL created
@@ -453,31 +1381,59 @@ paths:
                 properties:
                   url: { type: string }
                   sessionId: { type: string }
-
-  /api/tickets/by-token/{token}:
-    get:
-      operationId: getTicketByToken
-      summary: Look up a ticket by magic token
-      parameters:
-        - name: token
-          in: path
-          required: true
-          schema: { type: string }
-      responses:
-        "200":
-          description: Ticket found
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Rate limited
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  ticket: { type: object }
-                  event: { $ref: "#/components/schemas/Event" }
-        "404":
-          description: Token not found
+                  error: { type: string }
+                  retryAfter: { type: integer }
+
+  /api/checkout/etransfer:
+    post:
+      tags: [events]
+      operationId: etransferCheckout
+      summary: Create e-Transfer hold on a ticket with payment instructions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [eventId, ticketTypeId]
+              properties:
+                eventId: { type: string }
+                ticketTypeId: { type: string }
+                email: { type: string, format: email }
+                name: { type: string }
+                invite: { type: string }
+      responses:
+        "200":
+          description: E-Transfer hold created with payment instructions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ticketId: { type: string }
+                  holdExpiresAt: { type: string, format: date-time }
+                  paymentInstructions: { type: object }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/webhook/payment:
     post:
+      tags: [events]
       operationId: paymentWebhook
       summary: Payment webhook from pay service
       security:
@@ -491,8 +1447,28 @@ paths:
         "200":
           description: Event received
 
+  /api/proxy/connections:
+    get:
+      tags: [events]
+      operationId: proxyConnections
+      summary: Proxy connections list from connections service (same-origin cookie forwarding)
+      security:
+        - cookieAuth: []
+      responses:
+        "200":
+          description: Connections list
+          content:
+            application/json:
+              schema: { type: object }
+        "502":
+          description: Could not reach connections service
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
   /api/upload:
     post:
+      tags: [events]
       operationId: uploadEventImage
       summary: Upload event cover image
       security:
@@ -517,9 +1493,15 @@ paths:
                 type: object
                 properties:
                   url: { type: string }
+        "400":
+          description: Validation error (missing file, invalid type/size)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/media/{path}:
     get:
+      tags: [events]
       operationId: serveMedia
       summary: Serve media files
       parameters:
@@ -530,3 +1512,8 @@ paths:
       responses:
         "200":
           description: Media file
+        "404":
+          description: File not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }

--- a/apps/input/api-spec/openapi.yaml
+++ b/apps/input/api-spec/openapi.yaml
@@ -1,0 +1,263 @@
+openapi: "3.1.0"
+info:
+  title: imajin input
+  version: "1.0.0"
+  description: Media upload relay and Whisper speech-to-text transcription.
+
+servers:
+  - url: https://input.imajin.ai
+    description: production
+  - url: https://dev-input.imajin.ai
+    description: dev
+  - url: http://localhost:7010
+    description: local
+
+tags:
+  - name: input
+
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+    TranscriptionResult:
+      type: object
+      description: Whisper transcription result forwarded from the GPU node.
+      properties:
+        text:
+          type: string
+          description: Full transcript text.
+        segments:
+          type: array
+          description: Word- or sentence-level segments with timing.
+          items:
+            type: object
+            properties:
+              start: { type: number, description: "Segment start time in seconds" }
+              end: { type: number, description: "Segment end time in seconds" }
+              text: { type: string }
+    AssetReference:
+      type: object
+      description: Media asset reference returned by the media service after upload.
+      properties:
+        id: { type: string }
+        url: { type: string }
+        ownerDid: { type: string }
+        contentType: { type: string }
+        size: { type: integer }
+        createdAt: { type: string, format: date-time }
+    UsageStats:
+      type: object
+      description: Rate-limit usage statistics for the authenticated DID.
+      properties:
+        did:
+          type: string
+        usage:
+          type: object
+          description: >
+            Map of operation name to usage bucket. Each bucket contains
+            the request count within the current window.
+          additionalProperties:
+            type: object
+            properties:
+              count: { type: integer }
+              windowMs: { type: integer }
+              limit: { type: integer }
+              remaining: { type: integer }
+
+paths:
+  /api/health:
+    get:
+      operationId: getInputHealth
+      summary: Health check
+      tags: [input]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: input }
+
+  /api/transcribe:
+    post:
+      operationId: transcribeAudio
+      summary: Transcribe audio via Whisper
+      description: >
+        Accepts an audio file as multipart/form-data and relays it to the
+        internal GPU node running Whisper. Auth is optional — anonymous
+        callers are rate-limited by IP; authenticated callers by DID.
+      tags: [input]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+        - {}
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: Audio file (webm, mp3, wav, etc.)
+                language:
+                  type: string
+                  description: "Optional BCP-47 language hint passed to Whisper (e.g. en, fr)."
+      responses:
+        "200":
+          description: Transcription result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TranscriptionResult"
+        "400":
+          description: Missing or invalid audio file
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema: { type: integer }
+              description: Seconds until the rate-limit window resets
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Error"
+                  - type: object
+                    properties:
+                      retryAfterMs: { type: integer }
+        "502":
+          description: GPU node returned an error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "503":
+          description: GPU node unreachable
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/upload:
+    post:
+      operationId: uploadMedia
+      summary: Upload and relay a media file to the media service
+      description: >
+        Accepts a file as multipart/form-data, validates the session, and
+        forwards to the media service for storage and optional .fair
+        attribution. Returns the created asset reference.
+      tags: [input]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: File to upload
+                terms:
+                  type: string
+                  description: Optional .fair license/attribution terms JSON string.
+                context:
+                  type: string
+                  description: Optional context hint for automatic folder assignment.
+      responses:
+        "200":
+          description: Uploaded asset reference
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetReference"
+        "400":
+          description: Missing file
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema: { type: integer }
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Error"
+                  - type: object
+                    properties:
+                      retryAfterMs: { type: integer }
+        "502":
+          description: Media service returned an error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "503":
+          description: Media service unreachable
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/usage:
+    get:
+      operationId: getUsage
+      summary: Get rate-limit usage stats for the authenticated DID
+      tags: [input]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Usage statistics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageStats"
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/spec:
+    get:
+      operationId: getInputSpec
+      summary: Serve this OpenAPI spec
+      tags: [input]
+      responses:
+        "200":
+          description: OpenAPI YAML
+          content:
+            text/yaml:
+              schema: { type: string }

--- a/apps/learn/api-spec/openapi.yaml
+++ b/apps/learn/api-spec/openapi.yaml
@@ -1,0 +1,1185 @@
+openapi: "3.1.0"
+info:
+  title: imajin learn
+  version: "1.0.0"
+  description: >
+    Course creation, enrollment, and lesson-progress tracking. Creators build
+    courses with modules and lessons; students enroll (free or paid) and mark
+    progress. Completion attestations are emitted to the auth service.
+
+servers:
+  - url: https://learn.imajin.ai
+    description: production
+  - url: https://dev-learn.imajin.ai
+    description: dev
+  - url: http://localhost:7011
+    description: local
+
+tags:
+  - name: learn
+
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+    Course:
+      type: object
+      properties:
+        id: { type: string }
+        creatorDid: { type: string }
+        title: { type: string }
+        description: { type: string, nullable: true }
+        slug: { type: string }
+        price: { type: integer, description: "Price in minor currency units (0 = free)" }
+        currency: { type: string, default: CAD }
+        visibility: { type: string, enum: [public, private, trust] }
+        status: { type: string, enum: [draft, published, archived] }
+        imageUrl: { type: string, nullable: true }
+        imageAssetId: { type: string, nullable: true }
+        tags: { type: array, items: { type: string } }
+        metadata: { type: object }
+        courseType: { type: string, nullable: true }
+        eventSlug: { type: string, nullable: true }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+    CourseListItem:
+      allOf:
+        - $ref: "#/components/schemas/Course"
+        - type: object
+          properties:
+            moduleCount: { type: integer }
+            lessonCount: { type: integer }
+    Module:
+      type: object
+      properties:
+        id: { type: string }
+        courseId: { type: string }
+        title: { type: string }
+        description: { type: string, nullable: true }
+        sortOrder: { type: integer }
+    Lesson:
+      type: object
+      properties:
+        id: { type: string }
+        moduleId: { type: string }
+        title: { type: string }
+        contentType: { type: string, enum: [markdown, video, embed], description: "Defaults to markdown" }
+        content: { type: string, nullable: true }
+        durationMinutes: { type: integer, nullable: true }
+        sortOrder: { type: integer }
+        metadata: { type: object }
+    Enrollment:
+      type: object
+      properties:
+        id: { type: string }
+        courseId: { type: string }
+        studentDid: { type: string }
+        paymentId: { type: string, nullable: true }
+        enrolledAt: { type: string, format: date-time }
+        completedAt: { type: string, nullable: true, format: date-time }
+    Progress:
+      type: object
+      properties:
+        total: { type: integer }
+        completed: { type: integer }
+        percentage: { type: integer }
+
+paths:
+  /api/health:
+    get:
+      operationId: getLearnHealth
+      summary: Health check
+      tags: [learn]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: learn }
+                  timestamp: { type: string, format: date-time }
+
+  /api/courses:
+    get:
+      operationId: listCourses
+      summary: List published courses (public discovery)
+      description: >
+        Returns published courses. By default only public-visibility courses
+        are shown unless `creator_did` is specified.
+      tags: [learn]
+      parameters:
+        - name: creator_did
+          in: query
+          schema: { type: string }
+          description: Filter by creator DID (shows all visibility for that creator)
+        - name: tag
+          in: query
+          schema: { type: string }
+          description: Filter by tag
+        - name: status
+          in: query
+          schema: { type: string, default: published }
+          description: Filter by course status
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20, maximum: 100 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0 }
+      responses:
+        "200":
+          description: Paginated course list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  courses:
+                    type: array
+                    items: { $ref: "#/components/schemas/CourseListItem" }
+                  limit: { type: integer }
+                  offset: { type: integer }
+    post:
+      operationId: createCourse
+      summary: Create a new course
+      description: Requires a hard DID (cryptographic key-backed identity).
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title: { type: string }
+                description: { type: string }
+                slug: { type: string, description: "Auto-generated from title if omitted" }
+                price: { type: integer, description: "Price in minor currency units (0 = free)" }
+                currency: { type: string, default: CAD }
+                visibility: { type: string, enum: [public, private, trust], default: public }
+                imageUrl: { type: string }
+                imageAssetId: { type: string }
+                tags: { type: array, items: { type: string } }
+                metadata: { type: object }
+      responses:
+        "201":
+          description: Course created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Course" }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: Slug already exists
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}:
+    get:
+      operationId: getCourse
+      summary: Get course detail with modules and lessons
+      description: >
+        Public endpoint. Auth is optional — if authenticated, enrollment status
+        and progress are included. Creators see full lesson content and metadata.
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+        - {}
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Course detail
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Course"
+                  - type: object
+                    properties:
+                      modules:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: "#/components/schemas/Module"
+                            - type: object
+                              properties:
+                                lessons:
+                                  type: array
+                                  items: { $ref: "#/components/schemas/Lesson" }
+                      enrollment:
+                        nullable: true
+                        allOf:
+                          - $ref: "#/components/schemas/Enrollment"
+                          - type: object
+                            properties:
+                              progress: { $ref: "#/components/schemas/Progress" }
+                      isCreator: { type: boolean }
+                      isAuthenticated: { type: boolean }
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    patch:
+      operationId: updateCourse
+      summary: Update course fields (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                description: { type: string }
+                slug: { type: string }
+                price: { type: integer }
+                currency: { type: string }
+                visibility: { type: string, enum: [public, private, trust] }
+                status: { type: string, enum: [draft, published, archived] }
+                imageUrl: { type: string }
+                imageAssetId: { type: string }
+                tags: { type: array, items: { type: string } }
+                metadata: { type: object }
+                eventSlug: { type: string }
+                courseType: { type: string }
+      responses:
+        "200":
+          description: Updated course
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Course" }
+        "400":
+          description: No fields to update
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    delete:
+      operationId: deleteCourse
+      summary: Archive course (soft delete, owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Course archived
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/enroll:
+    post:
+      operationId: enrollInCourse
+      summary: Enroll in a course (free) or initiate payment (paid)
+      description: >
+        For free courses, creates enrollment immediately. For paid courses,
+        initiates a Stripe Checkout session via the pay service and returns
+        a redirect URL. Emits a `learn.enrolled` attestation on free enrollment.
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                successUrl:
+                  type: string
+                  description: Redirect URL after successful payment (paid courses only)
+                cancelUrl:
+                  type: string
+                  description: Redirect URL if payment is cancelled (paid courses only)
+      responses:
+        "200":
+          description: Already enrolled, or paid course checkout URL
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    description: Already enrolled
+                    properties:
+                      enrolled: { type: boolean, example: true }
+                      enrollment: { $ref: "#/components/schemas/Enrollment" }
+                  - type: object
+                    description: Paid course — redirect to checkout
+                    properties:
+                      enrolled: { type: boolean, example: false }
+                      checkoutUrl: { type: string }
+        "201":
+          description: Enrollment created (free course)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enrolled: { type: boolean, example: true }
+                  enrollment: { $ref: "#/components/schemas/Enrollment" }
+        "400":
+          description: Course not available for enrollment
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "502":
+          description: Payment service error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/progress:
+    get:
+      operationId: getCourseProgress
+      summary: Get enrollment status and per-lesson progress
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Progress detail
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enrollment:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      enrolledAt: { type: string, format: date-time }
+                      completedAt: { type: string, nullable: true, format: date-time }
+                  progress: { $ref: "#/components/schemas/Progress" }
+                  modules:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        title: { type: string }
+                        total: { type: integer }
+                        completed: { type: integer }
+                        lessons:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id: { type: string }
+                              title: { type: string }
+                              contentType: { type: string }
+                              durationMinutes: { type: integer, nullable: true }
+                              status: { type: string, enum: [not_started, in_progress, completed] }
+                              completedAt: { type: string, nullable: true, format: date-time }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not enrolled
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/students:
+    get:
+      operationId: listCourseStudents
+      summary: List enrolled students with progress (course owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Student list with progress
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  courseTitle: { type: string }
+                  totalStudents: { type: integer }
+                  totalLessons: { type: integer }
+                  students:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        studentDid: { type: string }
+                        displayName: { type: string, nullable: true }
+                        email: { type: string, nullable: true }
+                        handle: { type: string, nullable: true }
+                        enrolledAt: { type: string, format: date-time }
+                        completedAt: { type: string, nullable: true, format: date-time }
+                        progress: { $ref: "#/components/schemas/Progress" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/lessons/{lessonId}/complete:
+    post:
+      operationId: completeLesson
+      summary: Mark a lesson as complete
+      description: >
+        Marks the lesson as completed in the enrollment progress record.
+        If all lessons are now complete, the enrollment is flagged as completed
+        and a `learn.completed` attestation is emitted.
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: lessonId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Completion recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  lessonId: { type: string }
+                  status: { type: string, example: completed }
+                  completedAt: { type: string, format: date-time }
+                  courseProgress: { $ref: "#/components/schemas/Progress" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not enrolled
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course or lesson not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/modules:
+    get:
+      operationId: listModules
+      summary: List modules for a course
+      tags: [learn]
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Module list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  modules:
+                    type: array
+                    items: { $ref: "#/components/schemas/Module" }
+        "404":
+          description: Course not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    post:
+      operationId: createModule
+      summary: Add a module to a course (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title: { type: string }
+                description: { type: string }
+                sortOrder: { type: integer, description: "Auto-assigned if omitted" }
+      responses:
+        "201":
+          description: Module created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Module" }
+        "400":
+          description: Title is required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/modules/reorder:
+    patch:
+      operationId: reorderModules
+      summary: Reorder modules within a course (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [order]
+              properties:
+                order:
+                  type: array
+                  items: { type: string }
+                  description: Ordered array of module IDs
+      responses:
+        "200":
+          description: Modules in new order
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  modules:
+                    type: array
+                    items: { $ref: "#/components/schemas/Module" }
+        "400":
+          description: order must be an array
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/modules/{moduleId}:
+    patch:
+      operationId: updateModule
+      summary: Update a module (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: moduleId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                description: { type: string }
+                sortOrder: { type: integer }
+      responses:
+        "200":
+          description: Updated module
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Module" }
+        "400":
+          description: No fields to update
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course or module not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    delete:
+      operationId: deleteModule
+      summary: Delete a module and its lessons (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: moduleId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Module deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course or module not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/modules/{moduleId}/lessons:
+    get:
+      operationId: listLessons
+      summary: List lessons in a module
+      tags: [learn]
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: moduleId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Lesson list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  lessons:
+                    type: array
+                    items: { $ref: "#/components/schemas/Lesson" }
+        "404":
+          description: Course not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    post:
+      operationId: createLesson
+      summary: Add a lesson to a module (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: moduleId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title: { type: string }
+                contentType: { type: string, enum: [markdown, video, embed], default: markdown }
+                content: { type: string }
+                durationMinutes: { type: integer }
+                sortOrder: { type: integer, description: "Auto-assigned if omitted" }
+                metadata: { type: object }
+      responses:
+        "201":
+          description: Lesson created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Lesson" }
+        "400":
+          description: Title is required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course or module not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/modules/{moduleId}/lessons/reorder:
+    patch:
+      operationId: reorderLessons
+      summary: Reorder lessons within a module (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: moduleId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [order]
+              properties:
+                order:
+                  type: array
+                  items: { type: string }
+                  description: Ordered array of lesson IDs
+      responses:
+        "200":
+          description: Lessons in new order
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  lessons:
+                    type: array
+                    items: { $ref: "#/components/schemas/Lesson" }
+        "400":
+          description: order must be an array
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/courses/{slug}/modules/{moduleId}/lessons/{lessonId}:
+    get:
+      operationId: getLesson
+      summary: Get lesson content
+      description: >
+        For paid courses, unauthenticated requests or non-enrolled students
+        receive metadata only with `content: null` and `locked: true`.
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+        - {}
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: moduleId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: lessonId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Lesson (full or locked preview)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Lesson"
+                  - type: object
+                    properties:
+                      locked: { type: boolean, description: "True when content is withheld due to paywall" }
+        "401":
+          description: Authentication required for paid course
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course or lesson not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    patch:
+      operationId: updateLesson
+      summary: Update a lesson (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: moduleId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: lessonId
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                contentType: { type: string, enum: [markdown, video, embed] }
+                content: { type: string }
+                durationMinutes: { type: integer }
+                sortOrder: { type: integer }
+                metadata: { type: object }
+      responses:
+        "200":
+          description: Updated lesson
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Lesson" }
+        "400":
+          description: No fields to update
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course or lesson not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    delete:
+      operationId: deleteLesson
+      summary: Delete a lesson (owner only)
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema: { type: string }
+        - name: moduleId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: lessonId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Lesson deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the course owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Course not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/my/courses:
+    get:
+      operationId: myEnrolledCourses
+      summary: List courses the authenticated user is enrolled in
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Enrolled courses with progress
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  courses:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: "#/components/schemas/Course"
+                        - type: object
+                          properties:
+                            enrollment:
+                              type: object
+                              properties:
+                                id: { type: string }
+                                enrolledAt: { type: string, format: date-time }
+                                completedAt: { type: string, nullable: true, format: date-time }
+                            progress: { $ref: "#/components/schemas/Progress" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/my/teaching:
+    get:
+      operationId: myTeachingCourses
+      summary: List courses the authenticated user created
+      tags: [learn]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Created courses with enrollment and content counts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  courses:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: "#/components/schemas/Course"
+                        - type: object
+                          properties:
+                            enrollmentCount: { type: integer }
+                            moduleCount: { type: integer }
+                            lessonCount: { type: integer }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/spec:
+    get:
+      operationId: getLearnSpec
+      summary: Serve this OpenAPI spec
+      tags: [learn]
+      responses:
+        "200":
+          description: OpenAPI YAML
+          content:
+            text/yaml:
+              schema: { type: string }

--- a/apps/links/api-spec/openapi.yaml
+++ b/apps/links/api-spec/openapi.yaml
@@ -8,8 +8,11 @@ servers:
     description: production
   - url: https://dev-links.imajin.ai
     description: dev
-  - url: http://localhost:7102
+  - url: http://localhost:7014
     description: local
+
+tags:
+  - name: links
 
 components:
   securitySchemes:
@@ -17,6 +20,9 @@ components:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
   schemas:
     LinkPage:
       type: object
@@ -25,12 +31,14 @@ components:
         did: { type: string }
         handle: { type: string }
         title: { type: string }
-        bio: { type: string }
-        avatar: { type: string }
+        bio: { type: string, nullable: true }
+        avatar: { type: string, nullable: true }
+        avatarAssetId: { type: string, nullable: true }
         theme: { type: object }
         socialLinks: { type: object }
         isPublic: { type: boolean }
         createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
     Link:
       type: object
       properties:
@@ -38,13 +46,14 @@ components:
         pageId: { type: string }
         title: { type: string }
         url: { type: string }
-        icon: { type: string }
-        thumbnail: { type: string }
+        icon: { type: string, nullable: true }
+        thumbnail: { type: string, nullable: true }
         position: { type: integer }
         isActive: { type: boolean }
         visibility: { type: string, enum: [public, private] }
         clicks: { type: integer }
         createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
     Error:
       type: object
       required: [error]
@@ -52,12 +61,31 @@ components:
         error: { type: string }
 
 paths:
+  /api/health:
+    get:
+      operationId: healthCheck
+      summary: Service health check
+      tags: [links]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: links }
+                  timestamp: { type: string, format: date-time }
+
   /api/pages:
     post:
       operationId: createLinksPage
       summary: Create a link-in-bio page — one per DID
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -70,6 +98,7 @@ paths:
                 title: { type: string }
                 bio: { type: string }
                 avatar: { type: string }
+                avatarAssetId: { type: string }
                 theme: { type: object }
                 themePreset: { type: string, description: "Named theme preset (e.g., dark, light)" }
                 socialLinks: { type: object }
@@ -79,15 +108,30 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/LinkPage" }
+        "400":
+          description: Validation error (invalid handle format, missing required fields)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "409":
           description: Page or handle already exists
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/pages/mine:
     get:
       operationId: getMyLinksPage
       summary: Get authenticated user's link page with all links
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       responses:
         "200":
           description: User's links page (page: null if not created)
@@ -105,26 +149,42 @@ paths:
                   - type: object
                     properties:
                       page: { type: "null" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/pages/auto-create:
     post:
       operationId: autoCreateLinksPage
       summary: Auto-create a link page from identity data (handle + name)
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       responses:
         "201":
           description: Page created
           content:
             application/json:
               schema: { $ref: "#/components/schemas/LinkPage" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "409":
           description: Page already exists
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/pages/{handle}:
     get:
       operationId: getLinksPage
       summary: Get a public link page with active links
+      tags: [links]
       parameters:
         - name: handle
           in: path
@@ -145,13 +205,21 @@ paths:
                         items: { $ref: "#/components/schemas/Link" }
         "403":
           description: Page is private
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "404":
           description: Not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     put:
       operationId: updateLinksPage
       summary: Update link page (owner only)
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: handle
           in: path
@@ -167,6 +235,7 @@ paths:
                 title: { type: string }
                 bio: { type: string }
                 avatar: { type: string }
+                avatarAssetId: { type: string }
                 theme: { type: object }
                 socialLinks: { type: object }
                 isPublic: { type: boolean }
@@ -176,11 +245,28 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/LinkPage" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the page owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Page not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
       operationId: deleteLinksPage
       summary: Delete link page (owner only) — links cascade
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: handle
           in: path
@@ -189,13 +275,36 @@ paths:
       responses:
         "200":
           description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the page owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Page not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/pages/{handle}/links:
     post:
       operationId: addLinks
       summary: Add links to a page (owner only)
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: handle
           in: path
@@ -233,13 +342,35 @@ paths:
                   links:
                     type: array
                     items: { $ref: "#/components/schemas/Link" }
+        "400":
+          description: Validation error (missing title, invalid URL)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the page owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Page not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/pages/{handle}/stats:
     get:
       operationId: getPageStats
       summary: Get page click statistics (owner only) — last 30 days
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: handle
           in: path
@@ -277,13 +408,30 @@ paths:
                       properties:
                         referrer: { type: string }
                         clicks: { type: integer }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the page owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Page not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/links/{id}:
     put:
       operationId: updateLink
       summary: Update a link (owner only)
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -309,11 +457,33 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Link" }
+        "400":
+          description: Invalid URL
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the page owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Link not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
       operationId: deleteLink
       summary: Delete a link (owner only)
+      tags: [links]
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -322,11 +492,33 @@ paths:
       responses:
         "200":
           description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the page owner
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Link not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/links/{id}/click:
     post:
       operationId: recordClick
       summary: Record a link click (privacy-preserving — only referrer domain and country stored)
+      tags: [links]
       parameters:
         - name: id
           in: path
@@ -341,3 +533,16 @@ paths:
                 type: object
                 properties:
                   recorded: { type: boolean }
+
+  /api/spec:
+    get:
+      operationId: getSpec
+      summary: Serve the OpenAPI spec YAML
+      tags: [links]
+      responses:
+        "200":
+          description: OpenAPI YAML document
+          content:
+            text/yaml:
+              schema:
+                type: string

--- a/apps/market/api-spec/openapi.yaml
+++ b/apps/market/api-spec/openapi.yaml
@@ -1,0 +1,594 @@
+openapi: "3.1.0"
+info:
+  title: imajin market
+  version: "1.0.0"
+  description: Peer-to-peer marketplace with tiered seller access (off-platform contact, on-platform checkout, trust-gated), .fair revenue distribution, and Stripe-powered payments via the pay service.
+servers:
+  - url: https://market.imajin.ai
+    description: production
+  - url: https://dev-market.imajin.ai
+    description: dev
+  - url: http://localhost:7015
+    description: local
+
+tags:
+  - name: market
+
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    Listing:
+      type: object
+      properties:
+        id: { type: string }
+        sellerDid: { type: string }
+        title: { type: string }
+        description: { type: string, nullable: true }
+        price:
+          type: number
+          description: "Price as a decimal number"
+        currency:
+          type: string
+          description: "ISO 4217 currency code, default CAD"
+          example: CAD
+        category: { type: string, nullable: true }
+        images:
+          type: array
+          items: { type: string }
+          description: "Array of image URLs, max 8"
+        imageAssetIds:
+          type: array
+          items: { type: string }
+          description: "Corresponding asset IDs for CDN-managed images"
+        quantity: { type: integer, nullable: true }
+        sellerTier:
+          type: string
+          enum: [public_offplatform, public_onplatform, trust_gated]
+          description: "public_offplatform: buyer contacts seller directly; public_onplatform: checkout via pay service; trust_gated: requires trust threshold"
+        contactInfo:
+          type: object
+          nullable: true
+          description: "Required for public_offplatform tier"
+          properties:
+            phone: { type: string }
+            email: { type: string }
+            whatsapp: { type: string }
+        trustThreshold: { type: number, nullable: true }
+        rangeKm:
+          type: integer
+          description: "Geographic availability radius in kilometres, default 50"
+        fairManifest:
+          type: object
+          nullable: true
+          description: ".fair revenue distribution manifest used by the pay service"
+        metadata: { type: object }
+        status:
+          type: string
+          enum: [active, paused, sold, removed]
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+    ListingPreview:
+      type: object
+      description: "Compact listing shape returned by the public profile-listings endpoint"
+      properties:
+        id: { type: string }
+        title: { type: string }
+        price: { type: number }
+        currency: { type: string }
+        images:
+          type: array
+          items: { type: string }
+        category: { type: string, nullable: true }
+        sellerTier: { type: string }
+        createdAt: { type: string, format: date-time }
+    SellerSettings:
+      type: object
+      properties:
+        showMarketItems:
+          type: boolean
+          description: "Whether the seller's active listings appear on their public profile"
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error: { type: string }
+
+paths:
+  /api/health:
+    get:
+      operationId: healthCheck
+      summary: Service health check
+      tags: [market]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  service: { type: string, example: market }
+                  timestamp: { type: string, format: date-time }
+
+  /api/listings:
+    get:
+      operationId: listListings
+      summary: Browse and search active listings. Authenticated sellers viewing their own listings can see all statuses.
+      tags: [market]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+        - {}
+      parameters:
+        - name: category
+          in: query
+          required: false
+          schema: { type: string }
+          description: "Filter by category (partial match)"
+        - name: status
+          in: query
+          required: false
+          schema: { type: string, enum: [active, paused, sold, removed], default: active }
+          description: "Filter by status. Unauthenticated callers only see active listings."
+        - name: currency
+          in: query
+          required: false
+          schema: { type: string }
+          description: "Filter by ISO 4217 currency code"
+        - name: seller_tier
+          in: query
+          required: false
+          schema: { type: string, enum: [public_offplatform, public_onplatform, trust_gated] }
+        - name: seller_did
+          in: query
+          required: false
+          schema: { type: string }
+          description: "Filter to a specific seller's listings"
+        - name: sort
+          in: query
+          required: false
+          schema: { type: string, enum: [newest, price_asc, price_desc], default: newest }
+        - name: page
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, default: 1 }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+      responses:
+        "200":
+          description: Paginated listings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  listings:
+                    type: array
+                    items: { $ref: "#/components/schemas/Listing" }
+                  total: { type: integer }
+                  page: { type: integer }
+                  limit: { type: integer }
+                  hasMore: { type: boolean }
+    post:
+      operationId: createListing
+      summary: Create a new listing. public_offplatform tier requires at least one contactInfo field.
+      tags: [market]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title, price]
+              properties:
+                title: { type: string }
+                description: { type: string }
+                price:
+                  type: number
+                  minimum: 0.01
+                currency: { type: string, default: CAD }
+                category: { type: string }
+                images:
+                  type: array
+                  items: { type: string }
+                  maxItems: 8
+                imageAssetIds:
+                  type: array
+                  items: { type: string }
+                  maxItems: 8
+                quantity: { type: integer, default: 1 }
+                sellerTier:
+                  type: string
+                  enum: [public_offplatform, public_onplatform, trust_gated]
+                  default: public_offplatform
+                contactInfo:
+                  type: object
+                  description: "Required when sellerTier is public_offplatform (default)"
+                  properties:
+                    phone: { type: string }
+                    email: { type: string }
+                    whatsapp: { type: string }
+                trustThreshold: { type: number }
+                rangeKm: { type: integer, default: 50 }
+                metadata: { type: object }
+      responses:
+        "201":
+          description: Listing created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Listing" }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/listings/{id}:
+    get:
+      operationId: getListing
+      summary: Get a single listing by ID (public)
+      tags: [market]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Listing detail
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Listing" }
+        "404":
+          description: Listing not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    patch:
+      operationId: updateListing
+      summary: Update a listing (seller only). Cannot update sold or removed listings. Status can only be set to active or paused.
+      tags: [market]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                description: { type: string }
+                price: { type: number, minimum: 0.01 }
+                currency: { type: string }
+                category: { type: string }
+                images:
+                  type: array
+                  items: { type: string }
+                  maxItems: 8
+                imageAssetIds:
+                  type: array
+                  items: { type: string }
+                  maxItems: 8
+                quantity: { type: integer }
+                sellerTier:
+                  type: string
+                  enum: [public_offplatform, public_onplatform, trust_gated]
+                contactInfo:
+                  type: object
+                  properties:
+                    phone: { type: string }
+                    email: { type: string }
+                    whatsapp: { type: string }
+                rangeKm: { type: integer }
+                metadata: { type: object }
+                status:
+                  type: string
+                  enum: [active, paused]
+                  description: "Seller can pause or re-activate a listing; sold/removed transitions are system-managed"
+      responses:
+        "200":
+          description: Listing updated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Listing" }
+        "400":
+          description: Validation error or invalid status transition
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the listing seller
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Listing not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    delete:
+      operationId: removeListing
+      summary: Soft-delete a listing (seller only) — sets status to removed
+      tags: [market]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Listing removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not the listing seller
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Listing not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/listings/{id}/purchase:
+    post:
+      operationId: purchaseListing
+      summary: Initiate a checkout session via the pay service. Not available for public_offplatform listings (contact seller directly). Returns a Stripe checkout URL.
+      tags: [market]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+        - {}
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                quantity:
+                  type: integer
+                  minimum: 1
+                  default: 1
+      responses:
+        "200":
+          description: Checkout session created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                    description: "Stripe hosted checkout URL — redirect the buyer here"
+                  sessionId:
+                    type: string
+                    description: "Stripe checkout session ID"
+        "400":
+          description: Listing not active or not available for on-platform purchase
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Listing not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/my/listings:
+    get:
+      operationId: getMyListings
+      summary: Get the authenticated seller's own listings (all statuses visible)
+      tags: [market]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema: { type: string, enum: [active, paused, sold, removed] }
+          description: "Optionally filter by status"
+        - name: sort
+          in: query
+          required: false
+          schema: { type: string, enum: [newest, price_asc, price_desc], default: newest }
+        - name: page
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, default: 1 }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+      responses:
+        "200":
+          description: Paginated seller listings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  listings:
+                    type: array
+                    items: { $ref: "#/components/schemas/Listing" }
+                  total: { type: integer }
+                  page: { type: integer }
+                  limit: { type: integer }
+                  hasMore: { type: boolean }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/seller/settings:
+    get:
+      operationId: getSellerSettings
+      summary: Get seller settings for the authenticated user. Creates a default row if none exists.
+      tags: [market]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Seller settings
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SellerSettings" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    patch:
+      operationId: updateSellerSettings
+      summary: Update seller settings for the authenticated user
+      tags: [market]
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [showMarketItems]
+              properties:
+                showMarketItems:
+                  type: boolean
+                  description: "Whether to display active listings on the seller's public profile"
+      responses:
+        "200":
+          description: Settings updated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/SellerSettings" }
+        "400":
+          description: showMarketItems must be a boolean
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/seller/{did}/profile-listings:
+    get:
+      operationId: getProfileListings
+      summary: Get a seller's active listings for public profile display. Returns empty array if the seller has not enabled profile integration.
+      tags: [market]
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+          description: "Seller DID"
+      responses:
+        "200":
+          description: Profile listings (up to 8, newest first)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  listings:
+                    type: array
+                    items: { $ref: "#/components/schemas/ListingPreview" }
+                  enabled:
+                    type: boolean
+                    description: "false when the seller has disabled profile market integration"
+
+  /api/webhook:
+    post:
+      operationId: handleWebhook
+      summary: Receive payment events from the pay service. Authenticated via x-webhook-secret header or body.secret. Decrements quantity and marks listings sold when payment succeeds.
+      tags: [market]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  description: "Event type, e.g. payment.succeeded"
+                status:
+                  type: string
+                  description: "Payment status, e.g. paid, succeeded"
+                secret:
+                  type: string
+                  description: "Webhook secret (alternative to x-webhook-secret header)"
+                metadata:
+                  type: object
+                  properties:
+                    listingId: { type: string }
+                    sellerDid: { type: string }
+                    buyerDid: { type: string }
+      responses:
+        "200":
+          description: Webhook received and processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  received: { type: boolean }
+        "401":
+          description: Invalid or missing webhook secret
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }

--- a/apps/media/api-spec/openapi.yaml
+++ b/apps/media/api-spec/openapi.yaml
@@ -17,6 +17,9 @@ components:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
   schemas:
     Asset:
       type: object
@@ -29,19 +32,34 @@ components:
         storagePath: { type: string }
         hash: { type: string, description: "SHA-256 hex" }
         fairManifest: { type: object }
-        classification: { type: string }
-        classificationConfidence: { type: integer }
+        fairPath: { type: string }
+        classification: { type: string, nullable: true }
+        classificationConfidence: { type: integer, nullable: true }
         metadata: { type: object }
         status: { type: string, enum: [active, deleted] }
         createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time, nullable: true }
+    AssetUploadResponse:
+      type: object
+      properties:
+        id: { type: string }
+        url: { type: string, description: "Public URL to serve the asset" }
+        filename: { type: string }
+        mimeType: { type: string }
+        size: { type: integer }
+        hash: { type: string }
+        storagePath: { type: string }
+        fairManifest: { type: object }
+        createdAt: { type: string, format: date-time }
+        deduplicated: { type: boolean, description: "True if the exact same file already existed for this owner" }
     Folder:
       type: object
       properties:
         id: { type: string }
         ownerDid: { type: string }
         name: { type: string }
-        parentId: { type: string }
-        icon: { type: string }
+        parentId: { type: string, nullable: true }
+        icon: { type: string, nullable: true }
         isSystem: { type: boolean }
         sortOrder: { type: integer }
         assetCount: { type: integer }
@@ -49,29 +67,44 @@ components:
     FairManifest:
       type: object
       properties:
-        version: { type: string }
-        asset: { type: string }
+        fair: { type: string }
+        id: { type: string }
+        type: { type: string }
         owner: { type: string }
+        created: { type: string, format: date-time }
+        source: { type: string }
         access:
           oneOf:
             - type: string
               enum: [public, private]
             - type: object
               properties:
-                type: { type: string, enum: [trust-graph] }
+                type: { type: string, enum: [trust-graph, conversation] }
                 allowedDids: { type: array, items: { type: string } }
         attribution: { type: array, items: { type: object } }
         transfer: { type: object }
-        createdAt: { type: string, format: date-time }
+    AssetReference:
+      type: object
+      properties:
+        id: { type: string }
+        assetId: { type: string }
+        service: { type: string }
+        entityType: { type: string }
+        entityId: { type: string }
     Error:
       type: object
       required: [error]
       properties:
         error: { type: string }
 
+tags:
+  - name: media
+    description: imajin media service
+
 paths:
   /api/health:
     get:
+      tags: [media]
       operationId: healthCheck
       summary: Service health check
       responses:
@@ -87,8 +120,9 @@ paths:
 
   /api/assets:
     post:
+      tags: [media]
       operationId: uploadAsset
-      summary: Upload a file (50 MB max) — auto-creates .fair manifest and async classification
+      summary: Upload a file (50 MB max) — auto-creates .fair manifest, deduplicates by SHA-256, async ML classification, auto-assigns to context folder
       security:
         - cookieAuth: []
       requestBody:
@@ -103,29 +137,64 @@ paths:
                   type: string
                   format: binary
                   description: "Allowed: image/*, audio/*, video/*, text/*, application/pdf"
-                filename: { type: string }
+                filename:
+                  type: string
+                  description: "Override filename (default: file.name from upload)"
+                context:
+                  type: string
+                  description: "JSON string: {app?, feature?, entityId?, access?} — access=public makes manifest public; feature/app triggers auto-folder assignment"
       responses:
         "201":
           description: Asset uploaded
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Asset" }
+              schema: { $ref: "#/components/schemas/AssetUploadResponse" }
+        "200":
+          description: Deduplicated — same file already exists for this owner
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/AssetUploadResponse"
+                  - type: object
+                    properties:
+                      deduplicated: { type: boolean, enum: [true] }
         "400":
           description: Missing file field
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "413":
           description: File exceeds 50 MB limit
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "415":
           description: MIME type not allowed
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Rate limit exceeded (20 uploads per 60 seconds per IP)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     get:
+      tags: [media]
       operationId: listAssets
-      summary: List assets for authenticated user
+      summary: List assets for authenticated user — also accepts internal Bearer + X-Owner-DID for service-to-service
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: type
           in: query
           schema: { type: string }
-          description: "MIME type prefix filter (e.g., image, audio, video)"
+          description: "MIME type prefix filter (e.g., image, audio, video, text)"
+        - name: search
+          in: query
+          schema: { type: string }
+          description: "Filename search (case-insensitive substring)"
         - name: sort
           in: query
           schema: { type: string, default: created }
@@ -155,6 +224,7 @@ paths:
 
   /api/assets/{id}:
     get:
+      tags: [media]
       operationId: getAsset
       summary: Serve asset file with .fair access control. Supports thumbnail resizing (?w=) and conditional GET (ETag).
       parameters:
@@ -177,18 +247,91 @@ paths:
             ETag:
               schema: { type: string }
             X-Fair-Access:
-              schema: { type: string, enum: [public, private, trust-graph] }
+              schema: { type: string, enum: [public, private, trust-graph, conversation] }
             Cache-Control:
               schema: { type: string }
         "304":
           description: Not modified (ETag match)
         "403":
           description: Access denied per .fair manifest
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  reason: { type: string }
+        "404":
+          description: Asset not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    delete:
+      tags: [media]
+      operationId: deleteAsset
+      summary: Hard-delete asset and files from storage (owner only)
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Asset deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+        "401":
+          description: Authentication required
+        "403":
+          description: Forbidden — not the owner
+        "404":
+          description: Asset not found
+    patch:
+      tags: [media]
+      operationId: renameAsset
+      summary: Rename asset filename (owner only) — renames the file on disk
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [filename]
+              properties:
+                filename: { type: string }
+      responses:
+        "200":
+          description: Renamed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  filename: { type: string }
+        "400":
+          description: filename is required
+        "403":
+          description: Forbidden
         "404":
           description: Asset not found
 
   /api/assets/{id}/fair:
     get:
+      tags: [media]
       operationId: getAssetFair
       summary: Get .fair manifest for an asset (same access rules as the asset itself)
       parameters:
@@ -210,8 +353,81 @@ paths:
         "404":
           description: Manifest not found
 
+  /api/assets/{id}/content:
+    get:
+      tags: [media]
+      operationId: getAssetContent
+      summary: Read text content of a text/* or application/json asset — internal Bearer also accepted for public/trust-graph
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: File text content
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content: { type: string }
+                  filename: { type: string }
+        "403":
+          description: Forbidden
+        "404":
+          description: Asset not found
+        "415":
+          description: Not a text file
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  mimeType: { type: string }
+    put:
+      tags: [media]
+      operationId: updateAssetContent
+      summary: Overwrite text file content (owner only) — updates hash and size in DB
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [content]
+              properties:
+                content: { type: string }
+      responses:
+        "200":
+          description: Content updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+        "400":
+          description: content must be a string
+        "403":
+          description: Forbidden
+        "404":
+          description: Asset not found
+
   /api/assets/{id}/folders:
     put:
+      tags: [media]
       operationId: setAssetFolders
       summary: Set folder assignments for an asset (replaces all existing assignments)
       security:
@@ -245,6 +461,7 @@ paths:
 
   /api/assets/{id}/classify:
     post:
+      tags: [media]
       operationId: classifyAsset
       summary: Re-classify an existing asset (owner only)
       security:
@@ -269,8 +486,49 @@ paths:
                       category: { type: string }
                       confidence: { type: number }
 
+  /api/assets/{id}/references:
+    post:
+      tags: [media]
+      operationId: registerAssetReference
+      summary: Register a service entity reference to an asset (internal — requires Bearer AUTH_INTERNAL_API_KEY)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [service, entityType, entityId]
+              properties:
+                service: { type: string, description: "Service name, e.g. 'profile', 'chat'" }
+                entityType: { type: string, description: "Entity type, e.g. 'avatar', 'message'" }
+                entityId: { type: string }
+      responses:
+        "201":
+          description: Reference registered
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  reference: { $ref: "#/components/schemas/AssetReference" }
+        "400":
+          description: Missing required fields
+        "401":
+          description: Unauthorized
+        "404":
+          description: Asset not found
+
   /api/folders:
     get:
+      tags: [media]
       operationId: listFolders
       summary: List all folders with asset counts
       security:
@@ -287,8 +545,9 @@ paths:
                     type: array
                     items: { $ref: "#/components/schemas/Folder" }
     post:
+      tags: [media]
       operationId: createFolder
-      summary: Create a folder
+      summary: Create a folder — parentId must belong to same owner
       security:
         - cookieAuth: []
       requestBody:
@@ -308,9 +567,14 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Folder" }
+        "400":
+          description: name is required
+        "404":
+          description: Parent folder not found
 
   /api/folders/init:
     post:
+      tags: [media]
       operationId: initFolders
       summary: Create default system folders (Photos, Audio, Videos, Documents, Uncategorized) — idempotent
       security:
@@ -329,9 +593,17 @@ paths:
                     items: { $ref: "#/components/schemas/Folder" }
         "200":
           description: Already initialized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  created: { type: array, items: {} }
 
   /api/folders/{id}:
     patch:
+      tags: [media]
       operationId: updateFolder
       summary: Rename, move, or change folder icon
       security:
@@ -357,9 +629,14 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Folder" }
+        "400":
+          description: Invalid input
+        "404":
+          description: Folder not found or parent not found
     delete:
+      tags: [media]
       operationId: deleteFolder
-      summary: Delete folder (assets stay, only folder assignments removed)
+      summary: Delete folder (assets stay, only folder assignments removed) — system folders cannot be deleted
       security:
         - cookieAuth: []
       parameters:
@@ -372,3 +649,77 @@ paths:
           description: Folder deleted
         "403":
           description: Cannot delete system folders
+        "404":
+          description: Folder not found
+
+  /api/presence/{did}:
+    get:
+      tags: [media]
+      operationId: getPresence
+      summary: Read .imajin folder contents (soul.md, context.md, config.json) for a DID (internal — requires Bearer MEDIA_INTERNAL_API_KEY)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Presence data (seeded=false if .imajin folder not found)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  did: { type: string }
+                  soul: { type: string, nullable: true, description: "Contents of soul.md" }
+                  context: { type: string, nullable: true, description: "Contents of context.md" }
+                  config: { type: object, nullable: true, description: "Parsed contents of config.json" }
+                  seeded: { type: boolean }
+        "401":
+          description: Unauthorized
+
+  /api/seed/presence:
+    post:
+      tags: [media]
+      operationId: seedPresence
+      summary: Seed default .imajin/ presence files for a DID (internal — requires Bearer MEDIA_INTERNAL_API_KEY) — idempotent
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [did]
+              properties:
+                did: { type: string }
+                handle: { type: string, description: "Used to personalise soul.md content" }
+      responses:
+        "201":
+          description: Presence seeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  folderId: { type: string }
+                  assetIds: { type: array, items: { type: string } }
+                  files: { type: array, items: { type: string } }
+        "200":
+          description: Already seeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  folderId: { type: string }
+                  assetIds: { type: array, items: { type: string } }
+        "400":
+          description: did is required
+        "401":
+          description: Unauthorized

--- a/apps/pay/api-spec/openapi.yaml
+++ b/apps/pay/api-spec/openapi.yaml
@@ -11,6 +11,10 @@ servers:
   - url: http://localhost:7004
     description: local
 
+tags:
+  - name: pay
+    description: imajin pay service
+
 components:
   securitySchemes:
     cookieAuth:
@@ -35,20 +39,22 @@ components:
       type: object
       properties:
         did: { type: string }
-        cashAmount: { type: number }
-        creditAmount: { type: number }
+        cashAmount: { type: number, description: "Real money balance (USD)" }
+        creditAmount: { type: number, description: "Platform credit balance (non-withdrawable)" }
         total: { type: number }
-        currency: { type: string }
+        currency: { type: string, default: USD }
         updatedAt: { type: string, format: date-time }
     Transaction:
       type: object
       properties:
         id: { type: string }
-        did: { type: string }
+        fromDid: { type: string }
+        toDid: { type: string }
         amount: { type: number }
         currency: { type: string }
         service: { type: string }
         type: { type: string }
+        status: { type: string }
         metadata: { type: object }
         createdAt: { type: string, format: date-time }
     Error:
@@ -60,11 +66,22 @@ components:
 paths:
   /api/health:
     get:
+      tags: [pay]
       operationId: healthCheck
-      summary: Service health check
+      summary: Service health check — checks all configured payment providers
       responses:
         "200":
           description: Service healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, enum: [healthy, degraded, unhealthy] }
+                  providers: { type: object }
+                  timestamp: { type: string, format: date-time }
+        "503":
+          description: One or more providers unhealthy
           content:
             application/json:
               schema:
@@ -76,8 +93,10 @@ paths:
 
   /api/balance/{did}:
     get:
+      tags: [pay]
       operationId: getBalance
-      summary: Get balance for a DID
+      summary: Get current balance for a DID
+      description: Returns cash and credit balances. The authenticated identity must match the requested DID.
       security:
         - cookieAuth: []
         - bearerAuth: []
@@ -86,6 +105,7 @@ paths:
           in: path
           required: true
           schema: { type: string }
+          description: "URL-encoded DID"
       responses:
         "200":
           description: Balance retrieved
@@ -97,11 +117,21 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Forbidden — can only access your own balance
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/balance/gift:
     post:
+      tags: [pay]
       operationId: giftCredits
-      summary: Bulk gift credits to multiple recipients
+      summary: Bulk gift credits from a business DID to multiple recipients
+      description: |
+        Debits `from_did`'s cash balance for the total gifted `cash_amount`, and atomically
+        credits each recipient's cash and credit buckets.
+        The authenticated identity must match `from_did`.
       security:
         - bearerAuth: []
       requestBody:
@@ -117,6 +147,7 @@ paths:
                   type: array
                   items:
                     type: object
+                    required: [did, cash_amount, credit_amount]
                     properties:
                       did: { type: string }
                       cash_amount: { type: number }
@@ -125,16 +156,39 @@ paths:
       responses:
         "200":
           description: Credits gifted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  batchId: { type: string }
+                  count: { type: number }
+        "400":
+          description: Insufficient balance or invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Forbidden — can only gift from your own DID
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
 
   /api/balance/event-topup:
     post:
+      tags: [pay]
       operationId: eventTopup
-      summary: Multiplier-based event credit gifting
+      summary: Multiplier-based credit gifting for event attendees
+      description: |
+        Debit `from_did`'s cash for `ticket_price × recipient count`. Credit each recipient
+        with `ticket_price` cash (refund) and `ticket_price × (multiplier - 1)` credits (bonus).
+        multiplier 1.0 = refund only; multiplier 10.0 = refund + 9× credits.
+        Authenticated via Bearer token; `from_did` must match session.
       security:
         - bearerAuth: []
       requestBody:
@@ -147,21 +201,52 @@ paths:
               properties:
                 from_did: { type: string }
                 event_id: { type: string }
-                multiplier: { type: number }
-                recipient_dids: { type: array, items: { type: string } }
+                multiplier: { type: number, minimum: 1.0, description: "Credit multiplier (≥ 1.0)" }
+                recipient_dids:
+                  type: array
+                  items: { type: string }
+                  minItems: 1
                 metadata:
                   type: object
                   required: [ticket_price]
                   properties:
-                    ticket_price: { type: number }
+                    ticket_price: { type: number, description: "Per-recipient ticket price (USD)" }
       responses:
         "200":
           description: Event credits applied
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  batchId: { type: string }
+                  count: { type: number }
+                  cashPerRecipient: { type: number }
+                  creditPerRecipient: { type: number }
+        "400":
+          description: Insufficient balance, invalid multiplier, or missing ticket_price
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Forbidden — can only top up from your own DID
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/balance/withdraw:
     post:
+      tags: [pay]
       operationId: withdraw
-      summary: Withdraw cash balance to Stripe Connect account
+      summary: Withdraw cash balance to a connected Stripe account
+      description: |
+        Only `cash_amount` (real money) can be withdrawn — credits cannot be withdrawn.
+        Minimum withdrawal is $1.00 (100 cents). Creates a Stripe Transfer to the connected account.
       security:
         - cookieAuth: []
       requestBody:
@@ -172,9 +257,9 @@ paths:
               type: object
               required: [amount, account_id]
               properties:
-                amount: { type: number }
+                amount: { type: integer, description: "Amount in cents (minimum 100)" }
                 currency: { type: string, default: usd }
-                account_id: { type: string }
+                account_id: { type: string, description: "Stripe connected account ID" }
       responses:
         "200":
           description: Withdrawal initiated
@@ -188,11 +273,25 @@ paths:
                   transferId: { type: string }
                   amount: { type: number }
                   currency: { type: string }
+        "400":
+          description: Insufficient balance or below minimum
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/balance/transfer:
     post:
+      tags: [pay]
       operationId: transferBalance
-      summary: Transfer balance between DIDs (service-to-service)
+      summary: Transfer balance from one DID to another
+      description: |
+        Burns credits first, then cash. The transfer recipient receives cash (real value earned).
+        The authenticated identity must match `from_did`.
       security:
         - bearerAuth: []
       requestBody:
@@ -205,16 +304,44 @@ paths:
               properties:
                 from_did: { type: string }
                 to_did: { type: string }
-                amount: { type: number }
+                amount: { type: number, description: "Amount in dollars (combined cash+credit)" }
                 metadata: { type: object }
       responses:
         "200":
           description: Transfer complete
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactionId: { type: string }
+                  fromDid: { type: string }
+                  toDid: { type: string }
+                  amount: { type: number }
+        "400":
+          description: Insufficient balance
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Forbidden — can only transfer from your own DID
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/balance/topup:
     post:
+      tags: [pay]
       operationId: topupBalance
       summary: Credit cash balance — internal service-to-service only
+      description: |
+        Represents real money received (e.g. from Stripe webhook). Always credits `cash_amount`.
+        Authenticated via PAY_SERVICE_API_KEY Bearer token.
       security:
         - apiKeyAuth: []
       requestBody:
@@ -226,18 +353,41 @@ paths:
               required: [did, amount, service, type]
               properties:
                 did: { type: string }
-                amount: { type: number }
-                service: { type: string }
-                type: { type: string }
+                amount: { type: number, description: "Amount in dollars" }
+                service: { type: string, description: "Originating service (e.g. coffee, events)" }
+                type: { type: string, description: "Transaction type label" }
                 metadata: { type: object }
       responses:
         "200":
           description: Balance topped up
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactionId: { type: string }
+                  did: { type: string }
+                  amount: { type: number }
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized (invalid API key)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/charge:
     post:
+      tags: [pay]
       operationId: createCharge
-      summary: Create a payment charge
+      summary: Create a direct payment charge
+      description: |
+        For Stripe: creates a PaymentIntent (requires frontend to confirm with `clientSecret`).
+        For Solana: returns an unsigned transaction (requires wallet signature).
+        Auth is optional — if provided, the charged DID is linked to the transaction.
       security:
         - bearerAuth: []
       requestBody:
@@ -248,20 +398,51 @@ paths:
               type: object
               required: [amount, currency, to]
               properties:
-                amount: { type: number }
-                currency: { type: string }
-                to: { type: string }
+                amount: { type: integer, description: "Cents for fiat; lamports for SOL; base units for tokens" }
+                currency:
+                  type: string
+                  enum: [USD, CAD, SOL, USDC, MJN]
+                to:
+                  type: object
+                  description: "Recipient — at least one field required"
+                  properties:
+                    stripeCustomerId: { type: string }
+                    solanaAddress: { type: string }
+                    did: { type: string }
                 description: { type: string }
-                metadata: { type: object }
+                metadata:
+                  type: object
+                  additionalProperties: { type: string }
                 idempotencyKey: { type: string }
       responses:
         "200":
           description: Charge created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  provider: { type: string, enum: [stripe, solana] }
+                  status: { type: string, enum: [pending, requires_action, succeeded, failed] }
+                  amount: { type: number }
+                  currency: { type: string }
+                  clientSecret: { type: string, description: "Stripe PaymentIntent client secret" }
+                  signature: { type: string, description: "Solana — if pre-signed" }
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/checkout:
     post:
+      tags: [pay]
       operationId: createCheckout
-      summary: Create a Stripe checkout session
+      summary: Create a hosted Stripe Checkout session
+      description: |
+        Returns a URL to redirect the customer to Stripe Checkout. Supports `.fair` manifests for
+        multi-party revenue splits via `fairManifest`. Rate-limited to 10 req/min per IP.
       security:
         - bearerAuth: []
       requestBody:
@@ -274,20 +455,29 @@ paths:
               properties:
                 items:
                   type: array
+                  minItems: 1
                   items:
                     type: object
+                    required: [name, amount, quantity]
                     properties:
                       name: { type: string }
                       description: { type: string }
-                      amount: { type: number }
-                      quantity: { type: number }
-                currency: { type: string }
-                successUrl: { type: string }
-                cancelUrl: { type: string }
-                customerEmail: { type: string }
-                metadata: { type: object }
-                fairManifest: { type: object }
-                connectedAccountId: { type: string }
+                      amount: { type: integer, description: "Price in cents" }
+                      quantity: { type: integer }
+                      image: { type: string }
+                currency:
+                  type: string
+                  enum: [USD, CAD, EUR, GBP]
+                mode: { type: string, enum: [payment, subscription], default: payment }
+                customerEmail: { type: string, format: email }
+                successUrl: { type: string, format: uri }
+                cancelUrl: { type: string, format: uri }
+                metadata:
+                  type: object
+                  additionalProperties: { type: string }
+                fairManifest: { type: object, description: ".fair multi-party split manifest" }
+                connectedAccountId: { type: string, description: "Stripe Connect account for platform fees" }
+                sellerDid: { type: string }
       responses:
         "200":
           description: Checkout session created
@@ -297,14 +487,36 @@ paths:
                 type: object
                 properties:
                   id: { type: string }
-                  url: { type: string }
+                  url: { type: string, format: uri }
                   expiresAt: { type: string, format: date-time }
                   transactionId: { type: string }
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "429":
+          description: Too many requests
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/settle:
     post:
+      tags: [pay]
       operationId: fairSettle
-      summary: .fair multi-party revenue settlement — internal only
+      summary: Execute a .fair multi-party settlement
+      description: |
+        Validates `from_did` has sufficient balance, then atomically:
+        - Debits `from_did` (credits first, then cash)
+        - Credits each recipient in the fair_manifest chain (as cash — real value earned)
+        - Logs all transactions
+        - Emits attestations (customer + transaction.settled)
+
+        Set `funded: true` for externally-funded payments (e.g. Stripe) to skip the balance
+        check and debit step.
+
+        Authenticated via PAY_SERVICE_API_KEY Bearer token (internal service-to-service).
       security:
         - apiKeyAuth: []
       requestBody:
@@ -319,6 +531,8 @@ paths:
                 total_amount: { type: number }
                 service: { type: string }
                 type: { type: string }
+                funded: { type: boolean, description: "true = externally funded (Stripe etc.) — skip balance check" }
+                funded_provider: { type: string, description: "stripe | solana — for audit log" }
                 fair_manifest:
                   type: object
                   required: [chain]
@@ -327,6 +541,7 @@ paths:
                       type: array
                       items:
                         type: object
+                        required: [did, amount, role]
                         properties:
                           did: { type: string }
                           amount: { type: number }
@@ -335,11 +550,33 @@ paths:
       responses:
         "200":
           description: Settlement complete
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  batchId: { type: string }
+                  transactionIds: { type: array, items: { type: string } }
+                  recipients: { type: integer }
+        "400":
+          description: Insufficient balance or invalid manifest
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized (invalid API key)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/escrow:
     post:
+      tags: [pay]
       operationId: createEscrow
-      summary: Create an escrow
+      summary: Create an escrow — hold funds until released
+      description: |
+        Holds funds from `from` until conditions are met (time-based auto-release or
+        multi-signature release). Requires Bearer auth.
       security:
         - bearerAuth: []
       requestBody:
@@ -352,15 +589,48 @@ paths:
               properties:
                 amount: { type: number }
                 currency: { type: string }
-                from: { type: string }
-                to: { type: string }
-                arbiter: { type: string }
-                conditions: { type: object }
-                metadata: { type: object }
+                from: { type: string, description: "DID of depositor" }
+                to: { type: string, description: "DID of recipient" }
+                arbiter: { type: string, description: "DID of dispute resolver" }
+                conditions:
+                  type: object
+                  properties:
+                    releaseAfter: { type: string, format: date-time, description: "ISO date for auto-release" }
+                    requireSignatures:
+                      type: array
+                      items: { type: string }
+                      description: "DIDs that must sign to release"
+                metadata:
+                  type: object
+                  additionalProperties: { type: string }
       responses:
         "201":
           description: Escrow created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  provider: { type: string, enum: [stripe, solana] }
+                  status: { type: string, enum: [held] }
+                  amount: { type: number }
+                  currency: { type: string }
+                  from: { type: string }
+                  to: { type: string }
+                  createdAt: { type: string, format: date-time }
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     put:
+      tags: [pay]
       operationId: releaseEscrow
       summary: Release or refund an escrow
       security:
@@ -371,17 +641,35 @@ paths:
           application/json:
             schema:
               type: object
+              required: [action, escrowId]
               properties:
                 action: { type: string, enum: [release, refund] }
                 escrowId: { type: string }
       responses:
         "200":
           description: Escrow settled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  status: { type: string, enum: [released, refunded] }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/connect/onboard:
     post:
+      tags: [pay]
       operationId: stripeConnectOnboard
-      summary: Start Stripe Connect Express onboarding
+      summary: Start Stripe Connect Express onboarding for the authenticated DID
+      description: |
+        Creates a Stripe Express account for the authenticated DID (if not exists) and returns
+        an onboarding URL. Only human (hard) DIDs — not agents. If already has an account,
+        generates a new Account Link for re-onboarding.
       security:
         - cookieAuth: []
       requestBody:
@@ -392,8 +680,8 @@ paths:
               type: object
               required: [return_url, refresh_url]
               properties:
-                return_url: { type: string }
-                refresh_url: { type: string }
+                return_url: { type: string, format: uri }
+                refresh_url: { type: string, format: uri }
       responses:
         "200":
           description: Onboarding link created
@@ -403,17 +691,31 @@ paths:
                 type: object
                 properties:
                   accountId: { type: string }
-                  onboardingUrl: { type: string }
+                  onboardingUrl: { type: string, format: uri }
+                  isNew: { type: boolean }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Agents cannot onboard
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/connect/status:
     get:
+      tags: [pay]
       operationId: stripeConnectStatus
-      summary: Check Stripe Connect account status
+      summary: Check Stripe Connect account status for a DID
+      description: Returns the connected account status from DB (kept fresh by webhook).
       parameters:
-        - name: account_id
+        - name: did
           in: query
           required: true
           schema: { type: string }
+          description: "DID to check"
       responses:
         "200":
           description: Account status
@@ -422,15 +724,62 @@ paths:
               schema:
                 type: object
                 properties:
-                  accountId: { type: string }
+                  id: { type: string }
+                  did: { type: string }
+                  stripeAccountId: { type: string }
                   chargesEnabled: { type: boolean }
                   payoutsEnabled: { type: boolean }
                   detailsSubmitted: { type: boolean }
+                  onboardingComplete: { type: boolean }
+        "404":
+          description: No connected account for this DID
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/connect/dashboard:
+    get:
+      tags: [pay]
+      operationId: stripeConnectDashboard
+      summary: Generate a Stripe Express Dashboard login link
+      description: Generates a one-time login link for the Stripe Express dashboard for the connected account. Auth required.
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: did
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Dashboard URL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url: { type: string, format: uri }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: No connected account
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/connect/webhook:
     post:
+      tags: [pay]
       operationId: stripeConnectWebhook
-      summary: Stripe Connect webhook — account.updated events
+      summary: Stripe Connect webhook — connected account events
+      description: |
+        Handles Stripe Connect webhook events:
+        - `account.updated` — refresh onboarding status in DB
+        - `payout.paid` — log successful payout
+        - `payout.failed` — log failed payout
       security:
         - stripeWebhook: []
       requestBody:
@@ -444,9 +793,12 @@ paths:
 
   /api/transactions/{did}:
     get:
+      tags: [pay]
       operationId: listTransactions
       summary: List transactions for a DID
+      description: Returns paginated transactions. The authenticated identity must match the requested DID.
       security:
+        - cookieAuth: []
         - bearerAuth: []
       parameters:
         - name: did
@@ -455,13 +807,13 @@ paths:
           schema: { type: string }
         - name: service
           in: query
-          schema: { type: string }
+          schema: { type: string, description: "Filter by originating service (e.g. coffee)" }
         - name: type
           in: query
-          schema: { type: string }
+          schema: { type: string, description: "Filter by transaction type" }
         - name: limit
           in: query
-          schema: { type: integer, default: 50 }
+          schema: { type: integer, default: 50, maximum: 200 }
         - name: offset
           in: query
           schema: { type: integer, default: 0 }
@@ -479,12 +831,25 @@ paths:
                   limit: { type: integer }
                   offset: { type: integer }
                   count: { type: integer }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Forbidden — can only access your own transactions
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/transactions/{did}/summary:
     get:
+      tags: [pay]
       operationId: transactionSummary
-      summary: Transaction summary grouped by service
+      summary: Aggregated transaction summary grouped by service
+      description: Returns earned/spent breakdown by service. The authenticated identity must match the requested DID.
       security:
+        - cookieAuth: []
         - bearerAuth: []
       parameters:
         - name: did
@@ -499,18 +864,39 @@ paths:
               schema:
                 type: object
                 properties:
-                  services: { type: object }
+                  services:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      properties:
+                        earned: { type: number }
+                        spent: { type: number }
+                        net: { type: number }
                   total:
                     type: object
                     properties:
                       earned: { type: number }
                       spent: { type: number }
                       net: { type: number }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/webhook:
     post:
+      tags: [pay]
       operationId: stripeWebhook
-      summary: Stripe webhook — payment_intent, checkout.session, subscription, invoice events
+      summary: Stripe webhook — payment events
+      description: |
+        Handles Stripe webhook events:
+        - `payment_intent.succeeded` — record successful charge, trigger balance update
+        - `payment_intent.payment_failed` — record failure
+        - `checkout.session.completed` — fulfill order, trigger settlement
+        - `customer.subscription.created/updated/deleted` — provision/revoke access
+        - `invoice.paid` — recurring payment received
+        Idempotent — skips already-processed events.
       security:
         - stripeWebhook: []
       requestBody:
@@ -521,3 +907,15 @@ paths:
       responses:
         "200":
           description: Event received
+
+  /api/spec:
+    get:
+      tags: [pay]
+      operationId: getSpec
+      summary: Serve the OpenAPI spec YAML
+      responses:
+        "200":
+          description: OpenAPI YAML
+          content:
+            text/yaml:
+              schema: { type: string }

--- a/apps/profile/api-spec/openapi.yaml
+++ b/apps/profile/api-spec/openapi.yaml
@@ -11,12 +11,18 @@ servers:
   - url: http://localhost:7005
     description: local
 
+tags:
+  - name: profile
+
 components:
   securitySchemes:
     cookieAuth:
       type: apiKey
       in: cookie
       name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
   schemas:
     Profile:
       type: object
@@ -28,6 +34,7 @@ components:
         bio: { type: string }
         avatar: { type: string }
         metadata: { type: object }
+        inferenceEnabled: { type: boolean }
         createdAt: { type: string, format: date-time }
     Error:
       type: object
@@ -36,8 +43,38 @@ components:
         error: { type: string }
 
 paths:
+  /api/health:
+    get:
+      tags: [profile]
+      operationId: healthCheck
+      summary: Service health check
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  service: { type: string }
+                  timestamp: { type: string, format: date-time }
+
+  /api/spec:
+    get:
+      tags: [profile]
+      operationId: getSpec
+      summary: Serve OpenAPI spec (YAML)
+      responses:
+        "200":
+          description: OpenAPI YAML spec
+          content:
+            text/yaml:
+              schema: { type: string }
+
   /api/profile:
     post:
+      tags: [profile]
       operationId: createProfileAuth
       summary: Create a profile for authenticated user
       security:
@@ -51,10 +88,14 @@ paths:
               required: [displayName, displayType]
               properties:
                 displayName: { type: string }
-                displayType: { type: string }
+                displayType: { type: string, enum: [human, agent, presence] }
                 avatar: { type: string }
+                avatarAssetId: { type: string }
                 bio: { type: string }
                 handle: { type: string }
+                email: { type: string, format: email }
+                phone: { type: string }
+                optInUpdates: { type: boolean }
                 metadata: { type: object }
       responses:
         "201":
@@ -62,21 +103,38 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Profile" }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: Profile already exists or handle taken
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/profile/search:
     get:
+      tags: [profile]
       operationId: searchProfiles
       summary: Search profiles
       parameters:
         - name: q
           in: query
           schema: { type: string }
+          description: "Search query (matches handle and displayName)"
         - name: type
           in: query
-          schema: { type: string }
+          schema: { type: string, enum: [human, agent, presence] }
         - name: limit
           in: query
-          schema: { type: integer, default: 20 }
+          schema: { type: integer, default: 20, maximum: 100 }
         - name: offset
           in: query
           schema: { type: integer, default: 0 }
@@ -91,9 +149,17 @@ paths:
                   profiles:
                     type: array
                     items: { $ref: "#/components/schemas/Profile" }
+                  pagination:
+                    type: object
+                    properties:
+                      total: { type: integer }
+                      limit: { type: integer }
+                      offset: { type: integer }
+                      hasMore: { type: boolean }
 
   /api/profile/claim-handle:
     post:
+      tags: [profile]
       operationId: claimHandle
       summary: Claim a handle for the authenticated user
       security:
@@ -118,9 +184,68 @@ paths:
                   success: { type: boolean }
                   handle: { type: string }
                   profile: { $ref: "#/components/schemas/Profile" }
+        "400":
+          description: Invalid handle format
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Profile not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: Handle already taken
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/profile/inference:
+    post:
+      tags: [profile]
+      operationId: toggleInference
+      summary: Toggle AI presence (inference) on or off for the authenticated user
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [enabled]
+              properties:
+                enabled: { type: boolean }
+      responses:
+        "200":
+          description: Updated profile with inferenceEnabled flag
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Profile" }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Profile not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/profile/{id}:
     get:
+      tags: [profile]
       operationId: getProfile
       summary: Get profile by DID or handle
       parameters:
@@ -141,6 +266,7 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
     put:
+      tags: [profile]
       operationId: updateProfile
       summary: Update profile
       security:
@@ -161,7 +287,18 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Profile" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
+      tags: [profile]
       operationId: deleteProfile
       summary: Delete profile
       security:
@@ -174,9 +311,20 @@ paths:
       responses:
         "200":
           description: Profile deleted
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Not authorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/profile/{id}/counts:
     get:
+      tags: [profile]
       operationId: getProfileCounts
       summary: Get follower, following, and connection counts
       parameters:
@@ -196,8 +344,117 @@ paths:
                   following: { type: integer }
                   connections: { type: integer }
 
+  /api/profile/{id}/query:
+    post:
+      tags: [profile]
+      operationId: queryProfile
+      summary: Non-streaming AI presence query — requires trust distance ≤ 2
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+          description: "Target profile DID or handle"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [message]
+              properties:
+                message: { type: string }
+                conversationId: { type: string }
+      responses:
+        "200":
+          description: Inference response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  response: { type: string }
+                  usage:
+                    type: object
+                    properties:
+                      promptTokens: { type: integer }
+                      completionTokens: { type: integer }
+                      cost: { type: number }
+                      settled: { type: boolean }
+                  model: { type: string }
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Inference not enabled or trust distance too large
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Profile not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/profile/{id}/stream:
+    post:
+      tags: [profile]
+      operationId: streamProfile
+      summary: Streaming AI presence query (NDJSON) — requires trust distance ≤ 2
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+          description: "Target profile DID or handle"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string }
+                messages:
+                  type: array
+                  items: { type: object }
+                  description: "useChat-style message array; mutually exclusive with message"
+      responses:
+        "200":
+          description: "NDJSON stream of events: {type: text|tool_call|tool_result|done|error, ...}"
+          content:
+            text/plain:
+              schema: { type: string }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Inference not enabled or trust distance too large
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Profile not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
   /api/register:
     post:
+      tags: [profile]
       operationId: registerProfile
       summary: Create profile with public key (no session required)
       requestBody:
@@ -208,7 +465,7 @@ paths:
               type: object
               required: [publicKey, displayName]
               properties:
-                publicKey: { type: string }
+                publicKey: { type: string, description: "Ed25519 public key as hex string" }
                 handle: { type: string }
                 displayName: { type: string }
                 bio: { type: string }
@@ -224,9 +481,20 @@ paths:
                   did: { type: string }
                   handle: { type: string }
                   displayName: { type: string }
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "409":
+          description: Profile already exists or handle taken
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/soft-register:
     post:
+      tags: [profile]
       operationId: softRegister
       summary: Create a guest (soft DID) identity
       requestBody:
@@ -242,7 +510,7 @@ paths:
                 sourceId: { type: string }
       responses:
         "200":
-          description: Guest identity created
+          description: Guest identity created or returned if already exists
           content:
             application/json:
               schema:
@@ -251,9 +519,15 @@ paths:
                   did: { type: string }
                   isNew: { type: boolean }
                   displayName: { type: string }
+        "400":
+          description: Email or phone required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/claim:
     post:
+      tags: [profile]
       operationId: claimIdentity
       summary: Merge guest identity into a hard DID
       requestBody:
@@ -280,9 +554,26 @@ paths:
                   guestDid: { type: string }
                   newDid: { type: string }
                   connectionsTransferred: { type: integer }
+                  message: { type: string }
+        "400":
+          description: Missing required fields
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Verification required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Target profile not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/follow:
     post:
+      tags: [profile]
       operationId: followUser
       summary: Follow a user
       security:
@@ -305,7 +596,18 @@ paths:
                 type: object
                 properties:
                   followed: { type: boolean }
+        "400":
+          description: Missing DID or self-follow
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
     delete:
+      tags: [profile]
       operationId: unfollowUser
       summary: Unfollow a user
       security:
@@ -328,9 +630,15 @@ paths:
                 type: object
                 properties:
                   unfollowed: { type: boolean }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/follow/status:
     get:
+      tags: [profile]
       operationId: followStatus
       summary: Check if authenticated user follows a DID
       security:
@@ -349,9 +657,20 @@ paths:
                 type: object
                 properties:
                   following: { type: boolean }
+        "400":
+          description: Missing did param
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/handle-check:
     get:
+      tags: [profile]
       operationId: checkHandleAvailability
       summary: Check if a handle is available
       parameters:
@@ -368,11 +687,12 @@ paths:
                 type: object
                 properties:
                   available: { type: boolean }
-                  reason: { type: string }
+                  reason: { type: string, enum: [invalid, taken] }
                   message: { type: string }
 
   /api/presence/update:
     post:
+      tags: [profile]
       operationId: updatePresence
       summary: Update last seen timestamp
       requestBody:
@@ -388,9 +708,21 @@ paths:
       responses:
         "200":
           description: Presence updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+        "400":
+          description: Missing required fields
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/presence/{did}:
     get:
+      tags: [profile]
       operationId: getPresence
       summary: Get presence status for a DID
       parameters:
@@ -407,10 +739,16 @@ paths:
                 type: object
                 properties:
                   online: { type: boolean }
-                  lastSeen: { type: string, format: date-time }
+                  lastSeen: { type: string, format: date-time, nullable: true }
+        "404":
+          description: Profile not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/upload:
     post:
+      tags: [profile]
       operationId: uploadAvatar
       summary: Upload avatar image
       security:
@@ -436,9 +774,15 @@ paths:
                 type: object
                 properties:
                   url: { type: string }
+        "400":
+          description: Validation error (missing file, invalid type/size)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/media/{path}:
     get:
+      tags: [profile]
       operationId: serveMedia
       summary: Serve media files from /mnt/media
       parameters:
@@ -450,9 +794,15 @@ paths:
       responses:
         "200":
           description: Media file
+        "404":
+          description: File not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /api/auth/session:
     get:
+      tags: [profile]
       operationId: getAuthSession
       summary: Proxy to auth service session
       security:
@@ -463,14 +813,22 @@ paths:
 
   /api/auth/logout:
     post:
+      tags: [profile]
       operationId: authLogout
       summary: Clear session cookie
       responses:
         "200":
           description: Logged out
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
 
   /api/auth/register:
     post:
+      tags: [profile]
       operationId: authRegister
       summary: Proxy to auth service register
       requestBody:

--- a/apps/registry/api-spec/openapi.yaml
+++ b/apps/registry/api-spec/openapi.yaml
@@ -11,8 +11,18 @@ servers:
   - url: http://localhost:7002
     description: local
 
+tags:
+  - name: registry
+
 components:
   securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
     attestation:
       type: http
       scheme: bearer
@@ -70,8 +80,93 @@ components:
         error: { type: string }
 
 paths:
+  /api/health:
+    get:
+      tags: [registry]
+      operationId: healthCheck
+      summary: Service health check
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  service: { type: string }
+                  timestamp: { type: string, format: date-time }
+
+  /api/spec:
+    get:
+      tags: [registry]
+      operationId: getSpec
+      summary: Serve OpenAPI spec (YAML)
+      responses:
+        "200":
+          description: OpenAPI YAML spec
+          content:
+            text/yaml:
+              schema: { type: string }
+
+  /api/specs:
+    get:
+      tags: [registry]
+      operationId: listServices
+      summary: List all registered imajin services with their spec URLs
+      responses:
+        "200":
+          description: Service list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  services:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        description: { type: string }
+                        icon: { type: string }
+                        label: { type: string }
+                        visibility: { type: string }
+                        category: { type: string }
+                        url: { type: string }
+                        spec: { type: string }
+
+  /api/specs/{service}:
+    get:
+      tags: [registry]
+      operationId: getServiceSpec
+      summary: Proxy and return the OpenAPI spec for a named service
+      parameters:
+        - name: service
+          in: path
+          required: true
+          schema: { type: string }
+          description: "Service name (e.g. profile, events, auth)"
+      responses:
+        "200":
+          description: Service spec (YAML or JSON as returned by service)
+          content:
+            text/yaml:
+              schema: { type: string }
+        "404":
+          description: Unknown service
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "502":
+          description: Could not reach service
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
   /api/builds/verify:
     get:
+      tags: [registry]
       operationId: listApprovedBuilds
       summary: List all approved builds
       parameters:
@@ -94,6 +189,7 @@ paths:
                     type: array
                     items: { $ref: "#/components/schemas/ApprovedBuild" }
     post:
+      tags: [registry]
       operationId: verifyBuild
       summary: Check if a build hash is approved
       requestBody:
@@ -129,6 +225,7 @@ paths:
 
   /api/node/register:
     post:
+      tags: [registry]
       operationId: registerNode
       summary: Register a new node — verifies Ed25519 attestation and provisions subdomain
       requestBody:
@@ -140,6 +237,10 @@ paths:
               required: [attestation]
               properties:
                 attestation: { $ref: "#/components/schemas/NodeAttestation" }
+                chainLog:
+                  type: array
+                  items: { type: string }
+                  description: "Optional chain verification log"
       responses:
         "201":
           description: Node registered
@@ -151,6 +252,7 @@ paths:
                   status: { type: string, enum: [verified] }
                   subdomain: { type: string, example: "jin.imajin.ai" }
                   expiresAt: { type: number }
+                  chainVerified: { type: boolean }
         "200":
           description: Node renewed (existing node)
           content:
@@ -162,6 +264,7 @@ paths:
                   subdomain: { type: string }
                   expiresAt: { type: number }
                   renewed: { type: boolean }
+                  chainVerified: { type: boolean }
         "400":
           description: Invalid attestation structure or hostname format
           content:
@@ -203,6 +306,7 @@ paths:
 
   /api/node/heartbeat:
     post:
+      tags: [registry]
       operationId: nodeHeartbeat
       summary: Node liveness ping — verifies Ed25519 signature against registered public key
       requestBody:
@@ -252,6 +356,7 @@ paths:
 
   /api/node/list:
     get:
+      tags: [registry]
       operationId: listNodes
       summary: List registered nodes
       parameters:
@@ -283,6 +388,7 @@ paths:
                   limit: { type: integer }
                   offset: { type: integer }
     head:
+      tags: [registry]
       operationId: nodeStats
       summary: Network statistics in response headers
       responses:
@@ -300,6 +406,7 @@ paths:
 
   /api/node/lookup/{id}:
     get:
+      tags: [registry]
       operationId: lookupNode
       summary: Look up a node by DID or hostname
       parameters:
@@ -319,3 +426,91 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
+
+  /api/node/resolve/{did}:
+    get:
+      tags: [registry]
+      operationId: resolveNodeByDid
+      summary: Resolve any DID (node DID or chain DID) to a node endpoint
+      parameters:
+        - name: did
+          in: path
+          required: true
+          schema: { type: string }
+          description: "did:imajin:... (node DID) or did:dfos:... (chain DID)"
+      responses:
+        "200":
+          description: Node resolved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  node:
+                    type: object
+                    properties:
+                      hostname: { type: string }
+                      subdomain: { type: string }
+                      status: { type: string }
+                      services: { type: array, items: { type: string } }
+        "400":
+          description: DID is required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: No node found for this DID
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /relay/{path}:
+    get:
+      tags: [registry]
+      operationId: relayGet
+      summary: DFOS web relay — catch-all GET handler
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema: { type: string }
+          description: "Relay sub-path (catch-all)"
+      responses:
+        "200":
+          description: Relay response
+    post:
+      tags: [registry]
+      operationId: relayPost
+      summary: DFOS web relay — catch-all POST handler
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema: { type: string }
+          description: "Relay sub-path (catch-all)"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        "200":
+          description: Relay response
+    put:
+      tags: [registry]
+      operationId: relayPut
+      summary: DFOS web relay — catch-all PUT handler
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema: { type: string }
+          description: "Relay sub-path (catch-all)"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        "200":
+          description: Relay response

--- a/apps/www/api-spec/openapi.yaml
+++ b/apps/www/api-spec/openapi.yaml
@@ -1,0 +1,403 @@
+openapi: "3.1.0"
+info:
+  title: imajin www
+  version: "1.0.0"
+  description: Imajin home — platform health dashboard, email subscriptions, bug reporting, and well-known mobile app association files.
+servers:
+  - url: https://www.imajin.ai
+    description: production
+  - url: https://dev-www.imajin.ai
+    description: dev
+  - url: http://localhost:7007
+    description: local
+
+tags:
+  - name: www
+    description: imajin www service
+
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: imajin_session
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: "Bearer token (imajin_tok_* API token)"
+  schemas:
+    BugReport:
+      type: object
+      properties:
+        id: { type: string, example: "bug_..." }
+        reporterDid: { type: string }
+        reporterName: { type: string }
+        type:
+          type: string
+          enum: [bug, suggestion, question, other]
+        description: { type: string }
+        screenshotUrl: { type: string }
+        pageUrl: { type: string }
+        userAgent: { type: string }
+        viewport: { type: string }
+        status:
+          type: string
+          enum: [new, reviewed, imported, closed, duplicate]
+        adminNotes: { type: string }
+        duplicateOf: { type: string }
+        githubIssueNumber: { type: integer }
+        githubIssueUrl: { type: string }
+        reviewedBy: { type: string }
+        reviewedAt: { type: string, format: date-time }
+        createdAt: { type: string, format: date-time }
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error: { type: string }
+
+paths:
+  /api/health:
+    get:
+      tags: [www]
+      operationId: healthCheck
+      summary: Platform-wide health dashboard
+      description: |
+        Pings all platform services (www, auth, pay, profile, registry, events, chat,
+        connections, input, media, coffee, dykil, links, learn, market) via HEAD request.
+        Any response (including 4xx) is considered `up`; 5xx is `degraded`; timeout/error is `down`.
+      responses:
+        "200":
+          description: Health status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [operational, degraded]
+                  timestamp: { type: string, format: date-time }
+                  services:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        label: { type: string }
+                        url: { type: string }
+                        status: { type: string, enum: [up, down, degraded] }
+                        responseTime: { type: integer, nullable: true }
+                        statusCode: { type: integer, nullable: true }
+                        error: { type: string }
+
+  /api/subscribe:
+    post:
+      tags: [www]
+      operationId: subscribe
+      summary: Subscribe an email address to platform updates
+      description: |
+        Subscribes the email to the `updates` mailing list. Creates the contact and list if they
+        do not exist. Re-subscribes contacts that previously unsubscribed. Idempotent — returns
+        200 with `already on the list` message if already subscribed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email:
+                  type: string
+                  format: email
+                source:
+                  type: string
+                  default: register
+                  description: "Subscription source label (e.g. register, landing)"
+      responses:
+        "200":
+          description: Subscribed (or already subscribed)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+                  message: { type: string }
+        "400":
+          description: Invalid or missing email
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/bugs:
+    post:
+      tags: [www]
+      operationId: submitBugReport
+      summary: Submit a new bug report
+      description: |
+        Authenticated users can submit bug reports, suggestions, questions, or general feedback.
+        The user-agent is captured automatically from the request headers.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [description]
+              properties:
+                type:
+                  type: string
+                  enum: [bug, suggestion, question, other]
+                  default: bug
+                description:
+                  type: string
+                  description: "Description of the issue (required, non-empty)"
+                screenshotUrl: { type: string, format: uri }
+                pageUrl: { type: string, format: uri }
+                viewport: { type: string, description: "e.g. 1440x900" }
+      responses:
+        "201":
+          description: Bug report submitted
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BugReport" }
+        "400":
+          description: description is required
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+    get:
+      tags: [www]
+      operationId: listBugReports
+      summary: List bug reports for the authenticated user (or all with ?scope=all)
+      description: |
+        Without `scope=all`: returns only the authenticated user's own reports.
+        With `scope=all`: returns all reports (reporter details redacted for others' reports).
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: scope
+          in: query
+          schema: { type: string, enum: [all] }
+          description: "Pass `all` to return all reports (reporter details redacted)"
+      responses:
+        "200":
+          description: Bug report list
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/BugReport" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/bugs/admin:
+    get:
+      tags: [www]
+      operationId: listAllBugReportsAdmin
+      summary: List all bug reports — admin only
+      description: Returns all reports ordered by createdAt desc. Optionally filter by status. Requires admin identity.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [new, reviewed, imported, closed, duplicate]
+      responses:
+        "200":
+          description: All bug reports
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/BugReport" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Forbidden — admin only
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/bugs/{id}:
+    patch:
+      tags: [www]
+      operationId: updateBugReport
+      summary: Update a bug report — admin only
+      description: Allows admins to update the status, add notes, or mark as duplicate.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [new, reviewed, imported, closed, duplicate]
+                adminNotes: { type: string }
+                duplicateOf: { type: string }
+      responses:
+        "200":
+          description: Bug report updated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BugReport" }
+        "400":
+          description: Invalid JSON
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Forbidden — admin only
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Bug report not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/bugs/{id}/import:
+    post:
+      tags: [www]
+      operationId: importBugToGithub
+      summary: Create a GitHub issue from a bug report — admin only
+      description: |
+        Creates a GitHub issue in the configured repository (`GITHUB_REPO`) using `GITHUB_TOKEN`.
+        Marks the report as `imported` and stores the GitHub issue number and URL.
+        Requires admin identity and `GITHUB_TOKEN` env var.
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: GitHub issue created and report updated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BugReport" }
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "403":
+          description: Forbidden — admin only
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "404":
+          description: Bug report not found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500":
+          description: GITHUB_TOKEN not configured
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "502":
+          description: GitHub API error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /.well-known/apple-app-site-association:
+    get:
+      tags: [www]
+      operationId: appleAppSiteAssociation
+      summary: iOS Universal Links / Webcredentials association file
+      description: |
+        Dynamically generated AASA file establishing cross-subdomain trust for iOS.
+        Enables seamless auth handoff across all platform subdomains for PWA/native app scenarios.
+        Cached for 24 hours.
+      responses:
+        "200":
+          description: Apple App Site Association JSON
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  webcredentials: { type: object }
+                  applinks: { type: object }
+
+  /.well-known/assetlinks.json:
+    get:
+      tags: [www]
+      operationId: androidAssetLinks
+      summary: Android Digital Asset Links file
+      description: |
+        Dynamically generated Digital Asset Links file declaring all platform subdomains as
+        trusted. Prevents "wants to access other apps" warnings on cross-subdomain navigation.
+        Cached for 24 hours.
+      responses:
+        "200":
+          description: Android Asset Links JSON array
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    relation:
+                      type: array
+                      items: { type: string }
+                    target: { type: object }
+
+  /api/spec:
+    get:
+      tags: [www]
+      operationId: getSpec
+      summary: Serve the OpenAPI spec YAML
+      responses:
+        "200":
+          description: OpenAPI YAML
+          content:
+            text/yaml:
+              schema: { type: string }


### PR DESCRIPTION
Regenerated and updated OpenAPI 3.1 specs for all 15 services.

**Updated (11 existing):** auth, chat, coffee, connections, dykil, events, links, media, pay, profile, registry

**Created (4 new):** input, learn, market, www

~7,800 lines added/updated across 15 spec files. Each spec documents all route handlers with auth requirements, request/response schemas, and error responses.

Closes #455