### PR TITLE
feat: wire up notify callers across services (#479 phase 2)

### DIFF
--- a/apps/coffee/.env.example
+++ b/apps/coffee/.env.example
@@ -16,6 +16,10 @@ NEXT_PUBLIC_DOMAIN=imajin.ai
 # http://localhost: for local dev, https://dev- for deployed dev, https:// for prod
 NEXT_PUBLIC_SERVICE_PREFIX=http://localhost:
 
+# Notify
+NOTIFY_SERVICE_URL=http://localhost:3008
+NOTIFY_WEBHOOK_SECRET=dev-secret-change-me
+
 # Runtime
 PORT=
 NODE_ENV=

--- a/apps/coffee/app/api/webhook/payment/route.ts
+++ b/apps/coffee/app/api/webhook/payment/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { db, tips, coffeePages } from '@/db';
 import { eq } from 'drizzle-orm';
 import { settleTip } from '@/lib/settle';
-import { sendEmail, tipReceivedEmail, tipSentEmail } from '@/lib/email';
+import { notify } from '@imajin/notify';
 import { getEmailForDid } from '@imajin/auth';
 
 const PROFILE_SERVICE_URL = process.env.PROFILE_SERVICE_URL || 'http://localhost:3005';
@@ -85,44 +85,31 @@ export async function POST(request: NextRequest) {
         const displayFrom = fromName || 'Anonymous';
         const pageUrl = handle ? `${COFFEE_URL}/${handle}` : COFFEE_URL;
 
-        // Email the recipient
+        // Notify recipient
         if (recipientDid) {
-          try {
-            const recipientEmail = await resolveEmailForDid(recipientDid);
-            if (recipientEmail) {
-              await sendEmail({
-                to: recipientEmail,
-                subject: `☕ ${displayFrom} just tipped you ${displayAmount}`,
-                html: tipReceivedEmail({
-                  recipientName: pageTitle || 'there',
-                  fromName: displayFrom,
-                  amount: displayAmount,
-                  message: message || undefined,
-                  pageUrl,
-                }),
-              });
-            }
-          } catch (emailErr) {
-            console.error('[webhook] Recipient email failed (non-fatal):', emailErr);
-          }
+          const recipientEmail = await resolveEmailForDid(recipientDid).catch(() => null);
+          notify.send({
+            to: recipientDid,
+            scope: "coffee:tip",
+            data: {
+              ...(recipientEmail && { email: recipientEmail }),
+              amount: displayAmount,
+              tipperName: displayFrom,
+            },
+          }).catch((err) => console.error('[webhook] Notify recipient error:', err));
         }
 
-        // Email the sender
-        if (fromEmail) {
-          try {
-            await sendEmail({
-              to: fromEmail,
-              subject: `🧡 Thanks for tipping ${pageTitle || 'a creator'} ${displayAmount}`,
-              html: tipSentEmail({
-                fromName: displayFrom,
-                recipientName: pageTitle || 'a creator',
-                amount: displayAmount,
-                pageUrl,
-              }),
-            });
-          } catch (emailErr) {
-            console.error('[webhook] Sender email failed (non-fatal):', emailErr);
-          }
+        // Notify sender
+        if (fromDid) {
+          notify.send({
+            to: fromDid,
+            scope: "coffee:tip-sent",
+            data: {
+              ...(fromEmail && { email: fromEmail }),
+              amount: displayAmount,
+              pageName: pageTitle || 'a creator',
+            },
+          }).catch((err) => console.error('[webhook] Notify sender error:', err));
         }
 
         break;

--- a/apps/coffee/package.json
+++ b/apps/coffee/package.json
@@ -18,6 +18,7 @@
     "@imajin/config": "workspace:*",
     "@imajin/db": "workspace:*",
     "@imajin/email": "workspace:*",
+    "@imajin/notify": "workspace:*",
     "@imajin/ui": "workspace:*",
     "drizzle-orm": "^0.45.1",
     "next": "^14.2.0",

--- a/apps/connections/.env.example
+++ b/apps/connections/.env.example
@@ -16,6 +16,10 @@ SENDGRID_FROM=Jin <jin@imajin.ai>
 
 # Public URLs (client-side)
 NEXT_PUBLIC_APP_URL=http://localhost:3003
+
+# Notify
+NOTIFY_SERVICE_URL=http://localhost:3008
+NOTIFY_WEBHOOK_SECRET=dev-secret-change-me
 NEXT_PUBLIC_DOMAIN=imajin.ai
 # http://localhost: for local dev, https://dev- for deployed dev, https:// for prod
 NEXT_PUBLIC_SERVICE_PREFIX=http://localhost:

--- a/apps/connections/app/api/invites/[code]/accept/route.ts
+++ b/apps/connections/app/api/invites/[code]/accept/route.ts
@@ -3,6 +3,7 @@ import { eq, sql } from 'drizzle-orm';
 import { db, invites, profiles, pods, podMembers } from '../../../../../src/db/index';
 import { generateId } from '../../../../../src/lib/id';
 import { emitAttestation } from '@imajin/auth';
+import { notify } from '@imajin/notify';
 
 const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL!;
 const INVITE_COOLDOWN_DAYS = 7;
@@ -119,6 +120,24 @@ export async function POST(
       .set({ nextInviteAvailableAt: cooldownEnd })
       .where(eq(profiles.did, session.did));
   }
+
+  // Notify inviter — fire and forget
+  (async () => {
+    const [inviterProfile] = await db
+      .select()
+      .from(profiles)
+      .where(eq(profiles.did, invite.fromDid))
+      .limit(1);
+
+    notify.send({
+      to: invite.fromDid,
+      scope: "connection:invite-accepted",
+      data: {
+        ...(inviterProfile?.contactEmail && { email: inviterProfile.contactEmail }),
+        name: session.handle || session.did.slice(0, 16),
+      },
+    }).catch((err: unknown) => console.error("Notify error:", err));
+  })().catch((err: unknown) => console.error("Notify setup error:", err));
 
   emitAttestation({
     issuer_did: session.did,

--- a/apps/connections/package.json
+++ b/apps/connections/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@imajin/auth": "workspace:*",
+    "@imajin/notify": "workspace:*",
     "@imajin/config": "workspace:*",
     "@imajin/db": "workspace:*",
     "@imajin/email": "workspace:*",

--- a/apps/events/.env.example
+++ b/apps/events/.env.example
@@ -49,6 +49,10 @@ NEXT_PUBLIC_REGISTRY_URL=http://localhost:3002
 NEXT_PUBLIC_SERVICE_PREFIX=http://localhost:
 NEXT_PUBLIC_WWW_URL=http://localhost:3000
 
+# Notify
+NOTIFY_SERVICE_URL=http://localhost:3008
+NOTIFY_WEBHOOK_SECRET=dev-secret-change-me
+
 # Runtime
 PORT=
 NODE_ENV=

--- a/apps/events/app/api/register/[ticketId]/route.ts
+++ b/apps/events/app/api/register/[ticketId]/route.ts
@@ -12,6 +12,7 @@ import { db, tickets, events, ticketTypes, ticketRegistrations } from '@/src/db'
 import { eq, and } from 'drizzle-orm';
 import { randomBytes } from 'crypto';
 import { sendEmail, ticketConfirmationEmail, generateQRCode } from '@/src/lib/email';
+import { notify } from '@imajin/notify';
 
 export async function POST(
   request: NextRequest,
@@ -125,6 +126,18 @@ export async function POST(
       .update(tickets)
       .set({ registrationStatus: 'complete' })
       .where(eq(tickets.id, ticket.id));
+
+    // Notify attendee — fire and forget
+    if (ticket.ownerDid && registration.email) {
+      notify.send({
+        to: ticket.ownerDid,
+        scope: "event:registration",
+        data: {
+          email: registration.email,
+          eventTitle: event.title,
+        },
+      }).catch((err) => console.error("Notify error:", err));
+    }
 
     // Send ticket confirmation email to the registered attendee (skip if no email, e.g. Dykil form)
     if (registration.email) try {

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -16,6 +16,7 @@ import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
 import { randomBytes } from 'crypto';
 import { getClient } from '@imajin/db';
 import { emitAttestation } from '@imajin/auth';
+import { notify } from '@imajin/notify';
 
 // Configure ed25519 with sha512
 ed.hashes.sha512 = sha512;
@@ -339,6 +340,19 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     .where(eq(ticketTypes.id, ticketType.id));
 
   console.log(`Created ${createdTickets.length} ticket(s) for ${customerEmail}`);
+
+  // Notify buyer — fire and forget
+  notify.send({
+    to: ownerDid,
+    scope: "event:ticket",
+    data: {
+      email: customerEmail,
+      eventTitle: event.title,
+      ticketType: ticketType.name,
+      amount: amountTotal,
+      currency: currency.toUpperCase(),
+    },
+  }).catch((err) => console.error("Notify error:", err));
 
   // Add buyer to event chat conversation_members (non-fatal)
   // The event DID is the conversation DID

--- a/apps/events/package.json
+++ b/apps/events/package.json
@@ -28,6 +28,7 @@
     "react": "^18",
     "react-dom": "^18",
     "@imajin/input": "workspace:*",
+    "@imajin/notify": "workspace:*",
     "html5-qrcode": "^2.3.8"
   },
   "devDependencies": {

--- a/apps/market/app/api/listings/[id]/purchase/route.ts
+++ b/apps/market/app/api/listings/[id]/purchase/route.ts
@@ -90,6 +90,7 @@ export async function POST(
         metadata: {
           service: 'market',
           listingId: listing.id,
+          listingTitle: listing.title,
           sellerDid: listing.sellerDid,
           ...(buyerDid && { buyerDid }),
         },

--- a/apps/pay/.env.example
+++ b/apps/pay/.env.example
@@ -33,6 +33,10 @@ NEXT_PUBLIC_DOMAIN=imajin.ai
 # http://localhost: for local dev, https://dev- for deployed dev, https:// for prod
 NEXT_PUBLIC_SERVICE_PREFIX=http://localhost:
 
+# Notify
+NOTIFY_SERVICE_URL=http://localhost:3008
+NOTIFY_WEBHOOK_SECRET=dev-secret-change-me
+
 # Runtime
 PORT=
 NODE_ENV=

--- a/apps/pay/app/api/webhook/route.ts
+++ b/apps/pay/app/api/webhook/route.ts
@@ -18,6 +18,7 @@ import Stripe from 'stripe';
 import { db, transactions } from '@/src/db';
 import { eq } from 'drizzle-orm';
 import { genId } from '@/src/lib/id';
+import { notify } from '@imajin/notify';
 
 // Lazy Stripe initialization to avoid build-time errors in CI
 let _stripe: Stripe | null = null;
@@ -228,8 +229,40 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
     await notifyEventsService('checkout.completed', session);
   }
 
-  // Add other service callbacks here as needed
-  // e.g., if (session.metadata?.orderId) { await notifyShopService(...) }
+  // Market: fire sale + purchase notifications
+  if (session.metadata?.service === 'market' && session.metadata?.sellerDid) {
+    const sellerDid = session.metadata.sellerDid;
+    const buyerDid = session.metadata.buyerDid;
+    const listingTitle = session.metadata.listingTitle;
+    const amount = session.amount_total ?? 0;
+    const currency = (session.currency ?? 'usd').toUpperCase();
+    const buyerEmail = session.customer_email || session.customer_details?.email || undefined;
+    const buyerName = session.customer_details?.name || undefined;
+
+    notify.send({
+      to: sellerDid,
+      scope: "market:sale",
+      data: {
+        listingTitle,
+        amount,
+        currency,
+        ...(buyerName && { buyerName }),
+      },
+    }).catch((err) => console.error("Notify market:sale error:", err));
+
+    if (buyerDid) {
+      notify.send({
+        to: buyerDid,
+        scope: "market:purchase",
+        data: {
+          ...(buyerEmail && { email: buyerEmail }),
+          listingTitle,
+          amount,
+          currency,
+        },
+      }).catch((err) => console.error("Notify market:purchase error:", err));
+    }
+  }
 }
 
 /**

--- a/apps/pay/package.json
+++ b/apps/pay/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@imajin/auth": "workspace:*",
+    "@imajin/notify": "workspace:*",
     "@imajin/config": "workspace:*",
     "@imajin/fair": "workspace:*",
     "@imajin/db": "workspace:^",


### PR DESCRIPTION
Wires `@imajin/notify` into 5 services. All notification calls are fire-and-forget.

### Changes

| Service | Action | Scope |
|---------|--------|-------|
| Coffee webhook | **Replaced** direct sendEmail | coffee:tip, coffee:tip-sent |
| Events webhook | **Added** notify alongside existing email | event:ticket |
| Events register | **Added** notify alongside existing email | event:registration |
| Pay webhook | **New** notifications (market had no emails) | market:sale, market:purchase |
| Connections accept | **New** notification to inviter | connection:invite-accepted |

Events keeps its direct email sends for now — ticket confirmation emails have QR codes and complex HTML that the simple notify templates don't cover yet. Notify calls added alongside for in-app notification tracking.

`@imajin/notify` added as workspace dependency to events, coffee, pay, connections. NOTIFY_SERVICE_URL + NOTIFY_WEBHOOK_SECRET added to all .env.examples.

Part of #479