### PR TITLE
feat(coffee): scope-aware service — use actingAs DID for page ownership (#609)

### DIFF
--- a/apps/coffee/app/api/pages/[handle]/route.ts
+++ b/apps/coffee/app/api/pages/[handle]/route.ts
@@ -47,6 +47,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Fetch existing page
@@ -59,7 +60,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check ownership
-    if (existing.did !== identity.id) {
+    if (existing.did !== did) {
       return errorResponse('Not authorized to update this page', 403);
     }
 
@@ -122,6 +123,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Fetch existing page
@@ -134,7 +136,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check ownership
-    if (existing.did !== identity.id) {
+    if (existing.did !== did) {
       return errorResponse('Not authorized to delete this page', 403);
     }
 

--- a/apps/coffee/app/api/pages/mine/route.ts
+++ b/apps/coffee/app/api/pages/mine/route.ts
@@ -14,10 +14,11 @@ export async function GET(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     const page = await db.query.coffeePages.findFirst({
-      where: (pages, { eq }) => eq(pages.did, identity.id),
+      where: (pages, { eq }) => eq(pages.did, did),
     });
 
     if (!page) {

--- a/apps/coffee/app/api/pages/route.ts
+++ b/apps/coffee/app/api/pages/route.ts
@@ -14,6 +14,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     const body = await request.json();
@@ -51,7 +52,7 @@ export async function POST(request: NextRequest) {
 
     // Check if page already exists for this DID
     const existingDid = await db.query.coffeePages.findFirst({
-      where: (pages, { eq }) => eq(pages.did, identity.id),
+      where: (pages, { eq }) => eq(pages.did, did),
     });
 
     if (existingDid) {
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
     // Create page
     const [page] = await db.insert(coffeePages).values({
       id: generateId('page'),
-      did: identity.id,
+      did,
       handle,
       title,
       bio: bio || null,

--- a/apps/coffee/app/api/tips/[did]/route.ts
+++ b/apps/coffee/app/api/tips/[did]/route.ts
@@ -21,9 +21,10 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
 
-  // Check ownership
-  if (identity.id !== did) {
+  // Check ownership — allow viewing tips for the effective DID (scope's income)
+  if (effectiveDid !== did) {
     return errorResponse('Not authorized to view these tips', 403);
   }
 


### PR DESCRIPTION
Makes coffee page ownership scope-aware. Tip sending stays personal.

**Changed:** 4 files
- Page create, mine, update/delete — ownerDid uses effective DID
- Tips received list — ownership check uses effective DID
- `tip/route.ts` untouched — fromDid stays as identity.id (you tip as yourself)

Closes #609