### PR TITLE
fix(chat): collapse N+1 unread queries + dedupe pollers + pool config (#481)

### DIFF
--- a/apps/chat/src/app/api/conversations/unread/route.ts
+++ b/apps/chat/src/app/api/conversations/unread/route.ts
@@ -2,7 +2,7 @@ import { SESSION_COOKIE_NAME } from "@imajin/config";
 import { NextRequest, NextResponse } from 'next/server';
 import { db, conversationReadsV2, messagesV2 } from '@/db';
 import { getClient } from '@imajin/db';
-import { and, eq, gt, ne, inArray, sql } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { corsHeaders, corsOptions } from '@/lib/utils';
 
 const rawSql = getClient();
@@ -75,43 +75,20 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ total: 0, conversations: [] }, { headers: cors });
     }
 
-    const readMap = new Map(readRecords.map(r => [r.conversationDid, r.lastReadAt]));
-
     const conversationDids = Array.from(didSet);
 
-    const unreadCounts = await Promise.all(
-      conversationDids.map(async (conversationDid) => {
-        const lastReadAt = readMap.get(conversationDid);
+    const unreadRows = await rawSql<{ conversation_did: string; unread: number }[]>`
+      SELECT m.conversation_did, count(*)::int as unread
+      FROM chat.messages_v2 m
+      LEFT JOIN chat.conversation_reads_v2 cr
+        ON cr.conversation_did = m.conversation_did AND cr.did = ${did}
+      WHERE m.conversation_did = ANY(${conversationDids})
+        AND m.from_did != ${did}
+        AND m.created_at > COALESCE(cr.last_read_at, '-infinity'::timestamptz)
+      GROUP BY m.conversation_did
+    `;
 
-        let unreadCount = 0;
-        if (lastReadAt) {
-          const [result] = await db
-            .select({ count: sql<number>`count(*)::int` })
-            .from(messagesV2)
-            .where(
-              and(
-                eq(messagesV2.conversationDid, conversationDid),
-                gt(messagesV2.createdAt, lastReadAt),
-                ne(messagesV2.fromDid, did),
-              )
-            );
-          unreadCount = result?.count || 0;
-        } else {
-          const [result] = await db
-            .select({ count: sql<number>`count(*)::int` })
-            .from(messagesV2)
-            .where(
-              and(
-                eq(messagesV2.conversationDid, conversationDid),
-                ne(messagesV2.fromDid, did),
-              )
-            );
-          unreadCount = result?.count || 0;
-        }
-
-        return { id: conversationDid, unread: unreadCount };
-      })
-    );
+    const unreadCounts = unreadRows.map(r => ({ id: r.conversation_did, unread: r.unread }));
 
     const conversationsWithUnread = unreadCounts.filter((c) => c.unread > 0);
     const total = conversationsWithUnread.reduce((sum, c) => sum + c.unread, 0);

--- a/apps/chat/src/app/components/NavBarWithUnread.tsx
+++ b/apps/chat/src/app/components/NavBarWithUnread.tsx
@@ -1,46 +1,15 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
 import { NavBar } from '@imajin/ui';
-import { useWebSocket } from '@/hooks/useWebSocket';
+import { useUnreadCount } from '@/contexts/UnreadCountContext';
 
 export function NavBarWithUnread() {
-  const [unreadCount, setUnreadCount] = useState(0);
-  const { lastMessage } = useWebSocket();
-
-  const fetchUnreadCount = useCallback(async () => {
-    try {
-      const res = await fetch('/api/conversations/unread');
-      if (res.ok) {
-        const data = await res.json();
-        setUnreadCount(data.total || 0);
-      }
-    } catch {
-      // Ignore errors
-    }
-  }, []);
-
-  useEffect(() => {
-    // Initial fetch
-    fetchUnreadCount();
-
-    // Poll for updates every 30 seconds
-    const interval = setInterval(fetchUnreadCount, 30000);
-
-    return () => clearInterval(interval);
-  }, [fetchUnreadCount]);
-
-  // Refetch when new message arrives via WebSocket
-  useEffect(() => {
-    if (lastMessage?.type === 'new_message') {
-      fetchUnreadCount();
-    }
-  }, [lastMessage, fetchUnreadCount]);
+  const { total } = useUnreadCount();
 
   return (
     <NavBar
       currentService="Chat"
-      unreadMessages={unreadCount}
+      unreadMessages={total}
       servicePrefix={process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://'}
       domain={process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai'}
     />

--- a/apps/chat/src/app/components/UnreadTitleManager.tsx
+++ b/apps/chat/src/app/components/UnreadTitleManager.tsx
@@ -1,67 +1,29 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import { useWebSocket } from '@/hooks/useWebSocket';
+import { useEffect, useState } from 'react';
+import { useUnreadCount } from '@/contexts/UnreadCountContext';
 
 export function UnreadTitleManager() {
-  const [unreadCount, setUnreadCount] = useState(0);
+  const { total } = useUnreadCount();
   const [isVisible, setIsVisible] = useState(true);
-  const { lastMessage } = useWebSocket();
-
-  const fetchUnreadCount = useCallback(async () => {
-    try {
-      const res = await fetch('/api/conversations/unread');
-      if (res.ok) {
-        const data = await res.json();
-        setUnreadCount(data.total || 0);
-      }
-    } catch {
-      // Ignore errors
-    }
-  }, []);
 
   useEffect(() => {
-    // Initial fetch
-    fetchUnreadCount();
-
-    // Poll for updates every 30 seconds
-    const interval = setInterval(fetchUnreadCount, 30000);
-
-    // Listen for visibility changes
-    const handleVisibilityChange = () => {
-      setIsVisible(!document.hidden);
-      if (!document.hidden) {
-        // When tab becomes visible, fetch latest count
-        fetchUnreadCount();
-      }
-    };
-
+    const handleVisibilityChange = () => setIsVisible(!document.hidden);
     document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      clearInterval(interval);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [fetchUnreadCount]);
-
-  // Refetch when new message arrives via WebSocket
-  useEffect(() => {
-    if (lastMessage?.type === 'new_message') {
-      fetchUnreadCount();
-    }
-  }, [lastMessage, fetchUnreadCount]);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, []);
 
   useEffect(() => {
     const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX?.includes('dev-')
       ? ' [DEV]'
       : '';
 
-    if (!isVisible && unreadCount > 0) {
-      document.title = `(${unreadCount}) Imajin Chat${prefix}`;
+    if (!isVisible && total > 0) {
+      document.title = `(${total}) Imajin Chat${prefix}`;
     } else {
       document.title = `Imajin Chat${prefix}`;
     }
-  }, [unreadCount, isVisible]);
+  }, [total, isVisible]);
 
   return null;
 }

--- a/apps/chat/src/app/layout.tsx
+++ b/apps/chat/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { NavBarWithUnread } from './components/NavBarWithUnread';
 import { IdentityProvider } from '@/contexts/IdentityContext';
 import { UnreadTitleManager } from './components/UnreadTitleManager';
+import { UnreadCountProvider } from '@/contexts/UnreadCountContext';
 import { buildPublicUrl } from '@imajin/config';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
@@ -36,13 +37,15 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className="min-h-screen bg-[#0a0a0a] text-white">
-        <NavBarWithUnread />
-        <IdentityProvider>
-          <UnreadTitleManager />
-          <main className="container mx-auto px-4 py-8">
-            {children}
-          </main>
-        </IdentityProvider>
+        <UnreadCountProvider>
+          <NavBarWithUnread />
+          <IdentityProvider>
+            <UnreadTitleManager />
+            <main className="container mx-auto px-4 py-8">
+              {children}
+            </main>
+          </IdentityProvider>
+        </UnreadCountProvider>
       </body>
     </html>
   );

--- a/apps/chat/src/contexts/UnreadCountContext.tsx
+++ b/apps/chat/src/contexts/UnreadCountContext.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { useWebSocket } from '@/hooks/useWebSocket';
+
+interface UnreadCountContextValue {
+  total: number;
+}
+
+const UnreadCountContext = createContext<UnreadCountContextValue>({ total: 0 });
+
+export function UnreadCountProvider({ children }: { children: React.ReactNode }) {
+  const [total, setTotal] = useState(0);
+  const { lastMessage } = useWebSocket();
+
+  const fetchUnreadCount = useCallback(async () => {
+    try {
+      const res = await fetch('/api/conversations/unread');
+      if (res.ok) {
+        const data = await res.json();
+        setTotal(data.total || 0);
+      }
+    } catch {
+      // Ignore errors
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUnreadCount();
+    const interval = setInterval(fetchUnreadCount, 30000);
+    const handleVisibilityChange = () => {
+      if (!document.hidden) fetchUnreadCount();
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [fetchUnreadCount]);
+
+  useEffect(() => {
+    if (lastMessage?.type === 'new_message') {
+      fetchUnreadCount();
+    }
+  }, [lastMessage, fetchUnreadCount]);
+
+  return (
+    <UnreadCountContext.Provider value={{ total }}>
+      {children}
+    </UnreadCountContext.Provider>
+  );
+}
+
+export function useUnreadCount() {
+  return useContext(UnreadCountContext);
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9,7 +9,11 @@ function getClient() {
     if (!process.env.DATABASE_URL) {
       throw new Error('DATABASE_URL environment variable is not set');
     }
-    _client = postgres(process.env.DATABASE_URL);
+    _client = postgres(process.env.DATABASE_URL, {
+      max: 10,
+      idle_timeout: 20,
+      connect_timeout: 10,
+    });
   }
   return _client;
 }


### PR DESCRIPTION
## Summary

- **N+1 → 1 query**: Replaced `Promise.all(conversationDids.map(...))` in `/api/conversations/unread` with a single `LEFT JOIN ... GROUP BY` query — 20 conversations = 1 query instead of 20+
- **Dedupe pollers**: Created `UnreadCountContext` (React context) that fetches once; both `NavBarWithUnread` and `UnreadTitleManager` now consume the same state instead of each polling independently every 30s
- **Pool bounds**: Added `max: 10 / idle_timeout: 20 / connect_timeout: 10` to `postgres()` in `@imajin/db` to prevent unbounded connection growth

## Test plan

- [ ] Open chat page, confirm unread badge and tab title both update correctly
- [ ] Verify only one `/api/conversations/unread` request fires per 30s interval (not two)
- [ ] On new message via WebSocket, confirm both badge and title refresh
- [ ] Tab hide/show triggers a refetch and title flips to `(N) Imajin Chat`
- [ ] DB connection count stays bounded under idle load

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)