### PR TITLE
feat(events): check-in webhook + WLED bridge #551

### DIFF
--- a/apps/events/.env.example
+++ b/apps/events/.env.example
@@ -14,6 +14,8 @@ CONNECTIONS_SERVICE_URL=http://localhost:3003
 
 # Webhooks
 WEBHOOK_SECRET=your-webhook-secret
+# Optional: POST check-in events to this URL (e.g. a WLED bridge for physical presence lighting)
+CHECKIN_WEBHOOK_URL=
 
 # Email (SMTP — Proton Bridge or similar)
 SMTP_HOST=127.0.0.1

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/check-in/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/check-in/route.ts
@@ -68,6 +68,37 @@ export async function POST(
       }).catch((err) => console.error('Attestation emit error:', err));
     }
 
+    // Fire-and-forget check-in webhook — do not block check-in on failure
+    const webhookUrl = process.env.CHECKIN_WEBHOOK_URL;
+    if (webhookUrl) {
+      (async () => {
+        try {
+          const [countRow] = await sql`
+            SELECT COUNT(*) as count FROM events.tickets
+            WHERE event_id = ${id} AND used_at IS NOT NULL
+          `;
+          const [eventRow] = await sql`
+            SELECT title FROM events.events WHERE id = ${id}
+          `;
+          await fetch(webhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              event: 'checkin',
+              eventId: id,
+              eventTitle: eventRow?.title ?? null,
+              ticketId,
+              ownerDid: ticket.owner_did ?? null,
+              checkedInAt: updated.used_at,
+              attendeeCount: Number(countRow?.count ?? 0),
+            }),
+          });
+        } catch (err) {
+          console.error('Check-in webhook error:', err);
+        }
+      })();
+    }
+
     return NextResponse.json({ ticket: { id: updated.id, usedAt: updated.used_at } });
   } catch (error) {
     console.error('Failed to check in ticket:', error);

--- a/scripts/wled-bridge.mjs
+++ b/scripts/wled-bridge.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * WLED Bridge — listens for check-in webhooks and flashes a WLED unit.
+ *
+ * Usage:
+ *   UNIT_IP=192.168.1.149 node scripts/wled-bridge.mjs
+ *   UNIT_IP=192.168.1.149 PORT=8080 FLASH_COLOR=255,0,0 node scripts/wled-bridge.mjs
+ */
+
+import http from 'node:http';
+
+// --- Config -----------------------------------------------------------
+
+function parseRgb(str, fallback) {
+  const parts = (str || '').split(',').map(Number);
+  if (parts.length === 3 && parts.every((n) => !isNaN(n))) return parts;
+  return fallback;
+}
+
+const UNIT_IP = process.env.UNIT_IP || null;
+const PORT = parseInt(process.env.PORT || '7890', 10);
+const FLASH_COLOR = parseRgb(process.env.FLASH_COLOR, [0, 255, 0]);
+const AMBIENT_COLOR = parseRgb(process.env.AMBIENT_COLOR, [255, 165, 0]);
+const FLASH_DURATION_MS = parseInt(process.env.FLASH_DURATION_MS || '3000', 10);
+const AMBIENT_BRI = parseInt(process.env.AMBIENT_BRI || '128', 10);
+const FLASH_BRI = parseInt(process.env.FLASH_BRI || '255', 10);
+
+if (!UNIT_IP) {
+  console.error('Error: UNIT_IP is required. Set it as an environment variable.');
+  console.error('  UNIT_IP=192.168.1.149 node scripts/wled-bridge.mjs');
+  process.exit(1);
+}
+
+// --- WLED API ---------------------------------------------------------
+
+function wledPost(state) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(state);
+    const req = http.request(
+      {
+        hostname: UNIT_IP,
+        port: 80,
+        path: '/json/state',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        res.resume();
+        resolve(res.statusCode);
+      }
+    );
+    req.on('error', reject);
+    req.setTimeout(3000, () => req.destroy(new Error('WLED request timed out')));
+    req.write(body);
+    req.end();
+  });
+}
+
+async function flash() {
+  try {
+    await wledPost({ on: true, bri: FLASH_BRI, seg: [{ col: [FLASH_COLOR] }] });
+    console.log(`  → WLED flash rgb(${FLASH_COLOR.join(',')}) sent`);
+  } catch (err) {
+    console.error(`  → WLED flash failed: ${err.message}`);
+  }
+
+  setTimeout(async () => {
+    try {
+      await wledPost({ on: true, bri: AMBIENT_BRI, seg: [{ col: [AMBIENT_COLOR] }] });
+      console.log(`  → WLED ambient rgb(${AMBIENT_COLOR.join(',')}) restored`);
+    } catch (err) {
+      console.error(`  → WLED ambient restore failed: ${err.message}`);
+    }
+  }, FLASH_DURATION_MS);
+}
+
+// --- HTTP Server ------------------------------------------------------
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', () => resolve(''));
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        status: 'ok',
+        unitIp: UNIT_IP,
+        flashColor: FLASH_COLOR,
+        ambientColor: AMBIENT_COLOR,
+        flashDurationMs: FLASH_DURATION_MS,
+      })
+    );
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const raw = await readBody(req);
+    let payload;
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      return;
+    }
+
+    if (payload.event !== 'checkin') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, skipped: true }));
+      return;
+    }
+
+    console.log(
+      `\nCheck-in: ${payload.eventTitle || payload.eventId} — ticket ${payload.ticketId}`
+    );
+    console.log(
+      `  owner: ${payload.ownerDid || 'unknown'} | attendees so far: ${payload.attendeeCount}`
+    );
+
+    flash();
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+server.listen(PORT, () => {
+  const rgb = (c) => `rgb(${c.join(',')})`;
+  console.log(`WLED Bridge listening on :${PORT}`);
+  console.log(`Unit IP: ${UNIT_IP}`);
+  console.log(`Flash: ${rgb(FLASH_COLOR)} for ${FLASH_DURATION_MS}ms → ambient ${rgb(AMBIENT_COLOR)}`);
+  console.log('');
+  console.log('Usage:');
+  console.log(`  UNIT_IP=${UNIT_IP} node scripts/wled-bridge.mjs`);
+  console.log(
+    `  UNIT_IP=${UNIT_IP} PORT=8080 FLASH_COLOR=255,0,0 node scripts/wled-bridge.mjs`
+  );
+});


### PR DESCRIPTION
## What

Two pieces for physical presence at events:

### 1. Check-in webhook (`apps/events`)
When a ticket is scanned, fires a POST to `CHECKIN_WEBHOOK_URL` (if set) with event info, ticket ID, attendee count. Fire-and-forget — never blocks check-in.

### 2. WLED bridge (`scripts/wled-bridge.mjs`)
Zero-dependency Node.js server. Receives webhook, flashes the Unit green via WLED HTTP API, returns to ambient after configurable duration.

### Usage at venue
```bash
# On laptop at venue (Tailscale connected)
UNIT_IP=192.168.1.149 node scripts/wled-bridge.mjs

# On server (events .env.local)
CHECKIN_WEBHOOK_URL=http://<laptop-tailscale-ip>:7890
```

Closes #551