### PR TITLE
fix(auth): password login — base64 decoding + JSON keypair parsing (#519)

### DIFF
--- a/apps/auth/app/login/components/PasswordAuthTab.tsx
+++ b/apps/auth/app/login/components/PasswordAuthTab.tsx
@@ -133,7 +133,16 @@ export default function PasswordAuthTab({ nextUrl, onMfaRequired, onSuccess }: P
       // Decrypt stored key client-side
       let privateKeyHex: string;
       try {
-        privateKeyHex = await decryptStoredKey(storedKeyData.encryptedKey, storedKeyData.salt, password);
+        const decrypted = await decryptStoredKey(storedKeyData.encryptedKey, storedKeyData.salt, password);
+
+        // The setup encrypts the full localStorage JSON: {"privateKey":"...","publicKey":"..."}
+        // Try parsing as JSON first, fall back to raw hex
+        try {
+          const parsed = JSON.parse(decrypted);
+          privateKeyHex = parsed.privateKey || parsed.keypair?.privateKey || decrypted;
+        } catch {
+          privateKeyHex = decrypted;
+        }
       } catch {
         setError('Incorrect password. Please try again.');
         return;


### PR DESCRIPTION
Two bugs in password login flow:

1. **Base64 vs hex mismatch** — Setup encrypts with base64 (`btoa`). Login was decoding with `hexToBytes`. Fixed to use `base64ToBytes`.

2. **Full keypair JSON vs raw key** — Setup encrypts the full localStorage JSON (`{privateKey, publicKey}`). Login expected just the 64-char hex private key. Now parses JSON first, extracts `privateKey`, falls back to raw.

Both bugs made every password login attempt fail with 'Incorrect password'.