### PR TITLE
feat(ui): forest switcher — navigate between groups in NavBar and Launcher (#588)

### DIFF
--- a/packages/ui/src/acting-as.ts
+++ b/packages/ui/src/acting-as.ts
@@ -1,0 +1,21 @@
+export function getActingAs(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('imajin:acting-as');
+}
+
+export function setActingAs(did: string | null): void {
+  if (typeof window === 'undefined') return;
+  if (did) {
+    localStorage.setItem('imajin:acting-as', did);
+    document.cookie = `x-acting-as=${did}; path=/; max-age=31536000; SameSite=Lax`;
+  } else {
+    localStorage.removeItem('imajin:acting-as');
+    document.cookie = 'x-acting-as=; path=/; max-age=0';
+  }
+  window.dispatchEvent(new CustomEvent('imajin:acting-as-changed', { detail: { did } }));
+}
+
+export function getActingAsHeaders(): Record<string, string> {
+  const did = getActingAs();
+  return did ? { 'X-Acting-As': did } : {};
+}

--- a/packages/ui/src/app-launcher.tsx
+++ b/packages/ui/src/app-launcher.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
+import { useForests } from './use-forests';
 
 export interface LauncherService {
   name: string;
@@ -21,6 +22,8 @@ export interface AppLauncherProps {
   inline?: boolean;
   /** Layout variant: 'list' (default) or 'grid' (4-column icon grid) */
   variant?: 'list' | 'grid';
+  /** Auth service URL — enables forest switcher when provided */
+  authUrl?: string;
 }
 
 /** Services that belong in the profile dropdown, not the launcher flyout */
@@ -47,10 +50,20 @@ function groupByCategory(services: LauncherService[]): { core: LauncherService[]
   };
 }
 
-export function AppLauncher({ registryUrl, currentService, tier = 'anonymous', inline = false, variant = 'list' }: AppLauncherProps) {
+function scopeIcon(scope: string): string {
+  if (scope === 'community') return '🏛️';
+  if (scope === 'org') return '🏢';
+  if (scope === 'family') return '👨‍👩‍👦';
+  return '🌲';
+}
+
+export function AppLauncher({ registryUrl, currentService, tier = 'anonymous', inline = false, variant = 'list', authUrl }: AppLauncherProps) {
   const [services, setServices] = useState<LauncherService[]>([]);
   const [showPanel, setShowPanel] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
+
+  const showForests = tier === 'hard' || tier === 'creator';
+  const { forests, activeForest, setActiveForest } = useForests(showForests && authUrl ? authUrl : null);
 
   useEffect(() => {
     fetch(`${registryUrl}/api/specs`)
@@ -115,6 +128,41 @@ export function AppLauncher({ registryUrl, currentService, tier = 'anonymous', i
     );
   }
 
+  const forestsSection = showForests && (forests.length > 0 || authUrl) ? (
+    <div className="border-t border-gray-200 dark:border-gray-800 mt-1 pt-1">
+      <div className="px-3 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+        🌲 Your Forests
+      </div>
+      {forests.map((forest) => {
+        const isActive = forest.groupDid === activeForest;
+        return (
+          <button
+            key={forest.groupDid}
+            onClick={() => { setActiveForest(isActive ? null : forest.groupDid); setShowPanel(false); }}
+            className={`w-full text-left flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition ${
+              isActive
+                ? 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 font-medium'
+                : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+            }`}
+          >
+            <span className="text-lg flex-shrink-0">{scopeIcon(forest.scope)}</span>
+            <span>{forest.name || forest.handle || forest.groupDid.slice(0, 12)}</span>
+            {isActive && <span className="ml-auto text-amber-600 dark:text-amber-400 font-bold text-xs">✓</span>}
+          </button>
+        );
+      })}
+      {authUrl && (
+        <a
+          href={`${authUrl}/groups/new`}
+          className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition no-underline"
+        >
+          <span className="text-lg flex-shrink-0">🌱</span>
+          <span>Grow a forest</span>
+        </a>
+      )}
+    </div>
+  ) : null;
+
   const footer = (
     <div className="border-t border-gray-200 dark:border-gray-800 mt-1 pt-1">
       <a
@@ -153,6 +201,7 @@ export function AppLauncher({ registryUrl, currentService, tier = 'anonymous', i
           </div>
         </div>
       )}
+      {forestsSection}
       {footer}
     </>
   ) : (
@@ -186,6 +235,7 @@ export function AppLauncher({ registryUrl, currentService, tier = 'anonymous', i
           {meta.map(renderTile)}
         </div>
       )}
+      {forestsSection}
       {footer}
     </>
   );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -27,3 +27,7 @@ export { NotificationBell } from './notification-bell';
 export { ActionSheet } from './action-sheet';
 
 export { themeInitScript } from './theme-init';
+
+export { getActingAs, setActingAs, getActingAsHeaders } from './acting-as';
+export { useForests } from './use-forests';
+export type { Forest } from './use-forests';

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { AppLauncher } from './app-launcher';
 import { NotificationBell } from './notification-bell';
 import { getPort } from '@imajin/config';
+import { useForests } from './use-forests';
 
 export interface NavIdentity {
   isLoggedIn: boolean;
@@ -51,6 +52,13 @@ function buildUrl(service: string, prefix: string, domain: string, overrides?: S
   }
 
   return `${prefix}${service}.${domain}`;
+}
+
+function scopeIcon(scope: string): string {
+  if (scope === 'community') return '🏛️';
+  if (scope === 'org') return '🏢';
+  if (scope === 'family') return '👨‍👩‍👦';
+  return '🌲';
 }
 
 function buildUserLinks(prefix: string, domain: string, overrides?: ServiceUrls) {
@@ -202,6 +210,13 @@ export function NavBar({
     return () => clearInterval(interval);
   }, [identity?.isLoggedIn, identity?.tier, servicePrefix, domain, serviceUrls]);
 
+  // Forests (group identities)
+  const authUrl = buildUrl('auth', servicePrefix, domain, serviceUrls);
+  const { forests, activeForest, setActiveForest } = useForests(
+    identity?.isLoggedIn && identity?.tier !== 'soft' ? authUrl : null
+  );
+  const activeForestData = forests.find((f) => f.groupDid === activeForest) ?? null;
+
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -242,6 +257,7 @@ export function NavBar({
             currentService={currentService}
             tier={launcherTier}
             variant="grid"
+            authUrl={identity?.isLoggedIn && identity?.tier !== 'soft' ? authUrl : undefined}
           />
           {identity?.isLoggedIn && identity?.tier !== 'soft' && (
             <>
@@ -305,14 +321,23 @@ export function NavBar({
                 onClick={() => setShowDropdown(!showDropdown)}
                 className="flex items-center gap-2 px-3 py-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition"
               >
-                <span className="text-xl">👤</span>
+                <span className="text-xl">
+                  {activeForestData ? scopeIcon(activeForestData.scope) : '👤'}
+                </span>
                 <span className="text-sm font-medium">
-                  {identity.handle
+                  {activeForestData
+                    ? (activeForestData.name || activeForestData.handle || 'Forest')
+                    : identity.handle
                     ? `@${identity.handle}`
                     : identity.name
                     ? identity.name
                     : identity.did?.slice(0, 12) + '...'}
                 </span>
+                {activeForestData && (
+                  <span className="text-[10px] text-amber-600 dark:text-amber-400 font-medium leading-none">
+                    acting as
+                  </span>
+                )}
               </button>
 
               {showDropdown && (
@@ -364,6 +389,40 @@ export function NavBar({
                         className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-2 no-underline text-inherit"
                       >
                         <span>🤝</span> Connections
+                      </a>
+                      <hr className="my-1 border-gray-200 dark:border-gray-800" />
+                      <div className="px-4 py-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                        🌲 Your Forests
+                      </div>
+                      {forests.map((forest) => {
+                        const isActive = forest.groupDid === activeForest;
+                        return (
+                          <button
+                            key={forest.groupDid}
+                            onClick={() => {
+                              setActiveForest(isActive ? null : forest.groupDid);
+                              setShowDropdown(false);
+                            }}
+                            className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-2"
+                          >
+                            <span>{scopeIcon(forest.scope)}</span>
+                            <span className={isActive ? 'font-medium' : ''}>
+                              {forest.name || forest.handle || forest.groupDid.slice(0, 12)}
+                            </span>
+                            <span className="text-[10px] text-gray-400 dark:text-gray-500 capitalize">
+                              ({forest.scope})
+                            </span>
+                            {isActive && (
+                              <span className="ml-auto text-amber-600 dark:text-amber-400 font-bold text-xs">✓</span>
+                            )}
+                          </button>
+                        );
+                      })}
+                      <a
+                        href={`${authUrl}/groups/new`}
+                        className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-2 no-underline text-inherit text-gray-500 dark:text-gray-400"
+                      >
+                        <span>🌱</span> Grow a forest
                       </a>
                       <hr className="my-1 border-gray-200 dark:border-gray-800" />
                       <button
@@ -419,6 +478,7 @@ export function NavBar({
             currentService={currentService}
             tier={launcherTier}
             inline
+            authUrl={identity?.isLoggedIn && identity?.tier !== 'soft' ? authUrl : undefined}
           />
           {identity?.isLoggedIn && identity?.tier !== 'soft' && (
             <div className="flex items-center gap-2 mt-3 pt-3 border-t border-gray-200 dark:border-gray-800">

--- a/packages/ui/src/use-forests.ts
+++ b/packages/ui/src/use-forests.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getActingAs, setActingAs } from './acting-as';
+
+export interface Forest {
+  groupDid: string;
+  role: string;
+  scope: string;
+  name: string | null;
+  handle: string | null;
+}
+
+export function useForests(authUrl: string | null): {
+  forests: Forest[];
+  loading: boolean;
+  activeForest: string | null;
+  setActiveForest: (did: string | null) => void;
+} {
+  const [forests, setForests] = useState<Forest[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [activeForest, setActiveForestState] = useState<string | null>(null);
+
+  useEffect(() => {
+    setActiveForestState(getActingAs());
+  }, []);
+
+  useEffect(() => {
+    if (!authUrl) return;
+    setLoading(true);
+    fetch(`${authUrl}/api/groups`, { credentials: 'include' })
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (Array.isArray(data)) setForests(data);
+        else if (data?.groups) setForests(data.groups);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [authUrl]);
+
+  function setActiveForest(did: string | null) {
+    setActingAs(did);
+    setActiveForestState(did);
+    window.location.reload();
+  }
+
+  return { forests, loading, activeForest, setActiveForest };
+}


### PR DESCRIPTION
Closes #588

Depends on #590 (merged).

## What

Forest switcher UI — navigate between personal identity and group identities (forests) from the NavBar and Launcher.

### New Files
- **`acting-as.ts`** — `getActingAs()`, `setActingAs(did)`, `getActingAsHeaders()`. Persists to localStorage (`imajin:acting-as`) + cookie (`x-acting-as`). Fires `imajin:acting-as-changed` CustomEvent for cross-component reactivity.
- **`use-forests.ts`** — `useForests(authUrl)` hook. Fetches `GET /api/groups`, tracks active forest, `setActiveForest()` triggers reload.

### NavBar Changes
- **Profile dropdown** gets a 🌲 Your Forests section (between Connections and theme toggle)
- Each forest shows scope icon (🏛️ community, 🏢 org, 👨‍👩‍👦 family), name, and scope label
- Click to activate, click again to deactivate (toggle)
- Checkmark on active forest
- "🌱 Grow a forest" link to `{authUrl}/groups/new`
- **Avatar area** reflects active forest: scope icon replaces 👤, forest name replaces handle, "acting as" badge

### Launcher Changes
- Forests section below app categories (hard/creator tier only)
- Amber highlight on active forest
- Same toggle behavior + "Grow a forest" link

### Exports
`getActingAs`, `setActingAs`, `getActingAsHeaders`, `useForests`, `Forest` — all from `@imajin/ui`

## Notes
- `/groups/new` page doesn't exist yet — link is ready for when it's built
- `window.location.reload()` on forest switch is intentional — ensures all server components get the new cookie
- `scopeIcon()` duplicated between nav-bar and app-launcher (could extract but keeping simple for now)