### PR TITLE
feat(events): QR ticket scanner on admin dashboard (#500)

### DIFF
--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useToast } from '@imajin/ui';
+import { TicketScanner } from './ticket-scanner';
 
 interface Profile {
   name: string | null;
@@ -133,6 +134,7 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
   const [surveyLoading, setSurveyLoading] = useState(false);
   const [resendState, setResendState] = useState<Record<string, 'sending' | 'sent'>>({});
   const [resendToast, setResendToast] = useState<{ email: string } | null>(null);
+  const [scannerOpen, setScannerOpen] = useState(false);
 
   const load = useCallback(() => {
     setLoading(true);
@@ -168,6 +170,12 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
       setActionLoading(null);
     }
   };
+
+  const handleScannerCheckIn = useCallback((ticketId: string) => {
+    setGuests(prev => prev.map(g =>
+      g.id === ticketId ? { ...g, usedAt: g.usedAt ?? new Date().toISOString() } : g
+    ));
+  }, []);
 
   const handleConfirmETransfer = async (ticketId: string) => {
     setConfirmETransfer(null);
@@ -305,7 +313,28 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
       <div className="px-6 pt-6 pb-4">
-        <h2 className="text-xl font-semibold mb-3">Guest List</h2>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-xl font-semibold">Guest List</h2>
+          <button
+            onClick={() => setScannerOpen(v => !v)}
+            className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
+          >
+            {scannerOpen ? '✕ Close Scanner' : '📷 Scan Tickets'}
+          </button>
+        </div>
+
+        {scannerOpen && (
+          <div className="mb-4">
+            <TicketScanner
+              eventId={eventId}
+              onCheckIn={handleScannerCheckIn}
+              lookupGuest={(id) => {
+                const g = guests.find(g => g.id === id);
+                return g ? { attendeeName: g.attendeeName, ticketType: g.ticketType } : undefined;
+              }}
+            />
+          </div>
+        )}
 
         {/* Summary badge */}
         {guests.length > 0 && (

--- a/apps/events/app/admin/[eventId]/ticket-scanner.tsx
+++ b/apps/events/app/admin/[eventId]/ticket-scanner.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface GuestInfo {
+  attendeeName: string | null;
+  ticketType: string;
+}
+
+interface TicketScannerProps {
+  eventId: string;
+  onCheckIn: (ticketId: string) => void;
+  lookupGuest?: (ticketId: string) => GuestInfo | undefined;
+}
+
+type ScanResult =
+  | { type: 'success'; attendeeName: string | null; ticketType: string | null }
+  | { type: 'error'; message: string };
+
+function playTone(frequency: number, duration: number) {
+  try {
+    const ctx = new AudioContext();
+    const osc = ctx.createOscillator();
+    osc.frequency.value = frequency;
+    osc.connect(ctx.destination);
+    osc.start();
+    setTimeout(() => { osc.stop(); ctx.close(); }, duration);
+  } catch {
+    // Audio not available — fail silently
+  }
+}
+
+export function TicketScanner({ eventId, onCheckIn, lookupGuest }: TicketScannerProps) {
+  const [result, setResult] = useState<ScanResult | null>(null);
+  const [cameraError, setCameraError] = useState<string | null>(null);
+  const scannerRef = useRef<import('html5-qrcode').Html5Qrcode | null>(null);
+  const recentScans = useRef<Map<string, number>>(new Map());
+  const processingRef = useRef(false);
+
+  const stopScanner = async () => {
+    if (scannerRef.current) {
+      try {
+        await scannerRef.current.stop();
+        scannerRef.current.clear();
+      } catch {
+        // Already stopped
+      }
+      scannerRef.current = null;
+    }
+  };
+
+  const handleScan = async (ticketId: string) => {
+    if (processingRef.current) return;
+
+    const now = Date.now();
+    const lastScan = recentScans.current.get(ticketId);
+    if (lastScan && now - lastScan < 5000) return;
+    recentScans.current.set(ticketId, now);
+
+    processingRef.current = true;
+
+    try {
+      const res = await fetch(`/api/events/${eventId}/tickets/${ticketId}/check-in`, { method: 'POST' });
+      const data = await res.json();
+
+      if (res.ok) {
+        playTone(880, 150);
+        onCheckIn(ticketId);
+        const guest = lookupGuest?.(ticketId);
+        setResult({
+          type: 'success',
+          attendeeName: guest?.attendeeName ?? data.ticket?.attendeeName ?? null,
+          ticketType: guest?.ticketType ?? data.ticket?.ticketType ?? null,
+        });
+      } else {
+        playTone(220, 200);
+        const msg =
+          data.error === 'already checked in' ? '❌ Already checked in'
+          : data.error === 'not valid' ? '❌ Ticket not valid'
+          : res.status === 404 ? '❌ Ticket not found'
+          : res.status === 403 ? '❌ Not authorized'
+          : '❌ Check-in failed';
+        setResult({ type: 'error', message: msg });
+      }
+    } catch {
+      playTone(220, 200);
+      setResult({ type: 'error', message: '❌ Connection error' });
+    }
+
+    setTimeout(() => {
+      setResult(null);
+      processingRef.current = false;
+    }, 2500);
+  };
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      const { Html5Qrcode } = await import('html5-qrcode');
+      if (!mounted) return;
+      const scanner = new Html5Qrcode('qr-reader');
+      scannerRef.current = scanner;
+      try {
+        await scanner.start(
+          { facingMode: 'environment' },
+          { fps: 10, qrbox: { width: 250, height: 250 } },
+          handleScan,
+          () => {},
+        );
+      } catch {
+        if (mounted) setCameraError('Camera unavailable or permission denied.');
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      stopScanner();
+      processingRef.current = false;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div
+      className="relative rounded-xl overflow-hidden border border-gray-700 bg-[#0a0a0a]"
+      style={{ maxWidth: 480, aspectRatio: '16/9' }}
+    >
+      {cameraError ? (
+        <div className="absolute inset-0 flex items-center justify-center text-red-400 text-sm px-4 text-center">
+          {cameraError}
+        </div>
+      ) : (
+        <div id="qr-reader" className="w-full h-full" />
+      )}
+
+      {result && (
+        <div
+          className={`absolute inset-0 flex flex-col items-center justify-center text-white text-center px-4 ${
+            result.type === 'success' ? 'bg-green-700/90' : 'bg-red-700/90'
+          }`}
+        >
+          {result.type === 'success' ? (
+            <>
+              <span className="text-4xl mb-2">✅</span>
+              {result.attendeeName && (
+                <p className="text-lg font-semibold">{result.attendeeName}</p>
+              )}
+              {result.ticketType && (
+                <p className="text-sm text-green-200 mt-1">{result.ticketType}</p>
+              )}
+              {!result.attendeeName && (
+                <p className="text-lg font-semibold">Checked In</p>
+              )}
+            </>
+          ) : (
+            <p className="text-lg font-semibold">{result.message}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/events/package.json
+++ b/apps/events/package.json
@@ -27,7 +27,8 @@
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",
-    "@imajin/input": "workspace:*"
+    "@imajin/input": "workspace:*",
+    "html5-qrcode": "^2.3.8"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
+      html5-qrcode:
+        specifier: ^2.3.8
+        version: 2.3.8
       next:
         specifier: 14.2.35
         version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1005,11 +1008,11 @@ importers:
         specifier: workspace:^
         version: link:../../packages/ui
       '@metalabel/dfos-protocol':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@metalabel/dfos-web-relay':
-        specifier: ^0.4.1
-        version: 0.4.1(@metalabel/dfos-protocol@0.4.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@metalabel/dfos-protocol@0.5.0)
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(@types/pg@8.16.0)(postgres@3.4.8)(prisma@5.22.0)
@@ -1199,8 +1202,8 @@ importers:
         specifier: workspace:*
         version: link:../auth
       '@metalabel/dfos-protocol':
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.5.0
+        version: 0.5.0
       '@noble/curves':
         specifier: ^1.8.1
         version: 1.9.7
@@ -2452,14 +2455,11 @@ packages:
   '@metalabel/dfos-protocol@0.1.0':
     resolution: {integrity: sha512-wXCyZGQM2L9q1ptERuzFoGyVSytEf3iM7/cAGZ28OMmfZ2vgsFZbJajArk4ZnYx8VLLMNrByCKGmlDs/+CT1sg==}
 
-  '@metalabel/dfos-protocol@0.2.0':
-    resolution: {integrity: sha512-8nprwkeIwEbWTSFvhkeA2iF8L8kckAOheaP4cbdlEAy3hr893z+YoMamwZw6U6w3WYNpdo655u9DFNdOI6CsSA==}
+  '@metalabel/dfos-protocol@0.5.0':
+    resolution: {integrity: sha512-J6vA4PMI7S7aRaw3DtNztfy17fA08hE/QEspAya58m+L/o2umfTx1DvuXob9w1rC0fyiUgtjYp0iQwXLFrZBlQ==}
 
-  '@metalabel/dfos-protocol@0.4.0':
-    resolution: {integrity: sha512-NsBzWbv8Ekmd8B1I9icNLg/4zMvVFUA0A7Z/jr6MAwt/FlWu3w+22Rw1kriHM3b0KX2o+vvCRBCdq183xJAPHg==}
-
-  '@metalabel/dfos-web-relay@0.4.1':
-    resolution: {integrity: sha512-+I/KkoW5zK/4I8iQnB8qsoKElSifZjY5tKC7vdnzAjmRO+AdOMt3Eb6Vr9zgUeBAe6RKxRK7IHdS0dnepmyFHQ==}
+  '@metalabel/dfos-web-relay@0.5.0':
+    resolution: {integrity: sha512-MlKP8KQKJEUFVbbzpbGkO8RDVJQZ3A3m9fXM26HE/+nPRLtLHyxXtq/l5kGvPjybx5P8KTgkXHLG2FA1TX2igA==}
     peerDependencies:
       '@metalabel/dfos-protocol': ^0.4.0
 
@@ -4831,6 +4831,9 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html5-qrcode@2.3.8:
+    resolution: {integrity: sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -8011,7 +8014,7 @@ snapshots:
       multiformats: 13.4.2
       zod: 4.3.6
 
-  '@metalabel/dfos-protocol@0.2.0':
+  '@metalabel/dfos-protocol@0.5.0':
     dependencies:
       '@ipld/dag-cbor': 9.2.5
       '@noble/curves': 2.0.1
@@ -8019,17 +8022,9 @@ snapshots:
       multiformats: 13.4.2
       zod: 4.3.6
 
-  '@metalabel/dfos-protocol@0.4.0':
+  '@metalabel/dfos-web-relay@0.5.0(@metalabel/dfos-protocol@0.5.0)':
     dependencies:
-      '@ipld/dag-cbor': 9.2.5
-      '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
-      multiformats: 13.4.2
-      zod: 4.3.6
-
-  '@metalabel/dfos-web-relay@0.4.1(@metalabel/dfos-protocol@0.4.0)':
-    dependencies:
-      '@metalabel/dfos-protocol': 0.4.0
+      '@metalabel/dfos-protocol': 0.5.0
       hono: 4.12.8
       zod: 4.3.6
 
@@ -10788,6 +10783,8 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  html5-qrcode@2.3.8: {}
 
   htmlparser2@8.0.2:
     dependencies:


### PR DESCRIPTION
Adds a QR ticket scanner to the event admin page. Organizers/cohosts open their phone camera, scan attendee QR codes, get instant visual + audio feedback.

### How it works
- "📷 Scan Tickets" button above the guest list toggles the camera viewfinder
- Scans QR → calls existing `POST /api/events/[id]/tickets/[ticketId]/check-in`
- Green flash + attendee name on success, red flash + error on failure
- Audio tones via Web Audio API (880Hz success, 220Hz error)
- Auto-resumes scanning after 2.5 seconds (continuous mode for queues)
- 5-second duplicate scan debounce
- Guest list updates in real-time on successful scan

### Files
- `ticket-scanner.tsx` — new component (162 lines)
- `guest-list.tsx` — scanner integration (+31 lines)
- `html5-qrcode` added to events dependencies

No backend changes — uses existing check-in API.

Closes #500