### PR TITLE
feat: attestation chain coverage — emit at all trust-relevant seams (#461)

### DIFF
--- a/apps/coffee/app/api/tip/route.ts
+++ b/apps/coffee/app/api/tip/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { db, coffeePages, tips } from '@/db';
-import { requireAuth } from '@imajin/auth';
+import { requireAuth, emitAttestation } from '@imajin/auth';
 import { jsonResponse, errorResponse, generateId } from '@/lib/utils';
 import { rateLimit, getClientIP } from '@/lib/rate-limit';
 
@@ -136,6 +136,18 @@ export async function POST(request: NextRequest) {
         status: 'pending',
       });
 
+      // Fire and forget — never block the response
+      if (fromDid) {
+        emitAttestation({
+          issuer_did: fromDid,
+          subject_did: page.did,
+          type: 'tip.received',
+          context_id: tipId,
+          context_type: 'coffee',
+          payload: { amount, currency },
+        }).catch((err) => console.error('Attestation emit error:', err));
+      }
+
       // Return checkout URL for redirect
       return jsonResponse({
         tipId,
@@ -160,6 +172,18 @@ export async function POST(request: NextRequest) {
         paymentId: 'pending',
         status: 'pending',
       });
+
+      // Fire and forget — never block the response
+      if (fromDid) {
+        emitAttestation({
+          issuer_did: fromDid,
+          subject_did: page.did,
+          type: 'tip.received',
+          context_id: tipId,
+          context_type: 'coffee',
+          payload: { amount, currency: 'SOL' },
+        }).catch((err) => console.error('Attestation emit error:', err));
+      }
 
       return jsonResponse({
         tipId,

--- a/apps/connections/app/api/pods/route.ts
+++ b/apps/connections/app/api/pods/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireAuth, requireGraphMember } from '@/lib/auth';
+import { emitAttestation } from '@imajin/auth';
 import { generateId } from '@/lib/id';
 import { db, pods, podMembers } from '@/db';
 import { eq, and, isNull } from 'drizzle-orm';
@@ -44,6 +45,16 @@ export async function POST(request: Request) {
     addedBy: auth.identity.id,
     joinedAt: now,
   });
+
+  // Fire and forget — never block the response
+  emitAttestation({
+    issuer_did: auth.identity.id,
+    subject_did: auth.identity.id,
+    type: 'pod.created',
+    context_id: pod.id,
+    context_type: 'pod',
+    payload: { name: pod.name, type: pod.type },
+  }).catch((err: unknown) => console.error('Attestation emit error:', err));
 
   return NextResponse.json({ pod }, { status: 201 });
 }

--- a/apps/events/app/api/events/route.ts
+++ b/apps/events/app/api/events/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, events, ticketTypes } from '@/src/db';
-import { requireHardDID } from '@imajin/auth';
+import { requireHardDID, emitAttestation } from '@imajin/auth';
 import { and, asc, desc, eq, gt } from 'drizzle-orm';
 import { randomBytes } from 'crypto';
 
@@ -123,6 +123,16 @@ export async function POST(request: NextRequest) {
       status: 'draft',
       metadata: { fair: fairManifest },
     }).returning();
+
+    // Fire and forget — never block the response
+    emitAttestation({
+      issuer_did: identity.id,
+      subject_did: identity.id,
+      type: 'event.created',
+      context_id: event.id,
+      context_type: 'event',
+      payload: { eventDid: event.did, title },
+    }).catch((err) => console.error('Attestation emit error:', err));
 
     // Create ticket types if provided
     const createdTicketTypes = [];

--- a/apps/events/app/api/tickets/[id]/confirm-payment/route.ts
+++ b/apps/events/app/api/tickets/[id]/confirm-payment/route.ts
@@ -8,7 +8,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { db, tickets, ticketTypes, events } from '@/src/db';
-import { requireAuth } from '@imajin/auth';
+import { requireAuth, emitAttestation } from '@imajin/auth';
 import { isEventOrganizer } from '@/src/lib/organizer';
 import { eq, sql } from 'drizzle-orm';
 
@@ -67,6 +67,19 @@ export async function POST(
       .update(ticketTypes)
       .set({ sold: sql`${ticketTypes.sold} + 1` })
       .where(eq(ticketTypes.id, ticket.ticketTypeId));
+
+    // Fetch event to get creator DID for attestation
+    const [event] = await db.select().from(events).where(eq(events.id, ticket.eventId)).limit(1);
+
+    // Fire and forget — never block the response
+    emitAttestation({
+      issuer_did: ticket.ownerDid,
+      subject_did: event?.creatorDid ?? ticket.eventId,
+      type: 'ticket.purchased',
+      context_id: ticket.eventId,
+      context_type: 'event',
+      payload: { ticketId: confirmed.id },
+    }).catch((err) => console.error('Attestation emit error:', err));
 
     return NextResponse.json({ ticket: confirmed });
   } catch (error) {

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -15,6 +15,7 @@ import { sha512 } from '@noble/hashes/sha2.js';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
 import { randomBytes } from 'crypto';
 import { getClient } from '@imajin/db';
+import { emitAttestation } from '@imajin/auth';
 
 // Configure ed25519 with sha512
 ed.hashes.sha512 = sha512;
@@ -319,8 +320,18 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     }).returning();
 
     createdTickets.push(ticket);
+
+    // Fire and forget — never block the response
+    emitAttestation({
+      issuer_did: ownerDid,
+      subject_did: event.creatorDid,
+      type: 'ticket.purchased',
+      context_id: event.id,
+      context_type: 'event',
+      payload: { ticketId: ticket.id, amount: amountTotal / quantity, currency },
+    }).catch((err) => console.error('Attestation emit error:', err));
   }
-  
+
   // Update sold count
   await db
     .update(ticketTypes)

--- a/apps/market/app/api/listings/route.ts
+++ b/apps/market/app/api/listings/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { db, listings } from '@/db';
-import { requireAuth, getSession } from '@imajin/auth';
+import { requireAuth, getSession, emitAttestation } from '@imajin/auth';
 import { generateId, jsonResponse, errorResponse } from '@/lib/utils';
 import { resolveMediaRef } from '@imajin/media';
 import { eq, ilike, and, desc, asc, sql, ne } from 'drizzle-orm';
@@ -84,6 +84,16 @@ export async function POST(request: NextRequest) {
       showContactInfo: showContactInfo ?? false,
       expiresAt: expiresAt ? new Date(expiresAt) : null,
     }).returning();
+
+    // Fire and forget — never block the response
+    emitAttestation({
+      issuer_did: identity.id,
+      subject_did: identity.id,
+      type: 'listing.created',
+      context_id: listing.id,
+      context_type: 'market',
+      payload: { title, price, currency: listing.currency },
+    }).catch((err) => console.error('Attestation emit error:', err));
 
     return jsonResponse(listing, 201);
   } catch (error) {

--- a/apps/market/app/api/webhook/route.ts
+++ b/apps/market/app/api/webhook/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest } from 'next/server';
 import { db, listings } from '@/db';
+import { emitAttestation } from '@imajin/auth';
 import { jsonResponse, errorResponse } from '@/lib/utils';
 import { eq } from 'drizzle-orm';
 
@@ -60,6 +61,16 @@ export async function POST(request: NextRequest) {
               .where(eq(listings.id, listingId));
           }
         }
+
+        // Fire and forget — never block the response
+        emitAttestation({
+          issuer_did: body.metadata?.buyerDid,
+          subject_did: listing.sellerDid,
+          type: 'listing.purchased',
+          context_id: listingId,
+          context_type: 'market',
+          payload: { amount: body.metadata?.amount },
+        }).catch((err: unknown) => console.error('Attestation emit error:', err));
       }
     }
 

--- a/apps/profile/app/api/profile/claim-handle/route.ts
+++ b/apps/profile/app/api/profile/claim-handle/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { db, profiles } from '@/db';
-import { requireAuth } from '@imajin/auth';
+import { requireAuth, emitAttestation } from '@imajin/auth';
 import { jsonResponse, errorResponse, isValidHandle } from '@/lib/utils';
 import { eq } from 'drizzle-orm';
 
@@ -57,8 +57,18 @@ export async function POST(request: NextRequest) {
       .where(eq(profiles.did, identity.id))
       .returning();
 
-    return jsonResponse({ 
-      success: true, 
+    // Fire and forget — never block the response
+    emitAttestation({
+      issuer_did: identity.id,
+      subject_did: identity.id,
+      type: 'handle.claimed',
+      context_id: handle,
+      context_type: 'profile',
+      payload: { handle },
+    }).catch((err) => console.error('Attestation emit error:', err));
+
+    return jsonResponse({
+      success: true,
       handle: updated.handle,
       profile: updated,
     });


### PR DESCRIPTION
Adds attestation emissions across 5 services. Every trust-relevant action now decorates the chain.

### New attestations
| Type | Service | Where |
|------|---------|-------|
| `event.created` | events | Event creation |
| `ticket.purchased` | events | Stripe webhook + manual confirm-payment |
| `listing.created` | market | Listing creation |
| `listing.purchased` | market | Market webhook |
| `handle.claimed` | profile | Handle claim |
| `tip.received` | coffee | Tip route |
| `pod.created` | connections | Pod creation |

All follow the existing fire-and-forget pattern (`emitAttestation().catch()`). No blocking on the request path.

### Already emitting (unchanged)
- `event.attendance` + `institution.verified` — events check-in
- `transaction.settled` + `customer` — pay
- `connection.invited` + `connection.accepted` + `vouch` — connections
- `course.enrolled` + `course.completed` — learn
- `session.created` — auth

Closes #461