### PR TITLE
feat(ui): add dark/light theme toggle with system-wide light mode support

### DIFF
--- a/apps/auth/app/layout.tsx
+++ b/apps/auth/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { NavBar } from './components/NavBar';
 import { buildPublicUrl } from '@imajin/config';
+import { themeInitScript } from '@imajin/ui';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -32,8 +33,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="min-h-screen bg-[#0a0a0a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="min-h-screen bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white">
         <NavBar currentService="Auth" />
         <main className="container mx-auto px-4 py-8">
           {children}

--- a/apps/chat/src/app/layout.tsx
+++ b/apps/chat/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { NavBarWithUnread } from './components/NavBarWithUnread';
 import { IdentityProvider } from '@/contexts/IdentityContext';
 import { UnreadTitleManager } from './components/UnreadTitleManager';
 import { UnreadCountProvider } from '@/contexts/UnreadCountContext';
-import { ToastProvider } from '@imajin/ui';
+import { ToastProvider, themeInitScript } from '@imajin/ui';
 import { buildPublicUrl } from '@imajin/config';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
@@ -36,8 +36,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="h-screen bg-[#0a0a0a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="h-screen bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white">
         <ToastProvider>
           <UnreadCountProvider>
             <NavBarWithUnread />

--- a/apps/connections/app/layout.tsx
+++ b/apps/connections/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { NavBar } from '@imajin/ui';
+import { NavBar, themeInitScript } from '@imajin/ui';
 import { IdentityProvider } from './context/IdentityContext';
 import './globals.css';
 import { Providers } from './providers';
@@ -16,8 +16,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="dark">
-      <body className="min-h-screen bg-[#0a0a0a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="min-h-screen bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white">
         <NavBar currentService="Connections" servicePrefix={prefix} domain={domain} />
         <Providers>
           <IdentityProvider>

--- a/apps/events/app/layout.tsx
+++ b/apps/events/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { NavBar } from './components/NavBar';
 import { Providers } from './providers';
 import { buildPublicUrl } from '@imajin/config';
+import { themeInitScript } from '@imajin/ui';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -42,8 +43,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="min-h-screen bg-[#0a0a0a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="min-h-screen bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white">
         <NavBar currentService="Events" />
         <Providers>
           <main className="container mx-auto px-4 py-8">

--- a/apps/market/app/layout.tsx
+++ b/apps/market/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { NavBar } from '@imajin/ui';
+import { NavBar, themeInitScript } from '@imajin/ui';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -16,7 +16,10 @@ export default function RootLayout({
   const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
 
   return (
-    <html lang="en" className="dark">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100">
         <NavBar
           currentService="Market"

--- a/apps/media/app/layout.tsx
+++ b/apps/media/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { themeInitScript } from "@imajin/ui";
 
 export const metadata: Metadata = {
   title: "Imajin Media",
@@ -12,8 +13,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="h-screen flex flex-col overflow-hidden bg-[#1a1a1a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="h-screen flex flex-col overflow-hidden bg-white dark:bg-[#1a1a1a] text-gray-900 dark:text-white">
         {children}
       </body>
     </html>

--- a/apps/pay/app/layout.tsx
+++ b/apps/pay/app/layout.tsx
@@ -3,6 +3,7 @@ import { buildPublicUrl } from '@imajin/config';
 import './globals.css';
 import { NavBar } from './components/NavBar';
 import { Providers } from './providers';
+import { themeInitScript } from '@imajin/ui';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -33,8 +34,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="min-h-screen bg-[#0a0a0a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="min-h-screen bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white">
         <NavBar currentService="Pay" />
         <Providers>
           <main className="container mx-auto px-4 py-8">

--- a/apps/profile/app/layout.tsx
+++ b/apps/profile/app/layout.tsx
@@ -3,6 +3,7 @@ import { buildPublicUrl } from '@imajin/config';
 import './globals.css';
 import { NavBar } from './components/NavBar';
 import { IdentityProvider } from './context/IdentityContext';
+import { themeInitScript } from '@imajin/ui';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -36,8 +37,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="min-h-screen bg-[#0a0a0a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="min-h-screen bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white">
         <IdentityProvider>
           <NavBar currentService="Profile" />
           <main className="container mx-auto px-4 py-8">

--- a/apps/registry/app/layout.tsx
+++ b/apps/registry/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { buildPublicUrl } from '@imajin/config';
 import './globals.css';
 import { NavBar } from './components/NavBar';
+import { themeInitScript } from '@imajin/ui';
 
 const prefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -32,8 +33,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="min-h-screen bg-[#0a0a0a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="min-h-screen bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white">
         <NavBar currentService="Registry" />
         <main className="container mx-auto px-4 py-8">
           {children}

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import { themeInitScript } from '@imajin/ui';
 import { cookies } from 'next/headers';
 import { NavBar } from './components/NavBar';
 import { BugReportButton } from '@/components/bug-report-button';
@@ -75,8 +76,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="dark">
-      <body className="min-h-screen antialiased bg-[#0a0a0a] text-white">
+    <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body className="min-h-screen antialiased bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white">
         <NavBar currentService="Home" />
         <Providers>{children}</Providers>
         <BugReportWidget />

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -25,3 +25,5 @@ export type { Notification, NotificationContextValue } from './notification-prov
 export { NotificationBell } from './notification-bell';
 
 export { ActionSheet } from './action-sheet';
+
+export { themeInitScript } from './theme-init';

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -150,6 +150,23 @@ export function NavBar({
   const [showDropdown, setShowDropdown] = useState(false);
   const [showMobileMenu, setShowMobileMenu] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark');
+
+  useEffect(() => {
+    const saved = typeof window !== 'undefined' ? localStorage.getItem('theme') : null;
+    setTheme(saved === 'light' ? 'light' : 'dark');
+  }, []);
+
+  function toggleTheme() {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+    if (next === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }
 
   // Auto-fetch identity if no prop provided
   const autoIdentity = useAutoIdentity(servicePrefix, domain, serviceUrls);
@@ -346,6 +363,12 @@ export function NavBar({
                         <span>🤝</span> Connections
                       </a>
                       <hr className="my-1 border-gray-200 dark:border-gray-800" />
+                      <button
+                        onClick={toggleTheme}
+                        className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-2"
+                      >
+                        <span>{theme === 'dark' ? '☀️' : '🌙'}</span> {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+                      </button>
                       <a
                         href={`${buildUrl('www', servicePrefix, domain, serviceUrls)}/bugs`}
                         className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-2 no-underline text-inherit"

--- a/packages/ui/src/theme-init.ts
+++ b/packages/ui/src/theme-init.ts
@@ -1,0 +1,10 @@
+export const themeInitScript = `
+  (function() {
+    var theme = localStorage.getItem('theme');
+    if (theme === 'light') {
+      document.documentElement.classList.remove('dark');
+    } else {
+      document.documentElement.classList.add('dark');
+    }
+  })()
+`;


### PR DESCRIPTION
Closes #534

**Theme toggle** in NavBar profile dropdown (between Connections and Report a Bug):
- ☀️ Light Mode / 🌙 Dark Mode — shows what you'll switch to
- Persists to localStorage, toggles `dark` class on `<html>`
- No page reload needed

**Flash prevention:** `themeInitScript` runs in `<head>` before React hydration. Reads localStorage, defaults to dark.

**Layout audit** across all 10 app layouts:
- Removed hardcoded `className="dark"` from `<html>` (init script handles it)
- Added light-mode-safe base styles: `bg-white dark:bg-[#0a0a0a] text-gray-900 dark:text-white`
- Market was already correct, just needed script + dark class removal

**Not in scope:** Page-level component light mode fixes (follow-up work per service).