### PR TITLE
feat(notify): broadcast + unsubscribe + interest signals (#540, #541)

### DIFF
--- a/apps/auth/app/api/identity/[did]/contact/route.ts
+++ b/apps/auth/app/api/identity/[did]/contact/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, identities, credentials } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+
+/**
+ * GET /api/identity/:did/contact
+ *
+ * Internal endpoint — resolve a DID to its contact email.
+ * Used by the notify service to resolve DID → email for broadcast sends.
+ *
+ * Auth: x-webhook-secret header (same secret as NOTIFY_WEBHOOK_SECRET on notify service).
+ *
+ * Lookup order:
+ *   1. TODO(#546): auth.identities.contact_email once that column is backfilled
+ *   2. auth.credentials where type='email' (login email)
+ *
+ * Returns: { did, email }
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const secret = request.headers.get('x-webhook-secret');
+  if (!secret || secret !== process.env.NOTIFY_WEBHOOK_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { did } = await params;
+  const decodedDid = decodeURIComponent(did);
+
+  try {
+    // Verify identity exists
+    const [identity] = await db
+      .select({ id: identities.id })
+      .from(identities)
+      .where(eq(identities.id, decodedDid))
+      .limit(1);
+
+    if (!identity) {
+      return NextResponse.json({ error: 'Identity not found' }, { status: 404 });
+    }
+
+    // TODO(#546): Once contact_email is backfilled onto identities, prefer it here:
+    // const contactEmail = identity.contactEmail ?? credential.value
+    //
+    // For now, fall back to the credentials table (login email)
+    const [emailCredential] = await db
+      .select({ value: credentials.value })
+      .from(credentials)
+      .where(and(eq(credentials.did, decodedDid), eq(credentials.type, 'email')))
+      .limit(1);
+
+    if (!emailCredential?.value) {
+      return NextResponse.json({ error: 'No email found for DID' }, { status: 404 });
+    }
+
+    return NextResponse.json({ did: decodedDid, email: emailCredential.value });
+  } catch (error) {
+    console.error('Contact resolve error:', error);
+    return NextResponse.json({ error: 'Failed to resolve contact' }, { status: 500 });
+  }
+}

--- a/apps/chat/src/app/api/conversations/[id]/messages/route.ts
+++ b/apps/chat/src/app/api/conversations/[id]/messages/route.ts
@@ -256,6 +256,10 @@ export async function POST(
                 messagePreview: messageText.slice(0, 100),
               },
             }).catch((err: unknown) => console.error('Mention notify error:', err));
+
+            // Record interest signal — chat.mention → chat scope
+            notify.interest({ did: mentionedDid, attestationType: 'chat.mention' })
+              .catch((err: unknown) => console.error('Interest signal error:', err));
           } catch (err) {
             console.error('Handle resolution error:', err);
           }

--- a/apps/chat/src/app/api/d/[did]/messages/route.ts
+++ b/apps/chat/src/app/api/d/[did]/messages/route.ts
@@ -315,6 +315,10 @@ export async function POST(
                 messagePreview: messageText.slice(0, 100),
               },
             }).catch((err: unknown) => console.error('Mention notify error:', err));
+
+            // Record interest signal — chat.mention → chat scope
+            notify.interest({ did: mentionedDid, attestationType: 'chat.mention' })
+              .catch((err: unknown) => console.error('Interest signal error:', err));
           } catch (err) {
             console.error('Handle resolution error:', err);
           }

--- a/apps/coffee/app/api/webhook/payment/route.ts
+++ b/apps/coffee/app/api/webhook/payment/route.ts
@@ -97,6 +97,10 @@ export async function POST(request: NextRequest) {
               tipperName: displayFrom,
             },
           }).catch((err) => console.error('[webhook] Notify recipient error:', err));
+
+          // Record interest signal — tip.received → coffee scope
+          notify.interest({ did: recipientDid, attestationType: 'tip.received' })
+            .catch((err) => console.error('[webhook] Interest signal error:', err));
         }
 
         // Notify sender
@@ -110,6 +114,10 @@ export async function POST(request: NextRequest) {
               pageName: pageTitle || 'a creator',
             },
           }).catch((err) => console.error('[webhook] Notify sender error:', err));
+
+          // Record interest signal — tip.sent → coffee scope
+          notify.interest({ did: fromDid, attestationType: 'tip.sent' })
+            .catch((err) => console.error('[webhook] Interest signal error:', err));
         }
 
         break;

--- a/apps/connections/app/api/invites/[code]/accept/route.ts
+++ b/apps/connections/app/api/invites/[code]/accept/route.ts
@@ -137,6 +137,12 @@ export async function POST(
         name: session.handle || session.did.slice(0, 16),
       },
     }).catch((err: unknown) => console.error("Notify error:", err));
+
+    // Record interest signals — connection.accepted → connections scope (both parties)
+    notify.interest({ did: invite.fromDid, attestationType: 'connection.accepted' })
+      .catch((err: unknown) => console.error("Interest signal error:", err));
+    notify.interest({ did: session.did, attestationType: 'connection.accepted' })
+      .catch((err: unknown) => console.error("Interest signal error:", err));
   })().catch((err: unknown) => console.error("Notify setup error:", err));
 
   emitAttestation({

--- a/apps/events/app/api/register/[ticketId]/route.ts
+++ b/apps/events/app/api/register/[ticketId]/route.ts
@@ -137,6 +137,10 @@ export async function POST(
           eventTitle: event.title,
         },
       }).catch((err) => console.error("Notify error:", err));
+
+      // Record interest signal — event.rsvp → events scope
+      notify.interest({ did: ticket.ownerDid, attestationType: 'event.rsvp' })
+        .catch((err) => console.error("Interest signal error:", err));
     }
 
     // Send ticket confirmation email to the registered attendee (skip if no email, e.g. Dykil form)

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -354,6 +354,10 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     },
   }).catch((err) => console.error("Notify error:", err));
 
+  // Record interest signal — ticket.purchased → events scope
+  notify.interest({ did: ownerDid, attestationType: 'ticket.purchased' })
+    .catch((err) => console.error("Interest signal error:", err));
+
   // Add buyer to event chat conversation_members (non-fatal)
   // The event DID is the conversation DID
   const CHAT_URL = process.env.CHAT_SERVICE_URL || process.env.CHAT_URL;

--- a/apps/market/app/api/listings/route.ts
+++ b/apps/market/app/api/listings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { db, listings } from '@/db';
 import { requireAuth, getSession, emitAttestation } from '@imajin/auth';
+import { notify } from '@imajin/notify';
 import { generateId, jsonResponse, errorResponse } from '@/lib/utils';
 import { resolveMediaRef } from '@imajin/media';
 import { eq, ilike, and, desc, asc, sql, ne } from 'drizzle-orm';
@@ -94,6 +95,10 @@ export async function POST(request: NextRequest) {
       context_type: 'market',
       payload: { title, price, currency: listing.currency },
     }).catch((err) => console.error('Attestation emit error:', err));
+
+    // Record interest signal — listing.created → market scope
+    notify.interest({ did: identity.id, attestationType: 'listing.created' })
+      .catch((err) => console.error('Interest signal error:', err));
 
     return jsonResponse(listing, 201);
   } catch (error) {

--- a/apps/market/app/api/webhook/route.ts
+++ b/apps/market/app/api/webhook/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest } from 'next/server';
 import { db, listings } from '@/db';
 import { emitAttestation } from '@imajin/auth';
+import { notify } from '@imajin/notify';
 import { jsonResponse, errorResponse } from '@/lib/utils';
 import { eq } from 'drizzle-orm';
 
@@ -71,6 +72,16 @@ export async function POST(request: NextRequest) {
           context_type: 'market',
           payload: { amount: body.metadata?.amount },
         }).catch((err: unknown) => console.error('Attestation emit error:', err));
+
+        // Record interest signals — listing.purchased → market scope (buyer + seller)
+        if (body.metadata?.buyerDid) {
+          notify.interest({ did: body.metadata.buyerDid, attestationType: 'listing.purchased' })
+            .catch((err: unknown) => console.error('Interest signal error:', err));
+        }
+        if (listing.sellerDid) {
+          notify.interest({ did: listing.sellerDid, attestationType: 'listing.purchased' })
+            .catch((err: unknown) => console.error('Interest signal error:', err));
+        }
       }
     }
 

--- a/apps/notify/.env.example
+++ b/apps/notify/.env.example
@@ -2,6 +2,13 @@ DATABASE_URL=postgres://imajin_dev:imajin_dev@localhost:5432/imajin_dev
 AUTH_SERVICE_URL=http://localhost:3001
 NOTIFY_WEBHOOK_SECRET=dev-secret-change-me
 
+# Registry service URL — for audience queries, preference checks, interest catalog
+REGISTRY_URL=http://localhost:3002
+
+# HMAC secret for one-click unsubscribe tokens (RFC 8058)
+# Generate with: openssl rand -hex 32
+UNSUBSCRIBE_HMAC_SECRET=dev-hmac-secret-change-me
+
 # Environment detection — controls session cookie name (dev vs prod)
 IMAJIN_ENV=dev
 

--- a/apps/notify/app/api/broadcast/route.ts
+++ b/apps/notify/app/api/broadcast/route.ts
@@ -1,0 +1,267 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+import { nanoid } from 'nanoid';
+import { createHmac } from 'crypto';
+import { db } from '@/db';
+import { notifications } from '@/db/schema';
+import { sendEmail } from '@imajin/email';
+
+// TODO(#538): These registry routes will be implemented by Agent 1.
+// Stubbed here with clear fallback behavior.
+
+const REGISTRY_URL = process.env.REGISTRY_URL;
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL;
+const UNSUBSCRIBE_HMAC_SECRET = process.env.UNSUBSCRIBE_HMAC_SECRET;
+
+const NOTIFY_URL = process.env.NEXT_PUBLIC_NOTIFY_URL || 'https://notify.imajin.ai';
+
+/** Max recipients per batch to avoid SendGrid rate limits */
+const BATCH_SIZE = 100;
+/** Delay between batches in milliseconds */
+const BATCH_DELAY_MS = 1000;
+
+function makeUnsubscribeToken(did: string, scope: string): string | null {
+  if (!UNSUBSCRIBE_HMAC_SECRET) return null;
+  return createHmac('sha256', UNSUBSCRIBE_HMAC_SECRET)
+    .update(`${did}:${scope}`)
+    .digest('hex');
+}
+
+function makeUnsubscribeUrl(did: string, scope: string): string | null {
+  const token = makeUnsubscribeToken(did, scope);
+  if (!token) return null;
+  return `${NOTIFY_URL}/api/unsubscribe?did=${encodeURIComponent(did)}&scope=${encodeURIComponent(scope)}&token=${token}`;
+}
+
+/**
+ * Fetch audience DIDs from registry for a scope.
+ * TODO(#538): Registry /api/audience/:scope implemented by Agent 1.
+ */
+async function fetchAudienceFromRegistry(
+  scope: string,
+  webhookSecret: string,
+): Promise<string[]> {
+  if (!REGISTRY_URL) {
+    console.warn('[broadcast] REGISTRY_URL not set — cannot fetch audience from registry');
+    return [];
+  }
+  try {
+    const res = await fetch(`${REGISTRY_URL}/api/audience/${encodeURIComponent(scope)}?channel=email`, {
+      headers: { 'x-webhook-secret': webhookSecret },
+      cache: 'no-store',
+    });
+    if (!res.ok) {
+      console.error(`[broadcast] Registry audience fetch failed: ${res.status}`);
+      return [];
+    }
+    const data = await res.json();
+    return Array.isArray(data.dids) ? data.dids : [];
+  } catch (err) {
+    console.error('[broadcast] Registry audience fetch error:', err);
+    return [];
+  }
+}
+
+/**
+ * Check registry preferences for a DID + scope.
+ * Returns true if the DID is eligible to receive marketing email for this scope.
+ * TODO(#538): Registry /api/preferences/:did implemented by Agent 1.
+ */
+async function checkRegistryPreferences(
+  did: string,
+  scope: string,
+  webhookSecret: string,
+): Promise<boolean> {
+  if (!REGISTRY_URL) return true; // optimistic if registry not configured
+  try {
+    const res = await fetch(
+      `${REGISTRY_URL}/api/preferences/${encodeURIComponent(did)}`,
+      { headers: { 'x-webhook-secret': webhookSecret }, cache: 'no-store' },
+    );
+    if (!res.ok) return true; // default to eligible on registry error
+    const prefs = await res.json();
+
+    // Global marketing kill-switch
+    if (prefs.globalMarketing === false) return false;
+
+    // Per-scope interest check (if the row exists)
+    const scopePrefs = (prefs.interests ?? []).find(
+      (i: { scope: string }) => i.scope === scope,
+    );
+    if (scopePrefs) {
+      if (scopePrefs.marketing === false) return false;
+      if (scopePrefs.email === false) return false;
+    }
+
+    return true;
+  } catch {
+    return true; // optimistic on error
+  }
+}
+
+/**
+ * Resolve a DID to a contact email via the auth service internal endpoint.
+ */
+async function resolveEmail(did: string, webhookSecret: string): Promise<string | null> {
+  if (!AUTH_SERVICE_URL) {
+    console.warn('[broadcast] AUTH_SERVICE_URL not set — cannot resolve email for', did);
+    return null;
+  }
+  try {
+    const res = await fetch(
+      `${AUTH_SERVICE_URL}/api/identity/${encodeURIComponent(did)}/contact`,
+      { headers: { 'x-webhook-secret': webhookSecret }, cache: 'no-store' },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.email ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * POST /api/broadcast
+ *
+ * Bulk-send a marketing email to an audience.
+ *
+ * Body:
+ *   scope       — interest scope ('events', 'market', 'coffee', ...)
+ *   dids?       — explicit list; if omitted, fetched from registry /api/audience/:scope
+ *   subject     — email subject
+ *   html        — email HTML body
+ *   text?       — plain text fallback
+ *   channels?   — default ['email']
+ *
+ * Auth: x-webhook-secret header (kernel services only)
+ */
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  const secret = request.headers.get('x-webhook-secret');
+  if (!secret || secret !== process.env.NOTIFY_WEBHOOK_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: cors });
+  }
+
+  let body: {
+    scope: string;
+    dids?: string[];
+    subject: string;
+    html: string;
+    text?: string;
+    channels?: ('email' | 'inapp' | 'chat')[];
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  const { scope, dids: explicitDids, subject, html, text, channels = ['email'] } = body;
+
+  if (!scope || !subject || !html) {
+    return NextResponse.json(
+      { error: 'Missing required fields: scope, subject, html' },
+      { status: 400, headers: cors },
+    );
+  }
+
+  // Resolve audience
+  let audienceDids: string[];
+  if (explicitDids && explicitDids.length > 0) {
+    audienceDids = explicitDids;
+  } else {
+    audienceDids = await fetchAudienceFromRegistry(scope, secret);
+    if (audienceDids.length === 0) {
+      return NextResponse.json(
+        { sent: 0, skipped: 0, errors: 0, message: 'No audience found' },
+        { headers: cors },
+      );
+    }
+  }
+
+  let sent = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  // Process in batches
+  for (let batchStart = 0; batchStart < audienceDids.length; batchStart += BATCH_SIZE) {
+    const batch = audienceDids.slice(batchStart, batchStart + BATCH_SIZE);
+
+    await Promise.all(
+      batch.map(async (did) => {
+        try {
+          // Check registry preferences (if we fetched audience ourselves, prefs are already
+          // baked in; if explicit dids, we still check per-DID)
+          const eligible = await checkRegistryPreferences(did, scope, secret);
+          if (!eligible) {
+            skipped++;
+            return;
+          }
+
+          const email = await resolveEmail(did, secret);
+          if (!email) {
+            skipped++;
+            return;
+          }
+
+          const unsubscribeUrl = makeUnsubscribeUrl(did, scope);
+          const channelsSent: string[] = [];
+
+          if (channels.includes('email')) {
+            const result = await sendEmail({
+              to: email,
+              subject,
+              html,
+              text,
+              ...(unsubscribeUrl ? { unsubscribeUrl } : {}),
+            });
+
+            if (result.success) {
+              channelsSent.push('email');
+              sent++;
+            } else {
+              errors++;
+            }
+          }
+
+          // Log to notifications table
+          if (channelsSent.length > 0) {
+            await db.insert(notifications).values({
+              id: `ntf_${nanoid(16)}`,
+              recipientDid: did,
+              scope,
+              urgency: 'low',
+              title: subject,
+              body: undefined,
+              data: { broadcast: true, channels },
+              channelsSent,
+              read: false,
+            }).catch((err) => console.error('[broadcast] DB insert error:', err));
+          }
+        } catch (err) {
+          console.error(`[broadcast] Error processing DID ${did}:`, err);
+          errors++;
+        }
+      }),
+    );
+
+    // Rate limit: pause between batches
+    if (batchStart + BATCH_SIZE < audienceDids.length) {
+      await sleep(BATCH_DELAY_MS);
+    }
+  }
+
+  console.log(`[broadcast] scope=${scope} sent=${sent} skipped=${skipped} errors=${errors}`);
+
+  return NextResponse.json({ sent, skipped, errors }, { headers: cors });
+}

--- a/apps/notify/app/api/interest/route.ts
+++ b/apps/notify/app/api/interest/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders, corsOptions } from '@imajin/config';
+
+const REGISTRY_URL = process.env.REGISTRY_URL;
+
+/**
+ * Fetch the scope that an attestation type maps to.
+ * TODO(#538): Registry /api/interests/:scope and interest catalog implemented by Agent 1.
+ *
+ * Returns the scope string, or null if no match found.
+ */
+async function resolveScopeForAttestation(
+  attestationType: string,
+  webhookSecret: string,
+): Promise<string | null> {
+  if (!REGISTRY_URL) {
+    console.warn('[interest] REGISTRY_URL not set — cannot resolve scope for', attestationType);
+    return null;
+  }
+  try {
+    // Fetch full interest catalog and find matching scope
+    const res = await fetch(`${REGISTRY_URL}/api/interests`, {
+      headers: { 'x-webhook-secret': webhookSecret },
+      cache: 'no-store',
+    });
+    if (!res.ok) {
+      console.error(`[interest] Registry interests fetch failed: ${res.status}`);
+      return null;
+    }
+    const data = await res.json();
+    const interests: { scope: string; triggers: string[] }[] = data.interests ?? [];
+    const match = interests.find((i) => i.triggers?.includes(attestationType));
+    return match?.scope ?? null;
+  } catch (err) {
+    console.error('[interest] Scope resolution error:', err);
+    return null;
+  }
+}
+
+/**
+ * Check whether a did_interests row already exists for DID + scope.
+ * TODO(#538): Registry /api/preferences/:did implemented by Agent 1.
+ */
+async function didInterestExists(
+  did: string,
+  scope: string,
+  webhookSecret: string,
+): Promise<boolean> {
+  if (!REGISTRY_URL) return false;
+  try {
+    const res = await fetch(
+      `${REGISTRY_URL}/api/preferences/${encodeURIComponent(did)}`,
+      { headers: { 'x-webhook-secret': webhookSecret }, cache: 'no-store' },
+    );
+    if (!res.ok) return false;
+    const prefs = await res.json();
+    const interests: { scope: string }[] = prefs.interests ?? [];
+    return interests.some((i) => i.scope === scope);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create a did_interests row via registry internal API.
+ * Channels enabled/disabled based on DID's auto_subscribe preference.
+ * TODO(#538): Registry POST /api/preferences/:did/interests/:scope implemented by Agent 1.
+ */
+async function createDidInterest(
+  did: string,
+  scope: string,
+  attestationType: string,
+  webhookSecret: string,
+): Promise<void> {
+  if (!REGISTRY_URL) {
+    console.warn('[interest] REGISTRY_URL not set — cannot create did_interest');
+    return;
+  }
+  try {
+    const res = await fetch(
+      `${REGISTRY_URL}/api/preferences/${encodeURIComponent(did)}/interests/${encodeURIComponent(scope)}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-webhook-secret': webhookSecret,
+        },
+        body: JSON.stringify({ createdByAttestation: attestationType }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      console.error(`[interest] Registry create did_interest failed: ${res.status} ${text}`);
+    }
+  } catch (err) {
+    console.error('[interest] Create did_interest error:', err);
+  }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * POST /api/interest
+ *
+ * Records an interest signal for a DID based on an attestation type.
+ * Called internally whenever a user performs an action that maps to an interest scope.
+ *
+ * Body: { did: string, attestationType: string }
+ * Auth: x-webhook-secret header
+ *
+ * Flow:
+ *   1. Look up which scope the attestationType maps to in the registry interest catalog
+ *   2. Check if did_interests row already exists — if so, no-op
+ *   3. If not: POST to registry to create did_interests row
+ *      (registry checks auto_subscribe preference to set channel defaults)
+ */
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  const secret = request.headers.get('x-webhook-secret');
+  if (!secret || secret !== process.env.NOTIFY_WEBHOOK_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: cors });
+  }
+
+  let body: { did: string; attestationType: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  const { did, attestationType } = body;
+  if (!did || !attestationType) {
+    return NextResponse.json(
+      { error: 'Missing required fields: did, attestationType' },
+      { status: 400, headers: cors },
+    );
+  }
+
+  // Step 1: Resolve scope
+  const scope = await resolveScopeForAttestation(attestationType, secret);
+  if (!scope) {
+    // Unknown attestation type — not an error, just nothing to record
+    return NextResponse.json({ ok: true, action: 'no_scope' }, { headers: cors });
+  }
+
+  // Step 2: Check if already exists
+  const exists = await didInterestExists(did, scope, secret);
+  if (exists) {
+    return NextResponse.json({ ok: true, action: 'already_exists' }, { headers: cors });
+  }
+
+  // Step 3: Create did_interests row via registry
+  await createDidInterest(did, scope, attestationType, secret);
+
+  return NextResponse.json({ ok: true, action: 'created', scope }, { headers: cors });
+}

--- a/apps/notify/app/api/unsubscribe/route.ts
+++ b/apps/notify/app/api/unsubscribe/route.ts
@@ -1,0 +1,209 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createHmac, timingSafeEqual } from 'crypto';
+
+const REGISTRY_URL = process.env.REGISTRY_URL;
+const UNSUBSCRIBE_HMAC_SECRET = process.env.UNSUBSCRIBE_HMAC_SECRET;
+
+/**
+ * Verify the unsubscribe token: HMAC-SHA256(secret, did:scope)
+ */
+function verifyToken(did: string, scope: string, token: string): boolean {
+  if (!UNSUBSCRIBE_HMAC_SECRET) return false;
+  const expected = createHmac('sha256', UNSUBSCRIBE_HMAC_SECRET)
+    .update(`${did}:${scope}`)
+    .digest('hex');
+  try {
+    return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(token, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Update registry preference to opt-out of marketing for this scope.
+ * TODO(#538): Registry PUT /api/preferences/:did/interests/:scope implemented by Agent 1.
+ */
+async function updateRegistryPreference(did: string, scope: string): Promise<void> {
+  if (!REGISTRY_URL) {
+    console.warn('[unsubscribe] REGISTRY_URL not set — cannot update registry preference');
+    return;
+  }
+  try {
+    const webhookSecret = process.env.NOTIFY_WEBHOOK_SECRET;
+    const res = await fetch(
+      `${REGISTRY_URL}/api/preferences/${encodeURIComponent(did)}/interests/${encodeURIComponent(scope)}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(webhookSecret ? { 'x-webhook-secret': webhookSecret } : {}),
+        },
+        body: JSON.stringify({ marketing: false, email: false }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      console.error(`[unsubscribe] Registry update failed: ${res.status} ${text}`);
+    }
+  } catch (err) {
+    console.error('[unsubscribe] Registry update error:', err);
+  }
+}
+
+function renderPage(title: string, message: string, detail?: string): NextResponse {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${title} — Imajin</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f9fafb;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      color: #111827;
+    }
+    .card {
+      background: #fff;
+      border-radius: 12px;
+      border: 1px solid #e5e7eb;
+      padding: 48px 40px;
+      max-width: 480px;
+      width: 100%;
+      text-align: center;
+    }
+    .icon { font-size: 48px; margin-bottom: 16px; }
+    h1 { font-size: 22px; font-weight: 600; margin-bottom: 12px; }
+    p { font-size: 15px; color: #6b7280; line-height: 1.6; }
+    .detail { margin-top: 8px; font-size: 13px; color: #9ca3af; }
+    a { color: #6b7280; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">✓</div>
+    <h1>${title}</h1>
+    <p>${message}</p>
+    ${detail ? `<p class="detail">${detail}</p>` : ''}
+  </div>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+}
+
+function renderErrorPage(message: string): NextResponse {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Error — Imajin</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f9fafb;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      color: #111827;
+    }
+    .card {
+      background: #fff;
+      border-radius: 12px;
+      border: 1px solid #e5e7eb;
+      padding: 48px 40px;
+      max-width: 480px;
+      width: 100%;
+      text-align: center;
+    }
+    .icon { font-size: 48px; margin-bottom: 16px; }
+    h1 { font-size: 22px; font-weight: 600; margin-bottom: 12px; }
+    p { font-size: 15px; color: #6b7280; line-height: 1.6; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">⚠</div>
+    <h1>Invalid Link</h1>
+    <p>${message}</p>
+  </div>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 400,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+}
+
+/**
+ * GET /api/unsubscribe?did=X&scope=Y&token=Z
+ *
+ * Renders a confirmation page and processes the unsubscribe immediately.
+ * Token is HMAC-SHA256(UNSUBSCRIBE_HMAC_SECRET, did:scope) — no DB lookup required.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const did = searchParams.get('did');
+  const scope = searchParams.get('scope');
+  const token = searchParams.get('token');
+
+  if (!did || !scope || !token) {
+    return renderErrorPage('Missing required parameters. This link may be incomplete.');
+  }
+
+  if (!verifyToken(did, scope, token)) {
+    return renderErrorPage('This unsubscribe link is invalid or has expired.');
+  }
+
+  // Process unsubscribe
+  await updateRegistryPreference(did, scope);
+
+  const scopeLabel = scope.charAt(0).toUpperCase() + scope.slice(1);
+  return renderPage(
+    "You've been unsubscribed",
+    `You'll no longer receive ${scopeLabel} marketing emails.`,
+    'You can manage your notification preferences at any time from your account settings.',
+  );
+}
+
+/**
+ * POST /api/unsubscribe
+ *
+ * One-click List-Unsubscribe handler per RFC 8058.
+ * Email clients send: List-Unsubscribe=One-Click in body (application/x-www-form-urlencoded)
+ * along with did, scope, token query params from the List-Unsubscribe header URL.
+ *
+ * Returns 200 on success — email clients expect a fast, simple response.
+ */
+export async function POST(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const did = searchParams.get('did');
+  const scope = searchParams.get('scope');
+  const token = searchParams.get('token');
+
+  if (!did || !scope || !token) {
+    return NextResponse.json({ error: 'Missing required parameters' }, { status: 400 });
+  }
+
+  if (!verifyToken(did, scope, token)) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 403 });
+  }
+
+  await updateRegistryPreference(did, scope);
+
+  return NextResponse.json({ ok: true });
+}

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -1,11 +1,16 @@
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
 const SENDGRID_FROM = process.env.SENDGRID_FROM || 'Jin <jin@imajin.ai>';
 
+// CAN-SPAM required physical address
+const PHYSICAL_ADDRESS = 'Imajin Inc., 123 Main Street, Vancouver, BC V6B 1A1, Canada';
+
 export interface SendEmailOptions {
   to: string;
   subject: string;
   html: string;
   text?: string;
+  /** When set, adds List-Unsubscribe / List-Unsubscribe-Post headers and a footer link */
+  unsubscribeUrl?: string;
 }
 
 export async function sendEmail(options: SendEmailOptions): Promise<{ success: boolean; error?: any; messageId?: string }> {
@@ -13,6 +18,21 @@ export async function sendEmail(options: SendEmailOptions): Promise<{ success: b
     console.warn('SENDGRID_API_KEY not set — skipping email to', options.to);
     return { success: false, error: 'No API key configured' };
   }
+
+  const headers: Record<string, string> = {};
+  if (options.unsubscribeUrl) {
+    headers['List-Unsubscribe'] = `<${options.unsubscribeUrl}>`;
+    headers['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click';
+  }
+
+  // Append unsubscribe footer to HTML when an unsubscribe URL is provided
+  const htmlBody = options.unsubscribeUrl
+    ? appendUnsubscribeFooter(options.html, options.unsubscribeUrl)
+    : options.html;
+
+  const textBody = options.text
+    ? (options.unsubscribeUrl ? `${options.text}\n\n---\nTo unsubscribe: ${options.unsubscribeUrl}\n${PHYSICAL_ADDRESS}` : options.text)
+    : stripHtml(htmlBody);
 
   try {
     const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
@@ -26,9 +46,10 @@ export async function sendEmail(options: SendEmailOptions): Promise<{ success: b
         from: parseSender(SENDGRID_FROM),
         subject: options.subject,
         content: [
-          { type: 'text/plain', value: options.text || stripHtml(options.html) },
-          { type: 'text/html', value: options.html },
+          { type: 'text/plain', value: textBody },
+          { type: 'text/html', value: htmlBody },
         ],
+        ...(Object.keys(headers).length > 0 && { headers }),
       }),
     });
 
@@ -44,6 +65,20 @@ export async function sendEmail(options: SendEmailOptions): Promise<{ success: b
     console.error('Email send failed:', error);
     return { success: false, error };
   }
+}
+
+function appendUnsubscribeFooter(html: string, unsubscribeUrl: string): string {
+  const footer = `
+<div style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e7eb;font-size:12px;color:#6b7280;text-align:center;font-family:sans-serif;">
+  <p style="margin:0 0 4px;">Don't want these emails? <a href="${unsubscribeUrl}" style="color:#6b7280;">Unsubscribe</a></p>
+  <p style="margin:0;">${PHYSICAL_ADDRESS}</p>
+</div>`;
+
+  // Insert before closing </body> if present, otherwise append
+  if (html.includes('</body>')) {
+    return html.replace('</body>', `${footer}</body>`);
+  }
+  return html + footer;
 }
 
 export function parseSender(from: string): { email: string; name?: string } {

--- a/packages/notify/src/index.ts
+++ b/packages/notify/src/index.ts
@@ -30,4 +30,63 @@ export async function send(params: {
   }
 }
 
-export const notify = { send };
+export async function broadcast(params: {
+  scope: string;
+  dids?: string[];
+  subject: string;
+  html: string;
+  text?: string;
+  channels?: ('email' | 'inapp' | 'chat')[];
+}): Promise<void> {
+  const notifyUrl = process.env.NOTIFY_SERVICE_URL;
+  const secret = process.env.NOTIFY_WEBHOOK_SECRET;
+  if (!notifyUrl || !secret) {
+    console.warn("Broadcast skipped: NOTIFY_SERVICE_URL or NOTIFY_WEBHOOK_SECRET not set");
+    return;
+  }
+  try {
+    const res = await fetch(`${notifyUrl}/api/broadcast`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-webhook-secret": secret,
+      },
+      body: JSON.stringify(params),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`Broadcast (${params.scope}) failed: ${res.status} ${text}`);
+    }
+  } catch (err) {
+    console.error(`Broadcast (${params.scope}) error:`, err);
+  }
+}
+
+export async function interest(params: {
+  did: string;
+  attestationType: string;
+}): Promise<void> {
+  const notifyUrl = process.env.NOTIFY_SERVICE_URL;
+  const secret = process.env.NOTIFY_WEBHOOK_SECRET;
+  if (!notifyUrl || !secret) {
+    return;
+  }
+  try {
+    const res = await fetch(`${notifyUrl}/api/interest`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-webhook-secret": secret,
+      },
+      body: JSON.stringify(params),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`Interest signal (${params.attestationType}) failed: ${res.status} ${text}`);
+    }
+  } catch (err) {
+    console.error(`Interest signal (${params.attestationType}) error:`, err);
+  }
+}
+
+export const notify = { send, broadcast, interest };


### PR DESCRIPTION
Closes #540, closes #541

Adds bulk email infrastructure to the notify service with consent-aware delivery.

### Broadcast
- `POST /api/broadcast` — bulk send with scope, optional DID list, batching (100/batch), rate limiting
- Resolves audience from registry or accepts explicit DIDs
- Checks registry preferences per-DID before sending
- Resolves DID→email via new auth endpoint

### Unsubscribe (RFC 8058)
- `GET /api/unsubscribe` — renders HTML confirmation page
- `POST /api/unsubscribe` — one-click List-Unsubscribe handler
- HMAC-SHA256 tokens (no DB lookup needed, timing-safe)
- Updates registry preferences on unsubscribe

### Interest signals
- `POST /api/interest` — receives attestation type, resolves scope, creates did_interests row
- Respects auto_subscribe preference

### Package updates
- `@imajin/notify`: added `broadcast()` and `interest()`
- `@imajin/email`: added `unsubscribeUrl` option, List-Unsubscribe headers, CAN-SPAM footer

### Caller wiring
Interest signals added to: events, market, coffee, connections, chat (fire-and-forget)

### Auth service
New internal endpoint: `GET /api/identity/:did/contact` — resolves DID to email

### Depends on
- #549 (registry interest metadata + preferences)