### PR TITLE
feat(registry): interest metadata + DID consent preferences (#538, #539)

### DIFF
--- a/apps/registry/.env.example
+++ b/apps/registry/.env.example
@@ -34,5 +34,8 @@ NEXT_PUBLIC_SERVICE_PREFIX=http://localhost:
 RELAY_DID=did:imajin:relay-dev
 RELAY_STORE=postgres
 
+# Internal service auth (audience endpoint — must match NOTIFY_WEBHOOK_SECRET in notify service)
+NOTIFY_WEBHOOK_SECRET=your-webhook-secret
+
 # Runtime
 NODE_ENV=

--- a/apps/registry/app/api/audience/[scope]/route.ts
+++ b/apps/registry/app/api/audience/[scope]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, didPreferences, didInterests } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+
+/**
+ * GET /api/audience/[scope]
+ * Internal endpoint — returns DIDs opted in for marketing for a given scope.
+ *
+ * A DID is included when:
+ *   - did_preferences.global_marketing = true (or no row — default true)
+ *   - did_interests.marketing = true for this scope
+ *
+ * Optional ?channel=email also requires did_interests.email = true.
+ *
+ * Auth: x-webhook-secret header (kernel services only)
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ scope: string }> }
+) {
+  // Verify webhook secret
+  const secret = request.headers.get('x-webhook-secret');
+  if (!secret || secret !== process.env.NOTIFY_WEBHOOK_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { scope } = await params;
+  const { searchParams } = new URL(request.url);
+  const channel = searchParams.get('channel'); // optional: 'email' | 'inapp' | 'chat'
+
+  try {
+    // Build conditions for did_interests
+    const interestConditions = [
+      eq(didInterests.scope, scope),
+      eq(didInterests.marketing, true),
+    ];
+
+    if (channel === 'email') {
+      interestConditions.push(eq(didInterests.email, true));
+    } else if (channel === 'inapp') {
+      interestConditions.push(eq(didInterests.inapp, true));
+    } else if (channel === 'chat') {
+      interestConditions.push(eq(didInterests.chat, true));
+    }
+
+    // Get all DIDs subscribed to this scope with marketing on
+    const scopeRows = await db
+      .select({ did: didInterests.did })
+      .from(didInterests)
+      .where(and(...interestConditions));
+
+    if (scopeRows.length === 0) {
+      return NextResponse.json({ dids: [], scope });
+    }
+
+    const scopeDids = scopeRows.map(r => r.did);
+
+    // Filter out DIDs that have explicitly set global_marketing = false
+    // DIDs with no row in did_preferences default to global_marketing = true
+    const optedOutRows = await db
+      .select({ did: didPreferences.did })
+      .from(didPreferences)
+      .where(eq(didPreferences.globalMarketing, false));
+
+    const optedOutSet = new Set(optedOutRows.map(r => r.did));
+    const dids = scopeDids.filter(did => !optedOutSet.has(did));
+
+    return NextResponse.json({ dids, scope, total: dids.length });
+  } catch (error) {
+    console.error('[audience/scope] get error:', error);
+    return NextResponse.json({ error: 'Failed to query audience' }, { status: 500 });
+  }
+}

--- a/apps/registry/app/api/interests/[scope]/route.ts
+++ b/apps/registry/app/api/interests/[scope]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { db, interests } from '@/src/db';
+import { eq } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * GET /api/interests/[scope]
+ * Get interest metadata + triggers for a specific scope
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ scope: string }> }
+) {
+  const cors = corsHeaders(request);
+
+  try {
+    const { scope } = await params;
+
+    const [interest] = await db
+      .select()
+      .from(interests)
+      .where(eq(interests.scope, scope))
+      .limit(1);
+
+    if (!interest) {
+      return NextResponse.json({ error: 'Interest not found' }, { status: 404, headers: cors });
+    }
+
+    return NextResponse.json({ interest }, { headers: cors });
+  } catch (error) {
+    console.error('[interests/scope] get error:', error);
+    return NextResponse.json({ error: 'Failed to get interest' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/registry/app/api/interests/route.ts
+++ b/apps/registry/app/api/interests/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { db, interests } from '@/src/db';
+import { asc } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * GET /api/interests
+ * List all registered interest scopes
+ */
+export async function GET(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  try {
+    const all = await db
+      .select()
+      .from(interests)
+      .orderBy(asc(interests.scope));
+
+    return NextResponse.json({ interests: all }, { headers: cors });
+  } catch (error) {
+    console.error('[interests] list error:', error);
+    return NextResponse.json({ error: 'Failed to list interests' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/registry/app/api/preferences/[did]/interests/[scope]/route.ts
+++ b/apps/registry/app/api/preferences/[did]/interests/[scope]/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { requireAuth } from '@imajin/auth';
+import { nanoid } from 'nanoid';
+import { db, didInterests, didPreferences } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * PUT /api/preferences/[did]/interests/[scope]
+ * Toggle per-scope marketing + channel booleans.
+ * Requires the authenticated session DID to match the :did param.
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string; scope: string }> }
+) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+
+  const { did, scope } = await params;
+
+  if (authResult.identity.id !== did) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: cors });
+  }
+
+  let body: { marketing?: boolean; email?: boolean; inapp?: boolean; chat?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  try {
+    const [existing] = await db
+      .select()
+      .from(didInterests)
+      .where(and(eq(didInterests.did, did), eq(didInterests.scope, scope)))
+      .limit(1);
+
+    let result;
+    if (existing) {
+      [result] = await db
+        .update(didInterests)
+        .set({
+          ...(body.marketing !== undefined && { marketing: body.marketing }),
+          ...(body.email !== undefined && { email: body.email }),
+          ...(body.inapp !== undefined && { inapp: body.inapp }),
+          ...(body.chat !== undefined && { chat: body.chat }),
+          updatedAt: new Date(),
+        })
+        .where(and(eq(didInterests.did, did), eq(didInterests.scope, scope)))
+        .returning();
+    } else {
+      const id = `din_${nanoid(16)}`;
+      [result] = await db
+        .insert(didInterests)
+        .values({
+          id,
+          did,
+          scope,
+          marketing: body.marketing ?? true,
+          email: body.email ?? true,
+          inapp: body.inapp ?? true,
+          chat: body.chat ?? true,
+        })
+        .returning();
+    }
+
+    return NextResponse.json({ interest: result }, { headers: cors });
+  } catch (error) {
+    console.error('[preferences/did/interests/scope] put error:', error);
+    return NextResponse.json({ error: 'Failed to update interest preference' }, { status: 500, headers: cors });
+  }
+}
+
+/**
+ * POST /api/preferences/[did]/interests/[scope]
+ * Create a per-scope interest row lazily (called by notify interest signal).
+ * Auth: x-webhook-secret (internal service call) OR session DID match.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string; scope: string }> }
+) {
+  const cors = corsHeaders(request);
+
+  const { did, scope } = await params;
+
+  // Allow internal service calls via webhook secret
+  const webhookSecret = request.headers.get('x-webhook-secret');
+  const isInternal = webhookSecret && webhookSecret === process.env.NOTIFY_WEBHOOK_SECRET;
+
+  if (!isInternal) {
+    // Fall back to session auth with DID check
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+    }
+    if (authResult.identity.id !== did) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: cors });
+    }
+  }
+
+  let body: { marketing?: boolean; email?: boolean; inapp?: boolean; chat?: boolean; createdByAttestation?: string };
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  try {
+    // Check if row already exists
+    const [existing] = await db
+      .select()
+      .from(didInterests)
+      .where(and(eq(didInterests.did, did), eq(didInterests.scope, scope)))
+      .limit(1);
+
+    if (existing) {
+      return NextResponse.json({ interest: existing, created: false }, { headers: cors });
+    }
+
+    // Check auto_subscribe preference to determine default channel state
+    const [globalPref] = await db
+      .select()
+      .from(didPreferences)
+      .where(eq(didPreferences.did, did))
+      .limit(1);
+
+    const autoSubscribe = globalPref?.autoSubscribe ?? true;
+    const id = `din_${nanoid(16)}`;
+
+    const [result] = await db
+      .insert(didInterests)
+      .values({
+        id,
+        did,
+        scope,
+        marketing: autoSubscribe,
+        email: autoSubscribe,
+        inapp: autoSubscribe,
+        chat: autoSubscribe,
+        createdByAttestation: body.createdByAttestation ?? null,
+      })
+      .returning();
+
+    return NextResponse.json({ interest: result, created: true }, { status: 201, headers: cors });
+  } catch (error) {
+    console.error('[preferences/did/interests/scope] post error:', error);
+    return NextResponse.json({ error: 'Failed to create interest preference' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/registry/app/api/preferences/[did]/route.ts
+++ b/apps/registry/app/api/preferences/[did]/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { requireAuth } from '@imajin/auth';
+import { db, didPreferences, didInterests, interests } from '@/src/db';
+import { eq, asc } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * GET /api/preferences/[did]
+ * Returns global prefs + all interest scopes with channel toggles for this DID.
+ * Requires the authenticated session DID to match the :did param.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+
+  const { did } = await params;
+
+  if (authResult.identity.id !== did) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: cors });
+  }
+
+  try {
+    // Get or return default global preferences
+    const [globalPref] = await db
+      .select()
+      .from(didPreferences)
+      .where(eq(didPreferences.did, did))
+      .limit(1);
+
+    // Get all interest scopes for this DID
+    const interestRows = await db
+      .select()
+      .from(didInterests)
+      .where(eq(didInterests.did, did))
+      .orderBy(asc(didInterests.scope));
+
+    return NextResponse.json({
+      preferences: globalPref ?? {
+        did,
+        globalMarketing: true,
+        autoSubscribe: true,
+        createdAt: null,
+        updatedAt: null,
+      },
+      interests: interestRows,
+    }, { headers: cors });
+  } catch (error) {
+    console.error('[preferences/did] get error:', error);
+    return NextResponse.json({ error: 'Failed to get preferences' }, { status: 500, headers: cors });
+  }
+}
+
+/**
+ * PUT /api/preferences/[did]
+ * Update global_marketing / auto_subscribe for this DID.
+ * Requires the authenticated session DID to match the :did param.
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+
+  const { did } = await params;
+
+  if (authResult.identity.id !== did) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: cors });
+  }
+
+  let body: { globalMarketing?: boolean; autoSubscribe?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  try {
+    const [existing] = await db
+      .select()
+      .from(didPreferences)
+      .where(eq(didPreferences.did, did))
+      .limit(1);
+
+    let result;
+    if (existing) {
+      [result] = await db
+        .update(didPreferences)
+        .set({
+          ...(body.globalMarketing !== undefined && { globalMarketing: body.globalMarketing }),
+          ...(body.autoSubscribe !== undefined && { autoSubscribe: body.autoSubscribe }),
+          updatedAt: new Date(),
+        })
+        .where(eq(didPreferences.did, did))
+        .returning();
+    } else {
+      [result] = await db
+        .insert(didPreferences)
+        .values({
+          did,
+          globalMarketing: body.globalMarketing ?? true,
+          autoSubscribe: body.autoSubscribe ?? true,
+        })
+        .returning();
+    }
+
+    return NextResponse.json({ preferences: result }, { headers: cors });
+  } catch (error) {
+    console.error('[preferences/did] put error:', error);
+    return NextResponse.json({ error: 'Failed to update preferences' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/registry/drizzle/0003_interest_did_preferences.sql
+++ b/apps/registry/drizzle/0003_interest_did_preferences.sql
@@ -1,0 +1,47 @@
+-- Interest metadata — declared by apps during registration
+CREATE TABLE "registry"."interests" (
+	"id" text PRIMARY KEY NOT NULL,
+	"scope" text NOT NULL,
+	"label" text NOT NULL,
+	"description" text,
+	"triggers" jsonb DEFAULT '[]'::jsonb,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "interests_scope_unique" UNIQUE("scope")
+);
+--> statement-breakpoint
+-- Global DID preferences
+CREATE TABLE "registry"."did_preferences" (
+	"did" text PRIMARY KEY NOT NULL,
+	"global_marketing" boolean DEFAULT true,
+	"auto_subscribe" boolean DEFAULT true,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+-- Per-scope interests — created lazily from attestation activity
+CREATE TABLE "registry"."did_interests" (
+	"id" text PRIMARY KEY NOT NULL,
+	"did" text NOT NULL,
+	"scope" text NOT NULL,
+	"marketing" boolean DEFAULT true,
+	"email" boolean DEFAULT true,
+	"inapp" boolean DEFAULT true,
+	"chat" boolean DEFAULT true,
+	"created_by_attestation" text,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "uniq_did_interests_did_scope" UNIQUE("did","scope")
+);
+--> statement-breakpoint
+CREATE INDEX "idx_did_interests_did" ON "registry"."did_interests" USING btree ("did");--> statement-breakpoint
+CREATE INDEX "idx_did_interests_scope" ON "registry"."did_interests" USING btree ("scope");--> statement-breakpoint
+-- Seed interest records for existing apps
+INSERT INTO "registry"."interests" ("id", "scope", "label", "description", "triggers") VALUES
+  ('int_events000000001', 'events', 'Events & Gatherings', 'Updates about events you''ve attended or shown interest in', '["ticket.purchased","event.created","event.rsvp"]'::jsonb),
+  ('int_market000000001', 'market', 'Marketplace', 'Updates about marketplace activity', '["listing.created","listing.purchased"]'::jsonb),
+  ('int_coffee000000001', 'coffee', 'Tips & Support', 'Updates about tips and support pages', '["tip.received","tip.sent"]'::jsonb),
+  ('int_connect00000001', 'connections', 'Connections', 'Updates about your network', '["connection.accepted","pod.created"]'::jsonb),
+  ('int_chat0000000001', 'chat', 'Chat & Messaging', 'Chat notifications and mentions', '["chat.mention"]'::jsonb),
+  ('int_learn000000001', 'learn', 'Learning', 'Course and learning updates', '["course.enrolled","module.completed"]'::jsonb)
+ON CONFLICT ("scope") DO NOTHING;

--- a/apps/registry/drizzle/meta/_journal.json
+++ b/apps/registry/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1774857600000,
       "tag": "0002_pending_operations",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1743379200000,
+      "tag": "0003_interest_did_preferences",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/registry/src/db/schema.ts
+++ b/apps/registry/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, jsonb, index, boolean, pgSchema } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, jsonb, index, boolean, pgSchema, unique } from 'drizzle-orm/pg-core';
 
 export const registrySchema = pgSchema('registry');
 
@@ -97,9 +97,57 @@ export const trustRelationships = registrySchema.table('trust', {
   toIdx: index('idx_registry_trust_to').on(table.toNode),
 }));
 
+/**
+ * Interest metadata — declared by apps during registration
+ */
+export const interests = registrySchema.table('interests', {
+  id: text('id').primaryKey(),                           // int_<nanoid>
+  scope: text('scope').notNull().unique(),               // 'events', 'market', 'coffee'
+  label: text('label').notNull(),                        // 'Events & Gatherings'
+  description: text('description'),                      // shown on preferences page
+  triggers: jsonb('triggers').default([]),               // ['ticket.purchased', 'event.created']
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+});
+
+/**
+ * Global DID preferences
+ */
+export const didPreferences = registrySchema.table('did_preferences', {
+  did: text('did').primaryKey(),
+  globalMarketing: boolean('global_marketing').default(true),
+  autoSubscribe: boolean('auto_subscribe').default(true),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+});
+
+/**
+ * Per-scope interests — created lazily from attestation activity
+ */
+export const didInterests = registrySchema.table('did_interests', {
+  id: text('id').primaryKey(),                           // din_<nanoid>
+  did: text('did').notNull(),
+  scope: text('scope').notNull(),                        // references interests.scope
+  marketing: boolean('marketing').default(true),         // receive marketing for this scope?
+  email: boolean('email').default(true),                 // email channel
+  inapp: boolean('inapp').default(true),                 // in-app channel
+  chat: boolean('chat').default(true),                   // chat DM channel
+  createdByAttestation: text('created_by_attestation'),  // e.g. 'ticket.purchased'
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  didIdx: index('idx_did_interests_did').on(table.did),
+  scopeIdx: index('idx_did_interests_scope').on(table.scope),
+  didScopeUnique: unique('uniq_did_interests_did_scope').on(table.did, table.scope),
+}));
+
 // Types
 export type Node = typeof nodes.$inferSelect;
 export type NewNode = typeof nodes.$inferInsert;
 export type ApprovedBuild = typeof approvedBuilds.$inferSelect;
 export type Heartbeat = typeof heartbeats.$inferSelect;
 export type TrustRelationship = typeof trustRelationships.$inferSelect;
+export type Interest = typeof interests.$inferSelect;
+export type NewInterest = typeof interests.$inferInsert;
+export type DidPreference = typeof didPreferences.$inferSelect;
+export type DidInterest = typeof didInterests.$inferSelect;


### PR DESCRIPTION
Closes #538, closes #539

Adds the consent/preference layer to registry — interest catalog, DID preferences, and audience query.

### New tables
- `registry.interests` — interest metadata declared by apps (scope, label, triggers)
- `registry.did_preferences` — global marketing toggle + auto-subscribe per DID
- `registry.did_interests` — per-scope channel toggles (email/inapp/chat), created lazily

### API routes
- `GET /api/interests` — list all registered interests
- `GET /api/interests/:scope` — get interest + triggers
- `GET /api/preferences/:did` — global prefs + all scopes (auth: DID owner)
- `PUT /api/preferences/:did` — update global marketing/auto-subscribe
- `PUT /api/preferences/:did/interests/:scope` — toggle per-scope channels
- `GET /api/audience/:scope` — returns opted-in DIDs (auth: webhook secret)

### Seed data
Six interests seeded: events, market, coffee, connections, chat, learn

### Migration
SQL migration file, not drizzle-kit push.