### PR TITLE
feat(auth): MFA TOTP + device tracking + stored keys (#432)

### DIFF
--- a/apps/auth/app/api/devices/[id]/route.ts
+++ b/apps/auth/app/api/devices/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/src/db';
+import { devices } from '@/src/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { corsHeaders } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * DELETE /api/devices/[id]
+ * Remove a device. Users can only remove their own devices.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const result = await db
+      .delete(devices)
+      .where(and(eq(devices.id, params.id), eq(devices.did, session.sub)))
+      .returning();
+
+    if (result.length === 0) {
+      return NextResponse.json({ error: 'Device not found' }, { status: 404, headers: cors });
+    }
+
+    return NextResponse.json({ deleted: true }, { headers: cors });
+
+  } catch (error) {
+    console.error('[devices/[id]] DELETE error:', error);
+    return NextResponse.json({ error: 'Failed to delete device' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/devices/route.ts
+++ b/apps/auth/app/api/devices/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/src/db';
+import { devices } from '@/src/db/schema';
+import { eq, desc } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { corsHeaders } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * GET /api/devices
+ * List known devices for the authenticated user.
+ */
+export async function GET(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const rows = await db
+      .select()
+      .from(devices)
+      .where(eq(devices.did, session.sub))
+      .orderBy(desc(devices.lastSeenAt));
+
+    return NextResponse.json({ devices: rows }, { headers: cors });
+
+  } catch (error) {
+    console.error('[devices] GET error:', error);
+    return NextResponse.json({ error: 'Failed to list devices' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/devices/trust/route.ts
+++ b/apps/auth/app/api/devices/trust/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/src/db';
+import { devices } from '@/src/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { corsHeaders } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * POST /api/devices/trust
+ * Mark a device as trusted.
+ *
+ * Body: { deviceId: string }
+ */
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const body = await request.json();
+    const { deviceId } = body;
+    if (!deviceId) {
+      return NextResponse.json({ error: 'deviceId required' }, { status: 400, headers: cors });
+    }
+
+    const result = await db
+      .update(devices)
+      .set({ trusted: true })
+      .where(and(eq(devices.id, deviceId), eq(devices.did, session.sub)))
+      .returning();
+
+    if (result.length === 0) {
+      return NextResponse.json({ error: 'Device not found' }, { status: 404, headers: cors });
+    }
+
+    return NextResponse.json({ device: result[0] }, { headers: cors });
+
+  } catch (error) {
+    console.error('[devices/trust] POST error:', error);
+    return NextResponse.json({ error: 'Failed to trust device' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/keys/retrieve/route.ts
+++ b/apps/auth/app/api/keys/retrieve/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verify as totpVerify } from 'otplib';
+import { db } from '@/src/db';
+import { storedKeys, mfaMethods } from '@/src/db/schema';
+import { eq, and, isNotNull } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { decryptSecret } from '@/lib/encrypt';
+import { corsHeaders } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * POST /api/keys/retrieve
+ * Return the stored encrypted private key after MFA verification.
+ * The key is returned as-is (still client-side encrypted) — server never sees plaintext.
+ *
+ * Body: { totpCode: string }
+ * Returns: { encryptedKey, salt, keyDerivation }
+ */
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const body = await request.json();
+    const { totpCode } = body;
+    if (!totpCode) {
+      return NextResponse.json({ error: 'totpCode required' }, { status: 400, headers: cors });
+    }
+
+    // MFA gate
+    const methods = await db
+      .select()
+      .from(mfaMethods)
+      .where(
+        and(
+          eq(mfaMethods.did, session.sub),
+          eq(mfaMethods.type, 'totp'),
+          isNotNull(mfaMethods.verifiedAt)
+        )
+      )
+      .limit(1);
+
+    if (methods.length === 0) {
+      return NextResponse.json({ error: 'No active MFA method found' }, { status: 403, headers: cors });
+    }
+
+    const mfaSecret = decryptSecret(methods[0].secret);
+    const mfaResult = await totpVerify({ token: totpCode, secret: mfaSecret });
+    if (!mfaResult.valid) {
+      return NextResponse.json({ error: 'Invalid TOTP code' }, { status: 401, headers: cors });
+    }
+
+    // Fetch the stored key
+    const keys = await db
+      .select()
+      .from(storedKeys)
+      .where(eq(storedKeys.did, session.sub))
+      .limit(1);
+
+    if (keys.length === 0) {
+      return NextResponse.json({ error: 'No stored key found' }, { status: 404, headers: cors });
+    }
+
+    const key = keys[0];
+
+    // Update usage timestamps
+    await db
+      .update(storedKeys)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(storedKeys.id, key.id));
+    await db
+      .update(mfaMethods)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(mfaMethods.id, methods[0].id));
+
+    return NextResponse.json(
+      { encryptedKey: key.encryptedKey, salt: key.salt, keyDerivation: key.keyDerivation },
+      { headers: cors }
+    );
+
+  } catch (error) {
+    console.error('[keys/retrieve] POST error:', error);
+    return NextResponse.json({ error: 'Failed to retrieve key' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/keys/store/route.ts
+++ b/apps/auth/app/api/keys/store/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verify as totpVerify } from 'otplib';
+import { nanoid } from 'nanoid';
+import { db } from '@/src/db';
+import { storedKeys, mfaMethods } from '@/src/db/schema';
+import { eq, and, isNotNull } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { decryptSecret } from '@/lib/encrypt';
+import { corsHeaders } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * POST /api/keys/store
+ * Store a client-side encrypted private key.
+ * Requires authentication + active TOTP verification.
+ * The server never sees the plaintext key — encryption happens client-side.
+ *
+ * Body: {
+ *   encryptedKey: string,    // AES-256-GCM ciphertext (client-side encrypted)
+ *   salt: string,            // PBKDF2 salt used client-side
+ *   totpCode: string,        // Active TOTP code for MFA gate
+ *   keyDerivation?: string,  // defaults to "pbkdf2"
+ *   deviceFingerprint?: string
+ * }
+ * Returns: { id: string, stored: true }
+ */
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const body = await request.json();
+    const { encryptedKey, salt, totpCode, keyDerivation, deviceFingerprint } = body;
+
+    if (!encryptedKey || !salt || !totpCode) {
+      return NextResponse.json(
+        { error: 'encryptedKey, salt, and totpCode are required' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    // MFA gate: verify TOTP before allowing key storage
+    const methods = await db
+      .select()
+      .from(mfaMethods)
+      .where(
+        and(
+          eq(mfaMethods.did, session.sub),
+          eq(mfaMethods.type, 'totp'),
+          isNotNull(mfaMethods.verifiedAt)
+        )
+      )
+      .limit(1);
+
+    if (methods.length === 0) {
+      return NextResponse.json(
+        { error: 'MFA required. Set up TOTP first via /api/mfa/totp/setup.' },
+        { status: 403, headers: cors }
+      );
+    }
+
+    const mfaSecret = decryptSecret(methods[0].secret);
+    const mfaResult = await totpVerify({ token: totpCode, secret: mfaSecret });
+    if (!mfaResult.valid) {
+      return NextResponse.json({ error: 'Invalid TOTP code' }, { status: 401, headers: cors });
+    }
+
+    // Upsert: one stored key per DID (unique constraint on did)
+    const existing = await db
+      .select({ id: storedKeys.id })
+      .from(storedKeys)
+      .where(eq(storedKeys.did, session.sub))
+      .limit(1);
+
+    if (existing.length > 0) {
+      await db
+        .update(storedKeys)
+        .set({
+          encryptedKey,
+          salt,
+          keyDerivation: keyDerivation ?? 'pbkdf2',
+          deviceFingerprint: deviceFingerprint ?? null,
+          lastUsedAt: new Date(),
+        })
+        .where(eq(storedKeys.id, existing[0].id));
+
+      // Update MFA last used
+      await db
+        .update(mfaMethods)
+        .set({ lastUsedAt: new Date() })
+        .where(eq(mfaMethods.id, methods[0].id));
+
+      return NextResponse.json({ id: existing[0].id, stored: true }, { headers: cors });
+    }
+
+    const id = `key_${nanoid(16)}`;
+    await db.insert(storedKeys).values({
+      id,
+      did: session.sub,
+      encryptedKey,
+      salt,
+      keyDerivation: keyDerivation ?? 'pbkdf2',
+      deviceFingerprint: deviceFingerprint ?? null,
+    });
+
+    await db
+      .update(mfaMethods)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(mfaMethods.id, methods[0].id));
+
+    return NextResponse.json({ id, stored: true }, { headers: cors });
+
+  } catch (error) {
+    console.error('[keys/store] POST error:', error);
+    return NextResponse.json({ error: 'Failed to store key' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/keys/stored/route.ts
+++ b/apps/auth/app/api/keys/stored/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/src/db';
+import { storedKeys } from '@/src/db/schema';
+import { eq } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { corsHeaders } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * DELETE /api/keys/stored
+ * Remove the stored encrypted key for the authenticated user.
+ * Requires authentication only (no MFA — this is a destructive action
+ * that the user should be able to perform if they lose their MFA device).
+ */
+export async function DELETE(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const result = await db
+      .delete(storedKeys)
+      .where(eq(storedKeys.did, session.sub))
+      .returning();
+
+    if (result.length === 0) {
+      return NextResponse.json({ error: 'No stored key found' }, { status: 404, headers: cors });
+    }
+
+    return NextResponse.json({ deleted: true }, { headers: cors });
+
+  } catch (error) {
+    console.error('[keys/stored] DELETE error:', error);
+    return NextResponse.json({ error: 'Failed to delete stored key' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/login/verify/route.ts
+++ b/apps/auth/app/api/login/verify/route.ts
@@ -130,6 +130,13 @@ export async function POST(request: NextRequest) {
       userAgent: request.headers.get("user-agent"),
     }).catch(err => console.error("Session attestation error:", err));
 
+    import('@/lib/log-device').then(({ logDevice }) => {
+      const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim()
+        ?? request.headers.get('x-real-ip');
+      const userAgent = request.headers.get('user-agent');
+      return logDevice({ did: identity.id, ip, userAgent });
+    }).catch(err => console.error('[login] Device log failed:', err));
+
     return response;
 
   } catch (error) {

--- a/apps/auth/app/api/mfa/totp/challenge/route.ts
+++ b/apps/auth/app/api/mfa/totp/challenge/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verify as totpVerify } from 'otplib';
+import { db } from '@/src/db';
+import { mfaMethods } from '@/src/db/schema';
+import { eq, and, isNotNull } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { decryptSecret } from '@/lib/encrypt';
+import { corsHeaders } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * POST /api/mfa/totp/challenge
+ * Verify a TOTP code during the login flow (MFA step).
+ * Requires an active session (partial login) or an authenticated session.
+ *
+ * Body: { code: string }
+ * Returns: { verified: true }
+ */
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const body = await request.json();
+    const { code } = body;
+    if (!code) {
+      return NextResponse.json({ error: 'code required' }, { status: 400, headers: cors });
+    }
+
+    // Find the active (verified) TOTP method
+    const methods = await db
+      .select()
+      .from(mfaMethods)
+      .where(
+        and(
+          eq(mfaMethods.did, session.sub),
+          eq(mfaMethods.type, 'totp'),
+          isNotNull(mfaMethods.verifiedAt)
+        )
+      )
+      .limit(1);
+
+    if (methods.length === 0) {
+      return NextResponse.json({ error: 'No active TOTP method found' }, { status: 400, headers: cors });
+    }
+
+    const method = methods[0];
+    const secret = decryptSecret(method.secret);
+    const result = await totpVerify({ token: code, secret });
+
+    if (!result.valid) {
+      return NextResponse.json({ error: 'Invalid TOTP code' }, { status: 401, headers: cors });
+    }
+
+    await db
+      .update(mfaMethods)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(mfaMethods.id, method.id));
+
+    return NextResponse.json({ verified: true }, { headers: cors });
+
+  } catch (error) {
+    console.error('[mfa/totp/challenge] POST error:', error);
+    return NextResponse.json({ error: 'Failed to verify TOTP challenge' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/mfa/totp/setup/route.ts
+++ b/apps/auth/app/api/mfa/totp/setup/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { generateSecret, generateURI } from 'otplib';
+import * as QRCode from 'qrcode';
+import { nanoid } from 'nanoid';
+import { db } from '@/src/db';
+import { mfaMethods } from '@/src/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { encryptSecret } from '@/lib/encrypt';
+import { corsHeaders } from '@imajin/config';
+
+const ISSUER = 'Imajin';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * POST /api/mfa/totp/setup
+ * Generate a TOTP secret and return the QR code URL.
+ * Requires authentication. Call /api/mfa/totp/verify afterwards to activate.
+ *
+ * Body: { name?: string }
+ * Returns: { secret, otpauthUrl, qrCode }
+ */
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const body = await request.json().catch(() => ({}));
+    const name: string = body.name || 'Authenticator App';
+
+    // Remove any unverified pending TOTP setup for this DID (clean state)
+    await db
+      .delete(mfaMethods)
+      .where(
+        and(
+          eq(mfaMethods.did, session.sub),
+          eq(mfaMethods.type, 'totp')
+        )
+      );
+
+    const secret = generateSecret();
+    const accountName = session.handle ?? session.sub;
+    const otpauthUrl = generateURI({ issuer: ISSUER, label: accountName, secret });
+    const qrCode = await QRCode.toDataURL(otpauthUrl);
+
+    // Store encrypted secret (unverified until /verify is called)
+    await db.insert(mfaMethods).values({
+      id: `mfa_${nanoid(16)}`,
+      did: session.sub,
+      type: 'totp',
+      secret: encryptSecret(secret),
+      name,
+    });
+
+    return NextResponse.json({ secret, otpauthUrl, qrCode }, { headers: cors });
+
+  } catch (error) {
+    console.error('[mfa/totp/setup] POST error:', error);
+    return NextResponse.json({ error: 'Failed to set up TOTP' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/mfa/totp/verify/route.ts
+++ b/apps/auth/app/api/mfa/totp/verify/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verify as totpVerify } from 'otplib';
+import { db } from '@/src/db';
+import { mfaMethods } from '@/src/db/schema';
+import { eq, and, isNull } from 'drizzle-orm';
+import { verifySessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { decryptSecret } from '@/lib/encrypt';
+import { corsHeaders } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+/**
+ * POST /api/mfa/totp/verify
+ * Verify a TOTP code to activate MFA after setup.
+ * Requires authentication and a prior call to /api/mfa/totp/setup.
+ *
+ * Body: { code: string }
+ * Returns: { verified: true }
+ */
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const cookieConfig = getSessionCookieOptions();
+    const token = request.cookies.get(cookieConfig.name)?.value;
+    if (!token) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: cors });
+    }
+    const session = await verifySessionToken(token);
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid or expired session' }, { status: 401, headers: cors });
+    }
+
+    const body = await request.json();
+    const { code } = body;
+    if (!code) {
+      return NextResponse.json({ error: 'code required' }, { status: 400, headers: cors });
+    }
+
+    // Find the pending (unverified) TOTP method for this DID
+    const methods = await db
+      .select()
+      .from(mfaMethods)
+      .where(
+        and(
+          eq(mfaMethods.did, session.sub),
+          eq(mfaMethods.type, 'totp'),
+          isNull(mfaMethods.verifiedAt)
+        )
+      )
+      .limit(1);
+
+    if (methods.length === 0) {
+      return NextResponse.json(
+        { error: 'No pending TOTP setup found. Call /api/mfa/totp/setup first.' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    const method = methods[0];
+    const secret = decryptSecret(method.secret);
+    const result = await totpVerify({ token: code, secret });
+
+    if (!result.valid) {
+      return NextResponse.json({ error: 'Invalid TOTP code' }, { status: 401, headers: cors });
+    }
+
+    // Activate
+    await db
+      .update(mfaMethods)
+      .set({ verifiedAt: new Date(), lastUsedAt: new Date() })
+      .where(eq(mfaMethods.id, method.id));
+
+    return NextResponse.json({ verified: true }, { headers: cors });
+
+  } catch (error) {
+    console.error('[mfa/totp/verify] POST error:', error);
+    return NextResponse.json({ error: 'Failed to verify TOTP' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/lib/encrypt.ts
+++ b/apps/auth/lib/encrypt.ts
@@ -1,0 +1,41 @@
+import { randomBytes, createCipheriv, createDecipheriv, createHash } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+
+function getEncryptionKey(): Buffer {
+  const keyHex = process.env.MFA_ENCRYPTION_KEY;
+  if (keyHex) {
+    return Buffer.from(keyHex, 'hex');
+  }
+  // Dev fallback: derive 32-byte key from a fixed seed
+  return createHash('sha256').update('dev-mfa-encryption-key-imajin').digest();
+}
+
+/**
+ * Encrypt a plaintext string using AES-256-GCM.
+ * Returns a colon-delimited string: iv:authTag:ciphertext (all hex).
+ */
+export function encryptSecret(plaintext: string): string {
+  const key = getEncryptionKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+/**
+ * Decrypt a string produced by encryptSecret.
+ */
+export function decryptSecret(ciphertext: string): string {
+  const key = getEncryptionKey();
+  const parts = ciphertext.split(':');
+  if (parts.length !== 3) throw new Error('Invalid ciphertext format');
+  const [ivHex, authTagHex, encryptedHex] = parts;
+  const iv = Buffer.from(ivHex, 'hex');
+  const authTag = Buffer.from(authTagHex, 'hex');
+  const encrypted = Buffer.from(encryptedHex, 'hex');
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+}

--- a/apps/auth/lib/log-device.ts
+++ b/apps/auth/lib/log-device.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'crypto';
+import { db } from '@/src/db';
+import { devices } from '@/src/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+/**
+ * Derive a stable device fingerprint from IP + User-Agent.
+ * Non-cryptographic — just a stable identifier, not a security boundary.
+ */
+export function deviceFingerprint(ip: string | null, userAgent: string | null): string {
+  return createHash('sha256')
+    .update(`${ip ?? ''}:${userAgent ?? ''}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+/**
+ * Record or refresh a device entry for the given DID.
+ * Non-fatal — caller must wrap in try/catch if needed.
+ */
+export async function logDevice(params: {
+  did: string;
+  ip: string | null;
+  userAgent: string | null;
+}): Promise<void> {
+  const { did, ip, userAgent } = params;
+  const fingerprint = deviceFingerprint(ip, userAgent);
+  const now = new Date();
+
+  // Upsert: insert if new, update lastSeenAt if already known
+  const existing = await db
+    .select({ id: devices.id })
+    .from(devices)
+    .where(and(eq(devices.did, did), eq(devices.fingerprint, fingerprint)))
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db
+      .update(devices)
+      .set({ lastSeenAt: now, ip, userAgent })
+      .where(eq(devices.id, existing[0].id));
+  } else {
+    await db.insert(devices).values({
+      id: `dev_${nanoid(16)}`,
+      did,
+      fingerprint,
+      ip,
+      userAgent,
+      firstSeenAt: now,
+      lastSeenAt: now,
+      trusted: false,
+    });
+  }
+}

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -17,11 +17,11 @@
   },
   "dependencies": {
     "@imajin/auth": "workspace:*",
-    "@imajin/media": "workspace:*",
-    "@imajin/dfos": "workspace:*",
     "@imajin/config": "workspace:*",
-    "@imajin/email": "workspace:*",
     "@imajin/db": "workspace:*",
+    "@imajin/dfos": "workspace:*",
+    "@imajin/email": "workspace:*",
+    "@imajin/media": "workspace:*",
     "@imajin/ui": "workspace:^",
     "@noble/ed25519": "^2.3.0",
     "@noble/hashes": "^1.3.0",
@@ -30,19 +30,22 @@
     "jose": "^6.1.3",
     "nanoid": "^5.0.0",
     "next": "^14.2.0",
+    "otplib": "^13.4.0",
+    "qrcode": "^1.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@types/qrcode": "^1.5.5",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@vitest/coverage-v8": "^3.0.0",
     "autoprefixer": "^10",
     "drizzle-kit": "^0.31.9",
     "postcss": "^8",
     "tailwindcss": "^3.4.0",
     "typescript": "^5",
-    "vitest": "^3.0.0",
-    "@vitest/coverage-v8": "^3.0.0"
+    "vitest": "^3.0.0"
   }
 }

--- a/apps/auth/src/db/schema.ts
+++ b/apps/auth/src/db/schema.ts
@@ -153,6 +153,59 @@ export const identityChains = authSchema.table('identity_chains', {
 export type IdentityChain = typeof identityChains.$inferSelect;
 export type NewIdentityChain = typeof identityChains.$inferInsert;
 
+/**
+ * Stored Keys — server-side encrypted private key storage
+ *
+ * Private key is encrypted client-side before being sent.
+ * Server never sees the plaintext key.
+ */
+export const storedKeys = authSchema.table('stored_keys', {
+  id: text('id').primaryKey(),                          // key_{nanoid}
+  did: text('did').notNull().references(() => identities.id),
+  encryptedKey: text('encrypted_key').notNull(),        // client-side AES-256-GCM ciphertext
+  salt: text('salt').notNull(),                         // PBKDF2 salt (client-side)
+  keyDerivation: text('key_derivation').notNull().default('pbkdf2'),
+  deviceFingerprint: text('device_fingerprint'),        // optional, which device stored this
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+}, (table) => ({
+  didUniq: uniqueIndex('idx_stored_keys_did').on(table.did),
+}));
+
+/**
+ * MFA Methods — registered MFA methods per identity
+ */
+export const mfaMethods = authSchema.table('mfa_methods', {
+  id: text('id').primaryKey(),                          // mfa_{nanoid}
+  did: text('did').notNull().references(() => identities.id),
+  type: text('type').notNull(),                         // 'totp' | 'passkey' | 'recovery_code'
+  secret: text('secret').notNull(),                     // AES-256-GCM encrypted server-side
+  name: text('name').notNull(),
+  verifiedAt: timestamp('verified_at', { withTimezone: true }),  // null = setup not completed
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+}, (table) => ({
+  didIdx: index('idx_mfa_methods_did').on(table.did),
+}));
+
+/**
+ * Devices — known devices per identity
+ */
+export const devices = authSchema.table('devices', {
+  id: text('id').primaryKey(),                          // dev_{nanoid}
+  did: text('did').notNull().references(() => identities.id),
+  fingerprint: text('fingerprint').notNull(),           // SHA-256(ip + userAgent)
+  name: text('name'),
+  ip: text('ip'),
+  userAgent: text('user_agent'),
+  trusted: boolean('trusted').notNull().default(false),
+  firstSeenAt: timestamp('first_seen_at', { withTimezone: true }).defaultNow(),
+  lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  didFingerprintUniq: uniqueIndex('idx_devices_did_fingerprint').on(table.did, table.fingerprint),
+  didIdx: index('idx_devices_did').on(table.did),
+}));
+
 // Types
 export type Identity = typeof identities.$inferSelect;
 export type NewIdentity = typeof identities.$inferInsert;
@@ -163,3 +216,9 @@ export type Attestation = typeof attestations.$inferSelect;
 export type NewAttestation = typeof attestations.$inferInsert;
 export type Credential = typeof credentials.$inferSelect;
 export type NewCredential = typeof credentials.$inferInsert;
+export type StoredKey = typeof storedKeys.$inferSelect;
+export type NewStoredKey = typeof storedKeys.$inferInsert;
+export type MfaMethod = typeof mfaMethods.$inferSelect;
+export type NewMfaMethod = typeof mfaMethods.$inferInsert;
+export type Device = typeof devices.$inferSelect;
+export type NewDevice = typeof devices.$inferInsert;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,12 @@ importers:
       next:
         specifier: ^14.2.0
         version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      otplib:
+        specifier: ^13.4.0
+        version: 13.4.0
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -167,6 +173,9 @@ importers:
       '@types/node':
         specifier: ^20
         version: 20.19.33
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
       '@types/react':
         specifier: ^18
         version: 18.3.28
@@ -2573,6 +2582,24 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@otplib/core@13.4.0':
+    resolution: {integrity: sha512-JqOGcvZQi2wIkEQo8f3/iAjstavpXy6gouIDMHygjNuH6Q0FjbHOiXMdcE94RwfgDNMABhzwUmvaPsxvgm9NYw==}
+
+  '@otplib/hotp@13.4.0':
+    resolution: {integrity: sha512-MJjE0x06mn2ptymz5qZmQveb+vWFuaIftqE0b5/TZZqUOK7l97cV8lRTmid5BpAQMwJDNLW6RnYxGeCRiNdekw==}
+
+  '@otplib/plugin-base32-scure@13.4.0':
+    resolution: {integrity: sha512-/t9YWJmMbB8bF5z8mXrBZc2FXBe8B/3hG5FhWr9K8cFwFhyxScbPysmZe8s1UTzSA6N+s8Uv8aIfCtVXPNjJWw==}
+
+  '@otplib/plugin-crypto-noble@13.4.0':
+    resolution: {integrity: sha512-KrvE4m7Zv+TT1944HzgqFJWJpKb6AyoxDbvhPStmBqdMlv5Gekb80d66cuFRL08kkPgJ5gXUSb5SFpYeB+bACg==}
+
+  '@otplib/totp@13.4.0':
+    resolution: {integrity: sha512-dK+vl0f0ekzf6mCENRI9AKS2NJUC7OjI3+X8e7QSnhQ2WM7I+i4PGpb3QxKi5hxjTtwVuoZwXR2CFtXdcRtNdQ==}
+
+  '@otplib/uri@13.4.0':
+    resolution: {integrity: sha512-x1ozBa5bPbdZCrrTL/HK21qchiK7jYElTu+0ft22abeEhiLYgH1+SIULvOcVk3CK8YwF4kdcidvkq4ciejucJA==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -3118,6 +3145,9 @@ packages:
 
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
+
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -5532,6 +5562,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  otplib@13.4.0:
+    resolution: {integrity: sha512-RUcYcRMCgRWhUE/XabRppXpUwCwaWBNHe5iPXhdvP8wwDGpGpsIf/kxX/ec3zFsOaM1Oq8lEhUqDwk6W7DHkwg==}
 
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
@@ -8086,6 +8119,33 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@otplib/core@13.4.0': {}
+
+  '@otplib/hotp@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/uri': 13.4.0
+
+  '@otplib/plugin-base32-scure@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@scure/base': 2.0.0
+
+  '@otplib/plugin-crypto-noble@13.4.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      '@otplib/core': 13.4.0
+
+  '@otplib/totp@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/hotp': 13.4.0
+      '@otplib/uri': 13.4.0
+
+  '@otplib/uri@13.4.0':
+    dependencies:
+      '@otplib/core': 13.4.0
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -8574,6 +8634,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.15.0': {}
+
+  '@scure/base@2.0.0': {}
 
   '@sinclair/typebox@0.27.10': {}
 
@@ -11791,6 +11853,15 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  otplib@13.4.0:
+    dependencies:
+      '@otplib/core': 13.4.0
+      '@otplib/hotp': 13.4.0
+      '@otplib/plugin-base32-scure': 13.4.0
+      '@otplib/plugin-crypto-noble': 13.4.0
+      '@otplib/totp': 13.4.0
+      '@otplib/uri': 13.4.0
 
   outvariant@1.4.0: {}
 


### PR DESCRIPTION
## Summary

- **TOTP MFA** — `/api/mfa/totp/setup`, `/verify`, `/challenge`: generate secret, QR code via `otplib`, store AES-256-GCM encrypted secret, activate on first verify
- **Device tracking** — `/api/devices` (list), `/api/devices/[id]` (delete), `/api/devices/trust`: SHA-256 fingerprint from IP+UA, upsert on every login, trust flag
- **Stored keys** — `/api/keys/store`, `/retrieve`, `/stored` (DELETE): server holds client-encrypted private key, MFA gate required for store/retrieve
- **Schema** — adds `stored_keys`, `mfa_methods`, `devices` tables to `auth` schema
- **`lib/encrypt.ts`** — AES-256-GCM encrypt/decrypt for TOTP secrets (uses `MFA_ENCRYPTION_KEY` env var, dev fallback)
- **`lib/log-device.ts`** — device upsert helper, wired into `login/verify` flow
- **Bug fix** — `otplib` v13 `verify()` returns `Promise<{valid: boolean}>` not `boolean`; fixed all check sites

## Test plan

- [ ] `POST /api/mfa/totp/setup` → returns `{ secret, otpauthUrl, qrCode }`
- [ ] Scan QR in authenticator app, `POST /api/mfa/totp/verify` with live code → `{ verified: true }`
- [ ] `POST /api/mfa/totp/challenge` with valid/invalid code
- [ ] Log in → `GET /api/devices` shows device entry
- [ ] `POST /api/devices/trust`, `DELETE /api/devices/[id]`
- [ ] `POST /api/keys/store` with TOTP code → stored; `POST /api/keys/retrieve` → returns encrypted blob
- [ ] `DELETE /api/keys/stored` → removed
- [ ] Schema migration: `stored_keys`, `mfa_methods`, `devices` tables exist in `auth` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)