### PR TITLE
feat(registry): scope-aware service — use actingAs DID for preferences (#613)

### DIFF
--- a/apps/registry/app/api/preferences/[did]/interests/[scope]/route.ts
+++ b/apps/registry/app/api/preferences/[did]/interests/[scope]/route.ts
@@ -27,7 +27,9 @@ export async function PUT(
 
   const { did, scope } = await params;
 
-  if (authResult.identity.id !== did) {
+  const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+
+  if (effectiveDid !== did) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: cors });
   }
 
@@ -104,7 +106,8 @@ export async function POST(
     if ('error' in authResult) {
       return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
     }
-    if (authResult.identity.id !== did) {
+    const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+    if (effectiveDid !== did) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: cors });
     }
   }

--- a/apps/registry/app/api/preferences/[did]/route.ts
+++ b/apps/registry/app/api/preferences/[did]/route.ts
@@ -26,7 +26,9 @@ export async function GET(
 
   const { did } = await params;
 
-  if (authResult.identity.id !== did) {
+  const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+
+  if (effectiveDid !== did) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: cors });
   }
 
@@ -79,7 +81,9 @@ export async function PUT(
 
   const { did } = await params;
 
-  if (authResult.identity.id !== did) {
+  const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
+
+  if (effectiveDid !== did) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403, headers: cors });
   }
 


### PR DESCRIPTION
Makes registry preferences and interests scope-aware.

**Changed:** 2 files — ownership checks use effective DID

Closes #613