### PR TITLE
feat(events): scope-aware service — use actingAs DID for event ownership (#603)

### DIFF
--- a/apps/events/app/api/events/[id]/cohosts/route.ts
+++ b/apps/events/app/api/events/[id]/cohosts/route.ts
@@ -84,6 +84,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = params;
 
   try {
@@ -93,7 +94,7 @@ export async function POST(
     }
 
     // Only owner can add cohosts
-    if (event.creatorDid !== identity.id) {
+    if (event.creatorDid !== did) {
       return NextResponse.json({ error: 'Only the event owner can add cohosts' }, { status: 403 });
     }
 
@@ -143,7 +144,7 @@ export async function POST(
     }
 
     // Can't add yourself
-    if (coHostDid === identity.id) {
+    if (coHostDid === did) {
       return NextResponse.json({ error: 'Cannot add yourself as cohost' }, { status: 400 });
     }
 

--- a/apps/events/app/api/events/[id]/fair/route.ts
+++ b/apps/events/app/api/events/[id]/fair/route.ts
@@ -20,6 +20,7 @@ export async function PATCH(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
@@ -33,7 +34,7 @@ export async function PATCH(
       return NextResponse.json({ error: 'Event not found' }, { status: 404 });
     }
 
-    const orgCheck = await isEventOrganizer(id, identity.id);
+    const orgCheck = await isEventOrganizer(id, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Not authorized to update this event' }, { status: 403 });
     }

--- a/apps/events/app/api/events/[id]/guests/route.ts
+++ b/apps/events/app/api/events/[id]/guests/route.ts
@@ -37,10 +37,11 @@ export async function GET(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
-    const orgCheck = await isEventOrganizer(id, identity.id);
+    const orgCheck = await isEventOrganizer(id, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }

--- a/apps/events/app/api/events/[id]/invites/[inviteId]/route.ts
+++ b/apps/events/app/api/events/[id]/invites/[inviteId]/route.ts
@@ -18,8 +18,9 @@ export async function DELETE(
   }
 
   const { id, inviteId } = await params;
+  const did = authResult.identity.actingAs || authResult.identity.id;
 
-  const check = await isEventOrganizer(id, authResult.identity.id);
+  const check = await isEventOrganizer(id, did);
   if (!check.authorized) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
   }

--- a/apps/events/app/api/events/[id]/invites/route.ts
+++ b/apps/events/app/api/events/[id]/invites/route.ts
@@ -22,7 +22,8 @@ export async function GET(
   }
 
   const { id } = await params;
-  const check = await isEventOrganizer(id, authResult.identity.id);
+  const did = authResult.identity.actingAs || authResult.identity.id;
+  const check = await isEventOrganizer(id, did);
   if (!check.authorized) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
   }
@@ -50,7 +51,8 @@ export async function POST(
   }
 
   const { id } = await params;
-  const check = await isEventOrganizer(id, authResult.identity.id);
+  const did = authResult.identity.actingAs || authResult.identity.id;
+  const check = await isEventOrganizer(id, did);
   if (!check.authorized) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
   }

--- a/apps/events/app/api/events/[id]/message/route.ts
+++ b/apps/events/app/api/events/[id]/message/route.ts
@@ -28,9 +28,10 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
-  const orgCheck = await isEventOrganizer(id, identity.id);
+  const orgCheck = await isEventOrganizer(id, did);
   if (!orgCheck.authorized) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/apps/events/app/api/events/[id]/route.ts
+++ b/apps/events/app/api/events/[id]/route.ts
@@ -67,6 +67,7 @@ export async function PATCH(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
@@ -80,7 +81,7 @@ export async function PATCH(
       return NextResponse.json({ error: 'Event not found' }, { status: 404 });
     }
 
-    if (event.creatorDid !== identity.id) {
+    if (event.creatorDid !== did) {
       return NextResponse.json({ error: 'Only the event creator can change status' }, { status: 403 });
     }
 
@@ -130,6 +131,7 @@ export async function PUT(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
@@ -145,7 +147,7 @@ export async function PUT(
     }
 
     // Check authorization: must be creator, admin, or cohost
-    const orgCheck = await isEventOrganizer(id, identity.id);
+    const orgCheck = await isEventOrganizer(id, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Not authorized to update this event' }, { status: 403 });
     }

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/check-in/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/check-in/route.ts
@@ -18,10 +18,11 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id, ticketId } = await params;
 
   try {
-    const orgCheck = await isEventOrganizer(id, identity.id);
+    const orgCheck = await isEventOrganizer(id, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/refund/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/refund/route.ts
@@ -28,6 +28,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id, ticketId } = await params;
 
   try {
@@ -37,7 +38,7 @@ export async function POST(
     }
 
     // Refund is owner-only (not cohosts)
-    if (event.creatorDid !== identity.id) {
+    if (event.creatorDid !== did) {
       return NextResponse.json({ error: 'Only the event owner can issue refunds' }, { status: 403 });
     }
 

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/registration/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/registration/route.ts
@@ -15,10 +15,11 @@ export async function GET(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id: eventId, ticketId } = await params;
 
   try {
-    const orgCheck = await isEventOrganizer(eventId, identity.id);
+    const orgCheck = await isEventOrganizer(eventId, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/resend-email/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/resend-email/route.ts
@@ -31,10 +31,11 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id: eventId, ticketId } = await params;
 
   try {
-    const orgCheck = await isEventOrganizer(eventId, identity.id);
+    const orgCheck = await isEventOrganizer(eventId, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }

--- a/apps/events/app/api/events/[id]/tiers/route.ts
+++ b/apps/events/app/api/events/[id]/tiers/route.ts
@@ -47,11 +47,12 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
     // Check authorization
-    const orgCheck = await isEventOrganizer(id, identity.id);
+    const orgCheck = await isEventOrganizer(id, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
     }
@@ -104,10 +105,11 @@ export async function PUT(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
-    const orgCheck = await isEventOrganizer(id, identity.id);
+    const orgCheck = await isEventOrganizer(id, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
     }

--- a/apps/events/app/api/events/mine/route.ts
+++ b/apps/events/app/api/events/mine/route.ts
@@ -14,13 +14,14 @@ export async function GET(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Get all events created by this user
     const userEvents = await db
       .select()
       .from(events)
-      .where(eq(events.creatorDid, identity.id))
+      .where(eq(events.creatorDid, did))
       .orderBy(desc(events.createdAt));
 
     // For each event, get ticket types and calculate sold/revenue

--- a/apps/events/app/api/events/route.ts
+++ b/apps/events/app/api/events/route.ts
@@ -18,6 +18,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     const body = await request.json();
@@ -94,7 +95,7 @@ export async function POST(request: NextRequest) {
         { did: PLATFORM_DID, role: 'platform', share: PLATFORM_FEE },
       ],
       distributions: [
-        { did: identity.id, role: 'creator', share: 1.0 },
+        { did, role: 'creator', share: 1.0 },
       ],
     };
 
@@ -104,7 +105,7 @@ export async function POST(request: NextRequest) {
       did: eventDid,
       publicKey: eventKeypair.publicKey,
       privateKey: eventKeypair.privateKey,
-      creatorDid: identity.id,
+      creatorDid: did,
       title,
       description,
       startsAt: new Date(startsAt),
@@ -162,7 +163,7 @@ export async function POST(request: NextRequest) {
         await fetch(`${CHAT_URL}/api/d/${encodeURIComponent(eventDid)}/members`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ memberDid: identity.id, role: 'admin' }),
+          body: JSON.stringify({ memberDid: did, role: 'admin' }),
         });
         // Update conversation name (the POST creates with empty name)
         const { getClient: getChatClient } = await import('@imajin/db');

--- a/apps/events/app/api/tickets/[id]/confirm-payment/route.ts
+++ b/apps/events/app/api/tickets/[id]/confirm-payment/route.ts
@@ -22,6 +22,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
@@ -41,7 +42,7 @@ export async function POST(
     }
 
     // Verify caller is an event organizer
-    const orgCheck = await isEventOrganizer(ticket.eventId, identity.id);
+    const orgCheck = await isEventOrganizer(ticket.eventId, did);
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
     }


### PR DESCRIPTION
Makes all event ownership queries scope-aware. When `X-Acting-As` is set, event creation, dashboard, organizer checks, and admin routes use the effective DID.

**Pattern:** `const did = identity.actingAs || identity.id`

**Changed:** 15 route files
- `/events/mine` — dashboard filters by effective DID
- `/events` POST — creatorDid set to effective DID
- All organizer checks pass effective DID to `isEventOrganizer()`
- Cohost ownership, tier management, invites, guests, fair, message routes

**Preserved as identity.id (audit trail):**
- `issuer_did` on attestations
- `checkedInBy` on check-in
- `addedBy` on cohost additions

**Untouched (personal, not scope):**
- `/events/[id]/my-ticket` — ticket ownership is personal
- `/events/[id]/queue` — queue position is personal  
- `/events/[id]/hold` — holds are personal

Closes #603