### PR TITLE
feat(auth): service-scoped controller access + validate actingAs in getSession

### DIFF
--- a/apps/auth/app/api/groups/[groupDid]/controllers/[controllerDid]/route.ts
+++ b/apps/auth/app/api/groups/[groupDid]/controllers/[controllerDid]/route.ts
@@ -108,7 +108,11 @@ export async function GET(
 
   try {
     const [membership] = await db
-      .select({ role: groupControllers.role, removedAt: groupControllers.removedAt })
+      .select({
+        role: groupControllers.role,
+        removedAt: groupControllers.removedAt,
+        allowedServices: groupControllers.allowedServices,
+      })
       .from(groupControllers)
       .where(
         and(
@@ -123,7 +127,11 @@ export async function GET(
       return NextResponse.json({ valid: false }, { status: 200 });
     }
 
-    return NextResponse.json({ valid: true, role: membership.role });
+    return NextResponse.json({
+      valid: true,
+      role: membership.role,
+      allowedServices: membership.allowedServices ?? null, // null = full access
+    });
   } catch (error) {
     console.error('[groups] Controller check error:', error);
     return NextResponse.json({ error: 'Failed to check controller' }, { status: 500 });

--- a/apps/auth/app/api/groups/[groupDid]/controllers/route.ts
+++ b/apps/auth/app/api/groups/[groupDid]/controllers/route.ts
@@ -44,7 +44,11 @@ export async function POST(
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { did, role = 'member' } = body as { did?: string; role?: string };
+  const { did, role = 'member', allowedServices = null } = body as {
+    did?: string;
+    role?: string;
+    allowedServices?: string[] | null;
+  };
 
   if (!did || typeof did !== 'string') {
     return NextResponse.json({ error: 'did required' }, { status: 400 });
@@ -77,7 +81,7 @@ export async function POST(
       // Reactivate
       await db
         .update(groupControllers)
-        .set({ removedAt: null, role, addedBy: caller.id, addedAt: new Date() })
+        .set({ removedAt: null, role, allowedServices, addedBy: caller.id, addedAt: new Date() })
         .where(
           and(
             eq(groupControllers.groupDid, groupDid),
@@ -89,6 +93,7 @@ export async function POST(
         groupDid,
         controllerDid: did,
         role,
+        allowedServices,
         addedBy: caller.id,
       });
     }

--- a/apps/auth/migrations/0006_add_allowed_services_to_controllers.sql
+++ b/apps/auth/migrations/0006_add_allowed_services_to_controllers.sql
@@ -1,0 +1,4 @@
+-- Add per-controller service scoping
+-- NULL/empty = full access (backwards compatible), populated = restricted to listed services
+ALTER TABLE auth.group_controllers
+  ADD COLUMN IF NOT EXISTS allowed_services TEXT[] DEFAULT NULL;

--- a/apps/auth/src/db/schema.ts
+++ b/apps/auth/src/db/schema.ts
@@ -225,6 +225,7 @@ export const groupControllers = authSchema.table('group_controllers', {
   groupDid: text('group_did').notNull(),
   controllerDid: text('controller_did').notNull(),
   role: text('role').notNull().default('member'),         // 'owner' | 'admin' | 'member'
+  allowedServices: text('allowed_services').array(),      // null = full access, ['events','pay'] = restricted
   addedBy: text('added_by'),
   addedAt: timestamp('added_at', { withTimezone: true }).defaultNow(),
   removedAt: timestamp('removed_at', { withTimezone: true }),

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,6 +3,7 @@ export { requireAuth } from "./require-auth";
 export type { AuthOptions } from "./require-auth";
 export { optionalAuth } from "./optional-auth";
 export { getSession } from "./session";
+export type { SessionOptions } from "./session";
 export { requireHardDID } from "./require-hard-did";
 export { requireEstablishedDID } from "./require-established-did";
 export { canonicalize, sign, signSync } from "./sign";

--- a/packages/auth/src/require-auth.ts
+++ b/packages/auth/src/require-auth.ts
@@ -5,6 +5,7 @@ const getAuthUrl = () => process.env.AUTH_SERVICE_URL!;
 
 export interface AuthOptions {
   verifyChain?: boolean; // If true, also verify the chain is valid (not just session)
+  service?: string;      // If set, validate that acting-as controller has access to this service
 }
 
 /**
@@ -83,19 +84,26 @@ async function validateBearerToken(
   }
 }
 
+interface ActingAsResult {
+  valid: boolean;
+  allowedServices?: string[] | null; // null = full access
+}
+
 /**
  * Validate that a caller is an active owner or admin controller of a group DID.
+ * Optionally checks if the controller has access to a specific service.
  * Uses the internal API to avoid recursive auth checks.
  */
 async function validateActingAs(
   callerDid: string,
-  groupDid: string
-): Promise<boolean> {
+  groupDid: string,
+  service?: string
+): Promise<ActingAsResult> {
   const authUrl = getAuthUrl();
   const internalApiKey = process.env.ATTESTATION_INTERNAL_API_KEY;
   if (!internalApiKey) {
     console.warn("[AUTH] ATTESTATION_INTERNAL_API_KEY not set — cannot validate act-as");
-    return false;
+    return { valid: false };
   }
   try {
     const res = await fetch(
@@ -105,12 +113,25 @@ async function validateActingAs(
         cache: "no-store",
       }
     );
-    if (!res.ok) return false;
+    if (!res.ok) return { valid: false };
     const data = await res.json();
-    return data.valid === true && (data.role === "owner" || data.role === "admin");
+    if (data.valid !== true || (data.role !== "owner" && data.role !== "admin")) {
+      return { valid: false };
+    }
+
+    const allowedServices: string[] | null = data.allowedServices ?? null;
+
+    // If a service is specified and the controller has a restricted list, check it
+    if (service && allowedServices && allowedServices.length > 0) {
+      if (!allowedServices.includes(service)) {
+        return { valid: false };
+      }
+    }
+
+    return { valid: true, allowedServices };
   } catch (err) {
     console.error("[AUTH] Act-as validation failed:", err);
-    return false;
+    return { valid: false };
   }
 }
 
@@ -162,11 +183,16 @@ export async function requireAuth(
   if ("identity" in result && result.identity) {
     const actingAs = request.headers.get("x-acting-as");
     if (actingAs) {
-      const allowed = await validateActingAs(result.identity.id, actingAs);
-      if (!allowed) {
+      const actingAsResult = await validateActingAs(
+        result.identity.id,
+        actingAs,
+        options?.service
+      );
+      if (!actingAsResult.valid) {
         return { error: "Not authorized to act as this group", status: 403 };
       }
       result.identity.actingAs = actingAs;
+      result.identity.actingAsServices = actingAsResult.allowedServices ?? undefined;
     }
   }
 

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -3,13 +3,61 @@ import type { Identity } from "./types";
 
 const getAuthUrl = () => process.env.AUTH_SERVICE_URL!;
 
+export interface SessionOptions {
+  service?: string; // If set, validate acting-as controller has access to this service
+}
+
+/**
+ * Validate that a caller is an active controller of a group DID.
+ * Server-side validation — same logic as requireAuth but callable from getSession.
+ */
+async function validateActingAsCookie(
+  callerDid: string,
+  groupDid: string,
+  service?: string
+): Promise<{ valid: boolean; allowedServices?: string[] | null }> {
+  const authUrl = getAuthUrl();
+  const internalApiKey = process.env.ATTESTATION_INTERNAL_API_KEY;
+  if (!internalApiKey) {
+    console.warn("[AUTH] ATTESTATION_INTERNAL_API_KEY not set — cannot validate act-as in getSession");
+    return { valid: false };
+  }
+  try {
+    const res = await fetch(
+      `${authUrl}/api/groups/${encodeURIComponent(groupDid)}/controllers/${encodeURIComponent(callerDid)}`,
+      {
+        headers: { Authorization: `Bearer ${internalApiKey}` },
+        cache: "no-store",
+      }
+    );
+    if (!res.ok) return { valid: false };
+    const data = await res.json();
+    if (data.valid !== true || (data.role !== "owner" && data.role !== "admin")) {
+      return { valid: false };
+    }
+
+    const allowedServices: string[] | null = data.allowedServices ?? null;
+    if (service && allowedServices && allowedServices.length > 0) {
+      if (!allowedServices.includes(service)) {
+        return { valid: false };
+      }
+    }
+
+    return { valid: true, allowedServices };
+  } catch (err) {
+    console.error("[AUTH] Act-as cookie validation failed:", err);
+    return { valid: false };
+  }
+}
+
 /**
  * Get session for server components (reads from Next.js cookie store).
+ * Validates the acting-as cookie server-side — rejects unauthorized scopes.
  *
  * Use in server components and server actions — NOT in API routes
  * (use requireAuth there instead).
  */
-export async function getSession(): Promise<Identity | null> {
+export async function getSession(options?: SessionOptions): Promise<Identity | null> {
   const { cookies } = await import("next/headers");
   const cookieStore = await cookies();
   const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME);
@@ -27,15 +75,28 @@ export async function getSession(): Promise<Identity | null> {
     if (!response.ok) return null;
 
     const data = await response.json();
-    const actingAs = cookieStore.get("x-acting-as")?.value;
-    return {
-      id: data.did,
+    const callerDid = data.did;
+
+    const identity: Identity = {
+      id: callerDid,
       type: data.type || "human",
       name: data.name,
       handle: data.handle,
       tier: data.tier || "soft",
-      actingAs: actingAs || undefined,
     };
+
+    // Validate acting-as cookie server-side (never trust raw cookie value)
+    const actingAsCookie = cookieStore.get("x-acting-as")?.value;
+    if (actingAsCookie) {
+      const result = await validateActingAsCookie(callerDid, actingAsCookie, options?.service);
+      if (result.valid) {
+        identity.actingAs = actingAsCookie;
+        identity.actingAsServices = result.allowedServices ?? undefined;
+      }
+      // If invalid, silently drop — user sees their own data, not an error
+    }
+
+    return identity;
   } catch (error) {
     console.error("[AUTH] Session fetch failed:", error);
     return null;

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -5,7 +5,8 @@ export interface Identity {
   handle?: string;
   tier?: "soft" | "preliminary" | "established";
   chainVerified?: boolean;
-  actingAs?: string; // DID of group the caller is acting on behalf of
+  actingAs?: string;            // DID of group the caller is acting on behalf of
+  actingAsServices?: string[];  // Services this controller can access (undefined = full access)
 }
 
 export interface AuthResult {


### PR DESCRIPTION
## Security Fix
`getSession()` was reading `x-acting-as` cookie and attaching it to the identity **without validation**. Server components using `getSession()` instead of `requireAuth()` would trust whatever DID the user put in the cookie. Fixed — now calls the same controller validation endpoint.

Invalid cookies are silently dropped (user sees their own data, no error).

## Service-Scoped Access
Controllers can now be restricted to specific services via `allowed_services` on `group_controllers`:

```sql
-- Full access (backwards compatible)
INSERT INTO auth.group_controllers (group_did, controller_did, role)
VALUES ('did:imajin:mooi', 'did:imajin:alice', 'admin');

-- Events only
INSERT INTO auth.group_controllers (group_did, controller_did, role, allowed_services)
VALUES ('did:imajin:mooi', 'did:imajin:bob', 'admin', '{events}');
```

- `null`/empty = full access (all existing controllers keep working)
- Populated = restricted to listed services
- `requireAuth(request, { service: 'events' })` rejects if not in list
- `getSession({ service: 'events' })` same behavior

## Changes
- **Migration:** `0006_add_allowed_services_to_controllers.sql`
- **Schema:** `allowedServices` column on `groupControllers`
- **require-auth.ts:** `validateActingAs` accepts service param, `AuthOptions.service`
- **session.ts:** Full rewrite — validates cookie, returns `actingAsServices`
- **types.ts:** `Identity.actingAsServices`
- **Controller endpoints:** Add/reactivate accept `allowedServices`, check endpoint returns it

Part of #602