### PR TITLE
feat: notify service — scaffold + caller package + templates (#479 phase 1)

### DIFF
--- a/apps/notify/.env.example
+++ b/apps/notify/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgres://imajin_dev:imajin_dev@localhost:5432/imajin_dev
+NOTIFY_WEBHOOK_SECRET=dev-secret-change-me
+AUTH_SERVICE_URL=http://localhost:3001
+NEXT_PUBLIC_AUTH_URL=http://localhost:3001

--- a/apps/notify/app/api/health/route.ts
+++ b/apps/notify/app/api/health/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function GET(request: NextRequest) {
+  const cors = corsHeaders(request);
+  return NextResponse.json({ ok: true, service: 'notify' }, { headers: cors });
+}

--- a/apps/notify/app/api/notifications/[id]/read/route.ts
+++ b/apps/notify/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { requireAuth } from '@imajin/auth';
+import { db } from '@/db';
+import { notifications } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+  const { identity } = authResult;
+  const did = identity.id;
+
+  const { id } = await params;
+
+  const updated = await db
+    .update(notifications)
+    .set({ read: true, readAt: new Date() })
+    .where(and(eq(notifications.id, id), eq(notifications.recipientDid, did)))
+    .returning({ id: notifications.id });
+
+  if (updated.length === 0) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404, headers: cors });
+  }
+
+  return NextResponse.json({ ok: true }, { headers: cors });
+}

--- a/apps/notify/app/api/notifications/read-all/route.ts
+++ b/apps/notify/app/api/notifications/read-all/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { requireAuth } from '@imajin/auth';
+import { db } from '@/db';
+import { notifications } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+  const { identity } = authResult;
+  const did = identity.id;
+
+  await db
+    .update(notifications)
+    .set({ read: true, readAt: new Date() })
+    .where(and(eq(notifications.recipientDid, did), eq(notifications.read, false)));
+
+  return NextResponse.json({ ok: true }, { headers: cors });
+}

--- a/apps/notify/app/api/notifications/route.ts
+++ b/apps/notify/app/api/notifications/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { requireAuth } from '@imajin/auth';
+import { db } from '@/db';
+import { notifications } from '@/db/schema';
+import { eq, and, lt, desc } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function GET(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+  const { identity } = authResult;
+  const did = identity.id;
+
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(parseInt(searchParams.get('limit') ?? '20', 10), 100);
+  const before = searchParams.get('before');
+
+  const conditions = [eq(notifications.recipientDid, did)];
+  if (before) {
+    conditions.push(lt(notifications.id, before));
+  }
+
+  const rows = await db
+    .select()
+    .from(notifications)
+    .where(and(...conditions))
+    .orderBy(desc(notifications.createdAt))
+    .limit(limit);
+
+  return NextResponse.json({ notifications: rows }, { headers: cors });
+}

--- a/apps/notify/app/api/notifications/unread/route.ts
+++ b/apps/notify/app/api/notifications/unread/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { requireAuth } from '@imajin/auth';
+import { db } from '@/db';
+import { notifications } from '@/db/schema';
+import { eq, and, count } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function GET(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+  const { identity } = authResult;
+  const did = identity.id;
+
+  const [result] = await db
+    .select({ count: count() })
+    .from(notifications)
+    .where(and(eq(notifications.recipientDid, did), eq(notifications.read, false)));
+
+  return NextResponse.json({ count: result?.count ?? 0 }, { headers: cors });
+}

--- a/apps/notify/app/api/preferences/[scope]/route.ts
+++ b/apps/notify/app/api/preferences/[scope]/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { requireAuth } from '@imajin/auth';
+import { nanoid } from 'nanoid';
+import { db } from '@/db';
+import { preferences } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ scope: string }> }
+) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+  const { identity } = authResult;
+  const did = identity.id;
+
+  const { scope } = await params;
+
+  let body: { email?: boolean; inapp?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  const existing = await db
+    .select()
+    .from(preferences)
+    .where(and(eq(preferences.did, did), eq(preferences.scope, scope)))
+    .limit(1);
+
+  if (existing.length > 0) {
+    const updated = await db
+      .update(preferences)
+      .set({
+        ...(body.email !== undefined && { email: body.email }),
+        ...(body.inapp !== undefined && { inapp: body.inapp }),
+      })
+      .where(and(eq(preferences.did, did), eq(preferences.scope, scope)))
+      .returning();
+    return NextResponse.json({ preference: updated[0] }, { headers: cors });
+  } else {
+    const id = `prf_${nanoid(16)}`;
+    const inserted = await db
+      .insert(preferences)
+      .values({
+        id,
+        did,
+        scope,
+        email: body.email ?? true,
+        inapp: body.inapp ?? true,
+      })
+      .returning();
+    return NextResponse.json({ preference: inserted[0] }, { headers: cors });
+  }
+}

--- a/apps/notify/app/api/preferences/route.ts
+++ b/apps/notify/app/api/preferences/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { requireAuth } from '@imajin/auth';
+import { db } from '@/db';
+import { preferences } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function GET(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+  const { identity } = authResult;
+  const did = identity.id;
+
+  const rows = await db
+    .select()
+    .from(preferences)
+    .where(eq(preferences.did, did));
+
+  return NextResponse.json({ preferences: rows }, { headers: cors });
+}

--- a/apps/notify/app/api/send/route.ts
+++ b/apps/notify/app/api/send/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { nanoid } from 'nanoid';
+import { db } from '@/db';
+import { notifications, preferences } from '@/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { getTemplate } from '@/templates';
+import { sendEmail } from '@imajin/email';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  // Verify webhook secret
+  const secret = request.headers.get('x-webhook-secret');
+  if (!secret || secret !== process.env.NOTIFY_WEBHOOK_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: cors });
+  }
+
+  let body: {
+    to: string;
+    scope: string;
+    title?: string;
+    body?: string;
+    data?: Record<string, unknown>;
+    urgency?: string;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  const { to, scope, data = {} } = body;
+  if (!to || !scope) {
+    return NextResponse.json({ error: 'Missing required fields: to, scope' }, { status: 400, headers: cors });
+  }
+
+  // Resolve template
+  const template = getTemplate(scope);
+  const urgency = body.urgency ?? template?.urgency ?? 'normal';
+  const title = body.title ?? (template ? template.title(data as Record<string, any>) : scope);
+  const notifBody = body.body ?? (template ? template.body(data as Record<string, any>) : undefined);
+
+  // Look up preferences (default: email + inapp both on)
+  const [pref] = await db
+    .select()
+    .from(preferences)
+    .where(and(eq(preferences.did, to), eq(preferences.scope, scope)))
+    .limit(1);
+
+  const emailEnabled = pref ? pref.email : true;
+  const inappEnabled = pref ? pref.inapp : true;
+
+  // Store notification
+  const id = `ntf_${nanoid(16)}`;
+  await db.insert(notifications).values({
+    id,
+    recipientDid: to,
+    scope,
+    urgency,
+    title,
+    body: notifBody ?? null,
+    data: data as any,
+    channelsSent: [],
+    read: false,
+  });
+
+  const channelsSent: string[] = [];
+
+  if (inappEnabled) {
+    channelsSent.push('inapp');
+  }
+
+  // Send email if enabled and template has email config
+  if (emailEnabled && template?.email) {
+    // We need the recipient's email — for now, use `to` if it looks like an email,
+    // otherwise skip (the profile service would need to resolve this)
+    const recipientEmail = (data as any).email as string | undefined;
+    if (recipientEmail) {
+      try {
+        await sendEmail({
+          to: recipientEmail,
+          subject: template.email.subject(data as Record<string, any>),
+          html: template.email.html(data as Record<string, any>),
+        });
+        channelsSent.push('email');
+      } catch (err) {
+        console.error('Email send failed for notification', id, err);
+      }
+    }
+  }
+
+  // Update channels_sent
+  if (channelsSent.length > 0) {
+    await db
+      .update(notifications)
+      .set({ channelsSent })
+      .where(eq(notifications.id, id));
+  }
+
+  return NextResponse.json({ id, sent: true }, { headers: cors });
+}

--- a/apps/notify/app/globals.css
+++ b/apps/notify/app/globals.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  color: #ededed;
+  background: #0a0a0a;
+  font-family: system-ui, -apple-system, sans-serif;
+}

--- a/apps/notify/app/layout.tsx
+++ b/apps/notify/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Notifications | Imajin',
+  description: 'Notification service for the Imajin network',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className="dark">
+      <body className="min-h-screen bg-[#0a0a0a] text-white">
+        <main className="container mx-auto px-4 py-8">
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/apps/notify/app/page.tsx
+++ b/apps/notify/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <div className="text-center py-16">
+      <h1 className="text-2xl font-bold text-white">Notify Service</h1>
+      <p className="text-zinc-400 mt-2">Notification service for the Imajin network.</p>
+    </div>
+  );
+}

--- a/apps/notify/app/settings/page.tsx
+++ b/apps/notify/app/settings/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Preference {
+  id: string;
+  did: string;
+  scope: string;
+  email: boolean;
+  inapp: boolean;
+}
+
+const SCOPE_GROUPS = [
+  {
+    label: 'Market',
+    scopes: [
+      { scope: 'market:sale', label: 'Listing sold' },
+      { scope: 'market:purchase', label: 'Purchase confirmed' },
+    ],
+  },
+  {
+    label: 'Events',
+    scopes: [
+      { scope: 'event:ticket', label: 'Ticket confirmed' },
+      { scope: 'event:registration', label: 'Registration complete' },
+    ],
+  },
+  {
+    label: 'Coffee',
+    scopes: [
+      { scope: 'coffee:tip', label: 'Tip received' },
+      { scope: 'coffee:tip-sent', label: 'Tip sent' },
+    ],
+  },
+  {
+    label: 'Connections',
+    scopes: [
+      { scope: 'connection:invite-accepted', label: 'Invitation accepted' },
+    ],
+  },
+];
+
+export default function SettingsPage() {
+  const [prefs, setPrefs] = useState<Record<string, Preference>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/preferences')
+      .then((r) => r.json())
+      .then((data) => {
+        const map: Record<string, Preference> = {};
+        for (const p of data.preferences ?? []) {
+          map[p.scope] = p;
+        }
+        setPrefs(map);
+      })
+      .catch(() => setError('Failed to load preferences'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function toggle(scope: string, channel: 'email' | 'inapp', value: boolean) {
+    setSaving(`${scope}:${channel}`);
+    try {
+      const res = await fetch(`/api/preferences/${encodeURIComponent(scope)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [channel]: value }),
+      });
+      if (!res.ok) throw new Error('Save failed');
+      const data = await res.json();
+      setPrefs((prev) => ({ ...prev, [scope]: data.preference }));
+    } catch {
+      setError('Failed to save preference');
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  function getPref(scope: string): { email: boolean; inapp: boolean } {
+    return prefs[scope] ?? { email: true, inapp: true };
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-2xl mx-auto py-8">
+        <p className="text-zinc-400">Loading preferences...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto py-8">
+      <h1 className="text-2xl font-bold text-white mb-2">Notification Settings</h1>
+      <p className="text-zinc-400 mb-8">Choose how you want to be notified for each event type.</p>
+
+      {error && (
+        <div className="mb-6 p-3 bg-red-950 border border-red-800 rounded-md text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-8">
+        {SCOPE_GROUPS.map((group) => (
+          <div key={group.label}>
+            <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wider mb-3">
+              {group.label}
+            </h2>
+            <div className="bg-zinc-900 border border-zinc-800 rounded-lg divide-y divide-zinc-800">
+              {group.scopes.map(({ scope, label }) => {
+                const pref = getPref(scope);
+                return (
+                  <div key={scope} className="flex items-center justify-between px-4 py-3">
+                    <span className="text-sm text-zinc-200">{label}</span>
+                    <div className="flex items-center gap-6">
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <span className="text-xs text-zinc-500">In-app</span>
+                        <button
+                          onClick={() => toggle(scope, 'inapp', !pref.inapp)}
+                          disabled={saving === `${scope}:inapp`}
+                          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${
+                            pref.inapp ? 'bg-white' : 'bg-zinc-700'
+                          }`}
+                        >
+                          <span
+                            className={`inline-block h-3 w-3 transform rounded-full bg-zinc-900 transition-transform ${
+                              pref.inapp ? 'translate-x-5' : 'translate-x-1'
+                            }`}
+                          />
+                        </button>
+                      </label>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <span className="text-xs text-zinc-500">Email</span>
+                        <button
+                          onClick={() => toggle(scope, 'email', !pref.email)}
+                          disabled={saving === `${scope}:email`}
+                          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${
+                            pref.email ? 'bg-white' : 'bg-zinc-700'
+                          }`}
+                        >
+                          <span
+                            className={`inline-block h-3 w-3 transform rounded-full bg-zinc-900 transition-transform ${
+                              pref.email ? 'translate-x-5' : 'translate-x-1'
+                            }`}
+                          />
+                        </button>
+                      </label>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/notify/drizzle.config.ts
+++ b/apps/notify/drizzle.config.ts
@@ -1,0 +1,20 @@
+import { readFileSync, existsSync } from "fs";
+const envPath = ".env.local";
+if (existsSync(envPath)) {
+  for (const line of readFileSync(envPath, "utf-8").split("\n")) {
+    const m = line.match(/^\s*([A-Z_][A-Z0-9_]*)\s*=\s*"?([^"]*)"?\s*$/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+  }
+}
+
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+  schemaFilter: ['notify'],
+});

--- a/apps/notify/next.config.js
+++ b/apps/notify/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ['@imajin/auth', '@imajin/config', '@imajin/db', '@imajin/email'],
+  typescript: { ignoreBuildErrors: true },
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/apps/notify/package.json
+++ b/apps/notify/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@imajin/notify-service",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port ${PORT:-3008}",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:pull": "drizzle-kit pull",
+    "db:studio": "drizzle-kit studio"
+  },
+  "dependencies": {
+    "@imajin/auth": "workspace:*",
+    "@imajin/config": "workspace:*",
+    "@imajin/db": "workspace:*",
+    "@imajin/email": "workspace:*",
+    "drizzle-orm": "^0.45.1",
+    "nanoid": "^5.0.0",
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "autoprefixer": "^10",
+    "drizzle-kit": "^0.31.9",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5"
+  }
+}

--- a/apps/notify/postcss.config.js
+++ b/apps/notify/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/notify/src/db/index.ts
+++ b/apps/notify/src/db/index.ts
@@ -1,0 +1,5 @@
+import { createDb } from '@imajin/db';
+import * as schema from './schema';
+
+export const db = createDb(schema);
+export * from './schema';

--- a/apps/notify/src/db/schema.ts
+++ b/apps/notify/src/db/schema.ts
@@ -1,0 +1,36 @@
+import { pgSchema, text, boolean, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+
+export const notifySchema = pgSchema("notify");
+
+export const notifications = notifySchema.table("notifications", {
+  id: text("id").primaryKey(),
+  recipientDid: text("recipient_did").notNull(),
+  senderDid: text("sender_did"),
+  scope: text("scope").notNull(),
+  urgency: text("urgency").notNull().default("normal"),
+  title: text("title").notNull(),
+  body: text("body"),
+  data: jsonb("data").default({}),
+  channelsSent: text("channels_sent").array().default([]),
+  read: boolean("read").default(false),
+  readAt: timestamp("read_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  recipientIdx: index("idx_notifications_recipient").on(table.recipientDid, table.createdAt),
+  unreadIdx: index("idx_notifications_unread").on(table.recipientDid),
+}));
+
+export const preferences = notifySchema.table("preferences", {
+  id: text("id").primaryKey(),
+  did: text("did").notNull(),
+  scope: text("scope").notNull(),
+  email: boolean("email").default(true),
+  inapp: boolean("inapp").default(true),
+}, (table) => ({
+  didScopeUnique: index("idx_preferences_did_scope").on(table.did, table.scope),
+}));
+
+export type Notification = typeof notifications.$inferSelect;
+export type NewNotification = typeof notifications.$inferInsert;
+export type Preference = typeof preferences.$inferSelect;
+export type NewPreference = typeof preferences.$inferInsert;

--- a/apps/notify/src/templates/index.ts
+++ b/apps/notify/src/templates/index.ts
@@ -1,0 +1,126 @@
+import { emailWrapper } from '@imajin/email';
+
+export interface NotifyTemplate {
+  scope: string;
+  urgency: "low" | "normal" | "urgent";
+  title: (data: Record<string, any>) => string;
+  body: (data: Record<string, any>) => string;
+  email?: {
+    subject: (data: Record<string, any>) => string;
+    html: (data: Record<string, any>) => string;
+  };
+}
+
+function simpleEmailHtml(title: string, body: string): string {
+  return emailWrapper(`
+    <tr>
+      <td style="background-color:#111111;border-radius:8px 8px 0 0;padding:32px 32px 24px;">
+        <h1 style="margin:0 0 8px;font-size:24px;font-weight:700;color:#ffffff;letter-spacing:-0.5px;">${title}</h1>
+        <p style="margin:0;font-size:16px;color:#a1a1aa;line-height:1.5;">${body}</p>
+      </td>
+    </tr>
+    <tr>
+      <td style="background-color:#111111;padding:0 32px 32px;border-radius:0 0 8px 8px;">
+        <div style="border-top:1px solid #262626;padding-top:20px;"></div>
+      </td>
+    </tr>
+  `);
+}
+
+export const templates: NotifyTemplate[] = [
+  {
+    scope: "market:sale",
+    urgency: "normal",
+    title: (_data) => "Your listing sold!",
+    body: (data) => data.listingTitle ? `Your listing "${data.listingTitle}" has been sold.` : "One of your listings has been sold.",
+    email: {
+      subject: (_data) => "Your listing sold!",
+      html: (data) => simpleEmailHtml(
+        "Your listing sold!",
+        data.listingTitle ? `Your listing "<strong style="color:#ffffff;">${data.listingTitle}</strong>" has been sold.` : "One of your listings has been sold."
+      ),
+    },
+  },
+  {
+    scope: "market:purchase",
+    urgency: "normal",
+    title: (_data) => "Purchase confirmed",
+    body: (data) => data.listingTitle ? `Your purchase of "${data.listingTitle}" is confirmed.` : "Your purchase has been confirmed.",
+    email: {
+      subject: (_data) => "Purchase confirmed",
+      html: (data) => simpleEmailHtml(
+        "Purchase confirmed",
+        data.listingTitle ? `Your purchase of "<strong style="color:#ffffff;">${data.listingTitle}</strong>" is confirmed.` : "Your purchase has been confirmed."
+      ),
+    },
+  },
+  {
+    scope: "event:ticket",
+    urgency: "normal",
+    title: (_data) => "Ticket confirmed",
+    body: (data) => data.eventTitle ? `Your ticket for "${data.eventTitle}" is confirmed.` : "Your ticket has been confirmed.",
+    email: {
+      subject: (data) => data.eventTitle ? `Ticket confirmed — ${data.eventTitle}` : "Ticket confirmed",
+      html: (data) => simpleEmailHtml(
+        "Ticket confirmed",
+        data.eventTitle ? `Your ticket for "<strong style="color:#ffffff;">${data.eventTitle}</strong>" is confirmed.` : "Your ticket has been confirmed."
+      ),
+    },
+  },
+  {
+    scope: "event:registration",
+    urgency: "normal",
+    title: (_data) => "Registration complete",
+    body: (data) => data.eventTitle ? `You're registered for "${data.eventTitle}".` : "Your registration is complete.",
+    email: {
+      subject: (data) => data.eventTitle ? `Registration complete — ${data.eventTitle}` : "Registration complete",
+      html: (data) => simpleEmailHtml(
+        "Registration complete",
+        data.eventTitle ? `You're registered for "<strong style="color:#ffffff;">${data.eventTitle}</strong>".` : "Your registration is complete."
+      ),
+    },
+  },
+  {
+    scope: "coffee:tip",
+    urgency: "normal",
+    title: (_data) => "You received a tip!",
+    body: (data) => data.amount ? `You received a tip of ${data.amount}.` : "Someone sent you a tip.",
+    email: {
+      subject: (_data) => "You received a tip!",
+      html: (data) => simpleEmailHtml(
+        "You received a tip!",
+        data.amount ? `You received a tip of <strong style="color:#ffffff;">${data.amount}</strong>.` : "Someone sent you a tip."
+      ),
+    },
+  },
+  {
+    scope: "coffee:tip-sent",
+    urgency: "low",
+    title: (_data) => "Tip sent",
+    body: (data) => data.amount ? `Your tip of ${data.amount} was sent.` : "Your tip was sent.",
+    email: {
+      subject: (_data) => "Tip sent",
+      html: (data) => simpleEmailHtml(
+        "Tip sent",
+        data.amount ? `Your tip of <strong style="color:#ffffff;">${data.amount}</strong> was sent.` : "Your tip was sent."
+      ),
+    },
+  },
+  {
+    scope: "connection:invite-accepted",
+    urgency: "normal",
+    title: (_data) => "Invitation accepted",
+    body: (data) => data.name ? `${data.name} accepted your invitation.` : "Your invitation was accepted.",
+    email: {
+      subject: (_data) => "Invitation accepted",
+      html: (data) => simpleEmailHtml(
+        "Invitation accepted",
+        data.name ? `<strong style="color:#ffffff;">${data.name}</strong> accepted your invitation.` : "Your invitation was accepted."
+      ),
+    },
+  },
+];
+
+export function getTemplate(scope: string): NotifyTemplate | undefined {
+  return templates.find((t) => t.scope === scope);
+}

--- a/apps/notify/tailwind.config.js
+++ b/apps/notify/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: "class",
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/notify/tsconfig.json
+++ b/apps/notify/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@imajin/notify",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {},
+  "dependencies": {}
+}

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -1,0 +1,33 @@
+export async function send(params: {
+  to: string;
+  scope: string;
+  title?: string;
+  body?: string;
+  data?: Record<string, unknown>;
+  urgency?: "low" | "normal" | "urgent";
+}): Promise<void> {
+  const notifyUrl = process.env.NOTIFY_SERVICE_URL;
+  const secret = process.env.NOTIFY_WEBHOOK_SECRET;
+  if (!notifyUrl || !secret) {
+    console.warn("Notification skipped: NOTIFY_SERVICE_URL or NOTIFY_WEBHOOK_SECRET not set");
+    return;
+  }
+  try {
+    const res = await fetch(`${notifyUrl}/api/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-webhook-secret": secret,
+      },
+      body: JSON.stringify(params),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`Notification (${params.scope}) failed: ${res.status} ${text}`);
+    }
+  } catch (err) {
+    console.error(`Notification (${params.scope}) error:`, err);
+  }
+}
+
+export const notify = { send };

--- a/packages/notify/tsconfig.json
+++ b/packages/notify/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Scaffolds the notification service and caller package.

### New: `apps/notify` (port 3008/7008)
- `POST /api/send` — internal, webhook-secret auth, resolves template + checks preferences + stores + emails
- `GET /api/notifications` — paginated list for authenticated user
- `GET /api/notifications/unread` — count
- `POST /api/notifications/:id/read` + `/read-all`
- `GET /api/preferences` + `PUT /api/preferences/:scope`
- `/settings` page — per-scope email/in-app toggles
- Schema: `notify.notifications` + `notify.preferences`

### New: `packages/notify` (`@imajin/notify`)
- `notify.send({ to, scope, data })` — fire-and-forget, same pattern as `emitAttestation`
- Silently skips if NOTIFY_SERVICE_URL not set

### Templates (7)
market:sale, market:purchase, event:ticket, event:registration, coffee:tip, coffee:tip-sent, connection:invite-accepted

### Phase 2 (next PR)
Wire up callers in pay, events, coffee, connections. Replace direct sendEmail calls.

Part of #479