### PR TITLE
fix(relay): add sequencer loop for out-of-order op handling (#518)

### DIFF
--- a/apps/registry/drizzle/0002_pending_operations.sql
+++ b/apps/registry/drizzle/0002_pending_operations.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "relay"."relay_pending_operations" (
+	"cid" text PRIMARY KEY NOT NULL,
+	"jws_token" text NOT NULL,
+	"received_at" timestamp with time zone DEFAULT now(),
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"last_error" text,
+	"status" text DEFAULT 'pending' NOT NULL
+);

--- a/apps/registry/src/db/relay-schema.ts
+++ b/apps/registry/src/db/relay-schema.ts
@@ -1,4 +1,4 @@
-import { pgSchema, text, timestamp, jsonb, serial, bigserial, index, primaryKey, customType } from 'drizzle-orm/pg-core';
+import { pgSchema, text, timestamp, jsonb, serial, bigserial, index, primaryKey, customType, integer } from 'drizzle-orm/pg-core';
 
 const bytea = customType<{ data: Buffer; notNull: false; default: false }>({
   dataType() {
@@ -59,6 +59,15 @@ export const relayCountersignatures = relaySchema.table('relay_countersignatures
 }, (table) => ({
   operationCidIdx: index('idx_relay_countersignatures_operation_cid').on(table.operationCid),
 }));
+
+export const relayPendingOperations = relaySchema.table('relay_pending_operations', {
+  cid: text('cid').primaryKey(),
+  jwsToken: text('jws_token').notNull(),
+  receivedAt: timestamp('received_at', { withTimezone: true }).defaultNow(),
+  attempts: integer('attempts').default(0).notNull(),
+  lastError: text('last_error'),
+  status: text('status').default('pending').notNull(),
+});
 
 export const relayOperationLog = relaySchema.table('relay_operation_log', {
   seq: bigserial('seq', { mode: 'bigint' }).primaryKey(),

--- a/apps/registry/src/relay/create-relay.ts
+++ b/apps/registry/src/relay/create-relay.ts
@@ -13,7 +13,7 @@ import { createRelay } from '@metalabel/dfos-web-relay';
 import type { RelayStore, RelayIdentity } from '@metalabel/dfos-web-relay';
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { ingestOperations060 } from './ingest';
+import { ingestOperations060, type SequencerStore } from './ingest';
 
 const IngestBody = z.object({
   operations: z.array(z.string()).min(1).max(100),
@@ -53,7 +53,8 @@ export async function createCustomRelay(options: {
       return c.json({ error: 'invalid request', details: parsed.error.issues }, 400);
     }
 
-    const results = await ingestOperations060(parsed.data.operations, store);
+    const sequencerStore = 'putPending' in store ? (store as unknown as SequencerStore) : undefined;
+    const results = await ingestOperations060(parsed.data.operations, store, sequencerStore);
     return c.json({ results });
   });
 

--- a/apps/registry/src/relay/ingest.ts
+++ b/apps/registry/src/relay/ingest.ts
@@ -36,6 +36,47 @@ export interface IngestionResult060 {
   chainId?: string;
 }
 
+export interface SequencerStore {
+  putPending(cid: string, jwsToken: string): Promise<void>;
+  getPendingOps(): Promise<Array<{ cid: string; jwsToken: string; attempts: number }>>;
+  updatePendingStatus(
+    cid: string,
+    status: 'pending' | 'resolved' | 'rejected',
+    error?: string,
+    incrementAttempts?: boolean,
+  ): Promise<void>;
+}
+
+// ─── Ingest mutex ─────────────────────────────────────────────────────────────
+
+let _ingestLock: Promise<void> = Promise.resolve();
+
+async function withMutex<T>(fn: () => Promise<T>): Promise<T> {
+  let release!: () => void;
+  const next = new Promise<void>((r) => {
+    release = r;
+  });
+  const prev = _ingestLock;
+  _ingestLock = next;
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+// ─── Dependency error detection ───────────────────────────────────────────────
+
+function isDependencyError(error: string): boolean {
+  return (
+    error.includes('unknown identity:') ||
+    error.includes('unknown key ') ||
+    error.includes('unknown previous operation:') ||
+    error.includes('content chain not found:')
+  );
+}
+
 // ─── Temporal guard ──────────────────────────────────────────────────────────
 
 const MAX_FUTURE_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -744,11 +785,86 @@ function dependencySort(ops: ClassifiedOp[]): ClassifiedOp[] {
   return result;
 }
 
+// ─── Single op dispatch ───────────────────────────────────────────────────────
+
+async function dispatchOp(op: ClassifiedOp, store: RelayStore): Promise<IngestionResult060> {
+  switch (op.kind) {
+    case 'identity-op':
+      return ingestIdentityOp(op.jwsToken, store);
+    case 'content-op':
+      return ingestContentOp(op.jwsToken, store);
+    case 'beacon':
+      return ingestBeacon(op.jwsToken, store);
+    case 'countersign':
+      return ingestCountersign(op.jwsToken, store);
+    case 'artifact':
+      return ingestArtifact(op.jwsToken, store);
+    default:
+      return { cid: op.operationCID ?? '', status: 'rejected', error: 'unrecognized operation type' };
+  }
+}
+
+// ─── Sequencer loop ───────────────────────────────────────────────────────────
+
+const MAX_SEQUENCER_ATTEMPTS = 10;
+
+async function runSequencerLoop(store: RelayStore, sequencerStore: SequencerStore): Promise<void> {
+  while (true) {
+    const pending = await sequencerStore.getPendingOps();
+    if (pending.length === 0) break;
+
+    const classified: ClassifiedOp[] = pending.map((p, i) => ({
+      ...classify(p.jwsToken),
+      originalIndex: i,
+    }));
+    const sorted = dependencySort(classified);
+
+    let madeProgress = false;
+
+    for (const op of sorted) {
+      const info = pending[op.originalIndex];
+
+      if (info.attempts >= MAX_SEQUENCER_ATTEMPTS) {
+        await sequencerStore.updatePendingStatus(
+          info.cid,
+          'rejected',
+          `max retry attempts (${MAX_SEQUENCER_ATTEMPTS}) exceeded`,
+        );
+        madeProgress = true;
+        continue;
+      }
+
+      let result: IngestionResult060;
+      try {
+        result = await dispatchOp(op, store);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'unexpected error';
+        result = { cid: info.cid, status: 'rejected', error: message };
+      }
+
+      if (result.status === 'new' || result.status === 'duplicate') {
+        await sequencerStore.updatePendingStatus(info.cid, 'resolved');
+        madeProgress = true;
+      } else if (result.status === 'rejected') {
+        if (result.error && isDependencyError(result.error)) {
+          await sequencerStore.updatePendingStatus(info.cid, 'pending', result.error, true);
+        } else {
+          await sequencerStore.updatePendingStatus(info.cid, 'rejected', result.error);
+          madeProgress = true;
+        }
+      }
+    }
+
+    if (!madeProgress) break;
+  }
+}
+
 // ─── Public entry point ───────────────────────────────────────────────────────
 
 export async function ingestOperations060(
   tokens: string[],
   store: RelayStore,
+  sequencerStore?: SequencerStore,
 ): Promise<IngestionResult060[]> {
   const classified: ClassifiedOp[] = tokens.map((token, i) => ({
     ...classify(token),
@@ -756,39 +872,53 @@ export async function ingestOperations060(
   }));
   const sorted = dependencySort(classified);
 
-  const indexedResults: Array<{ index: number; result: IngestionResult060 }> = [];
-
-  for (const op of sorted) {
-    try {
-      let result: IngestionResult060;
-      switch (op.kind) {
-        case 'identity-op':
-          result = await ingestIdentityOp(op.jwsToken, store);
-          break;
-        case 'content-op':
-          result = await ingestContentOp(op.jwsToken, store);
-          break;
-        case 'beacon':
-          result = await ingestBeacon(op.jwsToken, store);
-          break;
-        case 'countersign':
-          result = await ingestCountersign(op.jwsToken, store);
-          break;
-        case 'artifact':
-          result = await ingestArtifact(op.jwsToken, store);
-          break;
-        default:
-          result = { cid: '', status: 'rejected', error: 'unrecognized operation type' };
+  // Store all ops as pending before acquiring the mutex (lock-free storage)
+  if (sequencerStore) {
+    for (const op of classified) {
+      if (op.operationCID) {
+        await sequencerStore.putPending(op.operationCID, op.jwsToken);
       }
-      indexedResults.push({ index: op.originalIndex, result });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'unexpected error';
-      indexedResults.push({
-        index: op.originalIndex,
-        result: { cid: '', status: 'rejected', error: message },
-      });
     }
   }
+
+  const indexedResults = await withMutex(async () => {
+    const results: Array<{ index: number; result: IngestionResult060 }> = [];
+
+    for (const op of sorted) {
+      let result: IngestionResult060;
+      try {
+        result = await dispatchOp(op, store);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'unexpected error';
+        result = { cid: op.operationCID ?? '', status: 'rejected', error: message };
+      }
+
+      if (sequencerStore && op.operationCID) {
+        if (result.status === 'new') {
+          await sequencerStore.updatePendingStatus(op.operationCID, 'resolved');
+        } else if (result.status === 'rejected') {
+          if (result.error && isDependencyError(result.error)) {
+            // Keep as pending — will be retried by sequencer loop
+            await sequencerStore.updatePendingStatus(op.operationCID, 'pending', result.error, true);
+            // Return 'new' to caller: op is accepted into the pending queue
+            result = { ...result, status: 'new' };
+          } else {
+            await sequencerStore.updatePendingStatus(op.operationCID, 'rejected', result.error);
+          }
+        }
+        // 'duplicate': no status change needed (already resolved or pending)
+      }
+
+      results.push({ index: op.originalIndex, result });
+    }
+
+    // Run sequencer loop to resolve pending ops (including any from prior batches)
+    if (sequencerStore) {
+      await runSequencerLoop(store, sequencerStore);
+    }
+
+    return results;
+  });
 
   return indexedResults.sort((a, b) => a.index - b.index).map((r) => r.result);
 }

--- a/apps/registry/src/relay/postgres-store.ts
+++ b/apps/registry/src/relay/postgres-store.ts
@@ -1,4 +1,4 @@
-import { eq, and, gt } from 'drizzle-orm';
+import { eq, and, gt, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type {
   RelayStore,
@@ -18,6 +18,7 @@ import {
   relayBlobs,
   relayCountersignatures,
   relayOperationLog,
+  relayPendingOperations,
 } from '../db/relay-schema';
 
 // TODO: replace with imported types from @metalabel/dfos-web-relay once 0.5.0 is installed
@@ -223,6 +224,40 @@ export class PostgresRelayStore implements RelayStore {
       operationCid,
       jwsToken,
     });
+  }
+
+  async putPending(cid: string, jwsToken: string): Promise<void> {
+    await this.db
+      .insert(relayPendingOperations)
+      .values({ cid, jwsToken, status: 'pending' })
+      .onConflictDoNothing();
+  }
+
+  async getPendingOps(): Promise<Array<{ cid: string; jwsToken: string; attempts: number }>> {
+    const rows = await this.db
+      .select()
+      .from(relayPendingOperations)
+      .where(eq(relayPendingOperations.status, 'pending'))
+      .orderBy(relayPendingOperations.receivedAt);
+    return rows.map((r) => ({ cid: r.cid, jwsToken: r.jwsToken, attempts: r.attempts }));
+  }
+
+  async updatePendingStatus(
+    cid: string,
+    status: 'pending' | 'resolved' | 'rejected',
+    error?: string,
+    incrementAttempts?: boolean,
+  ): Promise<void> {
+    await this.db
+      .update(relayPendingOperations)
+      .set({
+        status,
+        lastError: error ?? null,
+        ...(incrementAttempts
+          ? { attempts: sql`${relayPendingOperations.attempts} + 1` }
+          : {}),
+      })
+      .where(eq(relayPendingOperations.cid, cid));
   }
 
   async appendToLog(entry: LogEntry): Promise<void> {


### PR DESCRIPTION
Adds Brandon's three-layer architecture to the DFOS relay:

**Layer 1 — Store-then-verify:** All ops stored in `relay_pending_operations` before verification. Lock-free. Ops never silently lost.

**Layer 2 — Sequencer loop:** After each batch, reads pending ops, processes through ingest pipeline, loops until fixed-point (no progress). Retryable dependency errors stay pending (max 10 attempts). Non-dependency errors reject immediately.

**Layer 3 — Ingest mutex:** Promise-based lock serializes chain-state mutations. Raw storage remains lock-free.

Fixes 3 failing conformance tests:
- TestCrossBatchContentBeforeIdentity
- TestCrossBatchExtensionBeforeGenesis  
- TestCrossBatchForkBeforeAncestor

+217 lines across 6 files. Includes migration for pending_operations table.

Ref #518