### PR TITLE
feat(chat): wire nicknames into useDidNames for global display (#579)

### DIFF
--- a/apps/chat/src/app/conversations/[type]/[slug]/page.tsx
+++ b/apps/chat/src/app/conversations/[type]/[slug]/page.tsx
@@ -212,7 +212,6 @@ function DIDConversationView({ did }: { did: string }) {
     if (loadingConnections || connections.length > 0) return;
     setLoadingConnections(true);
     try {
-      const connectionsUrl = `${SERVICE_PREFIX}connections.${DOMAIN}`;
       const res = await fetch(`${connectionsUrl}/api/connections`, { credentials: 'include' });
       if (!res.ok) return;
       const data = await res.json();
@@ -280,6 +279,7 @@ function DIDConversationView({ did }: { did: string }) {
   // Use same-origin proxy for access checks (cross-origin cookie forwarding is unreliable)
   const authUrl = '';  // empty = same origin, proxied via /api/access/[did]
   const mediaUrl = MEDIA_URL;
+  const connectionsUrl = `${SERVICE_PREFIX}connections.${DOMAIN}`;
 
   const displayName =
     convName ||
@@ -299,7 +299,7 @@ function DIDConversationView({ did }: { did: string }) {
   if (!identity) return <LoginPrompt />;
 
   return (
-    <ChatProvider chatUrl={chatUrl} authUrl={authUrl} mediaUrl={mediaUrl}>
+    <ChatProvider chatUrl={chatUrl} authUrl={authUrl} mediaUrl={mediaUrl} connectionsUrl={connectionsUrl}>
     <div className="mx-auto flex flex-col h-[calc(100dvh-88px)]">
       {/* Header */}
       <div className="flex items-center gap-4 pb-4 border-b border-gray-200 dark:border-gray-700">

--- a/apps/connections/app/api/nicknames/resolve/route.ts
+++ b/apps/connections/app/api/nicknames/resolve/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, nicknames } from '../../../../src/db/index';
+import { corsHeaders, corsOptions, withCors } from '@/lib/cors';
+import { requireAuth } from '@imajin/auth';
+import { eq, and, inArray } from 'drizzle-orm';
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
+  const { identity } = authResult;
+
+  const body = await request.json();
+  const dids: string[] = body.dids ?? [];
+
+  if (dids.length === 0) {
+    return withCors(NextResponse.json({ nicknames: {} }), request);
+  }
+
+  const rows = await db
+    .select({ target: nicknames.target, nickname: nicknames.nickname })
+    .from(nicknames)
+    .where(and(eq(nicknames.did, identity.id), inArray(nicknames.target, dids)));
+
+  const result: Record<string, string> = {};
+  for (const row of rows) {
+    result[row.target] = row.nickname;
+  }
+
+  return withCors(NextResponse.json({ nicknames: result }), request);
+}

--- a/packages/chat/src/ChatProvider.tsx
+++ b/packages/chat/src/ChatProvider.tsx
@@ -7,6 +7,7 @@ interface ChatConfig {
   authUrl: string;
   inputUrl?: string;
   mediaUrl?: string;
+  connectionsUrl?: string;
 }
 
 const ChatContext = createContext<ChatConfig | null>(null);
@@ -22,10 +23,11 @@ export function ChatProvider({
   authUrl,
   inputUrl,
   mediaUrl,
+  connectionsUrl,
   children,
 }: ChatConfig & { children: React.ReactNode }) {
   return (
-    <ChatContext.Provider value={{ chatUrl, authUrl, inputUrl, mediaUrl }}>
+    <ChatContext.Provider value={{ chatUrl, authUrl, inputUrl, mediaUrl, connectionsUrl }}>
       {children}
     </ChatContext.Provider>
   );

--- a/packages/chat/src/hooks/useDidNames.ts
+++ b/packages/chat/src/hooks/useDidNames.ts
@@ -5,13 +5,15 @@ import { useChatConfig } from '../ChatProvider';
 
 /**
  * Resolves DIDs to display names via auth lookup.
+ * Nicknames (from connections service) take priority over auth names.
  * Caches results and deduplicates in-flight requests.
  */
 export function useDidNames(dids: string[]): Record<string, string> {
-  const { chatUrl } = useChatConfig();
+  const { chatUrl, connectionsUrl } = useChatConfig();
   const [names, setNames] = useState<Record<string, string>>({});
   const pendingRef = useRef(new Set<string>());
   const cacheRef = useRef<Record<string, string>>({});
+  const nicknameCacheRef = useRef<Record<string, string>>({});
 
   const resolve = useCallback(async (did: string) => {
     if (cacheRef.current[did] || pendingRef.current.has(did)) return;
@@ -39,10 +41,47 @@ export function useDidNames(dids: string[]): Record<string, string> {
   }, [chatUrl]);
 
   useEffect(() => {
-    const uniqueDids = Array.from(new Set(dids)).filter(d => !cacheRef.current[d]);
+    const uniqueDids = Array.from(new Set(dids));
     uniqueDids.forEach(resolve);
   }, [dids, resolve]);
 
-  // Return merged cache + state
-  return { ...cacheRef.current, ...names };
+  useEffect(() => {
+    if (!connectionsUrl) return;
+    const uniqueDids = Array.from(new Set(dids));
+    if (uniqueDids.length === 0) return;
+
+    (async () => {
+      try {
+        const res = await fetch(`${connectionsUrl}/api/nicknames/resolve`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ dids: uniqueDids }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          const fetched: Record<string, string> = data.nicknames ?? {};
+          let changed = false;
+          for (const [did, nickname] of Object.entries(fetched)) {
+            if (nickname && nicknameCacheRef.current[did] !== nickname) {
+              nicknameCacheRef.current[did] = nickname;
+              changed = true;
+            }
+          }
+          if (changed) {
+            setNames(prev => ({ ...prev }));
+          }
+        }
+      } catch {
+        // Graceful fallback — auth names still resolve
+      }
+    })();
+  }, [dids, connectionsUrl]);
+
+  // Nickname wins over auth name
+  const merged: Record<string, string> = { ...cacheRef.current, ...names };
+  for (const [did, nickname] of Object.entries(nicknameCacheRef.current)) {
+    if (nickname) merged[did] = nickname;
+  }
+  return merged;
 }


### PR DESCRIPTION
## What

Nicknames set on the connections page now display everywhere DIDs are rendered — chat messages, member lists, member picker.

## How

- **New endpoint:** `POST /api/nicknames/resolve` on connections service — batch fetch nicknames for a list of DIDs (auth-protected, CORS wired)
- **ChatProvider:** added `connectionsUrl?` to config, passed through context
- **useDidNames:** batch-fetches nicknames in a separate `useEffect`, stores in `nicknameCacheRef`, nickname wins over auth name in the merge. Graceful fallback if connections service is unavailable.
- **Conversation page:** hoisted `connectionsUrl` and passes it to `<ChatProvider>`

## Display priority

nickname → display name → @handle → DID

## Files changed

- `apps/connections/app/api/nicknames/resolve/route.ts` — NEW
- `packages/chat/src/ChatProvider.tsx` — added connectionsUrl
- `packages/chat/src/hooks/useDidNames.ts` — nickname fetch + merge
- `apps/chat/src/app/conversations/[type]/[slug]/page.tsx` — pass connectionsUrl

Closes #579