### PR TITLE
feat(ui): notification bell + provider + toast integration (#479 phase 3)

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,3 +19,9 @@ export { PayoutSetupBanner } from './PayoutSetupBanner';
 
 export { ToastProvider, useToast } from './toast';
 export type { ToastType } from './toast';
+
+export { ActionSheet } from './action-sheet';
+
+export { NotificationProvider, useNotifications } from './notification-provider';
+export type { Notification, NotificationContextValue } from './notification-provider';
+export { NotificationBell } from './notification-bell';

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { AppLauncher } from './app-launcher';
+import { NotificationBell } from './notification-bell';
 import { getPort } from '@imajin/config';
 
 export interface NavIdentity {
@@ -245,6 +246,13 @@ export function NavBar({
             </>
           )}
         </div>
+
+        {/* Notification Bell (desktop) */}
+        {process.env.NEXT_PUBLIC_NOTIFY_URL && (
+          <div className="hidden sm:flex items-center">
+            <NotificationBell />
+          </div>
+        )}
 
         {/* Mobile hamburger */}
         <button

--- a/packages/ui/src/notification-bell.tsx
+++ b/packages/ui/src/notification-bell.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useNotifications } from './notification-provider';
+
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'Yesterday';
+  return `${days}d ago`;
+}
+
+function BellIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  );
+}
+
+export function NotificationBell() {
+  const { unreadCount, notifications, markAsRead, markAllAsRead, refresh } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const handleOpen = useCallback(async () => {
+    if (!open) {
+      setOpen(true);
+      setLoading(true);
+      await refresh();
+      setLoading(false);
+    } else {
+      setOpen(false);
+    }
+  }, [open, refresh]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  const hasUnread = notifications.some(n => !n.read);
+
+  return (
+    <div className="relative" ref={panelRef}>
+      <button
+        onClick={handleOpen}
+        className={`relative p-2 rounded-lg transition ${
+          open ? 'bg-gray-100 dark:bg-gray-800' : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+        }`}
+        title="Notifications"
+        aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ''}`}
+        aria-expanded={open}
+      >
+        <BellIcon className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full min-w-[1.1rem] h-[1.1rem] flex items-center justify-center px-1 leading-none pointer-events-none">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 bg-gray-900 border border-gray-700 rounded-lg shadow-lg z-50 flex flex-col max-h-[24rem]">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-700 shrink-0">
+            <span className="text-sm font-semibold text-white">Notifications</span>
+            {hasUnread && (
+              <button
+                onClick={() => markAllAsRead()}
+                className="text-xs text-blue-400 hover:text-blue-300 transition"
+              >
+                Mark all as read
+              </button>
+            )}
+          </div>
+
+          {/* Body */}
+          <div className="overflow-y-auto flex-1">
+            {loading ? (
+              <div className="px-4 py-6 text-center text-sm text-gray-400">Loading…</div>
+            ) : notifications.length === 0 ? (
+              <div className="px-4 py-6 text-center text-sm text-gray-400">No notifications yet</div>
+            ) : (
+              notifications.map(notification => (
+                <button
+                  key={notification.id}
+                  onClick={() => markAsRead(notification.id)}
+                  className={`w-full text-left px-4 py-3 border-b border-gray-800 last:border-0 hover:bg-gray-800 transition flex items-start gap-3 ${
+                    !notification.read ? 'bg-gray-800/50' : ''
+                  }`}
+                >
+                  {/* Unread dot — space always reserved so text aligns */}
+                  <span className="shrink-0 w-2 h-2 rounded-full mt-1.5 flex items-center justify-center">
+                    {!notification.read && (
+                      <span className="block w-2 h-2 rounded-full bg-blue-500" aria-hidden="true" />
+                    )}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-white truncate">{notification.title}</p>
+                    {notification.body && (
+                      <p className="text-xs text-gray-400 mt-0.5 line-clamp-2">{notification.body}</p>
+                    )}
+                    <p className="text-xs text-gray-500 mt-1">{relativeTime(notification.createdAt)}</p>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/notification-provider.tsx
+++ b/packages/ui/src/notification-provider.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
+import { useToast } from './toast';
+
+export interface Notification {
+  id: string;
+  title: string;
+  body?: string;
+  urgency?: 'normal' | 'urgent';
+  read: boolean;
+  createdAt: string;
+}
+
+export interface NotificationContextValue {
+  unreadCount: number;
+  notifications: Notification[];
+  markAsRead: (id: string) => Promise<void>;
+  markAllAsRead: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+const emptyValue: NotificationContextValue = {
+  unreadCount: 0,
+  notifications: [],
+  markAsRead: async () => {},
+  markAllAsRead: async () => {},
+  refresh: async () => {},
+};
+
+export function NotificationProvider({ children }: { children: React.ReactNode }) {
+  const notifyUrl = process.env.NEXT_PUBLIC_NOTIFY_URL;
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const hasWarnedRef = useRef(false);
+  const lastCountRef = useRef(-1); // -1 = not yet initialised, skip toast on first load
+  const lastNewIdRef = useRef<string | null>(null);
+  const { toast } = useToast();
+
+  // Keep toast functions in a ref so fetchAndMaybeToast doesn't need them as deps
+  const toastRef = useRef(toast);
+  toastRef.current = toast;
+
+  const fetchAndMaybeToast = useCallback(async () => {
+    if (!notifyUrl) return;
+    try {
+      const res = await fetch(`${notifyUrl}/api/notifications/unread`, { credentials: 'include' });
+      if (!res.ok) return;
+      const data = await res.json();
+      const count: number = data.count ?? 0;
+
+      if (lastCountRef.current >= 0 && count > lastCountRef.current) {
+        // New notifications arrived — fetch the latest one and toast
+        try {
+          const listRes = await fetch(`${notifyUrl}/api/notifications?limit=1`, { credentials: 'include' });
+          if (listRes.ok) {
+            const listData = await listRes.json();
+            const latest: Notification | undefined = listData.notifications?.[0] ?? listData[0];
+            if (latest && latest.id !== lastNewIdRef.current) {
+              lastNewIdRef.current = latest.id;
+              if (latest.urgency === 'urgent') {
+                toastRef.current.warning(latest.title);
+              } else {
+                toastRef.current.info(latest.title);
+              }
+            }
+          }
+        } catch {}
+      }
+
+      lastCountRef.current = count;
+      setUnreadCount(count);
+    } catch {
+      if (!hasWarnedRef.current) {
+        console.warn('[notifications] notify service unavailable — bell will show 0 unread');
+        hasWarnedRef.current = true;
+      }
+    }
+  }, [notifyUrl]);
+
+  useEffect(() => {
+    if (!notifyUrl) return;
+    fetchAndMaybeToast();
+    const interval = setInterval(fetchAndMaybeToast, 30_000);
+    return () => clearInterval(interval);
+  }, [notifyUrl, fetchAndMaybeToast]);
+
+  const refresh = useCallback(async () => {
+    if (!notifyUrl) return;
+    try {
+      const res = await fetch(`${notifyUrl}/api/notifications?limit=20`, { credentials: 'include' });
+      if (!res.ok) return;
+      const data = await res.json();
+      setNotifications(data.notifications ?? data ?? []);
+    } catch {}
+  }, [notifyUrl]);
+
+  const markAsRead = useCallback(async (id: string) => {
+    if (!notifyUrl) return;
+    try {
+      await fetch(`${notifyUrl}/api/notifications/${id}/read`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      setNotifications(prev => prev.map(n => n.id === id ? { ...n, read: true } : n));
+      setUnreadCount(prev => Math.max(0, prev - 1));
+    } catch {}
+  }, [notifyUrl]);
+
+  const markAllAsRead = useCallback(async () => {
+    if (!notifyUrl) return;
+    try {
+      await fetch(`${notifyUrl}/api/notifications/read-all`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+      setUnreadCount(0);
+      lastCountRef.current = 0;
+    } catch {}
+  }, [notifyUrl]);
+
+  return (
+    <NotificationContext.Provider value={{ unreadCount, notifications, markAsRead, markAllAsRead, refresh }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications(): NotificationContextValue {
+  return useContext(NotificationContext) ?? emptyValue;
+}


### PR DESCRIPTION
Notification UI components in `@imajin/ui`.

### New components
- **`NotificationProvider`** — context provider, polls `/api/notifications/unread` every 30s, manages state
- **`NotificationBell`** — bell icon in NavBar, unread badge, dropdown panel with notification history
- **`useNotifications`** — hook for consuming notification state

### Behavior
- Bell shows unread count (caps at 99+)
- Click opens dropdown with recent notifications
- Mark individual or all as read
- New notifications trigger toast via existing `useToast()`
- Gracefully degrades if `NEXT_PUBLIC_NOTIFY_URL` not set (bell doesn't render, no polling)

### Files
- `notification-provider.tsx` (134 lines)
- `notification-bell.tsx` (144 lines)
- `nav-bar.tsx` updated with bell
- `index.ts` exports updated

Part of #479