### PR TITLE
feat(auth): scoped group identities — multi-controller DIDs (#587)

### DIFF
--- a/apps/auth/.env.example
+++ b/apps/auth/.env.example
@@ -36,3 +36,6 @@ NODE_ENV=
 
 # Notify service auth (must match NOTIFY_WEBHOOK_SECRET in notify service)
 NOTIFY_WEBHOOK_SECRET=dev-secret-change-me
+
+# Group identity encryption (server-side key for group private keys)
+GROUP_KEY_ENCRYPTION_SECRET=change-me-in-production

--- a/apps/auth/app/api/groups/[groupDid]/controllers/[controllerDid]/route.ts
+++ b/apps/auth/app/api/groups/[groupDid]/controllers/[controllerDid]/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, groupControllers } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import { requireAuth, emitAttestation } from '@imajin/auth';
+
+/**
+ * DELETE /api/groups/[groupDid]/controllers/[controllerDid]
+ * Remove a controller (soft delete).
+ * Owner can remove anyone (except self). Admin can remove members only.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string; controllerDid: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+  const { groupDid, controllerDid } = await params;
+
+  const [callerMembership] = await db
+    .select({ role: groupControllers.role })
+    .from(groupControllers)
+    .where(
+      and(
+        eq(groupControllers.groupDid, groupDid),
+        eq(groupControllers.controllerDid, caller.id),
+        isNull(groupControllers.removedAt)
+      )
+    )
+    .limit(1);
+
+  if (!callerMembership || !['owner', 'admin'].includes(callerMembership.role)) {
+    return NextResponse.json({ error: 'Must be owner or admin to remove controllers' }, { status: 403 });
+  }
+
+  if (callerMembership.role === 'owner' && caller.id === controllerDid) {
+    return NextResponse.json({ error: 'Owner cannot remove themselves' }, { status: 400 });
+  }
+
+  // Check target's role
+  const [targetMembership] = await db
+    .select({ role: groupControllers.role })
+    .from(groupControllers)
+    .where(
+      and(
+        eq(groupControllers.groupDid, groupDid),
+        eq(groupControllers.controllerDid, controllerDid),
+        isNull(groupControllers.removedAt)
+      )
+    )
+    .limit(1);
+
+  if (!targetMembership) {
+    return NextResponse.json({ error: 'Controller not found' }, { status: 404 });
+  }
+
+  if (callerMembership.role === 'admin' && targetMembership.role !== 'member') {
+    return NextResponse.json({ error: 'Admin can only remove members' }, { status: 403 });
+  }
+
+  try {
+    await db
+      .update(groupControllers)
+      .set({ removedAt: new Date() })
+      .where(
+        and(
+          eq(groupControllers.groupDid, groupDid),
+          eq(groupControllers.controllerDid, controllerDid)
+        )
+      );
+
+    emitAttestation({
+      issuer_did: caller.id,
+      subject_did: controllerDid,
+      type: 'group.member.removed',
+      context_id: groupDid,
+      context_type: 'group',
+      payload: {},
+    }).catch((err) => console.error('[groups] Attestation failed (non-fatal):', err));
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[groups] Remove controller error:', error);
+    return NextResponse.json({ error: 'Failed to remove controller' }, { status: 500 });
+  }
+}
+
+/**
+ * GET /api/groups/[groupDid]/controllers/[controllerDid]
+ * Internal: check if a DID is an active controller with owner or admin role.
+ * Used by act-as middleware validation.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string; controllerDid: string }> }
+) {
+  const { groupDid, controllerDid } = await params;
+
+  // This endpoint is internal — validate via ATTESTATION_INTERNAL_API_KEY
+  const apiKey = request.headers.get('authorization')?.replace('Bearer ', '');
+  const expectedKey = process.env.ATTESTATION_INTERNAL_API_KEY;
+
+  if (!expectedKey || apiKey !== expectedKey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const [membership] = await db
+      .select({ role: groupControllers.role, removedAt: groupControllers.removedAt })
+      .from(groupControllers)
+      .where(
+        and(
+          eq(groupControllers.groupDid, groupDid),
+          eq(groupControllers.controllerDid, controllerDid),
+          isNull(groupControllers.removedAt)
+        )
+      )
+      .limit(1);
+
+    if (!membership) {
+      return NextResponse.json({ valid: false }, { status: 200 });
+    }
+
+    return NextResponse.json({ valid: true, role: membership.role });
+  } catch (error) {
+    console.error('[groups] Controller check error:', error);
+    return NextResponse.json({ error: 'Failed to check controller' }, { status: 500 });
+  }
+}

--- a/apps/auth/app/api/groups/[groupDid]/controllers/route.ts
+++ b/apps/auth/app/api/groups/[groupDid]/controllers/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, groupControllers } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import { requireAuth, emitAttestation } from '@imajin/auth';
+
+const VALID_ROLES = ['owner', 'admin', 'member'];
+
+/**
+ * POST /api/groups/[groupDid]/controllers
+ * Add a controller to the group. Caller must be owner or admin.
+ * Only owner can add admins.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+  const { groupDid } = await params;
+
+  const [callerMembership] = await db
+    .select({ role: groupControllers.role })
+    .from(groupControllers)
+    .where(
+      and(
+        eq(groupControllers.groupDid, groupDid),
+        eq(groupControllers.controllerDid, caller.id),
+        isNull(groupControllers.removedAt)
+      )
+    )
+    .limit(1);
+
+  if (!callerMembership || !['owner', 'admin'].includes(callerMembership.role)) {
+    return NextResponse.json({ error: 'Must be owner or admin to add controllers' }, { status: 403 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { did, role = 'member' } = body as { did?: string; role?: string };
+
+  if (!did || typeof did !== 'string') {
+    return NextResponse.json({ error: 'did required' }, { status: 400 });
+  }
+  if (!VALID_ROLES.includes(role)) {
+    return NextResponse.json({ error: `role must be one of: ${VALID_ROLES.join(', ')}` }, { status: 400 });
+  }
+  if (role === 'admin' && callerMembership.role !== 'owner') {
+    return NextResponse.json({ error: 'Only owner can add admins' }, { status: 403 });
+  }
+
+  try {
+    // Check if controller was previously removed (soft delete)
+    const [existing] = await db
+      .select({ removedAt: groupControllers.removedAt, role: groupControllers.role })
+      .from(groupControllers)
+      .where(
+        and(
+          eq(groupControllers.groupDid, groupDid),
+          eq(groupControllers.controllerDid, did)
+        )
+      )
+      .limit(1);
+
+    if (existing && !existing.removedAt) {
+      return NextResponse.json({ error: 'Already a controller' }, { status: 409 });
+    }
+
+    if (existing && existing.removedAt) {
+      // Reactivate
+      await db
+        .update(groupControllers)
+        .set({ removedAt: null, role, addedBy: caller.id, addedAt: new Date() })
+        .where(
+          and(
+            eq(groupControllers.groupDid, groupDid),
+            eq(groupControllers.controllerDid, did)
+          )
+        );
+    } else {
+      await db.insert(groupControllers).values({
+        groupDid,
+        controllerDid: did,
+        role,
+        addedBy: caller.id,
+      });
+    }
+
+    emitAttestation({
+      issuer_did: caller.id,
+      subject_did: did,
+      type: 'group.member.added',
+      context_id: groupDid,
+      context_type: 'group',
+      payload: { role },
+    }).catch((err) => console.error('[groups] Attestation failed (non-fatal):', err));
+
+    return NextResponse.json({ ok: true, groupDid, controllerDid: did, role }, { status: 201 });
+  } catch (error) {
+    console.error('[groups] Add controller error:', error);
+    return NextResponse.json({ error: 'Failed to add controller' }, { status: 500 });
+  }
+}

--- a/apps/auth/app/api/groups/[groupDid]/route.ts
+++ b/apps/auth/app/api/groups/[groupDid]/route.ts
@@ -1,0 +1,157 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, identities, groupIdentities, groupControllers } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import { requireAuth } from '@imajin/auth';
+
+const PROFILE_SERVICE_URL = process.env.PROFILE_SERVICE_URL!;
+const VALID_SCOPES = ['org', 'community', 'family'];
+
+/**
+ * GET /api/groups/[groupDid]
+ * Get group details. Caller must be an active controller.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+  const { groupDid } = await params;
+
+  try {
+    // Check caller is active controller
+    const [membership] = await db
+      .select({ role: groupControllers.role })
+      .from(groupControllers)
+      .where(
+        and(
+          eq(groupControllers.groupDid, groupDid),
+          eq(groupControllers.controllerDid, caller.id),
+          isNull(groupControllers.removedAt)
+        )
+      )
+      .limit(1);
+
+    if (!membership) {
+      return NextResponse.json({ error: 'Not a controller of this group' }, { status: 403 });
+    }
+
+    const [group] = await db
+      .select({
+        groupDid: groupIdentities.groupDid,
+        scope: groupIdentities.scope,
+        createdBy: groupIdentities.createdBy,
+        createdAt: groupIdentities.createdAt,
+        name: identities.name,
+        handle: identities.handle,
+      })
+      .from(groupIdentities)
+      .innerJoin(identities, eq(groupIdentities.groupDid, identities.id))
+      .where(eq(groupIdentities.groupDid, groupDid))
+      .limit(1);
+
+    if (!group) {
+      return NextResponse.json({ error: 'Group not found' }, { status: 404 });
+    }
+
+    const controllers = await db
+      .select({
+        controllerDid: groupControllers.controllerDid,
+        role: groupControllers.role,
+        addedBy: groupControllers.addedBy,
+        addedAt: groupControllers.addedAt,
+      })
+      .from(groupControllers)
+      .where(
+        and(
+          eq(groupControllers.groupDid, groupDid),
+          isNull(groupControllers.removedAt)
+        )
+      );
+
+    return NextResponse.json({ ...group, controllers });
+  } catch (error) {
+    console.error('[groups] Get error:', error);
+    return NextResponse.json({ error: 'Failed to get group' }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/groups/[groupDid]
+ * Update group (name, description, scope). Caller must be owner or admin.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ groupDid: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+  const { groupDid } = await params;
+
+  const [membership] = await db
+    .select({ role: groupControllers.role })
+    .from(groupControllers)
+    .where(
+      and(
+        eq(groupControllers.groupDid, groupDid),
+        eq(groupControllers.controllerDid, caller.id),
+        isNull(groupControllers.removedAt)
+      )
+    )
+    .limit(1);
+
+  if (!membership || !['owner', 'admin'].includes(membership.role)) {
+    return NextResponse.json({ error: 'Must be owner or admin' }, { status: 403 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { name, description, scope } = body as { name?: string; description?: string; scope?: string };
+
+  if (scope && !VALID_SCOPES.includes(scope)) {
+    return NextResponse.json({ error: `scope must be one of: ${VALID_SCOPES.join(', ')}` }, { status: 400 });
+  }
+
+  try {
+    if (name) {
+      await db
+        .update(identities)
+        .set({ name: name.trim().slice(0, 100), updatedAt: new Date() })
+        .where(eq(identities.id, groupDid));
+
+      // Update profile (fire-and-forget)
+      try {
+        await fetch(`${PROFILE_SERVICE_URL}/api/profiles/${encodeURIComponent(groupDid)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ displayName: name.trim().slice(0, 100), description }),
+        });
+      } catch (err) {
+        console.error('[groups] Profile update failed (non-fatal):', err);
+      }
+    }
+
+    if (scope) {
+      await db
+        .update(groupIdentities)
+        .set({ scope })
+        .where(eq(groupIdentities.groupDid, groupDid));
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[groups] Update error:', error);
+    return NextResponse.json({ error: 'Failed to update group' }, { status: 500 });
+  }
+}

--- a/apps/auth/app/api/groups/route.ts
+++ b/apps/auth/app/api/groups/route.ts
@@ -1,0 +1,216 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, identities, storedKeys, groupIdentities, groupControllers } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import { requireAuth } from '@imajin/auth';
+import { generateKeypair } from '@imajin/auth';
+import { didFromPublicKey } from '@/lib/crypto';
+import { emitAttestation } from '@imajin/auth';
+
+const PROFILE_SERVICE_URL = process.env.PROFILE_SERVICE_URL!;
+const VALID_SCOPES = ['org', 'community', 'family'] as const;
+type GroupScope = typeof VALID_SCOPES[number];
+
+function genId(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
+}
+
+async function encryptPrivateKey(privateKeyHex: string): Promise<{ encryptedKey: string; salt: string }> {
+  const secret = process.env.GROUP_KEY_ENCRYPTION_SECRET;
+  if (!secret) throw new Error('GROUP_KEY_ENCRYPTION_SECRET not set');
+
+  const saltBytes = crypto.getRandomValues(new Uint8Array(16));
+  const salt = Buffer.from(saltBytes).toString('base64');
+
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey']
+  );
+  const derivedKey = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: saltBytes, iterations: 100_000, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt']
+  );
+
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = new TextEncoder().encode(privateKeyHex);
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, derivedKey, plaintext);
+
+  // Prepend IV to ciphertext
+  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+  combined.set(iv);
+  combined.set(new Uint8Array(ciphertext), iv.length);
+
+  return { encryptedKey: Buffer.from(combined).toString('base64'), salt };
+}
+
+/**
+ * POST /api/groups
+ * Create a group identity (org, community, or family).
+ */
+export async function POST(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { scope, name, handle, description } = body as {
+    scope?: string;
+    name?: string;
+    handle?: string;
+    description?: string;
+  };
+
+  if (!scope || !VALID_SCOPES.includes(scope as GroupScope)) {
+    return NextResponse.json(
+      { error: `scope required: ${VALID_SCOPES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+  if (!name || typeof name !== 'string') {
+    return NextResponse.json({ error: 'name required' }, { status: 400 });
+  }
+  if (handle && !/^[a-z0-9_]{3,30}$/.test(handle)) {
+    return NextResponse.json(
+      { error: 'Handle must be 3-30 lowercase letters, numbers, or underscores' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Check handle uniqueness
+    if (handle) {
+      const existing = await db
+        .select({ id: identities.id })
+        .from(identities)
+        .where(eq(identities.handle, handle))
+        .limit(1);
+      if (existing.length > 0) {
+        return NextResponse.json({ error: 'Handle already taken' }, { status: 409 });
+      }
+    }
+
+    // Generate Ed25519 keypair server-side
+    const { privateKey, publicKey } = generateKeypair();
+    const groupDid = didFromPublicKey(publicKey);
+
+    // Encrypt and store private key
+    const { encryptedKey, salt } = await encryptPrivateKey(privateKey);
+    const keyId = genId('key');
+
+    // Store identity
+    await db.insert(identities).values({
+      id: groupDid,
+      type: scope,  // 'org' | 'community' | 'family'
+      publicKey,
+      handle: handle || null,
+      name: name.trim().slice(0, 100),
+      tier: 'preliminary',
+    });
+
+    // Store encrypted private key
+    await db.insert(storedKeys).values({
+      id: keyId,
+      did: groupDid,
+      encryptedKey,
+      salt,
+      keyDerivation: 'pbkdf2',
+    });
+
+    // Store group identity record
+    await db.insert(groupIdentities).values({
+      groupDid,
+      scope: scope as GroupScope,
+      createdBy: caller.id,
+    });
+
+    // Add creator as owner
+    await db.insert(groupControllers).values({
+      groupDid,
+      controllerDid: caller.id,
+      role: 'owner',
+      addedBy: caller.id,
+    });
+
+    // Create profile (fire-and-forget)
+    try {
+      await fetch(`${PROFILE_SERVICE_URL}/api/profiles`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          did: groupDid,
+          displayName: name.trim().slice(0, 100),
+          handle: handle || undefined,
+          description: description || undefined,
+          type: scope,
+        }),
+      });
+    } catch (err) {
+      console.error('[groups] Profile creation failed (non-fatal):', err);
+    }
+
+    // Emit attestation (fire-and-forget)
+    emitAttestation({
+      issuer_did: caller.id,
+      subject_did: groupDid,
+      type: 'group.created',
+      context_id: groupDid,
+      context_type: 'group',
+      payload: { scope, name: name.trim(), handle: handle || null },
+    }).catch((err) => console.error('[groups] Attestation failed (non-fatal):', err));
+
+    return NextResponse.json({ did: groupDid, scope, handle: handle || null, name: name.trim() }, { status: 201 });
+  } catch (error) {
+    console.error('[groups] Create error:', error);
+    return NextResponse.json({ error: 'Failed to create group' }, { status: 500 });
+  }
+}
+
+/**
+ * GET /api/groups
+ * List groups the caller controls.
+ */
+export async function GET(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+
+  try {
+    const rows = await db
+      .select({
+        groupDid: groupControllers.groupDid,
+        role: groupControllers.role,
+        scope: groupIdentities.scope,
+        name: identities.name,
+        handle: identities.handle,
+      })
+      .from(groupControllers)
+      .innerJoin(groupIdentities, eq(groupControllers.groupDid, groupIdentities.groupDid))
+      .innerJoin(identities, eq(groupControllers.groupDid, identities.id))
+      .where(
+        and(
+          eq(groupControllers.controllerDid, caller.id),
+          isNull(groupControllers.removedAt)
+        )
+      );
+
+    return NextResponse.json(rows);
+  } catch (error) {
+    console.error('[groups] List error:', error);
+    return NextResponse.json({ error: 'Failed to list groups' }, { status: 500 });
+  }
+}

--- a/apps/auth/migrations/0003_create_group_identities.sql
+++ b/apps/auth/migrations/0003_create_group_identities.sql
@@ -1,0 +1,20 @@
+-- Phase 1: Group identities — scoped multi-controller DIDs
+CREATE TABLE IF NOT EXISTS auth.group_identities (
+  group_did   TEXT PRIMARY KEY,
+  scope       TEXT NOT NULL,           -- 'org' | 'community' | 'family'
+  created_by  TEXT NOT NULL,           -- DID of creator
+  created_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Phase 2: Group controllers — who controls each group DID
+CREATE TABLE IF NOT EXISTS auth.group_controllers (
+  group_did       TEXT NOT NULL,
+  controller_did  TEXT NOT NULL,
+  role            TEXT NOT NULL DEFAULT 'member',  -- 'owner' | 'admin' | 'member'
+  added_by        TEXT,
+  added_at        TIMESTAMPTZ DEFAULT NOW(),
+  removed_at      TIMESTAMPTZ,                     -- soft delete
+  PRIMARY KEY (group_did, controller_did)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_controllers_controller ON auth.group_controllers (controller_did);

--- a/apps/auth/src/db/schema.ts
+++ b/apps/auth/src/db/schema.ts
@@ -207,6 +207,31 @@ export const devices = authSchema.table('devices', {
   didIdx: index('idx_devices_did').on(table.did),
 }));
 
+/**
+ * Group Identities — multi-controller DIDs for orgs, communities, families
+ */
+export const groupIdentities = authSchema.table('group_identities', {
+  groupDid: text('group_did').primaryKey(),               // references identities.id
+  scope: text('scope').notNull(),                         // 'org' | 'community' | 'family'
+  createdBy: text('created_by').notNull(),                // DID of creator
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});
+
+/**
+ * Group Controllers — members that control a group DID
+ */
+export const groupControllers = authSchema.table('group_controllers', {
+  groupDid: text('group_did').notNull(),
+  controllerDid: text('controller_did').notNull(),
+  role: text('role').notNull().default('member'),         // 'owner' | 'admin' | 'member'
+  addedBy: text('added_by'),
+  addedAt: timestamp('added_at', { withTimezone: true }).defaultNow(),
+  removedAt: timestamp('removed_at', { withTimezone: true }),
+}, (table) => ({
+  pk: index('idx_group_controllers_pk').on(table.groupDid, table.controllerDid),
+  controllerIdx: index('idx_group_controllers_controller').on(table.controllerDid),
+}));
+
 // Types
 export type Identity = typeof identities.$inferSelect;
 export type NewIdentity = typeof identities.$inferInsert;
@@ -223,3 +248,7 @@ export type MfaMethod = typeof mfaMethods.$inferSelect;
 export type NewMfaMethod = typeof mfaMethods.$inferInsert;
 export type Device = typeof devices.$inferSelect;
 export type NewDevice = typeof devices.$inferInsert;
+export type GroupIdentity = typeof groupIdentities.$inferSelect;
+export type NewGroupIdentity = typeof groupIdentities.$inferInsert;
+export type GroupController = typeof groupControllers.$inferSelect;
+export type NewGroupController = typeof groupControllers.$inferInsert;

--- a/packages/auth/src/require-auth.ts
+++ b/packages/auth/src/require-auth.ts
@@ -84,7 +84,39 @@ async function validateBearerToken(
 }
 
 /**
+ * Validate that a caller is an active owner or admin controller of a group DID.
+ * Uses the internal API to avoid recursive auth checks.
+ */
+async function validateActingAs(
+  callerDid: string,
+  groupDid: string
+): Promise<boolean> {
+  const authUrl = getAuthUrl();
+  const internalApiKey = process.env.ATTESTATION_INTERNAL_API_KEY;
+  if (!internalApiKey) {
+    console.warn("[AUTH] ATTESTATION_INTERNAL_API_KEY not set — cannot validate act-as");
+    return false;
+  }
+  try {
+    const res = await fetch(
+      `${authUrl}/api/groups/${encodeURIComponent(groupDid)}/controllers/${encodeURIComponent(callerDid)}`,
+      {
+        headers: { Authorization: `Bearer ${internalApiKey}` },
+        cache: "no-store",
+      }
+    );
+    if (!res.ok) return false;
+    const data = await res.json();
+    return data.valid === true && (data.role === "owner" || data.role === "admin");
+  } catch (err) {
+    console.error("[AUTH] Act-as validation failed:", err);
+    return false;
+  }
+}
+
+/**
  * Require authentication. Checks session cookie first, then Bearer token.
+ * Also handles X-Acting-As header for group identity impersonation.
  *
  * Works with both `Request` and `NextRequest`.
  */
@@ -123,6 +155,18 @@ export async function requireAuth(
     } catch (err) {
       console.error("[AUTH] Chain verification failed:", err);
       result.identity.chainVerified = false;
+    }
+  }
+
+  // Handle X-Acting-As header for group identity impersonation
+  if ("identity" in result && result.identity) {
+    const actingAs = request.headers.get("x-acting-as");
+    if (actingAs) {
+      const allowed = await validateActingAs(result.identity.id, actingAs);
+      if (!allowed) {
+        return { error: "Not authorized to act as this group", status: 403 };
+      }
+      result.identity.actingAs = actingAs;
     }
   }
 

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -27,12 +27,14 @@ export async function getSession(): Promise<Identity | null> {
     if (!response.ok) return null;
 
     const data = await response.json();
+    const actingAs = cookieStore.get("x-acting-as")?.value;
     return {
       id: data.did,
       type: data.type || "human",
       name: data.name,
       handle: data.handle,
       tier: data.tier || "soft",
+      actingAs: actingAs || undefined,
     };
   } catch (error) {
     console.error("[AUTH] Session fetch failed:", error);

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -5,6 +5,7 @@ export interface Identity {
   handle?: string;
   tier?: "soft" | "preliminary" | "established";
   chainVerified?: boolean;
+  actingAs?: string; // DID of group the caller is acting on behalf of
 }
 
 export interface AuthResult {

--- a/packages/auth/src/types/attestation.ts
+++ b/packages/auth/src/types/attestation.ts
@@ -22,6 +22,7 @@ export const ATTESTATION_TYPES = [
   'pod.member.added',
   'pod.member.removed',
   'pod.role.changed',
+  'group.created',
   'group.member.added',
   'group.member.removed',
   'group.member.left'


### PR DESCRIPTION
Closes #587

## What

Backend infrastructure for scoped group identities — multi-controller DIDs for orgs, communities, and families.

### Schema
- `auth.group_identities` — group DID → scope (org/community/family) + creator
- `auth.group_controllers` — group DID → controller DID + role (owner/admin/member), soft delete
- Hand-written migration: `0003_create_group_identities.sql`

### API Routes (`/api/groups`)
- **POST /api/groups** — create group identity (generates Ed25519 keypair server-side, encrypts private key with AES-256-GCM, creates identity + profile, adds creator as owner)
- **GET /api/groups** — list caller's groups with role
- **GET /api/groups/:did** — group details + controller list (membership-gated)
- **PATCH /api/groups/:did** — update name/description/scope (owner/admin)
- **POST /api/groups/:did/controllers** — add controller with role hierarchy enforcement
- **DELETE /api/groups/:did/controllers/:did** — soft-remove controller
- **GET /api/groups/:did/controllers/:did** — internal endpoint for act-as validation

### Act-As Middleware
- `requireAuth()` now checks `X-Acting-As` header
- Validates caller is an active owner/admin of the group DID
- Adds `actingAs` field to `Identity` type
- `getSession()` reads `x-acting-as` cookie for server components

### Other
- `group.created` attestation type added
- `GROUP_KEY_ENCRYPTION_SECRET` env var for group key encryption
- Handle claiming uses same namespace as personal handles (no collisions)

## Notes
- DFOS genesis chain creation deferred (will wire separately)
- `getSession()` reads act-as from cookie without validation — may want to restrict to API routes only
- Group private keys are custodial (platform holds them, controllers act through delegation)