### PR TITLE
feat(chat): @mention detection + notifications + rendering (#503)

### DIFF
--- a/apps/chat/.env.example
+++ b/apps/chat/.env.example
@@ -23,6 +23,9 @@ NEXT_PUBLIC_PROFILE_URL=http://localhost:3005
 # http://localhost: for local dev, https://dev- for deployed dev, https:// for prod
 NEXT_PUBLIC_SERVICE_PREFIX=http://localhost:
 
+NOTIFY_SERVICE_URL=http://localhost:3008
+NOTIFY_WEBHOOK_SECRET=dev-secret-change-me
+
 # Runtime
 NODE_ENV=
 NEXT_PUBLIC_CHAT_URL=

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@imajin/auth": "workspace:*",
+    "@imajin/notify": "workspace:*",
     "@imajin/chat": "workspace:*",
     "@imajin/config": "workspace:*",
     "@imajin/db": "workspace:*",

--- a/apps/chat/src/app/api/conversations/[id]/messages/route.ts
+++ b/apps/chat/src/app/api/conversations/[id]/messages/route.ts
@@ -5,8 +5,23 @@ import { requireAuth } from '@/lib/auth';
 import { jsonResponse, errorResponse, generateId } from '@/lib/utils';
 import { parseConversationDid } from '@/lib/conversation-did';
 import { hasCapability, requiredCapability, CAPABILITY_MESSAGES } from '@/lib/capabilities';
+import { notify } from '@imajin/notify';
 
 const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
+const PROFILE_SERVICE_URL = process.env.PROFILE_SERVICE_URL || 'http://localhost:3005';
+const MENTION_REGEX = /@([a-zA-Z0-9_-]+)/g;
+
+async function resolveHandleToDid(handle: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${PROFILE_SERVICE_URL}/api/profile/search?q=${encodeURIComponent(handle)}&limit=5`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const profile = (data.profiles || []).find((p: { handle?: string; did?: string }) => p.handle?.toLowerCase() === handle.toLowerCase());
+    return profile?.did ?? null;
+  } catch {
+    return null;
+  }
+}
 
 async function verifyAccess(did: string, cookieHeader: string | null): Promise<boolean> {
   try {
@@ -219,6 +234,33 @@ export async function POST(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ conversationId: conversationDid, message }),
       }).catch(() => {});
+    }
+
+    // Detect and notify @mentions — fire and forget
+    const messageText = typeof content === 'object' && (content as any).text ? (content as any).text : typeof content === 'string' ? content : '';
+    const mentionMatches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m: RegExpMatchArray) => m[1]);
+    if (mentionMatches.length > 0) {
+      const uniqueHandles = [...new Set<string>(mentionMatches)];
+      (async () => {
+        for (const handle of uniqueHandles) {
+          try {
+            const mentionedDid = await resolveHandleToDid(handle);
+            if (!mentionedDid || mentionedDid === identity.id) continue;
+            notify.send({
+              to: mentionedDid,
+              scope: 'chat:mention',
+              data: {
+                conversationId: conversationDid,
+                messageId,
+                senderName: identity.handle || identity.id.slice(0, 16),
+                messagePreview: messageText.slice(0, 100),
+              },
+            }).catch((err: unknown) => console.error('Mention notify error:', err));
+          } catch (err) {
+            console.error('Handle resolution error:', err);
+          }
+        }
+      })().catch(() => {});
     }
 
     return jsonResponse({ message }, 201);

--- a/apps/chat/src/app/api/d/[did]/messages/route.ts
+++ b/apps/chat/src/app/api/d/[did]/messages/route.ts
@@ -6,8 +6,23 @@ import { jsonResponse, errorResponse, generateId, corsHeaders, corsOptions } fro
 import { parseConversationDid } from '@/lib/conversation-did';
 import { unfurlLinks } from '@/lib/unfurl';
 import { canonicalize } from '@imajin/auth';
+import { notify } from '@imajin/notify';
 
 const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
+const PROFILE_SERVICE_URL = process.env.PROFILE_SERVICE_URL || 'http://localhost:3005';
+const MENTION_REGEX = /@([a-zA-Z0-9_-]+)/g;
+
+async function resolveHandleToDid(handle: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${PROFILE_SERVICE_URL}/api/profile/search?q=${encodeURIComponent(handle)}&limit=5`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const profile = (data.profiles || []).find((p: { handle?: string; did?: string }) => p.handle?.toLowerCase() === handle.toLowerCase());
+    return profile?.did ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Sign a message payload with the node's chain key via the auth service.
@@ -278,6 +293,33 @@ export async function POST(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ conversationId: did, message }),
       }).catch(() => {});
+    }
+
+    // Detect and notify @mentions — fire and forget
+    const messageText = typeof content === 'object' && (content as any).text ? (content as any).text : typeof content === 'string' ? content : '';
+    const mentionMatches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m: RegExpMatchArray) => m[1]);
+    if (mentionMatches.length > 0) {
+      const uniqueHandles = [...new Set<string>(mentionMatches)];
+      (async () => {
+        for (const handle of uniqueHandles) {
+          try {
+            const mentionedDid = await resolveHandleToDid(handle);
+            if (!mentionedDid || mentionedDid === identity.id) continue;
+            notify.send({
+              to: mentionedDid,
+              scope: 'chat:mention',
+              data: {
+                conversationId: did,
+                messageId,
+                senderName: identity.handle || identity.id.slice(0, 16),
+                messagePreview: messageText.slice(0, 100),
+              },
+            }).catch((err: unknown) => console.error('Mention notify error:', err));
+          } catch (err) {
+            console.error('Handle resolution error:', err);
+          }
+        }
+      })().catch(() => {});
     }
 
     // Unfurl link previews async — don't block the response

--- a/apps/notify/src/templates/index.ts
+++ b/apps/notify/src/templates/index.ts
@@ -107,6 +107,19 @@ export const templates: NotifyTemplate[] = [
     },
   },
   {
+    scope: "chat:mention",
+    urgency: "normal",
+    title: (data) => `${data.senderName || "Someone"} mentioned you`,
+    body: (data) => data.messagePreview || "You were mentioned in a conversation.",
+    email: {
+      subject: (data) => `${data.senderName || "Someone"} mentioned you — Imajin Chat`,
+      html: (data) => simpleEmailHtml(
+        `${data.senderName || "Someone"} mentioned you`,
+        data.messagePreview || "You were mentioned in a conversation."
+      ),
+    },
+  },
+  {
     scope: "connection:invite-accepted",
     urgency: "normal",
     title: (_data) => "Invitation accepted",

--- a/packages/chat/src/MessageBubble.tsx
+++ b/packages/chat/src/MessageBubble.tsx
@@ -9,6 +9,29 @@ import { LocationMessage } from './LocationMessage';
 import type { MessageContent } from './message-types';
 
 const URL_REGEX = /(https?:\/\/[^\s<]+[^\s<.,;:!?"')\]])/g;
+const MENTION_DISPLAY_REGEX = /@([a-zA-Z0-9_-]+)/g;
+
+function renderTextSegment(text: string, keyPrefix: string): (string | JSX.Element)[] {
+  const parts: (string | JSX.Element)[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  const regex = new RegExp(MENTION_DISPLAY_REGEX);
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    parts.push(
+      <span key={`${keyPrefix}-mention-${match.index}`} className="text-amber-400 font-medium">
+        @{match[1]}
+      </span>
+    );
+    lastIndex = regex.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+  return parts;
+}
 
 function linkifyText(text: string): (string | JSX.Element)[] {
   const parts: (string | JSX.Element)[] = [];
@@ -17,7 +40,8 @@ function linkifyText(text: string): (string | JSX.Element)[] {
   const regex = new RegExp(URL_REGEX);
   while ((match = regex.exec(text)) !== null) {
     if (match.index > lastIndex) {
-      parts.push(text.slice(lastIndex, match.index));
+      // Render non-URL segment with @mention highlighting
+      parts.push(...renderTextSegment(text.slice(lastIndex, match.index), `seg-${lastIndex}`));
     }
     const url = match[1];
     parts.push(
@@ -34,7 +58,7 @@ function linkifyText(text: string): (string | JSX.Element)[] {
     lastIndex = regex.lastIndex;
   }
   if (lastIndex < text.length) {
-    parts.push(text.slice(lastIndex));
+    parts.push(...renderTextSegment(text.slice(lastIndex), `seg-${lastIndex}`));
   }
   return parts;
 }


### PR DESCRIPTION
Phase 1 of chat mentions — detection, notifications, and rendering. No composer autocomplete yet (phase 2).

### Server-side
- Both message POST routes scan for `@handle` patterns after message insert
- Resolves handles to DIDs via auth service lookup
- Fires `notify.send({ scope: 'chat:mention' })` for each mention
- Fire-and-forget — never blocks message send
- Skips self-mentions

### Notify
- New `chat:mention` template added to notify service

### Client-side
- `MessageBubble` renders `@handle` in amber/orange (`text-amber-400 font-medium`)
- Integrates into existing `linkifyText()` — URLs and mentions both work in same text

### Phase 2 (follow-up)
- Composer `@` autocomplete with member dropdown

Closes #503