### PR TITLE
feat(links): scope-aware service — use actingAs DID for page and link ownership (#611)

### DIFF
--- a/apps/links/app/api/links/[id]/route.ts
+++ b/apps/links/app/api/links/[id]/route.ts
@@ -21,6 +21,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Fetch link with page
@@ -39,7 +40,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       where: eq(linkPages.id, link.pageId),
     });
 
-    if (!page || page.did !== identity.id) {
+    if (!page || page.did !== did) {
       return errorResponse('Not authorized to update this link', 403);
     }
 
@@ -91,6 +92,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Fetch link with page
@@ -109,7 +111,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
       where: eq(linkPages.id, link.pageId),
     });
 
-    if (!page || page.did !== identity.id) {
+    if (!page || page.did !== did) {
       return errorResponse('Not authorized to delete this link', 403);
     }
 

--- a/apps/links/app/api/pages/[handle]/links/route.ts
+++ b/apps/links/app/api/pages/[handle]/links/route.ts
@@ -21,6 +21,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Fetch page
@@ -33,7 +34,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check ownership
-    if (page.did !== identity.id) {
+    if (page.did !== did) {
       return errorResponse('Not authorized to add links to this page', 403);
     }
 

--- a/apps/links/app/api/pages/[handle]/route.ts
+++ b/apps/links/app/api/pages/[handle]/route.ts
@@ -60,6 +60,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Fetch existing page
@@ -72,7 +73,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check ownership
-    if (existing.did !== identity.id) {
+    if (existing.did !== did) {
       return errorResponse('Not authorized to update this page', 403);
     }
 
@@ -119,6 +120,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Fetch existing page
@@ -131,7 +133,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check ownership
-    if (existing.did !== identity.id) {
+    if (existing.did !== did) {
       return errorResponse('Not authorized to delete this page', 403);
     }
 

--- a/apps/links/app/api/pages/[handle]/stats/route.ts
+++ b/apps/links/app/api/pages/[handle]/stats/route.ts
@@ -21,6 +21,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Fetch page
@@ -33,7 +34,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check ownership
-    if (page.did !== identity.id) {
+    if (page.did !== did) {
       return errorResponse('Not authorized to view stats', 403);
     }
 

--- a/apps/links/app/api/pages/auto-create/route.ts
+++ b/apps/links/app/api/pages/auto-create/route.ts
@@ -14,11 +14,12 @@ export async function POST(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Check if page already exists
     const existing = await db.query.linkPages.findFirst({
-      where: eq(linkPages.did, identity.id),
+      where: eq(linkPages.did, did),
     });
 
     if (existing) {
@@ -26,13 +27,13 @@ export async function POST(request: NextRequest) {
     }
 
     // Use identity data to create the page
-    const handle = identity.handle || identity.id.slice(-12);
+    const handle = identity.handle || did.slice(-12);
     const title = identity.name || handle;
 
     // Create page
     const [page] = await db.insert(linkPages).values({
       id: generateId('page'),
-      did: identity.id,
+      did: did,
       handle,
       title,
       bio: null,

--- a/apps/links/app/api/pages/mine/route.ts
+++ b/apps/links/app/api/pages/mine/route.ts
@@ -14,10 +14,11 @@ export async function GET(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     const page = await db.query.linkPages.findFirst({
-      where: eq(linkPages.did, identity.id),
+      where: eq(linkPages.did, did),
     });
 
     if (!page) {

--- a/apps/links/app/api/pages/route.ts
+++ b/apps/links/app/api/pages/route.ts
@@ -15,6 +15,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     const body = await request.json();
@@ -35,7 +36,7 @@ export async function POST(request: NextRequest) {
 
     // Check if page already exists for this DID
     const existingDid = await db.query.linkPages.findFirst({
-      where: eq(linkPages.did, identity.id),
+      where: eq(linkPages.did, did),
     });
 
     if (existingDid) {
@@ -59,7 +60,7 @@ export async function POST(request: NextRequest) {
     // Create page
     const [page] = await db.insert(linkPages).values({
       id: generateId('page'),
-      did: identity.id,
+      did: did,
       handle,
       title,
       bio: bio || null,


### PR DESCRIPTION
Makes all links page and link operations scope-aware.

**Changed:** 7 files — all ownership checks + creation use effective DID

Closes #611