### PR TITLE
fix(chat): toggle reactions on click and prevent duplicate counting

### DIFF
--- a/packages/chat/src/hooks/useChatMessages.ts
+++ b/packages/chat/src/hooks/useChatMessages.ts
@@ -59,7 +59,7 @@ export function useChatMessages(did: string): UseChatMessagesResult {
           replyTo: msg.replyTo ?? msg.replyToMessageId,
           reactions: msg.reactions?.map((r: any) => ({
             ...r,
-            senderDid: r.senderDid ?? r.fromDid,
+            senderDid: r.senderDid ?? r.fromDid ?? r.did,
           })),
         };
       });


### PR DESCRIPTION
Closes #533

**Root cause:** Server sends reaction rows with `did` field (matching DB column name), but the frontend normalized reactions as `r.senderDid ?? r.fromDid` — missing the `did` fallback. Every server-loaded reaction had `senderDid: undefined`.

**Consequences:**
- `reacted` was always `false` after reload → clicking a reaction always took the 'add' path instead of toggling
- Duplicate check in optimistic update also failed → counter visually incremented on re-react

**Fix:** `r.senderDid ?? r.fromDid ?? r.did` — maps the server's field correctly. Toggle and dedup logic then works as intended.

One line change in `packages/chat/src/hooks/useChatMessages.ts`.