### PR TITLE
feat(chat): scope-aware service — use actingAs DID for conversations and messages (#607)

### DIFF
--- a/apps/chat/src/app/api/conversations/[id]/messages/[msgId]/route.ts
+++ b/apps/chat/src/app/api/conversations/[id]/messages/[msgId]/route.ts
@@ -32,6 +32,7 @@ export async function PUT(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { id, msgId } = await params;
   const conversationDid = decodeURIComponent(id);
 
@@ -47,7 +48,7 @@ export async function PUT(
       return errorResponse('Message not found', 404);
     }
 
-    if (message.fromDid !== identity.id) {
+    if (message.fromDid !== effectiveDid) {
       return errorResponse('You can only edit your own messages', 403);
     }
 
@@ -100,6 +101,7 @@ export async function DELETE(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { id, msgId } = await params;
   const conversationDid = decodeURIComponent(id);
 
@@ -116,7 +118,7 @@ export async function DELETE(
     }
 
     // Author can always delete their own; for others, check access via auth service
-    if (message.fromDid !== identity.id) {
+    if (message.fromDid !== effectiveDid) {
       const hasAccess = await verifyAccess(conversationDid, request.headers.get('Cookie'));
       if (!hasAccess) {
         return errorResponse('You do not have permission to delete this message', 403);

--- a/apps/chat/src/app/api/conversations/[id]/messages/route.ts
+++ b/apps/chat/src/app/api/conversations/[id]/messages/route.ts
@@ -137,6 +137,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { id } = await params;
   const conversationDid = decodeURIComponent(id);
 
@@ -185,7 +186,7 @@ export async function POST(
       await db.insert(conversationsV2).values({
         did: conversationDid,
         name,
-        createdBy: identity.id,
+        createdBy: effectiveDid,
       }).onConflictDoNothing();
     }
 
@@ -207,7 +208,7 @@ export async function POST(
     await db.insert(messagesV2).values({
       id: messageId,
       conversationDid,
-      fromDid: identity.id,
+      fromDid: effectiveDid,
       content,
       contentType,
       replyToMessageId: replyToMessageId || null,
@@ -245,7 +246,7 @@ export async function POST(
         for (const handle of uniqueHandles) {
           try {
             const mentionedDid = await resolveHandleToDid(handle);
-            if (!mentionedDid || mentionedDid === identity.id) continue;
+            if (!mentionedDid || mentionedDid === effectiveDid) continue;
             notify.send({
               to: mentionedDid,
               scope: 'chat:mention',

--- a/apps/chat/src/app/api/conversations/[id]/route.ts
+++ b/apps/chat/src/app/api/conversations/[id]/route.ts
@@ -67,6 +67,7 @@ export async function PATCH(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { id } = await params;
   const conversationDid = decodeURIComponent(id);
 
@@ -88,10 +89,10 @@ export async function PATCH(
       await db.insert(conversationsV2).values({
         did: conversationDid,
         name: name || null,
-        createdBy: identity.id,
+        createdBy: effectiveDid,
       }).onConflictDoNothing();
     } else {
-      if (conv.createdBy !== identity.id) {
+      if (conv.createdBy !== effectiveDid) {
         return errorResponse('Only the creator can update the name', 403);
       }
       await db
@@ -120,6 +121,7 @@ export async function DELETE(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { id } = await params;
   const conversationDid = decodeURIComponent(id);
 
@@ -132,7 +134,7 @@ export async function DELETE(
       return errorResponse('Conversation not found', 404);
     }
 
-    if (conv.createdBy !== identity.id) {
+    if (conv.createdBy !== effectiveDid) {
       return errorResponse('Only the creator can delete a conversation', 403);
     }
 

--- a/apps/chat/src/app/api/conversations/route.ts
+++ b/apps/chat/src/app/api/conversations/route.ts
@@ -21,6 +21,7 @@ export async function GET(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
 
   try {
     // Discover all conversation DIDs this user participates in (same logic as conversations-v2)
@@ -28,27 +29,27 @@ export async function GET(request: NextRequest) {
       db
         .select()
         .from(conversationReadsV2)
-        .where(eq(conversationReadsV2.did, identity.id)),
+        .where(eq(conversationReadsV2.did, effectiveDid)),
       db
         .selectDistinct({ conversationDid: messagesV2.conversationDid })
         .from(messagesV2)
-        .where(eq(messagesV2.fromDid, identity.id)),
+        .where(eq(messagesV2.fromDid, effectiveDid)),
       db
         .select({ did: conversationsV2.did })
         .from(conversationsV2)
-        .where(eq(conversationsV2.createdBy, identity.id)),
+        .where(eq(conversationsV2.createdBy, effectiveDid)),
       rawSql`
         SELECT p.conversation_did
         FROM connections.pods p
         JOIN connections.pod_members pm ON pm.pod_id = p.id
-        WHERE pm.did = ${identity.id}
+        WHERE pm.did = ${effectiveDid}
           AND pm.removed_at IS NULL
           AND p.conversation_did IS NOT NULL
       `,
       rawSql`
         SELECT conversation_did
         FROM chat.conversation_members
-        WHERE member_did = ${identity.id}
+        WHERE member_did = ${effectiveDid}
           AND left_at IS NULL
       `,
     ]);
@@ -96,7 +97,7 @@ export async function GET(request: NextRequest) {
               and(
                 eq(messagesV2.conversationDid, conv.did),
                 gt(messagesV2.createdAt, lastReadAt),
-                ne(messagesV2.fromDid, identity.id),
+                ne(messagesV2.fromDid, effectiveDid),
               )
             );
           unread = row?.count ?? 0;
@@ -107,7 +108,7 @@ export async function GET(request: NextRequest) {
             .where(
               and(
                 eq(messagesV2.conversationDid, conv.did),
-                ne(messagesV2.fromDid, identity.id),
+                ne(messagesV2.fromDid, effectiveDid),
               )
             );
           unread = row?.count ?? 0;
@@ -140,7 +141,7 @@ export async function GET(request: NextRequest) {
             .where(
               and(
                 eq(messagesV2.conversationDid, conv.did),
-                ne(messagesV2.fromDid, identity.id),
+                ne(messagesV2.fromDid, effectiveDid),
               )
             )
             .limit(1);
@@ -154,7 +155,7 @@ export async function GET(request: NextRequest) {
               .where(
                 and(
                   eq(conversationReadsV2.conversationDid, conv.did),
-                  ne(conversationReadsV2.did, identity.id),
+                  ne(conversationReadsV2.did, effectiveDid),
                 )
               )
               .limit(1);
@@ -166,7 +167,7 @@ export async function GET(request: NextRequest) {
             const otherMembers = await rawSql`
               SELECT member_did FROM chat.conversation_members
               WHERE conversation_did = ${conv.did}
-                AND member_did != ${identity.id}
+                AND member_did != ${effectiveDid}
               LIMIT 1
             `;
             if (otherMembers.length > 0) {
@@ -175,7 +176,7 @@ export async function GET(request: NextRequest) {
           }
 
           // 4. Fallback: created_by != me means I'm the other party
-          if (!otherDid && conv.createdBy !== identity.id) {
+          if (!otherDid && conv.createdBy !== effectiveDid) {
             otherDid = conv.createdBy;
           }
           if (otherDid) {
@@ -242,6 +243,7 @@ export async function POST(request: NextRequest) {
     }
 
     const { identity } = authResult;
+    const effectiveDid = identity.actingAs || identity.id;
 
     if (!participantDids || !Array.isArray(participantDids) || participantDids.length === 0) {
       return errorResponse('participantDids is required');
@@ -259,7 +261,7 @@ export async function POST(request: NextRequest) {
       }
 
       const otherDid = participantDids[0];
-      const convDid = dmDid(identity.id, otherDid);
+      const convDid = dmDid(effectiveDid, otherDid);
 
       const existing = await db.query.conversationsV2.findFirst({
         where: eq(conversationsV2.did, convDid),
@@ -272,13 +274,13 @@ export async function POST(request: NextRequest) {
       await db.insert(conversationsV2).values({
         did: convDid,
         type: 'dm',
-        createdBy: identity.id,
+        createdBy: effectiveDid,
       }).onConflictDoNothing();
 
       // Track both parties so we can resolve names without reversing the hash
       await rawSql`
         INSERT INTO chat.conversation_members (conversation_did, member_did, role)
-        VALUES (${convDid}, ${identity.id}, 'member'), (${convDid}, ${otherDid}, 'member')
+        VALUES (${convDid}, ${effectiveDid}, 'member'), (${convDid}, ${otherDid}, 'member')
         ON CONFLICT (conversation_did, member_did) DO NOTHING
       `;
 
@@ -294,7 +296,7 @@ export async function POST(request: NextRequest) {
       return errorResponse('Group conversations require a name');
     }
 
-    const allMembers = [...new Set([identity.id, ...participantDids])];
+    const allMembers = [...new Set([effectiveDid, ...participantDids])];
 
     // Random group DID — group identity is the room, not the members
     const groupId = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
@@ -304,21 +306,21 @@ export async function POST(request: NextRequest) {
       did: convDid,
       type: 'group',
       name,
-      createdBy: identity.id,
+      createdBy: effectiveDid,
     }).onConflictDoNothing();
 
     // Insert members
     await rawSql`
       INSERT INTO chat.conversation_members (conversation_did, member_did, role)
       SELECT ${convDid}, unnest(${allMembers}::text[]),
-        CASE WHEN unnest = ${identity.id} THEN 'owner' ELSE 'member' END
+        CASE WHEN unnest = ${effectiveDid} THEN 'owner' ELSE 'member' END
       ON CONFLICT (conversation_did, member_did) DO NOTHING
     `.catch(() => {
       // Fallback: insert one by one if unnest approach fails
       return Promise.all(allMembers.map(did =>
         rawSql`
           INSERT INTO chat.conversation_members (conversation_did, member_did, role)
-          VALUES (${convDid}, ${did}, ${did === identity.id ? 'owner' : 'member'})
+          VALUES (${convDid}, ${did}, ${did === effectiveDid ? 'owner' : 'member'})
           ON CONFLICT (conversation_did, member_did) DO NOTHING
         `
       ));

--- a/apps/chat/src/app/api/conversations/unread/route.ts
+++ b/apps/chat/src/app/api/conversations/unread/route.ts
@@ -1,28 +1,11 @@
-import { SESSION_COOKIE_NAME } from "@imajin/config";
 import { NextRequest, NextResponse } from 'next/server';
 import { db, conversationReadsV2, messagesV2 } from '@/db';
 import { getClient } from '@imajin/db';
 import { eq } from 'drizzle-orm';
+import { requireAuth } from '@/lib/auth';
 import { corsHeaders, corsOptions } from '@/lib/utils';
 
 const rawSql = getClient();
-
-async function getSessionDid(req: NextRequest): Promise<string | null> {
-  const cookie = req.cookies.get(SESSION_COOKIE_NAME);
-  if (!cookie) return null;
-
-  const authUrl = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
-  try {
-    const res = await fetch(`${authUrl}/api/session`, {
-      headers: { Cookie: `${SESSION_COOKIE_NAME}=${cookie.value}` },
-    });
-    if (!res.ok) return null;
-    const data = await res.json();
-    return data.did || data.identity?.did || null;
-  } catch {
-    return null;
-  }
-}
 
 export async function OPTIONS(req: NextRequest) {
   return corsOptions(req);
@@ -34,31 +17,34 @@ export async function OPTIONS(req: NextRequest) {
  */
 export async function GET(req: NextRequest) {
   const cors = corsHeaders(req);
-  try {
-    const did = await getSessionDid(req);
-    if (!did) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: cors });
-    }
+  const authResult = await requireAuth(req);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
+  }
 
+  const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
+
+  try {
     // Discover all conversation DIDs this user is involved in
     const [readRecords, sentMessages, createdConvs, podConvDids] = await Promise.all([
       db
         .select()
         .from(conversationReadsV2)
-        .where(eq(conversationReadsV2.did, did)),
+        .where(eq(conversationReadsV2.did, effectiveDid)),
       db
         .selectDistinct({ conversationDid: messagesV2.conversationDid })
         .from(messagesV2)
-        .where(eq(messagesV2.fromDid, did)),
+        .where(eq(messagesV2.fromDid, effectiveDid)),
       db
         .select({ did: conversationReadsV2.conversationDid })
         .from(conversationReadsV2)
-        .where(eq(conversationReadsV2.did, did)),
+        .where(eq(conversationReadsV2.did, effectiveDid)),
       rawSql`
         SELECT p.conversation_did
         FROM connections.pods p
         JOIN connections.pod_members pm ON pm.pod_id = p.id
-        WHERE pm.did = ${did}
+        WHERE pm.did = ${effectiveDid}
           AND pm.removed_at IS NULL
           AND p.conversation_did IS NOT NULL
       `,
@@ -81,9 +67,9 @@ export async function GET(req: NextRequest) {
       SELECT m.conversation_did, count(*)::int as unread
       FROM chat.messages_v2 m
       LEFT JOIN chat.conversation_reads_v2 cr
-        ON cr.conversation_did = m.conversation_did AND cr.did = ${did}
+        ON cr.conversation_did = m.conversation_did AND cr.did = ${effectiveDid}
       WHERE m.conversation_did = ANY(${conversationDids})
-        AND m.from_did != ${did}
+        AND m.from_did != ${effectiveDid}
         AND m.created_at > COALESCE(cr.last_read_at, '-infinity'::timestamptz)
       GROUP BY m.conversation_did
     `;

--- a/apps/chat/src/app/api/d/[did]/members/[memberDid]/route.ts
+++ b/apps/chat/src/app/api/d/[did]/members/[memberDid]/route.ts
@@ -34,11 +34,12 @@ export async function DELETE(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { did, memberDid } = await params;
 
   try {
     // Cannot remove yourself — use leave instead
-    if (memberDid === identity.id) {
+    if (memberDid === effectiveDid) {
       return errorResponse('Cannot remove yourself — use the leave endpoint instead', 400, cors);
     }
 
@@ -46,7 +47,7 @@ export async function DELETE(
     const callerRows = await sql`
       SELECT role FROM chat.conversation_members
       WHERE conversation_did = ${did}
-        AND member_did = ${identity.id}
+        AND member_did = ${effectiveDid}
         AND left_at IS NULL
       LIMIT 1
     `;

--- a/apps/chat/src/app/api/d/[did]/members/route.ts
+++ b/apps/chat/src/app/api/d/[did]/members/route.ts
@@ -51,11 +51,12 @@ export async function POST(
       }
 
       const { identity } = authResult;
+      const effectiveDid = identity.actingAs || identity.id;
 
       const callerRows = await sql`
         SELECT role FROM chat.conversation_members
         WHERE conversation_did = ${did}
-          AND member_did = ${identity.id}
+          AND member_did = ${effectiveDid}
           AND left_at IS NULL
         LIMIT 1
       `;

--- a/apps/chat/src/app/api/d/[did]/messages/[msgId]/reactions/route.ts
+++ b/apps/chat/src/app/api/d/[did]/messages/[msgId]/reactions/route.ts
@@ -38,6 +38,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { did, msgId } = await params;
 
   const cookieHeader = request.headers.get('Cookie');
@@ -67,7 +68,7 @@ export async function POST(
 
     await db.insert(messageReactionsV2).values({
       messageId: msgId,
-      did: identity.id,
+      did: effectiveDid,
       emoji,
     }).onConflictDoNothing();
 
@@ -75,7 +76,7 @@ export async function POST(
     fetch(`http://localhost:${port}/__ws_broadcast`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ conversationId: did, type: 'reaction_added', messageId: msgId, emoji, senderDid: identity.id }),
+      body: JSON.stringify({ conversationId: did, type: 'reaction_added', messageId: msgId, emoji, senderDid: effectiveDid }),
     }).catch(() => {});
 
     return jsonResponse({ ok: true }, 201, cors);
@@ -99,6 +100,7 @@ export async function DELETE(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { did, msgId } = await params;
 
   const cookieHeader = request.headers.get('Cookie');
@@ -118,7 +120,7 @@ export async function DELETE(
     await db.delete(messageReactionsV2).where(
       and(
         eq(messageReactionsV2.messageId, msgId),
-        eq(messageReactionsV2.did, identity.id),
+        eq(messageReactionsV2.did, effectiveDid),
         eq(messageReactionsV2.emoji, emoji)
       )
     );
@@ -127,7 +129,7 @@ export async function DELETE(
     fetch(`http://localhost:${port}/__ws_broadcast`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ conversationId: did, type: 'reaction_removed', messageId: msgId, emoji, senderDid: identity.id }),
+      body: JSON.stringify({ conversationId: did, type: 'reaction_removed', messageId: msgId, emoji, senderDid: effectiveDid }),
     }).catch(() => {});
 
     return new Response(null, { status: 204, headers: cors });

--- a/apps/chat/src/app/api/d/[did]/messages/[msgId]/route.ts
+++ b/apps/chat/src/app/api/d/[did]/messages/[msgId]/route.ts
@@ -25,6 +25,7 @@ export async function PATCH(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { did, msgId } = await params;
 
   try {
@@ -39,7 +40,7 @@ export async function PATCH(
       return errorResponse('Message not found', 404, cors);
     }
 
-    if (existing.fromDid !== identity.id) {
+    if (existing.fromDid !== effectiveDid) {
       return errorResponse('You can only edit your own messages', 403, cors);
     }
 
@@ -94,6 +95,7 @@ export async function DELETE(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { did, msgId } = await params;
 
   try {
@@ -108,7 +110,7 @@ export async function DELETE(
       return errorResponse('Message not found', 404, cors);
     }
 
-    if (existing.fromDid !== identity.id) {
+    if (existing.fromDid !== effectiveDid) {
       return errorResponse('You can only delete your own messages', 403, cors);
     }
 

--- a/apps/chat/src/app/api/d/[did]/messages/route.ts
+++ b/apps/chat/src/app/api/d/[did]/messages/route.ts
@@ -177,6 +177,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { did } = await params;
 
   // Soft DIDs cannot send messages — they must verify their account first
@@ -231,7 +232,7 @@ export async function POST(
       await db.insert(conversationsV2).values({
         did,
         name: name || did,
-        createdBy: identity.id,
+        createdBy: effectiveDid,
       }).onConflictDoNothing();
     }
 
@@ -257,15 +258,15 @@ export async function POST(
     const signaturePayload = canonicalize({
       conversationDid: did,
       content,
-      fromDid: identity.id,
+      fromDid: effectiveDid,
       createdAt: createdAt.toISOString(),
     });
-    const signature = await signMessagePayload(identity.id, signaturePayload);
+    const signature = await signMessagePayload(effectiveDid, signaturePayload);
 
     await db.insert(messagesV2).values({
       id: messageId,
       conversationDid: did,
-      fromDid: identity.id,
+      fromDid: effectiveDid,
       content,
       contentType,
       replyToDid: replyToDid,
@@ -307,7 +308,7 @@ export async function POST(
         for (const handle of uniqueHandles) {
           try {
             const mentionedDid = await resolveHandleToDid(handle);
-            if (!mentionedDid || mentionedDid === identity.id) continue;
+            if (!mentionedDid || mentionedDid === effectiveDid) continue;
             notify.send({
               to: mentionedDid,
               scope: 'chat:mention',

--- a/apps/chat/src/app/api/d/[did]/read/route.ts
+++ b/apps/chat/src/app/api/d/[did]/read/route.ts
@@ -24,12 +24,13 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { did } = await params;
 
   try {
     await db.insert(conversationReadsV2).values({
       conversationDid: did,
-      did: identity.id,
+      did: effectiveDid,
       lastReadAt: new Date(),
     }).onConflictDoUpdate({
       target: [conversationReadsV2.conversationDid, conversationReadsV2.did],

--- a/apps/chat/src/app/api/invites/[id]/route.ts
+++ b/apps/chat/src/app/api/invites/[id]/route.ts
@@ -77,6 +77,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { id: inviteId } = await params;
 
   try {
@@ -100,7 +101,7 @@ export async function POST(
       return errorResponse('Invite has reached maximum uses', 410);
     }
 
-    if (invite.forDid && invite.forDid !== identity.id) {
+    if (invite.forDid && invite.forDid !== effectiveDid) {
       return errorResponse('This invite is for a different user', 403);
     }
 
@@ -134,6 +135,7 @@ export async function DELETE(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { id: inviteId } = await params;
 
   try {
@@ -145,7 +147,7 @@ export async function DELETE(
       return errorResponse('Invite not found', 404);
     }
 
-    if (invite.createdBy !== identity.id) {
+    if (invite.createdBy !== effectiveDid) {
       // Check if user has access to the conversation
       const hasAccess = await verifyAccess(invite.conversationId, request.headers.get('Cookie'));
       if (!hasAccess) {

--- a/apps/chat/src/app/api/invites/route.ts
+++ b/apps/chat/src/app/api/invites/route.ts
@@ -32,6 +32,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
 
   try {
     const body = await request.json();
@@ -57,7 +58,7 @@ export async function POST(request: NextRequest) {
     await db.insert(invites).values({
       id: inviteId,
       conversationId,
-      createdBy: identity.id,
+      createdBy: effectiveDid,
       forDid: forDid || null,
       maxUses: maxUses?.toString() || null,
       expiresAt,

--- a/apps/chat/src/app/api/messages/[msgId]/reactions/route.ts
+++ b/apps/chat/src/app/api/messages/[msgId]/reactions/route.ts
@@ -30,6 +30,7 @@ export async function GET(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { msgId } = await params;
 
   try {
@@ -51,7 +52,7 @@ export async function GET(
       .select({
         emoji: messageReactionsV2.emoji,
         count: sql<number>`count(*)::int`,
-        reacted: sql<boolean>`bool_or(${messageReactionsV2.did} = ${identity.id})`,
+        reacted: sql<boolean>`bool_or(${messageReactionsV2.did} = ${effectiveDid})`,
       })
       .from(messageReactionsV2)
       .where(eq(messageReactionsV2.messageId, msgId))
@@ -77,6 +78,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { msgId } = await params;
 
   try {
@@ -102,14 +104,14 @@ export async function POST(
 
     await db
       .insert(messageReactionsV2)
-      .values({ messageId: msgId, did: identity.id, emoji })
+      .values({ messageId: msgId, did: effectiveDid, emoji })
       .onConflictDoNothing();
 
     const reactions = await db
       .select({
         emoji: messageReactionsV2.emoji,
         count: sql<number>`count(*)::int`,
-        reacted: sql<boolean>`bool_or(${messageReactionsV2.did} = ${identity.id})`,
+        reacted: sql<boolean>`bool_or(${messageReactionsV2.did} = ${effectiveDid})`,
       })
       .from(messageReactionsV2)
       .where(eq(messageReactionsV2.messageId, msgId))
@@ -124,7 +126,7 @@ export async function POST(
         type: 'reaction_added',
         messageId: msgId,
         emoji,
-        did: identity.id,
+        did: effectiveDid,
         reactions,
       }),
     }).catch(() => {});
@@ -149,6 +151,7 @@ export async function DELETE(
   }
 
   const { identity } = authResult;
+  const effectiveDid = identity.actingAs || identity.id;
   const { msgId } = await params;
 
   try {
@@ -177,7 +180,7 @@ export async function DELETE(
       .where(
         and(
           eq(messageReactionsV2.messageId, msgId),
-          eq(messageReactionsV2.did, identity.id),
+          eq(messageReactionsV2.did, effectiveDid),
           eq(messageReactionsV2.emoji, emoji)
         )
       );
@@ -186,7 +189,7 @@ export async function DELETE(
       .select({
         emoji: messageReactionsV2.emoji,
         count: sql<number>`count(*)::int`,
-        reacted: sql<boolean>`bool_or(${messageReactionsV2.did} = ${identity.id})`,
+        reacted: sql<boolean>`bool_or(${messageReactionsV2.did} = ${effectiveDid})`,
       })
       .from(messageReactionsV2)
       .where(eq(messageReactionsV2.messageId, msgId))
@@ -201,7 +204,7 @@ export async function DELETE(
         type: 'reaction_removed',
         messageId: msgId,
         emoji,
-        did: identity.id,
+        did: effectiveDid,
         reactions,
       }),
     }).catch(() => {});

--- a/apps/chat/src/app/api/ws-token/route.ts
+++ b/apps/chat/src/app/api/ws-token/route.ts
@@ -19,7 +19,8 @@ export async function GET(request: NextRequest) {
   }
 
   const { identity } = authResult;
-  const token = createWsToken(identity.id);
+  const effectiveDid = identity.actingAs || identity.id;
+  const token = createWsToken(effectiveDid);
 
   return jsonResponse({ token }, 200, cors);
 }


### PR DESCRIPTION
Makes chat conversations, messages, reactions, read receipts, and invites scope-aware.

**Changed:** 15 files
- Conversation list/create, messages, reactions, read receipts — all use effective DID
- WS token — effective DID for websocket auth
- Invite create/accept — effective DID
- Unread count — replaced custom `getSessionDid` helper with `requireAuth` for proper actingAs parsing

**Untouched:**
- `d/[did]/members/leave` — you leave as yourself (identity.id)
- `issuer_did` on attestations — audit trail keeps identity.id

**Bonus:** Cleaned up unread route from custom session helper → standard requireAuth pattern

Closes #607