### PR TITLE
fix(relay): return rejected for missing-dep ops, keep pending for sequencer (#518)

### DIFF
--- a/apps/registry/src/relay/ingest.ts
+++ b/apps/registry/src/relay/ingest.ts
@@ -897,12 +897,12 @@ export async function ingestOperations060(
         if (result.status === 'new') {
           await sequencerStore.updatePendingStatus(op.operationCID, 'resolved');
         } else if (result.status === 'rejected') {
-          if (result.error && isDependencyError(result.error)) {
+          if (result.error && isDependencyError(result.error) && op.kind !== 'artifact') {
             // Keep as pending — will be retried by sequencer loop
+            // Return 'rejected' to caller so they see the correct status
             await sequencerStore.updatePendingStatus(op.operationCID, 'pending', result.error, true);
-            // Return 'new' to caller: op is accepted into the pending queue
-            result = { ...result, status: 'new' };
           } else {
+            // Permanent rejection (non-dep error, or artifact from unknown identity)
             await sequencerStore.updatePendingStatus(op.operationCID, 'rejected', result.error);
           }
         }


### PR DESCRIPTION
Fixes 3 conformance failures:
- TestArtifactFromUnknownIdentity — artifacts from unknown identities now permanently rejected (not queued)
- TestCrossBatchContentBeforeIdentity — returns `rejected` to caller, stores as pending internally, sequencer resolves when deps arrive
- TestCrossBatchExtensionBeforeGenesis — same pattern

4 lines changed. The caller sees `rejected`, the sequencer still retries dependency failures behind the scenes.