### PR TITLE
fix: footer width + groups/new page

### DIFF
--- a/apps/auth/app/groups/new/page.tsx
+++ b/apps/auth/app/groups/new/page.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState } from 'react';
+
+const SCOPES = [
+  { value: 'community', label: 'Community', icon: '🏛️', desc: 'A public or semi-public group' },
+  { value: 'org', label: 'Organization', icon: '🏢', desc: 'A business or project' },
+  { value: 'family', label: 'Family', icon: '👨‍👩‍👦', desc: 'A private family group' },
+] as const;
+
+export default function NewGroupPage() {
+  const [scope, setScope] = useState<string>('community');
+  const [name, setName] = useState('');
+  const [handle, setHandle] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setStatus('loading');
+    setError('');
+
+    try {
+      const res = await fetch('/api/groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          scope,
+          name: name.trim(),
+          handle: handle.trim() || undefined,
+          description: description.trim() || undefined,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setStatus('error');
+        setError(data.error || 'Something went wrong');
+        return;
+      }
+
+      // Redirect to the new group's settings
+      window.location.href = `/groups/${encodeURIComponent(data.did)}/settings`;
+    } catch {
+      setStatus('error');
+      setError('Failed to create forest');
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] p-4 md:p-8">
+      <div className="max-w-lg mx-auto space-y-6">
+
+        <div>
+          <a href="/groups" className="text-sm text-gray-500 hover:text-gray-300 transition">
+            ← Back to forests
+          </a>
+          <h1 className="text-2xl font-bold text-white mt-2 mb-1">🌱 Grow a Forest</h1>
+          <p className="text-sm text-gray-400">Create a new group identity.</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* Scope picker */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-300">Type</label>
+            <div className="grid grid-cols-3 gap-2">
+              {SCOPES.map(s => (
+                <button
+                  key={s.value}
+                  type="button"
+                  onClick={() => setScope(s.value)}
+                  className={`p-3 rounded-xl border text-center transition ${
+                    scope === s.value
+                      ? 'border-amber-500 bg-amber-500/10'
+                      : 'border-gray-800 hover:border-gray-700'
+                  }`}
+                >
+                  <span className="text-xl">{s.icon}</span>
+                  <p className={`text-sm font-medium mt-1 ${scope === s.value ? 'text-amber-400' : 'text-gray-300'}`}>
+                    {s.label}
+                  </p>
+                  <p className="text-xs text-gray-500 mt-0.5">{s.desc}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Name */}
+          <div className="space-y-1.5">
+            <label htmlFor="name" className="text-sm font-medium text-gray-300">Name</label>
+            <input
+              id="name"
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Mooi Summer Camp"
+              required
+              maxLength={100}
+              className="w-full bg-gray-900 border border-gray-800 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-amber-500/60"
+            />
+          </div>
+
+          {/* Handle */}
+          <div className="space-y-1.5">
+            <label htmlFor="handle" className="text-sm font-medium text-gray-300">
+              Handle <span className="text-gray-600">(optional)</span>
+            </label>
+            <div className="flex items-center gap-1">
+              <span className="text-gray-500 text-sm">@</span>
+              <input
+                id="handle"
+                type="text"
+                value={handle}
+                onChange={e => setHandle(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
+                placeholder="mooi"
+                maxLength={30}
+                className="flex-1 bg-gray-900 border border-gray-800 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-amber-500/60"
+              />
+            </div>
+            <p className="text-xs text-gray-600">3-30 characters, lowercase letters, numbers, underscores</p>
+          </div>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <label htmlFor="description" className="text-sm font-medium text-gray-300">
+              Description <span className="text-gray-600">(optional)</span>
+            </label>
+            <textarea
+              id="description"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder="What's this forest about?"
+              rows={3}
+              className="w-full bg-gray-900 border border-gray-800 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-amber-500/60 resize-none"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-400">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={status === 'loading' || !name.trim()}
+            className="w-full py-2.5 bg-amber-500 hover:bg-amber-400 disabled:opacity-50 text-gray-950 font-semibold rounded-lg transition-colors"
+          >
+            {status === 'loading' ? 'Creating…' : '🌱 Create Forest'}
+          </button>
+        </form>
+
+      </div>
+    </div>
+  );
+}

--- a/apps/www/src/components/LandingGrid.tsx
+++ b/apps/www/src/components/LandingGrid.tsx
@@ -179,23 +179,25 @@ export function EmailCapture() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center gap-2">
-      <span className="text-sm text-gray-500 shrink-0">Stay in the loop</span>
-      <input
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="your@email.com"
-        required
-        className="bg-gray-900 border border-gray-800 rounded-md px-3 py-1.5 text-sm text-gray-300 placeholder-gray-600 focus:outline-none focus:border-amber-500/60 w-48"
-      />
-      <button
-        type="submit"
-        disabled={status === 'loading'}
-        className="px-3 py-1.5 bg-amber-500 hover:bg-amber-400 disabled:opacity-50 text-gray-950 text-sm font-medium rounded-md transition-colors"
-      >
-        {status === 'loading' ? '…' : 'Subscribe'}
-      </button>
+    <form onSubmit={handleSubmit} className="flex flex-col gap-1.5">
+      <span className="text-sm text-gray-500">Stay in the loop</span>
+      <div className="flex items-center gap-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="your@email.com"
+          required
+          className="bg-gray-900 border border-gray-800 rounded-md px-3 py-1.5 text-sm text-gray-300 placeholder-gray-600 focus:outline-none focus:border-amber-500/60 w-48"
+        />
+        <button
+          type="submit"
+          disabled={status === 'loading'}
+          className="px-3 py-1.5 bg-amber-500 hover:bg-amber-400 disabled:opacity-50 text-gray-950 text-sm font-medium rounded-md transition-colors"
+        >
+          {status === 'loading' ? '…' : 'Subscribe'}
+        </button>
+      </div>
       {status === 'error' && <span className="text-xs text-red-400">{message}</span>}
     </form>
   );

--- a/packages/ui/src/app-launcher.tsx
+++ b/packages/ui/src/app-launcher.tsx
@@ -158,7 +158,7 @@ export function AppLauncher({ registryUrl, currentService, tier = 'anonymous', i
       })}
       {authUrl && (
         <a
-          href={`${authUrl}/groups/new`}
+          href={`${authUrl}/groups`}
           className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition no-underline"
         >
           <span className="text-lg flex-shrink-0">🌱</span>

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -431,7 +431,7 @@ export function NavBar({
                         );
                       })}
                       <a
-                        href={`${authUrl}/groups/new`}
+                        href={`${authUrl}/groups`}
                         className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition flex items-center gap-2 no-underline text-inherit text-gray-500 dark:text-gray-400"
                       >
                         <span>🌱</span> Grow a forest


### PR DESCRIPTION
1. **Footer EmailCapture** — moved 'Stay in the loop' label above the input/button row so the component doesn't stretch too wide

2. **groups/new page** — create forest form with scope picker (community/org/family), name, handle, description. Was linked from groups list page but didn't exist (404).