### PR TITLE
feat(connections): scope-aware service — use actingAs DID (#604)

### DIFF
--- a/apps/connections/app/api/connections/[did]/nickname/route.ts
+++ b/apps/connections/app/api/connections/[did]/nickname/route.ts
@@ -12,13 +12,14 @@ export async function GET(
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const { did: targetDid } = params;
 
   const [row] = await db
     .select()
     .from(nicknames)
-    .where(and(eq(nicknames.did, identity.id), eq(nicknames.target, targetDid)));
+    .where(and(eq(nicknames.did, did), eq(nicknames.target, targetDid)));
 
   return NextResponse.json({ nickname: row?.nickname ?? null });
 }
@@ -32,13 +33,14 @@ export async function PATCH(
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const { did: targetDid } = params;
   const { nickname } = await request.json();
 
   await db
     .insert(nicknames)
-    .values({ did: identity.id, target: targetDid, nickname })
+    .values({ did, target: targetDid, nickname })
     .onConflictDoUpdate({
       target: [nicknames.did, nicknames.target],
       set: { nickname },
@@ -56,12 +58,13 @@ export async function DELETE(
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const { did: targetDid } = params;
 
   await db
     .delete(nicknames)
-    .where(and(eq(nicknames.did, identity.id), eq(nicknames.target, targetDid)));
+    .where(and(eq(nicknames.did, did), eq(nicknames.target, targetDid)));
 
   return NextResponse.json({ ok: true });
 }

--- a/apps/connections/app/api/connections/[did]/route.ts
+++ b/apps/connections/app/api/connections/[did]/route.ts
@@ -16,11 +16,12 @@ export async function DELETE(
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
 
   const { did: targetDid } = await params;
 
   // Sort DIDs lexically to find the connection row
-  const [didA, didB] = [identity.id, targetDid].sort((a, b) => a.localeCompare(b));
+  const [didA, didB] = [effectiveDid, targetDid].sort((a, b) => a.localeCompare(b));
 
   const result = await db
     .update(connections)

--- a/apps/connections/app/api/connections/route.ts
+++ b/apps/connections/app/api/connections/route.ts
@@ -17,20 +17,21 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
   }
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const rows = await db
     .select()
     .from(connections)
     .where(
       and(
-        or(eq(connections.didA, identity.id), eq(connections.didB, identity.id)),
+        or(eq(connections.didA, did), eq(connections.didB, did)),
         isNull(connections.disconnectedAt)
       )
     );
 
   // Map so `did` is the OTHER person's DID
   const mapped = rows.map((row) => ({
-    did: row.didA === identity.id ? row.didB : row.didA,
+    did: row.didA === did ? row.didB : row.didA,
     connectedAt: row.connectedAt,
   }));
 
@@ -40,7 +41,7 @@ export async function GET(request: NextRequest) {
     ? await db
         .select()
         .from(nicknames)
-        .where(and(eq(nicknames.did, identity.id), inArray(nicknames.target, targetDids)))
+        .where(and(eq(nicknames.did, did), inArray(nicknames.target, targetDids)))
     : [];
   const nicknameMap = new Map(nicknameRows.map((n) => [n.target, n.nickname]));
 

--- a/apps/connections/app/api/nicknames/resolve/route.ts
+++ b/apps/connections/app/api/nicknames/resolve/route.ts
@@ -15,6 +15,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
   }
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const body = await request.json();
   const dids: string[] = body.dids ?? [];
@@ -26,7 +27,7 @@ export async function POST(request: NextRequest) {
   const rows = await db
     .select({ target: nicknames.target, nickname: nicknames.nickname })
     .from(nicknames)
-    .where(and(eq(nicknames.did, identity.id), inArray(nicknames.target, dids)));
+    .where(and(eq(nicknames.did, did), inArray(nicknames.target, dids)));
 
   const result: Record<string, string> = {};
   for (const row of rows) {

--- a/apps/connections/app/api/pods/[id]/members/route.ts
+++ b/apps/connections/app/api/pods/[id]/members/route.ts
@@ -8,9 +8,10 @@ export async function POST(request: Request, { params }: { params: { id: string 
   const auth = await requireAuth(request, { verifyChain: true });
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
+  const effectiveDid = auth.identity.actingAs || auth.identity.id;
   const [pod] = await db.select().from(pods).where(eq(pods.id, params.id));
   if (!pod) return NextResponse.json({ error: 'Pod not found' }, { status: 404 });
-  if (pod.ownerDid !== auth.identity.id) return NextResponse.json({ error: 'Only the owner can add members' }, { status: 403 });
+  if (pod.ownerDid !== effectiveDid) return NextResponse.json({ error: 'Only the owner can add members' }, { status: 403 });
 
   const body = await request.json();
   if (!body.did) return NextResponse.json({ error: 'did is required' }, { status: 400 });
@@ -43,9 +44,10 @@ export async function PATCH(request: Request, { params }: { params: { id: string
   const auth = await requireAuth(request, { verifyChain: true });
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
+  const effectiveDid = auth.identity.actingAs || auth.identity.id;
   const [pod] = await db.select().from(pods).where(eq(pods.id, params.id));
   if (!pod) return NextResponse.json({ error: 'Pod not found' }, { status: 404 });
-  if (pod.ownerDid !== auth.identity.id) return NextResponse.json({ error: 'Only the owner can change roles' }, { status: 403 });
+  if (pod.ownerDid !== effectiveDid) return NextResponse.json({ error: 'Only the owner can change roles' }, { status: 403 });
 
   const body = await request.json();
   if (!body.did) return NextResponse.json({ error: 'did is required' }, { status: 400 });
@@ -79,9 +81,10 @@ export async function DELETE(request: Request, { params }: { params: { id: strin
   const auth = await requireAuth(request, { verifyChain: true });
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
+  const effectiveDid = auth.identity.actingAs || auth.identity.id;
   const [pod] = await db.select().from(pods).where(eq(pods.id, params.id));
   if (!pod) return NextResponse.json({ error: 'Pod not found' }, { status: 404 });
-  if (pod.ownerDid !== auth.identity.id) return NextResponse.json({ error: 'Only the owner can remove members' }, { status: 403 });
+  if (pod.ownerDid !== effectiveDid) return NextResponse.json({ error: 'Only the owner can remove members' }, { status: 403 });
 
   const body = await request.json();
   if (!body.did) return NextResponse.json({ error: 'did is required' }, { status: 400 });

--- a/apps/connections/app/api/pods/[id]/route.ts
+++ b/apps/connections/app/api/pods/[id]/route.ts
@@ -22,11 +22,12 @@ export async function PATCH(request: Request, { params }: { params: { id: string
   const auth = await requireAuth(request);
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
+  const effectiveDid = auth.identity.actingAs || auth.identity.id;
   const body = await request.json();
   const [updated] = await db
     .update(pods)
     .set({ ...body, updatedAt: new Date() })
-    .where(and(eq(pods.id, params.id), eq(pods.ownerDid, auth.identity.id)))
+    .where(and(eq(pods.id, params.id), eq(pods.ownerDid, effectiveDid)))
     .returning();
 
   if (!updated) return NextResponse.json({ error: 'Pod not found or unauthorized' }, { status: 404 });
@@ -37,9 +38,10 @@ export async function DELETE(request: Request, { params }: { params: { id: strin
   const auth = await requireAuth(request);
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
+  const effectiveDid = auth.identity.actingAs || auth.identity.id;
   const [deleted] = await db
     .delete(pods)
-    .where(and(eq(pods.id, params.id), eq(pods.ownerDid, auth.identity.id)))
+    .where(and(eq(pods.id, params.id), eq(pods.ownerDid, effectiveDid)))
     .returning();
 
   if (!deleted) return NextResponse.json({ error: 'Pod not found or unauthorized' }, { status: 404 });

--- a/apps/connections/app/api/pods/route.ts
+++ b/apps/connections/app/api/pods/route.ts
@@ -9,11 +9,13 @@ export async function GET(request: Request) {
   const auth = await requireAuth(request);
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
+  const did = auth.identity.actingAs || auth.identity.id;
+
   const myPods = await db
     .select({ pod: pods })
     .from(podMembers)
     .innerJoin(pods, eq(pods.id, podMembers.podId))
-    .where(and(eq(podMembers.did, auth.identity.id), isNull(podMembers.removedAt)));
+    .where(and(eq(podMembers.did, did), isNull(podMembers.removedAt)));
 
   return NextResponse.json({ pods: myPods.map((r) => r.pod) });
 }
@@ -25,13 +27,14 @@ export async function POST(request: Request) {
   const body = await request.json();
   const id = generateId('pod_');
   const now = new Date();
+  const effectiveDid = auth.identity.actingAs || auth.identity.id;
 
   const [pod] = await db.insert(pods).values({
     id,
     name: body.name,
     description: body.description || null,
     avatar: body.avatar || null,
-    ownerDid: auth.identity.id,
+    ownerDid: effectiveDid,
     type: body.type || 'personal',
     visibility: body.visibility || 'private',
     createdAt: now,
@@ -40,7 +43,7 @@ export async function POST(request: Request) {
 
   await db.insert(podMembers).values({
     podId: id,
-    did: auth.identity.id,
+    did: effectiveDid,
     role: 'owner',
     addedBy: auth.identity.id,
     joinedAt: now,
@@ -49,7 +52,7 @@ export async function POST(request: Request) {
   // Fire and forget — never block the response
   emitAttestation({
     issuer_did: auth.identity.id,
-    subject_did: auth.identity.id,
+    subject_did: effectiveDid,
     type: 'pod.created',
     context_id: pod.id,
     context_type: 'pod',


### PR DESCRIPTION
Makes connections and pods scope-aware.

**Changed:** 7 files
- Connection list, disconnect, nicknames — filter by effective DID
- Nickname resolve — batch lookup uses effective DID
- Pod CRUD — ownerDid uses effective DID
- Pod member management — ownership check uses effective DID

**Preserved as identity.id:** `addedBy`, `linkedBy`, `issuer_did` on all attestations

Closes #604