### PR TITLE
feat(pay): scope-aware service — use actingAs DID for financial operations (#605)

### DIFF
--- a/apps/pay/app/api/balance/[did]/route.ts
+++ b/apps/pay/app/api/balance/[did]/route.ts
@@ -32,8 +32,9 @@ export async function GET(
     );
   }
 
-  // Must be requesting your own balance
-  if (authResult.identity.id !== decoded) {
+  // Must be requesting your own balance (or acting as scope)
+  const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+  if (effectiveDid !== decoded) {
     return NextResponse.json(
       { error: 'Forbidden - can only access your own balance' },
       { status: 403, headers: cors }

--- a/apps/pay/app/api/balance/event-topup/route.ts
+++ b/apps/pay/app/api/balance/event-topup/route.ts
@@ -23,7 +23,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, balances, transactions } from '@/src/db';
 import { eq, sql } from 'drizzle-orm';
-import { extractToken, validateToken } from '@/lib/auth';
+import { requireAuth } from '@imajin/auth';
 import { genId } from '@/src/lib/id';
 import { corsHeaders } from '@/src/lib/cors';
 
@@ -35,21 +35,15 @@ export async function POST(request: NextRequest) {
   const cors = corsHeaders(request);
 
   try {
-    const token = extractToken(request.headers.get('authorization'));
-    if (!token) {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
       return NextResponse.json(
-        { error: 'Unauthorized - no token provided' },
+        { error: 'Unauthorized' },
         { status: 401, headers: cors }
       );
     }
 
-    const validation = await validateToken(token);
-    if (!validation.valid || !validation.identity) {
-      return NextResponse.json(
-        { error: 'Unauthorized - invalid token' },
-        { status: 401, headers: cors }
-      );
-    }
+    const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
 
     const body = await request.json();
     const { from_did, event_id, multiplier, recipient_dids, metadata = {} } = body;
@@ -76,8 +70,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Auth check: from_did must match session
-    if (validation.identity.id !== from_did) {
+    // Auth check: from_did must match session (or acting-as scope)
+    if (effectiveDid !== from_did) {
       return NextResponse.json(
         { error: 'Forbidden - can only top up from your own DID' },
         { status: 403, headers: cors }

--- a/apps/pay/app/api/balance/gift/route.ts
+++ b/apps/pay/app/api/balance/gift/route.ts
@@ -17,7 +17,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, balances, transactions } from '@/src/db';
 import { eq, sql } from 'drizzle-orm';
-import { extractToken, validateToken } from '@/lib/auth';
+import { requireAuth } from '@imajin/auth';
 import { genId } from '@/src/lib/id';
 import { corsHeaders } from '@/src/lib/cors';
 
@@ -29,21 +29,15 @@ export async function POST(request: NextRequest) {
   const cors = corsHeaders(request);
 
   try {
-    const token = extractToken(request.headers.get('authorization'));
-    if (!token) {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
       return NextResponse.json(
-        { error: 'Unauthorized - no token provided' },
+        { error: 'Unauthorized' },
         { status: 401, headers: cors }
       );
     }
 
-    const validation = await validateToken(token);
-    if (!validation.valid || !validation.identity) {
-      return NextResponse.json(
-        { error: 'Unauthorized - invalid token' },
-        { status: 401, headers: cors }
-      );
-    }
+    const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
 
     const body = await request.json();
     const { from_did, recipients, metadata = {} } = body;
@@ -55,8 +49,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Auth check: from_did must match session
-    if (validation.identity.id !== from_did) {
+    // Auth check: from_did must match session (or acting-as scope)
+    if (effectiveDid !== from_did) {
       return NextResponse.json(
         { error: 'Forbidden - can only gift from your own DID' },
         { status: 403, headers: cors }

--- a/apps/pay/app/api/balance/transfer/route.ts
+++ b/apps/pay/app/api/balance/transfer/route.ts
@@ -17,7 +17,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, balances, transactions } from '@/src/db';
 import { eq, sql } from 'drizzle-orm';
-import { extractToken, validateToken } from '@/lib/auth';
+import { requireAuth } from '@imajin/auth';
 import { genId } from '@/src/lib/id';
 import { corsHeaders } from '@/src/lib/cors';
 
@@ -29,21 +29,15 @@ export async function POST(request: NextRequest) {
   const cors = corsHeaders(request);
 
   try {
-    const token = extractToken(request.headers.get('authorization'));
-    if (!token) {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
       return NextResponse.json(
-        { error: 'Unauthorized - no token provided' },
+        { error: 'Unauthorized' },
         { status: 401, headers: cors }
       );
     }
 
-    const validation = await validateToken(token);
-    if (!validation.valid || !validation.identity) {
-      return NextResponse.json(
-        { error: 'Unauthorized - invalid token' },
-        { status: 401, headers: cors }
-      );
-    }
+    const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
 
     const body = await request.json();
     const { from_did, to_did, amount, metadata = {} } = body;
@@ -55,8 +49,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Auth check: sender must match session
-    if (validation.identity.id !== from_did) {
+    // Auth check: sender must match session (or acting-as scope)
+    if (effectiveDid !== from_did) {
       return NextResponse.json(
         { error: 'Forbidden - can only transfer from your own DID' },
         { status: 403, headers: cors }

--- a/apps/pay/app/api/balance/withdraw/route.ts
+++ b/apps/pay/app/api/balance/withdraw/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const did = authResult.identity.id;
+  const did = authResult.identity.actingAs || authResult.identity.id;
 
   try {
     const body = await request.json();

--- a/apps/pay/app/api/charge/route.ts
+++ b/apps/pay/app/api/charge/route.ts
@@ -30,7 +30,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getPaymentService } from '@/lib/pay';
-import { extractToken, validateToken } from '@/lib/auth';
+import { requireAuth } from '@imajin/auth';
 import type { ChargeRequest, Currency, Recipient } from '@/lib';
 import { corsHeaders } from '@/src/lib/cors';
 
@@ -74,14 +74,11 @@ export async function POST(request: NextRequest) {
       );
     }
     
-    // Optional: validate auth token if provided
-    const token = extractToken(request.headers.get('authorization'));
+    // Optional: capture fromDid if authenticated
     let fromDid: string | undefined;
-    if (token) {
-      const validation = await validateToken(token);
-      if (validation.valid && validation.identity) {
-        fromDid = validation.identity.id;
-      }
+    const authResult = await requireAuth(request);
+    if (!('error' in authResult)) {
+      fromDid = authResult.identity.actingAs || authResult.identity.id;
     }
     
     const pay = getPaymentService();

--- a/apps/pay/app/api/checkout/route.ts
+++ b/apps/pay/app/api/checkout/route.ts
@@ -24,7 +24,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getPaymentService } from '@/lib/pay';
-import { extractToken, validateToken } from '@/lib/auth';
+import { requireAuth } from '@imajin/auth';
 import type { CheckoutRequest, FiatCurrency } from '@/lib';
 import { DEFAULT_PLATFORM_FEE_BPS } from '@/lib';
 import { db, transactions, connectedAccounts } from '@/src/db';
@@ -121,14 +121,11 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Optional: validate auth token if provided
-    const token = extractToken(request.headers.get('authorization'));
-    let identity = null;
-    if (token) {
-      const validation = await validateToken(token);
-      if (validation.valid) {
-        identity = validation.identity;
-      }
+    // Optional: capture identity if authenticated
+    let identity: { id: string; actingAs?: string } | null = null;
+    const authResult = await requireAuth(request);
+    if (!('error' in authResult)) {
+      identity = authResult.identity;
     }
     
     const pay = getPaymentService();
@@ -184,7 +181,7 @@ export async function POST(request: NextRequest) {
       id: txId,
       service: body.metadata?.service || 'unknown',
       type: body.metadata?.type || 'checkout',
-      fromDid: identity?.id || null,
+      fromDid: (identity?.actingAs || identity?.id) || null,
       toDid: body.metadata?.to_did || body.metadata?.recipient_did || 'platform',
       amount: (totalAmount / 100).toString(), // Convert cents to dollars
       currency: body.currency || 'USD',

--- a/apps/pay/app/api/connect/dashboard/route.ts
+++ b/apps/pay/app/api/connect/dashboard/route.ts
@@ -51,7 +51,8 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  if (authResult.identity.id !== did) {
+  const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+  if (effectiveDid !== did) {
     return NextResponse.json(
       { error: 'Not authorized to access this account' },
       { status: 403, headers: cors }

--- a/apps/pay/app/api/connect/onboard/route.ts
+++ b/apps/pay/app/api/connect/onboard/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: NextRequest) {
     }
 
     const stripe = getStripe();
-    const did = identity.id;
+    const did = identity.actingAs || identity.id;
 
     // Check if DID already has a connected account
     const existing = await db

--- a/apps/pay/app/api/connect/status/route.ts
+++ b/apps/pay/app/api/connect/status/route.ts
@@ -48,7 +48,8 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  if (authResult.identity.id !== did) {
+  const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+  if (effectiveDid !== did) {
     return NextResponse.json(
       { error: 'Not authorized to access this account' },
       { status: 403, headers: cors }

--- a/apps/pay/app/api/transactions/[did]/route.ts
+++ b/apps/pay/app/api/transactions/[did]/route.ts
@@ -9,7 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, transactions } from '@/src/db';
 import { eq, and, desc, or } from 'drizzle-orm';
-import { extractToken, validateToken } from '@/lib/auth';
+import { requireAuth } from '@imajin/auth';
 import { corsHeaders } from '@/src/lib/cors';
 
 export async function OPTIONS(request: NextRequest) {
@@ -25,24 +25,17 @@ export async function GET(
   try {
     const { did } = params;
 
-    // Auth: must be the DID owner
-    const token = extractToken(request.headers.get('authorization'));
-    if (!token) {
+    // Auth: must be the DID owner (or acting as scope)
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
       return NextResponse.json(
-        { error: 'Unauthorized - no token provided' },
+        { error: 'Unauthorized' },
         { status: 401, headers: cors }
       );
     }
 
-    const validation = await validateToken(token);
-    if (!validation.valid || !validation.identity) {
-      return NextResponse.json(
-        { error: 'Unauthorized - invalid token' },
-        { status: 401, headers: cors }
-      );
-    }
-
-    if (validation.identity.id !== did) {
+    const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+    if (effectiveDid !== did) {
       return NextResponse.json(
         { error: 'Forbidden - can only access your own transactions' },
         { status: 403, headers: cors }

--- a/apps/pay/app/api/transactions/[did]/summary/route.ts
+++ b/apps/pay/app/api/transactions/[did]/summary/route.ts
@@ -9,7 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, transactions } from '@/src/db';
 import { eq, and, sql, or } from 'drizzle-orm';
-import { extractToken, validateToken } from '@/lib/auth';
+import { requireAuth } from '@imajin/auth';
 import { corsHeaders } from '@/src/lib/cors';
 
 export async function OPTIONS(request: NextRequest) {
@@ -25,24 +25,17 @@ export async function GET(
   try {
     const { did } = params;
 
-    // Auth: must be the DID owner
-    const token = extractToken(request.headers.get('authorization'));
-    if (!token) {
+    // Auth: must be the DID owner (or acting as scope)
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
       return NextResponse.json(
-        { error: 'Unauthorized - no token provided' },
+        { error: 'Unauthorized' },
         { status: 401, headers: cors }
       );
     }
 
-    const validation = await validateToken(token);
-    if (!validation.valid || !validation.identity) {
-      return NextResponse.json(
-        { error: 'Unauthorized - invalid token' },
-        { status: 401, headers: cors }
-      );
-    }
-
-    if (validation.identity.id !== did) {
+    const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+    if (effectiveDid !== did) {
       return NextResponse.json(
         { error: 'Forbidden - can only access your own summary' },
         { status: 403, headers: cors }


### PR DESCRIPTION
Makes all financial operations scope-aware. Also migrates 7 routes from legacy `extractToken/validateToken` to `requireAuth` from `@imajin/auth`.

**Changed:** 12 files
- Balance check/withdraw — effective DID
- Transfer/gift/event-topup — sender validation uses effective DID
- Transaction list and summary — effective DID
- Stripe Connect onboard/status/dashboard — effective DID
- Charge and checkout — financial ownership uses effective DID

**Preserved as identity.id:** `identity_id` in checkout metadata (who initiated payment)

**Bonus:** Cleaned up old auth pattern → `requireAuth` in 7 files (-91 lines, +56 lines)

Closes #605