### PR TITLE
refactor(profile): consolidate feature toggles into JSONB column (#489)

### DIFF
--- a/apps/profile/app/[handle]/page.tsx
+++ b/apps/profile/app/[handle]/page.tsx
@@ -16,6 +16,16 @@ interface PageProps {
   params: Promise<{ handle: string }>;
 }
 
+interface FeatureToggles {
+  inference_enabled?: boolean;
+  show_market_items?: boolean;
+  show_events?: boolean;
+  links?: string | null;
+  coffee?: string | null;
+  dykil?: string | null;
+  learn?: string | null;
+}
+
 interface Profile {
   did: string;
   handle?: string;
@@ -26,14 +36,9 @@ interface Profile {
   email?: string;
   phone?: string;
   contactEmail?: string;
-  inferenceEnabled?: boolean;
-  showMarketItems?: boolean;
-  showEvents?: boolean;
+  featureToggles?: FeatureToggles;
   createdAt: string;
-  metadata?: {
-    links?: string;
-    coffee?: string;
-  };
+  metadata?: Record<string, string>;
 }
 
 interface ProfileCounts {
@@ -241,7 +246,7 @@ export default async function ProfilePage({ params }: PageProps) {
   const [counts, isFollowing, links] = await Promise.all([
     getProfileCounts(profile.did),
     viewerDid && !isSelf ? getFollowStatus(viewerDid, profile.did) : Promise.resolve(false),
-    profile.metadata?.links ? getLinks(profile.metadata.links) : Promise.resolve([]),
+    profile.featureToggles?.links ? getLinks(profile.featureToggles.links) : Promise.resolve([]),
   ]);
 
   const servicePrefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
@@ -335,20 +340,20 @@ export default async function ProfilePage({ params }: PageProps) {
             targetDid={profile.did}
             targetName={profile.displayName}
             targetHandle={profile.handle}
-            inferenceEnabled={!!profile.inferenceEnabled}
+            inferenceEnabled={!!profile.featureToggles?.inference_enabled}
             canAsk={!!viewerDid}
           />
-          {profile.metadata?.links && (
+          {profile.featureToggles?.links && (
             <a
-              href={`${servicePrefix}links.${domain}/${profile.metadata.links}`}
+              href={`${servicePrefix}links.${domain}/${profile.featureToggles.links}`}
               className="px-4 py-2 bg-gray-900 border border-gray-800 rounded-lg hover:bg-gray-800 transition text-white text-sm font-medium"
             >
               🔗 Links
             </a>
           )}
-          {profile.metadata?.coffee && (
+          {profile.featureToggles?.coffee && (
             <a
-              href={`${servicePrefix}coffee.${domain}/${profile.metadata.coffee}`}
+              href={`${servicePrefix}coffee.${domain}/${profile.featureToggles.coffee}`}
               className="px-4 py-2 bg-[#F59E0B]/10 border-[#F59E0B]/30 text-[#F59E0B] rounded-lg hover:bg-[#F59E0B]/20 transition border text-sm font-medium"
             >
               ☕ Tip Me
@@ -377,12 +382,12 @@ export default async function ProfilePage({ params }: PageProps) {
         )}
 
         {/* Upcoming events */}
-        {profile.showEvents && (
+        {profile.featureToggles?.show_events && (
           <UpcomingEvents did={profile.did} servicePrefix={servicePrefix} domain={domain} viewerDid={viewerDid} />
         )}
 
         {/* Market items */}
-        {profile.showMarketItems && (
+        {profile.featureToggles?.show_market_items && (
           <MarketItems did={profile.did} handle={profile.handle} servicePrefix={servicePrefix} domain={domain} />
         )}
 

--- a/apps/profile/app/api/profile/[id]/query/route.ts
+++ b/apps/profile/app/api/profile/[id]/query/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
   }
 
-  if (!profile.inferenceEnabled) {
+  if (!profile.featureToggles?.inference_enabled) {
     return NextResponse.json({ error: 'Inference not enabled for this profile' }, { status: 403 });
   }
 

--- a/apps/profile/app/api/profile/[id]/route.ts
+++ b/apps/profile/app/api/profile/[id]/route.ts
@@ -192,7 +192,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     const body = JSON.parse(bodyText);
-    const { displayName, displayType, avatar, avatarAssetId, bio, email, phone, metadata, visibility, inferenceEnabled, show_market_items, show_events } = body;
+    const { displayName, displayType, avatar, avatarAssetId, bio, email, phone, visibility, feature_toggles } = body;
 
     // Build update object
     const updates: Record<string, any> = {
@@ -211,10 +211,10 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (bio !== undefined) updates.bio = bio;
     if (email !== undefined) updates.contactEmail = email || null;
     if (phone !== undefined) updates.phone = phone || null;
-    if (metadata !== undefined) updates.metadata = metadata;
-    if (inferenceEnabled !== undefined) updates.inferenceEnabled = !!inferenceEnabled;
-    if (show_market_items !== undefined) updates.showMarketItems = !!show_market_items;
-    if (show_events !== undefined) updates.showEvents = !!show_events;
+    if (feature_toggles !== undefined) {
+      // Merge incoming feature_toggles over existing ones
+      updates.featureToggles = { ...(existing.featureToggles ?? {}), ...feature_toggles };
+    }
     if (visibility !== undefined) {
       if (!['public', 'incognito'].includes(visibility)) {
         return NextResponse.json({ error: 'visibility must be public or incognito' }, { status: 400, headers: cors });

--- a/apps/profile/app/api/profile/inference/route.ts
+++ b/apps/profile/app/api/profile/inference/route.ts
@@ -28,26 +28,28 @@ export async function POST(request: NextRequest) {
 
   const { enabled } = body;
 
+  // Fetch profile once (needed for both seeding and merge)
+  const existing = await db.query.profiles.findFirst({
+    where: (profiles, { eq }) => eq(profiles.did, identity.id),
+  });
+
   // Before enabling, fire-and-forget presence seed in media service
   if (enabled) {
     const mediaUrl = process.env.MEDIA_SERVICE_URL;
     const mediaKey = process.env.MEDIA_INTERNAL_API_KEY;
     if (mediaUrl && mediaKey) {
-      const profile = await db.query.profiles.findFirst({
-        where: (profiles, { eq }) => eq(profiles.did, identity.id),
-      });
       fetch(`${mediaUrl}/api/seed/presence`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${mediaKey}` },
-        body: JSON.stringify({ did: identity.id, handle: profile?.handle || undefined }),
+        body: JSON.stringify({ did: identity.id, handle: existing?.handle || undefined }),
       }).catch(err => console.error('[Presence] Seed failed (non-fatal):', err));
     }
   }
 
-  // Update inference_enabled on the profile row
+  // Merge inference_enabled into feature_toggles
   const result = await db
     .update(profiles)
-    .set({ inferenceEnabled: enabled })
+    .set({ featureToggles: { ...(existing?.featureToggles ?? {}), inference_enabled: enabled } })
     .where(eq(profiles.did, identity.id))
     .returning();
 

--- a/apps/profile/app/edit/page.tsx
+++ b/apps/profile/app/edit/page.tsx
@@ -6,6 +6,16 @@ import * as ed from '@noble/ed25519';
 import { useIdentity } from '../context/IdentityContext';
 import { ImageUpload } from '../components/ImageUpload';
 
+interface FeatureToggles {
+  inference_enabled?: boolean;
+  show_market_items?: boolean;
+  show_events?: boolean;
+  links?: string | null;
+  coffee?: string | null;
+  dykil?: string | null;
+  learn?: string | null;
+}
+
 interface Profile {
   did: string;
   handle?: string;
@@ -17,13 +27,8 @@ interface Profile {
   email?: string;
   phone?: string;
   visibility?: string;
-  metadata?: Record<string, string>;
-  inference_enabled?: boolean;
-  inferenceEnabled?: boolean;
-  show_market_items?: boolean;
-  showMarketItems?: boolean;
-  show_events?: boolean;
-  showEvents?: boolean;
+  feature_toggles?: FeatureToggles;
+  featureToggles?: FeatureToggles;
 }
 
 type AvatarMode = 'emoji' | 'image';
@@ -89,18 +94,19 @@ export default function EditProfilePage() {
       setPhone(profile.phone || '');
       setVisibility((profile.visibility as 'public' | 'incognito') || 'public');
 
-      // Set service toggles from metadata + dedicated columns
+      // Set service toggles from feature_toggles
+      const ft = profile.featureToggles ?? profile.feature_toggles ?? {};
       const toggles: Record<string, boolean> = {};
       for (const svc of SERVICES) {
         if (svc.key === 'inference') {
-          toggles[svc.key] = !!(profile.inferenceEnabled ?? profile.inference_enabled);
+          toggles[svc.key] = !!ft.inference_enabled;
         } else {
-          toggles[svc.key] = !!(profile.metadata && profile.metadata[svc.key]);
+          toggles[svc.key] = !!(ft[svc.key as keyof typeof ft]);
         }
       }
       setServiceToggles(toggles);
-      setShowMarketItems(!!(profile.showMarketItems ?? profile.show_market_items));
-      setShowEvents(!!(profile.showEvents ?? profile.show_events));
+      setShowMarketItems(!!ft.show_market_items);
+      setShowEvents(!!ft.show_events);
 
       // Detect avatar mode based on current avatar
       if (profile.avatar && (profile.avatar.startsWith('http') || profile.avatar.startsWith('/'))) {
@@ -123,12 +129,15 @@ export default function EditProfilePage() {
     setSaving(true);
 
     try {
-      const metadata: Record<string, string> = {};
+      const featureToggles: FeatureToggles = {
+        inference_enabled: !!serviceToggles['inference'],
+        show_market_items: showMarketItems,
+        show_events: showEvents,
+      };
       for (const svc of SERVICES) {
-        if (svc.key === 'inference') continue; // handled separately
-        if (serviceToggles[svc.key] && handle) {
-          metadata[svc.key] = handle;
-        }
+        if (svc.key === 'inference') continue;
+        (featureToggles as Record<string, string | boolean | null>)[svc.key] =
+          serviceToggles[svc.key] && handle ? handle : null;
       }
 
       const payload = JSON.stringify({
@@ -138,9 +147,7 @@ export default function EditProfilePage() {
         email: email || null,
         phone: phone || null,
         visibility,
-        metadata,
-        show_market_items: showMarketItems,
-        show_events: showEvents,
+        feature_toggles: featureToggles,
       });
 
       // Sign the request body with the user's Ed25519 private key

--- a/apps/profile/migrations/0004_add_feature_toggles.sql
+++ b/apps/profile/migrations/0004_add_feature_toggles.sql
@@ -1,0 +1,29 @@
+-- Migration: consolidate feature toggles into JSONB column
+-- Replaces: inference_enabled (bool), show_market_items (bool), show_events (bool)
+-- Also moves metadata keys (links, coffee, dykil, learn) into feature_toggles
+
+ALTER TABLE profile.profiles
+  ADD COLUMN feature_toggles jsonb NOT NULL DEFAULT '{}';
+
+-- Migrate existing boolean columns + metadata keys into feature_toggles
+UPDATE profile.profiles
+SET feature_toggles = jsonb_strip_nulls(jsonb_build_object(
+  'inference_enabled', inference_enabled,
+  'show_market_items', show_market_items,
+  'show_events',       show_events,
+  'links',             metadata->>'links',
+  'coffee',            metadata->>'coffee',
+  'dykil',             metadata->>'dykil',
+  'learn',             metadata->>'learn'
+));
+
+-- Remove migrated keys from metadata
+UPDATE profile.profiles
+SET metadata = metadata - 'links' - 'coffee' - 'dykil' - 'learn'
+WHERE metadata IS NOT NULL;
+
+-- Drop the old boolean columns
+ALTER TABLE profile.profiles
+  DROP COLUMN inference_enabled,
+  DROP COLUMN show_market_items,
+  DROP COLUMN show_events;

--- a/apps/profile/src/db/schema.ts
+++ b/apps/profile/src/db/schema.ts
@@ -1,6 +1,16 @@
-import { pgTable, text, timestamp, jsonb, index, integer, real, boolean, pgSchema, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, jsonb, index, integer, real, pgSchema, uniqueIndex } from 'drizzle-orm/pg-core';
 
 export const profileSchema = pgSchema('profile');
+
+export interface FeatureToggles {
+  inference_enabled?: boolean;
+  show_market_items?: boolean;
+  show_events?: boolean;
+  links?: string | null;
+  coffee?: string | null;
+  dykil?: string | null;
+  learn?: string | null;
+}
 
 /**
  * Profiles - public identity pages linked to DIDs
@@ -22,9 +32,7 @@ export const profiles = profileSchema.table('profiles', {
   nextInviteAvailableAt: timestamp('next_invite_available_at', { withTimezone: true }), // NULL = can invite now
   metadata: jsonb('metadata').default({}),                    // location, website, etc.
   lastSeenAt: timestamp('last_seen_at', { withTimezone: true }), // Online presence tracking
-  inferenceEnabled: boolean('inference_enabled').notNull().default(false), // Presence queryable
-  showMarketItems: boolean('show_market_items').notNull().default(false),
-  showEvents: boolean('show_events').notNull().default(false),
+  featureToggles: jsonb('feature_toggles').$type<FeatureToggles>().notNull().default({}), // All feature flags
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({


### PR DESCRIPTION
Consolidates profile feature toggles (3 boolean columns + 4 metadata keys) into a single `feature_toggles` JSONB column.

### What changed
- New `feature_toggles` JSONB column on `profile.profiles`
- Migration data-copies existing values, then drops old columns (`inference_enabled`, `show_market_items`, `show_events`) and removes migrated metadata keys
- Edit page reads/writes from `feature_toggles`
- Detail page reads from `feature_toggles`
- Inference route updated
- Query route updated

### Note
`apps/market/src/db/schema.ts` has its own `showMarketItems` on `seller_settings` — that's market's own toggle (controls cross-service profile widget visibility), separate from profile's display toggles. Not touched by this PR.

### Future
Third-party userspace apps (RFC-19) can declare profile widget capabilities. New toggles = new JSONB key. No schema migration needed.

Closes #489