### PR TITLE
feat(auth): forest admin settings — service toggles, landing page, controllers (#593)

### DIFF
--- a/apps/auth/app/groups/[groupDid]/settings/page.tsx
+++ b/apps/auth/app/groups/[groupDid]/settings/page.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { SERVICES, buildPublicUrl } from '@imajin/config';
+
+interface GroupDetails {
+  groupDid: string;
+  scope: string;
+  name: string;
+  handle: string;
+  createdBy: string;
+  controllers: Array<{
+    controllerDid: string;
+    role: string;
+    addedBy: string;
+    addedAt: string;
+  }>;
+}
+
+interface ForestConfig {
+  enabledServices: string[];
+  landingService: string | null;
+  theme: Record<string, unknown>;
+}
+
+const VISIBLE_SERVICES = SERVICES.filter(
+  (s) => s.visibility !== 'internal' && s.category !== 'meta' && s.category !== 'infrastructure'
+);
+
+function scopeIcon(scope: string): string {
+  if (scope === 'community') return '🏛️';
+  if (scope === 'org') return '🏢';
+  if (scope === 'family') return '👨‍👩‍👦';
+  return '🌲';
+}
+
+export default function ForestSettingsPage({ params }: { params: { groupDid: string } }) {
+  const { groupDid } = params;
+  const [loading, setLoading] = useState(true);
+  const [group, setGroup] = useState<GroupDetails | null>(null);
+  const [enabledServices, setEnabledServices] = useState<string[]>([]);
+  const [landingService, setLandingService] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const authUrl = typeof window !== 'undefined'
+    ? window.location.origin
+    : (process.env.NEXT_PUBLIC_AUTH_URL ?? '');
+  const profileUrl = buildPublicUrl('profile');
+
+  useEffect(() => {
+    loadData();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupDid]);
+
+  async function loadData() {
+    setLoading(true);
+    try {
+      const [groupRes, configRes] = await Promise.all([
+        fetch(`${authUrl}/api/groups/${encodeURIComponent(groupDid)}`, { credentials: 'include' }),
+        fetch(`${profileUrl}/api/forest/${encodeURIComponent(groupDid)}/config`, { credentials: 'include' }),
+      ]);
+
+      if (groupRes.ok) {
+        setGroup(await groupRes.json());
+      }
+      if (configRes.ok) {
+        const cfg: ForestConfig = await configRes.json();
+        setEnabledServices(cfg.enabledServices ?? []);
+        setLandingService(cfg.landingService ?? null);
+      }
+    } catch (err) {
+      console.error('Failed to load forest settings:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function toggleService(name: string) {
+    setEnabledServices(prev => {
+      const next = prev.includes(name) ? prev.filter(s => s !== name) : [...prev, name];
+      if (landingService && !next.includes(landingService)) {
+        setLandingService(null);
+      }
+      return next;
+    });
+  }
+
+  function showStatus(type: 'success' | 'error', text: string) {
+    setStatus({ type, text });
+    setTimeout(() => setStatus(null), 5000);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const res = await fetch(`${profileUrl}/api/forest/${encodeURIComponent(groupDid)}/config`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ enabledServices, landingService }),
+      });
+      if (res.ok) {
+        showStatus('success', 'Forest settings saved.');
+      } else {
+        const body = await res.json().catch(() => ({}));
+        showStatus('error', body.error || 'Failed to save settings.');
+      }
+    } catch {
+      showStatus('error', 'Network error. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center">
+        <div className="text-gray-400">Loading forest settings…</div>
+      </div>
+    );
+  }
+
+  const enabledServiceOptions = VISIBLE_SERVICES.filter(s => enabledServices.includes(s.name));
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] p-4 md:p-8">
+      <div className="max-w-3xl mx-auto space-y-8">
+
+        {/* Back link */}
+        <a
+          href={`${authUrl}/groups`}
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-300 transition no-underline"
+        >
+          ← Back to forests
+        </a>
+
+        {/* Header */}
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-white">
+              {group ? (group.name || group.handle || groupDid.slice(0, 16)) : groupDid.slice(0, 16)}
+            </h1>
+            {group && (
+              <span className="px-2 py-0.5 text-xs rounded-full border border-gray-700 text-gray-400 capitalize">
+                {scopeIcon(group.scope)} {group.scope}
+              </span>
+            )}
+          </div>
+          {group?.handle && (
+            <p className="text-gray-500 text-sm mt-1">@{group.handle}</p>
+          )}
+        </div>
+
+        {/* Status message */}
+        {status && (
+          <div className={`p-4 rounded-lg border ${status.type === 'success' ? 'bg-green-900/20 border-green-800 text-green-400' : 'bg-red-900/20 border-red-800 text-red-400'}`}>
+            {status.text}
+          </div>
+        )}
+
+        {/* Services section */}
+        <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-1">Services</h2>
+          <p className="text-sm text-gray-400 mb-6">Toggle which apps are available for this forest.</p>
+
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {VISIBLE_SERVICES.map(svc => {
+              const isEnabled = enabledServices.includes(svc.name);
+              return (
+                <button
+                  key={svc.name}
+                  onClick={() => toggleService(svc.name)}
+                  className={`flex flex-col items-start gap-1 p-3 rounded-xl border transition text-left ${
+                    isEnabled
+                      ? 'border-amber-500/60 bg-amber-500/10 text-white'
+                      : 'border-gray-800 bg-gray-900/30 text-gray-500 hover:border-gray-700 hover:text-gray-400'
+                  }`}
+                >
+                  <span className="text-xl">{svc.icon}</span>
+                  <span className="text-sm font-medium leading-tight">{svc.label}</span>
+                  <span className={`text-xs leading-tight ${isEnabled ? 'text-amber-400/70' : 'text-gray-600'}`}>
+                    {isEnabled ? 'Enabled' : 'Disabled'}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Landing page section */}
+        <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-1">Landing Page</h2>
+          <p className="text-sm text-gray-400 mb-6">Choose which app loads first for this forest.</p>
+
+          <select
+            value={landingService ?? ''}
+            onChange={e => setLandingService(e.target.value || null)}
+            className="w-full px-4 py-2 border border-gray-700 rounded-lg bg-black text-white focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+          >
+            <option value="">— Default (no preference) —</option>
+            {enabledServiceOptions.map(svc => (
+              <option key={svc.name} value={svc.name}>
+                {svc.icon} {svc.label}
+              </option>
+            ))}
+          </select>
+          {enabledServiceOptions.length === 0 && (
+            <p className="text-xs text-gray-600 mt-2">Enable at least one service to set a landing page.</p>
+          )}
+        </div>
+
+        {/* Controllers section */}
+        <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-1">Controllers</h2>
+          <p className="text-sm text-gray-400 mb-6">People who can manage this forest.</p>
+
+          {!group?.controllers?.length ? (
+            <p className="text-sm text-gray-500">No controllers found.</p>
+          ) : (
+            <div className="space-y-2">
+              {group.controllers.map(ctrl => (
+                <div key={ctrl.controllerDid} className="flex items-center justify-between p-3 bg-gray-900 rounded-lg border border-gray-800">
+                  <div className="flex items-center gap-3">
+                    <span className="text-xl">👤</span>
+                    <div>
+                      <p className="text-sm text-white font-medium font-mono">
+                        {ctrl.controllerDid.length > 24
+                          ? ctrl.controllerDid.slice(0, 20) + '…'
+                          : ctrl.controllerDid}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        Added {new Date(ctrl.addedAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                  </div>
+                  <span className={`px-2 py-0.5 text-xs rounded border capitalize ${
+                    ctrl.role === 'owner'
+                      ? 'border-amber-600 text-amber-400 bg-amber-900/20'
+                      : ctrl.role === 'admin'
+                      ? 'border-blue-700 text-blue-400 bg-blue-900/20'
+                      : 'border-gray-700 text-gray-400'
+                  }`}>
+                    {ctrl.role}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Save button */}
+        <div className="flex justify-end pb-8">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="px-6 py-2.5 bg-amber-500 hover:bg-amber-400 text-gray-950 font-semibold rounded-lg transition disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/apps/auth/app/groups/page.tsx
+++ b/apps/auth/app/groups/page.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface GroupSummary {
+  groupDid: string;
+  scope: string;
+  name: string;
+  handle: string;
+  role: string;
+  controllers?: Array<{ controllerDid: string; role: string }>;
+}
+
+function scopeIcon(scope: string): string {
+  if (scope === 'community') return '🏛️';
+  if (scope === 'org') return '🏢';
+  if (scope === 'family') return '👨‍👩‍👦';
+  return '🌲';
+}
+
+export default function GroupsPage() {
+  const [loading, setLoading] = useState(true);
+  const [groups, setGroups] = useState<GroupSummary[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/groups', { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          setGroups(data.groups ?? data ?? []);
+        } else if (res.status === 401) {
+          window.location.href = '/login?next=/groups';
+        }
+      } catch (err) {
+        console.error('Failed to load forests:', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center">
+        <div className="text-gray-400">Loading forests…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] p-4 md:p-8">
+      <div className="max-w-2xl mx-auto space-y-6">
+
+        <div>
+          <h1 className="text-2xl font-bold text-white mb-1">🌲 Your Forests</h1>
+          <p className="text-sm text-gray-400">Manage your group identities.</p>
+        </div>
+
+        {groups.length === 0 ? (
+          <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8 text-center">
+            <p className="text-gray-500 mb-4">You don&apos;t have any forests yet.</p>
+            <a
+              href="/groups/new"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-gray-950 font-semibold rounded-lg transition no-underline"
+            >
+              🌱 Grow a forest
+            </a>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {groups.map(group => (
+              <a
+                key={group.groupDid}
+                href={`/groups/${encodeURIComponent(group.groupDid)}/settings`}
+                className="block bg-[#0a0a0a] border border-gray-800 hover:border-gray-700 rounded-2xl p-6 transition no-underline group"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="text-2xl">{scopeIcon(group.scope)}</span>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="text-white font-semibold group-hover:text-amber-400 transition">
+                          {group.name || group.handle || group.groupDid.slice(0, 16)}
+                        </p>
+                        <span className="text-xs text-gray-500 capitalize">({group.scope})</span>
+                      </div>
+                      {group.handle && (
+                        <p className="text-xs text-gray-500">@{group.handle}</p>
+                      )}
+                      <p className="text-xs text-gray-600 mt-0.5">
+                        {group.controllers?.length ?? 1} controller{(group.controllers?.length ?? 1) !== 1 ? 's' : ''}
+                      </p>
+                    </div>
+                  </div>
+                  <span className="text-gray-600 group-hover:text-gray-400 transition text-sm">→</span>
+                </div>
+              </a>
+            ))}
+
+            <a
+              href="/groups/new"
+              className="block border border-dashed border-gray-800 hover:border-gray-600 rounded-2xl p-6 transition no-underline text-center text-gray-500 hover:text-gray-300"
+            >
+              🌱 Grow a forest
+            </a>
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -400,25 +400,34 @@ export function NavBar({
                       {forests.map((forest) => {
                         const isActive = forest.groupDid === activeForest;
                         return (
-                          <button
-                            key={forest.groupDid}
-                            onClick={() => {
-                              setActiveForest(isActive ? null : forest.groupDid);
-                              setShowDropdown(false);
-                            }}
-                            className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-2"
-                          >
-                            <span>{scopeIcon(forest.scope)}</span>
-                            <span className={isActive ? 'font-medium' : ''}>
-                              {forest.name || forest.handle || forest.groupDid.slice(0, 12)}
-                            </span>
-                            <span className="text-[10px] text-gray-400 dark:text-gray-500 capitalize">
-                              ({forest.scope})
-                            </span>
-                            {isActive && (
-                              <span className="ml-auto text-amber-600 dark:text-amber-400 font-bold text-xs">✓</span>
-                            )}
-                          </button>
+                          <div key={forest.groupDid} className="flex items-center group/forest">
+                            <button
+                              onClick={() => {
+                                setActiveForest(isActive ? null : forest.groupDid);
+                                setShowDropdown(false);
+                              }}
+                              className="flex-1 text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-2"
+                            >
+                              <span>{scopeIcon(forest.scope)}</span>
+                              <span className={isActive ? 'font-medium' : ''}>
+                                {forest.name || forest.handle || forest.groupDid.slice(0, 12)}
+                              </span>
+                              <span className="text-[10px] text-gray-400 dark:text-gray-500 capitalize">
+                                ({forest.scope})
+                              </span>
+                              {isActive && (
+                                <span className="ml-auto text-amber-600 dark:text-amber-400 font-bold text-xs">✓</span>
+                              )}
+                            </button>
+                            <a
+                              href={`${authUrl}/groups/${encodeURIComponent(forest.groupDid)}/settings`}
+                              onClick={e => e.stopPropagation()}
+                              className="pr-3 py-2 text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition opacity-0 group-hover/forest:opacity-100 no-underline text-sm"
+                              title="Forest settings"
+                            >
+                              ⚙️
+                            </a>
+                          </div>
                         );
                       })}
                       <a


### PR DESCRIPTION
Closes #593

## What

Forest settings UI for owners/admins to configure which services are enabled and set the landing page.

### New Pages

**`/groups`** — Forest list page
- Lists caller's forests with scope icons, name, handle, controller count
- Links to settings for each forest
- "Grow a forest" placeholder link to `/groups/new`
- Redirects to login if unauthenticated

**`/groups/:did/settings`** — Forest settings page
- **Service toggles**: grid of non-internal services, amber highlight when enabled, click to toggle
- **Landing page picker**: dropdown of enabled services, clears if selected service is disabled
- **Controllers list**: shows all controllers with role badges (owner/admin/member), DID truncation, add date
- **Save button**: PATCHes `{profileUrl}/api/forest/:did/config`
- Success/error status messages with auto-dismiss
- Fetches from both auth (group details) and profile (config) services

### NavBar Changes
- Gear icon (⚙️) added next to each forest in the dropdown, links to settings page
- Clicking the forest name still toggles act-as
- Gear icon is separate click target, doesn't trigger act-as toggle

### Styling
- Matches existing auth settings dark UI (`bg-[#0a0a0a]`)
- Amber primary actions, gray-800 borders, rounded-2xl cards
- Responsive grid (2→3→4 columns for service tiles)

## Dependencies
- #592 — Forest config API (merged)
- #587 — Group identities (merged)
- #588 — Forest switcher (merged)