### PR TITLE
feat(auth): contextual onboarding — scope-aware join page + keypair flow (#597 #598)

### DIFF
--- a/apps/auth/app/api/onboard/generate/route.ts
+++ b/apps/auth/app/api/onboard/generate/route.ts
@@ -1,0 +1,155 @@
+/**
+ * POST /api/onboard/generate
+ *
+ * Keypair-based onboarding: public key → DID → identity → session.
+ * No signature verification required — possession of the key is asserted client-side.
+ * Creates a 'soft' tier identity (can be upgraded later with a real signature).
+ *
+ * Body: { publicKey: string (hex, 64 chars), name?: string, scopeDid?: string, redirectUrl?: string }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/src/db';
+import { identities, credentials, groupControllers } from '@/src/db/schema';
+import { didFromPublicKey } from '@/lib/crypto';
+import { createSessionToken, getSessionCookieOptions } from '@/lib/jwt';
+import { emitAttestation } from '@imajin/auth';
+import { corsHeaders } from '@imajin/config';
+import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
+import { eq, and } from 'drizzle-orm';
+import { nanoid } from 'nanoid';
+
+const PROFILE_SERVICE_URL = process.env.PROFILE_SERVICE_URL!;
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 10, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const { publicKey, name, scopeDid, redirectUrl } = body;
+
+    // Validate publicKey
+    if (!publicKey || typeof publicKey !== 'string') {
+      return NextResponse.json({ error: 'publicKey required' }, { status: 400, headers: cors });
+    }
+    if (!/^[0-9a-fA-F]{64}$/.test(publicKey)) {
+      return NextResponse.json({ error: 'publicKey must be a 64-char hex string (Ed25519)' }, { status: 400, headers: cors });
+    }
+
+    const did = didFromPublicKey(publicKey);
+
+    // Check if DID already exists
+    const [existing] = await db
+      .select()
+      .from(identities)
+      .where(eq(identities.id, did))
+      .limit(1);
+
+    let identity = existing;
+    let created = false;
+
+    if (!identity) {
+      // Create new identity
+      [identity] = await db
+        .insert(identities)
+        .values({
+          id: did,
+          type: 'human',
+          publicKey,
+          name: name?.trim().slice(0, 100) || null,
+          tier: 'soft',
+          metadata: { source: 'keypair_onboard' },
+        })
+        .returning();
+      created = true;
+
+      // Insert keypair credential
+      await db.insert(credentials).values({
+        id: `cred_${nanoid(16)}`,
+        did,
+        type: 'keypair',
+        value: publicKey,
+        verifiedAt: new Date(),
+      }).onConflictDoNothing();
+    }
+
+    // Create session token
+    const tier = (identity.tier || 'soft') as 'soft' | 'preliminary' | 'established';
+    const sessionToken = await createSessionToken({
+      sub: did,
+      type: 'human',
+      tier,
+      handle: identity.handle || undefined,
+      name: identity.name || undefined,
+    });
+
+    const cookieOptions = getSessionCookieOptions();
+    const response = NextResponse.json(
+      { did, tier, created, redirectUrl: redirectUrl || null },
+      { status: created ? 201 : 200, headers: cors }
+    );
+
+    response.cookies.set(cookieOptions.name, sessionToken, cookieOptions.options);
+
+    // If scoped to a forest, add as member and set active forest cookie
+    if (scopeDid && typeof scopeDid === 'string') {
+      try {
+        const [existingMember] = await db
+          .select({ removedAt: groupControllers.removedAt })
+          .from(groupControllers)
+          .where(and(eq(groupControllers.groupDid, scopeDid), eq(groupControllers.controllerDid, did)))
+          .limit(1);
+        if (!existingMember) {
+          await db.insert(groupControllers).values({ groupDid: scopeDid, controllerDid: did, role: 'member', addedBy: scopeDid });
+        } else if (existingMember.removedAt) {
+          await db.update(groupControllers)
+            .set({ removedAt: null, role: 'member', addedBy: scopeDid, addedAt: new Date() })
+            .where(and(eq(groupControllers.groupDid, scopeDid), eq(groupControllers.controllerDid, did)));
+        }
+      } catch (err) {
+        console.error('[onboard/generate] Forest member add failed (non-fatal):', err);
+      }
+      emitAttestation({ issuer_did: scopeDid, subject_did: did, type: 'scope.onboard', context_id: scopeDid, context_type: 'forest' })
+        .catch(err => console.error('[onboard/generate] Scope attestation failed (non-fatal):', err));
+      response.cookies.set('x-acting-as', scopeDid, { path: '/', maxAge: 31536000, sameSite: 'lax' });
+    }
+
+    // Create profile row (fire-and-forget)
+    if (created) {
+      try {
+        await fetch(`${PROFILE_SERVICE_URL}/api/profile`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Cookie: `${cookieOptions.name}=${sessionToken}`,
+          },
+          body: JSON.stringify({
+            displayName: name?.trim().slice(0, 100) || 'Anonymous',
+            displayType: 'human',
+          }),
+        });
+      } catch (err) {
+        console.error('[onboard/generate] Profile creation failed (non-fatal):', err);
+      }
+    }
+
+    return response;
+
+  } catch (error) {
+    console.error('[onboard/generate] Error:', error);
+    return NextResponse.json({ error: 'Failed to onboard identity' }, { status: 500, headers: cors });
+  }
+}

--- a/apps/auth/app/api/onboard/route.ts
+++ b/apps/auth/app/api/onboard/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { email, name, redirectUrl, context } = body;
+    const { email, name, redirectUrl, context, scopeDid } = body;
 
     if (!email || typeof email !== 'string' || !email.includes('@')) {
       return NextResponse.json(
@@ -56,6 +56,7 @@ export async function POST(request: NextRequest) {
       token,
       redirectUrl: redirectUrl || null,
       context: context || null,
+      scopeDid: scopeDid || null,
       expiresAt: new Date(Date.now() + 15 * 60 * 1000),
     });
 

--- a/apps/auth/app/api/onboard/verify/route.ts
+++ b/apps/auth/app/api/onboard/verify/route.ts
@@ -6,9 +6,10 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/src/db';
-import { onboardTokens, identities, credentials } from '@/src/db/schema';
+import { onboardTokens, identities, credentials, groupControllers } from '@/src/db/schema';
 import { createSessionToken, getSessionCookieOptions, verifySessionToken } from '@/lib/jwt';
 import { emitSessionAttestation } from '@/lib/emit-session-attestation';
+import { emitAttestation } from '@imajin/auth';
 import { eq, and, gt, isNull } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 
@@ -198,6 +199,33 @@ export async function GET(request: NextRequest) {
       sessionToken,
       cookieOptions.options,
     );
+
+    // If onboard was scoped to a forest, add user as member and set active forest cookie
+    if (record.scopeDid) {
+      const scopeDid = record.scopeDid;
+      // Add as forest member directly (same-app operation)
+      try {
+        const [existing] = await db
+          .select({ removedAt: groupControllers.removedAt })
+          .from(groupControllers)
+          .where(and(eq(groupControllers.groupDid, scopeDid), eq(groupControllers.controllerDid, did)))
+          .limit(1);
+        if (!existing) {
+          await db.insert(groupControllers).values({ groupDid: scopeDid, controllerDid: did, role: 'member', addedBy: scopeDid });
+        } else if (existing.removedAt) {
+          await db.update(groupControllers)
+            .set({ removedAt: null, role: 'member', addedBy: scopeDid, addedAt: new Date() })
+            .where(and(eq(groupControllers.groupDid, scopeDid), eq(groupControllers.controllerDid, did)));
+        }
+      } catch (err) {
+        console.error('[onboard/verify] Forest member add failed (non-fatal):', err);
+      }
+      // Emit scope.onboard attestation
+      emitAttestation({ issuer_did: scopeDid, subject_did: did, type: 'scope.onboard', context_id: scopeDid, context_type: 'forest' })
+        .catch(err => console.error('[onboard/verify] Scope attestation failed (non-fatal):', err));
+      // Set active forest cookie
+      response.cookies.set('x-acting-as', scopeDid, { path: '/', maxAge: 31536000, sameSite: 'lax' });
+    }
 
     emitSessionAttestation({
       did,

--- a/apps/auth/app/groups/[groupDid]/settings/page.tsx
+++ b/apps/auth/app/groups/[groupDid]/settings/page.tsx
@@ -47,6 +47,9 @@ export default function ForestSettingsPage({ params }: { params: { groupDid: str
     ? window.location.origin
     : (process.env.NEXT_PUBLIC_AUTH_URL ?? '');
   const profileUrl = buildPublicUrl('profile');
+  const [copyLabel, setCopyLabel] = useState('Copy');
+
+  const onboardUrl = `${authUrl}/onboard?scope=${encodeURIComponent(groupDid)}`;
 
   useEffect(() => {
     loadData();
@@ -208,6 +211,29 @@ export default function ForestSettingsPage({ params }: { params: { groupDid: str
           {enabledServiceOptions.length === 0 && (
             <p className="text-xs text-gray-600 mt-2">Enable at least one service to set a landing page.</p>
           )}
+        </div>
+
+        {/* Onboarding section */}
+        <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-1">Onboarding</h2>
+          <p className="text-sm text-gray-400 mb-6">Share this link to invite people to your forest.</p>
+
+          <div className="flex items-center gap-2">
+            <code className="flex-1 px-3 py-2 bg-gray-900 border border-gray-800 rounded-lg text-sm text-gray-300 font-mono overflow-x-auto whitespace-nowrap">
+              {onboardUrl}
+            </code>
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(onboardUrl).then(() => {
+                  setCopyLabel('Copied!');
+                  setTimeout(() => setCopyLabel('Copy'), 2000);
+                });
+              }}
+              className="px-3 py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg text-sm text-gray-300 transition whitespace-nowrap"
+            >
+              {copyLabel}
+            </button>
+          </div>
         </div>
 
         {/* Controllers section */}

--- a/apps/auth/app/onboard/page.tsx
+++ b/apps/auth/app/onboard/page.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import { useState, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { buildPublicUrl } from '@imajin/config';
+import * as ed from '@noble/ed25519';
+
+// Bytes → hex
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+interface ForestProfile {
+  name?: string;
+  handle?: string;
+  avatarUrl?: string;
+  scope?: string;
+}
+
+type Flow = 'choose' | 'email' | 'email-sent' | 'keypair-confirm' | 'keypair-loading';
+
+function OnboardContent() {
+  const params = useSearchParams();
+  const scope = params.get('scope') || '';
+  const redirect = params.get('redirect') || params.get('redirectUrl') || '';
+
+  const [flow, setFlow] = useState<Flow>('choose');
+  const [forest, setForest] = useState<ForestProfile | null>(null);
+  const [forestLoading, setForestLoading] = useState(!!scope);
+
+  // Email flow
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [emailLoading, setEmailLoading] = useState(false);
+
+  // Keypair flow
+  const [keypair, setKeypair] = useState<{ privateKey: string; publicKey: string } | null>(null);
+  const [keypairAck, setKeypairAck] = useState(false);
+  const [keypairError, setKeypairError] = useState('');
+
+  useEffect(() => {
+    if (!scope) return;
+    const profileUrl = buildPublicUrl('profile');
+    fetch(`${profileUrl}/api/profile/${encodeURIComponent(scope)}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data) setForest(data);
+      })
+      .catch(() => {})
+      .finally(() => setForestLoading(false));
+  }, [scope]);
+
+  const forestName = forest?.name || forest?.handle || (scope ? scope.slice(0, 20) : null);
+
+  // ── Email flow ──────────────────────────────────────────────────────────
+
+  async function handleEmailSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setEmailError('');
+    if (!email.includes('@')) {
+      setEmailError('Please enter a valid email address.');
+      return;
+    }
+    setEmailLoading(true);
+    try {
+      const res = await fetch('/api/onboard', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          name: name.trim() || undefined,
+          scopeDid: scope || undefined,
+          redirectUrl: redirect || undefined,
+          context: forestName ? `Join ${forestName}` : undefined,
+        }),
+      });
+      if (res.ok) {
+        setFlow('email-sent');
+      } else {
+        const body = await res.json().catch(() => ({}));
+        setEmailError(body.error || 'Something went wrong. Please try again.');
+      }
+    } catch {
+      setEmailError('Network error. Please try again.');
+    } finally {
+      setEmailLoading(false);
+    }
+  }
+
+  // ── Keypair flow ────────────────────────────────────────────────────────
+
+  async function handleGenerateKeypair() {
+    setFlow('keypair-confirm');
+    setKeypairAck(false);
+    const privateKeyBytes = ed.utils.randomPrivateKey();
+    const publicKeyBytes = await ed.getPublicKeyAsync(privateKeyBytes);
+    setKeypair({
+      privateKey: bytesToHex(privateKeyBytes),
+      publicKey: bytesToHex(publicKeyBytes),
+    });
+  }
+
+  function downloadKeypair() {
+    if (!keypair) return;
+    const data = JSON.stringify({
+      publicKey: keypair.publicKey,
+      privateKey: keypair.privateKey,
+      note: 'Keep this file safe. Your private key cannot be recovered if lost.',
+      createdAt: new Date().toISOString(),
+    }, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'imajin-identity.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function handleKeypairContinue() {
+    if (!keypair || !keypairAck) return;
+    setFlow('keypair-loading');
+    setKeypairError('');
+    try {
+      const res = await fetch('/api/onboard/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          publicKey: keypair.publicKey,
+          name: name.trim() || undefined,
+          scopeDid: scope || undefined,
+          redirectUrl: redirect || undefined,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        window.location.href = data.redirectUrl || redirect || '/';
+      } else {
+        const body = await res.json().catch(() => ({}));
+        setKeypairError(body.error || 'Something went wrong. Please try again.');
+        setFlow('keypair-confirm');
+      }
+    } catch {
+      setKeypairError('Network error. Please try again.');
+      setFlow('keypair-confirm');
+    }
+  }
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  const loginUrl = `/login${redirect || scope ? `?next=${encodeURIComponent(redirect || '/')}${scope ? `&scope=${encodeURIComponent(scope)}` : ''}` : ''}`;
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center p-4">
+      <div className="w-full max-w-sm space-y-6">
+
+        {/* Forest header */}
+        <div className="text-center space-y-3">
+          {forestLoading ? (
+            <div className="w-16 h-16 rounded-full bg-gray-800 mx-auto animate-pulse" />
+          ) : forest?.avatarUrl ? (
+            <img src={forest.avatarUrl} alt="" className="w-16 h-16 rounded-full mx-auto object-cover border border-gray-700" />
+          ) : (
+            <div className="w-16 h-16 rounded-full bg-gray-800 mx-auto flex items-center justify-center text-2xl">
+              {forest?.scope === 'org' ? '🏢' : forest?.scope === 'family' ? '👨‍👩‍👦' : '🌲'}
+            </div>
+          )}
+          <div>
+            <h1 className="text-xl font-bold text-white">
+              {forestName ? `Join ${forestName}` : 'Get started'}
+            </h1>
+            {forest?.scope && (
+              <span className="inline-block mt-1 px-2 py-0.5 text-xs rounded-full border border-gray-700 text-gray-400 capitalize">
+                {forest.scope}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Flows */}
+        {flow === 'choose' && (
+          <div className="space-y-3">
+            <button
+              onClick={() => setFlow('email')}
+              className="w-full flex items-center gap-3 px-4 py-3 bg-gray-900 hover:bg-gray-800 border border-gray-700 hover:border-gray-600 rounded-xl text-white transition text-left"
+            >
+              <span className="text-lg">📧</span>
+              <span className="font-medium">Continue with email</span>
+            </button>
+            <button
+              onClick={handleGenerateKeypair}
+              className="w-full flex items-center gap-3 px-4 py-3 bg-amber-500 hover:bg-amber-400 rounded-xl text-gray-950 transition text-left font-semibold"
+            >
+              <span className="text-lg">🔑</span>
+              <span>Create identity</span>
+            </button>
+            <a
+              href={loginUrl}
+              className="w-full flex items-center justify-center px-4 py-3 bg-transparent border border-gray-800 hover:border-gray-600 rounded-xl text-gray-400 hover:text-gray-200 transition text-sm no-underline"
+            >
+              Already have an account? Log in
+            </a>
+          </div>
+        )}
+
+        {flow === 'email' && (
+          <form onSubmit={handleEmailSubmit} className="space-y-3">
+            <input
+              type="text"
+              placeholder="Your name (optional)"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full px-4 py-3 bg-gray-900 border border-gray-700 focus:border-amber-500 rounded-xl text-white placeholder-gray-600 outline-none transition"
+            />
+            <input
+              type="email"
+              placeholder="Email address"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+              autoFocus
+              className="w-full px-4 py-3 bg-gray-900 border border-gray-700 focus:border-amber-500 rounded-xl text-white placeholder-gray-600 outline-none transition"
+            />
+            {emailError && <p className="text-red-400 text-sm">{emailError}</p>}
+            <button
+              type="submit"
+              disabled={emailLoading}
+              className="w-full py-3 bg-amber-500 hover:bg-amber-400 disabled:opacity-50 rounded-xl text-gray-950 font-semibold transition"
+            >
+              {emailLoading ? 'Sending…' : 'Send verification email'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFlow('choose')}
+              className="w-full py-2 text-sm text-gray-500 hover:text-gray-300 transition"
+            >
+              ← Back
+            </button>
+          </form>
+        )}
+
+        {flow === 'email-sent' && (
+          <div className="text-center space-y-4 bg-gray-900 border border-gray-800 rounded-2xl p-6">
+            <div className="text-4xl">📬</div>
+            <h2 className="text-white font-semibold">Check your email</h2>
+            <p className="text-gray-400 text-sm">
+              We sent a verification link to <strong className="text-white">{email}</strong>.
+              Click it to continue.
+            </p>
+            <p className="text-gray-600 text-xs">Link expires in 15 minutes.</p>
+          </div>
+        )}
+
+        {flow === 'keypair-confirm' && keypair && (
+          <div className="space-y-4">
+            <div className="bg-gray-900 border border-amber-600/40 rounded-2xl p-5 space-y-4">
+              <div className="flex items-start gap-3">
+                <span className="text-xl mt-0.5">⚠️</span>
+                <div>
+                  <p className="text-white font-semibold text-sm">Save your recovery key</p>
+                  <p className="text-gray-400 text-sm mt-1">
+                    This is your only way to recover your identity. If you lose it, your account cannot be recovered.
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={downloadKeypair}
+                className="w-full flex items-center justify-center gap-2 py-2.5 border border-gray-700 hover:border-amber-500 rounded-xl text-gray-300 hover:text-amber-400 transition text-sm"
+              >
+                ⬇ Download imajin-identity.json
+              </button>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={keypairAck}
+                  onChange={e => setKeypairAck(e.target.checked)}
+                  className="mt-1 accent-amber-500"
+                />
+                <span className="text-gray-400 text-sm">I have saved my recovery key and understand it cannot be recovered if lost.</span>
+              </label>
+            </div>
+            {keypairError && <p className="text-red-400 text-sm">{keypairError}</p>}
+            <button
+              onClick={handleKeypairContinue}
+              disabled={!keypairAck}
+              className="w-full py-3 bg-amber-500 hover:bg-amber-400 disabled:opacity-40 rounded-xl text-gray-950 font-semibold transition"
+            >
+              Continue →
+            </button>
+            <button
+              type="button"
+              onClick={() => setFlow('choose')}
+              className="w-full py-2 text-sm text-gray-500 hover:text-gray-300 transition"
+            >
+              ← Back
+            </button>
+          </div>
+        )}
+
+        {flow === 'keypair-loading' && (
+          <div className="text-center space-y-3 py-6">
+            <div className="text-3xl animate-pulse">🔑</div>
+            <p className="text-gray-400 text-sm">Creating your identity…</p>
+          </div>
+        )}
+
+        {/* Footer */}
+        <p className="text-center text-xs text-gray-600">Powered by Imajin</p>
+      </div>
+    </div>
+  );
+}
+
+export default function OnboardPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center">
+        <div className="text-gray-600 text-sm">Loading…</div>
+      </div>
+    }>
+      <OnboardContent />
+    </Suspense>
+  );
+}

--- a/apps/auth/migrations/0005_add_scope_did_to_onboard_tokens.sql
+++ b/apps/auth/migrations/0005_add_scope_did_to_onboard_tokens.sql
@@ -1,0 +1,1 @@
+ALTER TABLE auth.onboard_tokens ADD COLUMN IF NOT EXISTS scope_did TEXT;

--- a/apps/auth/src/db/schema.ts
+++ b/apps/auth/src/db/schema.ts
@@ -74,6 +74,7 @@ export const onboardTokens = authSchema.table('onboard_tokens', {
   token: text('token').notNull().unique(),
   redirectUrl: text('redirect_url'),
   context: text('context'),                       // Human-readable: "Enroll in Intro to AI"
+  scopeDid: text('scope_did'),                    // Forest DID to join on completion
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
   usedAt: timestamp('used_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),

--- a/packages/auth/src/types/attestation.ts
+++ b/packages/auth/src/types/attestation.ts
@@ -25,7 +25,8 @@ export const ATTESTATION_TYPES = [
   'group.created',
   'group.member.added',
   'group.member.removed',
-  'group.member.left'
+  'group.member.left',
+  'scope.onboard'
 ] as const;
 
 export type AttestationType = typeof ATTESTATION_TYPES[number];


### PR DESCRIPTION
Closes #597
Closes #598

## What

Scope-aware onboarding: users arrive via link/QR/NFC, see forest branding, and join through email or instant keypair creation.

### Onboard Landing Page (`/onboard?scope=did:imajin:mooi&redirect=...`)
- Fetches forest profile (name, avatar) from profile service
- Three flows:
  - **Email** — enter email/name, sends verification, shows 'check your email'
  - **Create Identity** — generates Ed25519 keypair in browser, prompts key backup download, registers DID
  - **Log in** — redirects to login with scope/redirect preserved
- Dark theme, amber buttons, 'Powered by Imajin' footer
- Works without scope param too (generic Imajin onboard)

### Keypair Onboard API (`POST /api/onboard/generate`)
- Accepts `{ publicKey, name?, scopeDid?, redirectUrl? }`
- Validates public key, derives DID, creates identity (soft tier)
- Creates profile, adds to forest if scopeDid, emits attestation
- Sets session cookie + acting-as cookie
- Handles re-auth if DID already exists

### Scope Threading
- `onboard_tokens` gets `scope_did` column (migration 0005)
- `POST /api/onboard` accepts `scopeDid`, stores in token
- `GET /api/onboard/verify` on completion:
  - Adds user as forest member (direct DB insert, same app)
  - Emits `scope.onboard` attestation
  - Sets `x-acting-as` cookie
  - Handles reactivation of previously removed members

### Forest Settings
- New 'Onboarding' section with invite link + copy button
- URL: `auth.imajin.ai/onboard?scope={groupDid}`

### New Attestation Type
- `scope.onboard` added to `ATTESTATION_TYPES`

## The Flow
```
NFC tag / QR code / link
  → /onboard?scope=did:imajin:mooi
  → "Join Mooi" page
  → email or keypair
  → DID created + forest member + session
  → redirect to Mooi's landing service
```