### PR TITLE
feat(media): scope-aware service — use actingAs DID for asset ownership (#606)

### DIFF
--- a/apps/media/app/api/assets/[id]/classify/route.ts
+++ b/apps/media/app/api/assets/[id]/classify/route.ts
@@ -38,7 +38,8 @@ export async function POST(
   }
 
   // Owner check
-  if (asset.ownerDid !== identity.id) {
+  const ownerDid = identity.actingAs || identity.id;
+  if (asset.ownerDid !== ownerDid) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/apps/media/app/api/assets/[id]/content/route.ts
+++ b/apps/media/app/api/assets/[id]/content/route.ts
@@ -65,7 +65,7 @@ export async function GET(
     if ("error" in authResult) {
       return NextResponse.json({ error: "Authentication required" }, { status: 401 });
     }
-    if (authResult.identity.id !== asset.ownerDid) {
+    if ((authResult.identity.actingAs || authResult.identity.id) !== asset.ownerDid) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
   }
@@ -93,7 +93,7 @@ export async function PUT(
   if ("error" in authResult) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
-  const requesterDid = authResult.identity.id;
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
 
   let body: { content?: unknown };
   try {

--- a/apps/media/app/api/assets/[id]/fair/route.ts
+++ b/apps/media/app/api/assets/[id]/fair/route.ts
@@ -82,7 +82,7 @@ export async function GET(
         { status: 403 }
       );
     }
-    const requesterDid = authResult.identity.id;
+    const requesterDid = authResult.identity.actingAs || authResult.identity.id;
 
     if (accessType === "private") {
       if (requesterDid !== asset.ownerDid) {
@@ -123,7 +123,7 @@ export async function PUT(
   if ("error" in authResult) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
-  const requesterDid = authResult.identity.id;
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
 
   let asset;
   try {

--- a/apps/media/app/api/assets/[id]/folders/route.ts
+++ b/apps/media/app/api/assets/[id]/folders/route.ts
@@ -15,7 +15,7 @@ export async function PUT(
   if ("error" in authResult) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
-  const ownerDid = authResult.identity.id;
+  const ownerDid = authResult.identity.actingAs || authResult.identity.id;
 
   // Verify asset belongs to the authenticated user
   const [asset] = await db

--- a/apps/media/app/api/assets/[id]/route.ts
+++ b/apps/media/app/api/assets/[id]/route.ts
@@ -76,7 +76,7 @@ export async function GET(
         { status: 403 }
       );
     }
-    const requesterDid = authResult.identity.id;
+    const requesterDid = authResult.identity.actingAs || authResult.identity.id;
 
     if (accessType === "private") {
       if (requesterDid !== asset.ownerDid) {
@@ -176,7 +176,7 @@ export async function DELETE(
   if ("error" in authResult) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
-  const requesterDid = authResult.identity.id;
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
 
   let asset;
   try {
@@ -223,7 +223,7 @@ export async function PATCH(
   if ("error" in authResult) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
-  const requesterDid = authResult.identity.id;
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
 
   let body: { filename?: unknown };
   try {

--- a/apps/media/app/api/assets/[id]/transcribe/route.ts
+++ b/apps/media/app/api/assets/[id]/transcribe/route.ts
@@ -56,7 +56,8 @@ export async function GET(
   }
 
   // 2. Check ownership
-  if (asset.ownerDid !== identity.id) {
+  const ownerDid = identity.actingAs || identity.id;
+  if (asset.ownerDid !== ownerDid) {
     return NextResponse.json({ error: "Not your asset" }, { status: 403, headers: cors });
   }
 

--- a/apps/media/app/api/assets/route.ts
+++ b/apps/media/app/api/assets/route.ts
@@ -86,7 +86,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
   }
   const { identity } = authResult;
-  const ownerDid = identity.id;
+  const ownerDid = identity.actingAs || identity.id;
 
   // Parse multipart form data
   let formData: FormData;
@@ -324,7 +324,7 @@ export async function GET(request: NextRequest) {
     if ("error" in authResult) {
       return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
     }
-    ownerDid = authResult.identity.id;
+    ownerDid = authResult.identity.actingAs || authResult.identity.id;
   }
 
   const { searchParams } = new URL(request.url);

--- a/apps/media/app/api/folders/[id]/route.ts
+++ b/apps/media/app/api/folders/[id]/route.ts
@@ -15,7 +15,7 @@ export async function PATCH(
   if ("error" in authResult) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
-  const ownerDid = authResult.identity.id;
+  const ownerDid = authResult.identity.actingAs || authResult.identity.id;
 
   const [existing] = await db
     .select()
@@ -83,7 +83,7 @@ export async function DELETE(
   if ("error" in authResult) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
-  const ownerDid = authResult.identity.id;
+  const ownerDid = authResult.identity.actingAs || authResult.identity.id;
 
   const [existing] = await db
     .select()

--- a/apps/media/app/api/folders/init/route.ts
+++ b/apps/media/app/api/folders/init/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
   if ("error" in authResult) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
-  const ownerDid = authResult.identity.id;
+  const ownerDid = authResult.identity.actingAs || authResult.identity.id;
 
   // Check if any folders already exist for this user
   const existing = await db

--- a/apps/media/app/api/folders/route.ts
+++ b/apps/media/app/api/folders/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
   if ("error" in authResult) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
-  const ownerDid = authResult.identity.id;
+  const ownerDid = authResult.identity.actingAs || authResult.identity.id;
 
   try {
     const rows = await db
@@ -48,7 +48,7 @@ export async function POST(request: NextRequest) {
   if ("error" in authResult) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
-  const ownerDid = authResult.identity.id;
+  const ownerDid = authResult.identity.actingAs || authResult.identity.id;
 
   let body: { name?: string; parentId?: string; icon?: string };
   try {


### PR DESCRIPTION
Makes media asset and folder operations scope-aware.

**Changed:** 10 files
- Asset list, upload, PATCH, DELETE — ownerDid uses effective DID
- Asset content access, classify, fair, transcribe — ownership check uses effective DID
- Folder list, create, update, init — ownerDid uses effective DID

**Preserved as identity.id:** `X-Caller-DID` header on transcribe requests (audit trail)

Closes #606