### PR TITLE
fix(events): display event times in event timezone instead of UTC

### DIFF
--- a/apps/events/app/[eventId]/edit/form.tsx
+++ b/apps/events/app/[eventId]/edit/form.tsx
@@ -55,7 +55,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
   const [endDateTime, setEndDateTime] = useState(
     event.endsAt ? toLocalDateTimeString(new Date(event.endsAt)) : ''
   );
-  const [timezone, setTimezone] = useState((event as any).timezone || Intl.DateTimeFormat().resolvedOptions().timeZone);
+  const [timezone, setTimezone] = useState(event.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone);
   const [isVirtual, setIsVirtual] = useState(event.isVirtual || false);
   const [virtualUrl, setVirtualUrl] = useState(event.virtualUrl || '');
   const [venue, setVenue] = useState(event.venue || '');

--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -41,11 +41,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
   
   const eventDate = new Date(event.startsAt);
+  const eventTzMeta = event.timezone || 'UTC';
   const formattedDate = eventDate.toLocaleDateString('en-US', {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: eventTzMeta,
   });
   
   const ticketsList = await db
@@ -362,7 +364,7 @@ export default async function EventPage({ params, searchParams }: Props) {
     return true;
   });
   // Use event timezone if available, otherwise fall back to UTC
-  const eventTz = (event as any).timezone || 'UTC';
+  const eventTz = event.timezone || 'UTC';
   const formattedDate = eventDate.toLocaleDateString('en-US', {
     weekday: 'long',
     year: 'numeric',
@@ -379,6 +381,7 @@ export default async function EventPage({ params, searchParams }: Props) {
   const formattedEndTime = eventEndDate ? eventEndDate.toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
+    timeZoneName: 'short',
     timeZone: eventTz,
   }) : null;
   // If end date is a different day, show the full date too


### PR DESCRIPTION
Closes #545

Event detail pages were showing times in UTC. Now uses the event's stored IANA timezone (e.g. `America/New_York`) with timezone abbreviation displayed (EST/EDT/PST etc). Falls back to UTC with explicit label when no timezone set.

Changes:
- `app/[eventId]/page.tsx` — format times in event timezone, show timezone abbreviation on end time
- `app/[eventId]/edit/form.tsx` — clean up timezone type access
- OG metadata also uses event timezone