### PR TITLE
fix(ui): home page logo + mobile launcher grid

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -51,8 +51,8 @@ export default async function Home() {
 
       {/* LOGO + TAGLINE */}
       <section className="flex flex-col items-center text-center mb-12">
-        <div className="w-12 h-12 flex items-center justify-center mb-3">
-          今人 (ima-jin)
+        <div className="w-16 h-16 rounded-2xl bg-amber-500/10 flex items-center justify-center mb-3">
+          <span className="text-4xl font-bold text-amber-500">今</span>
         </div>
         <p className="text-lg text-gray-400">The sovereign browser.</p>
         <p className="text-sm text-gray-500 mt-1">

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -490,6 +490,7 @@ export function NavBar({
             currentService={currentService}
             tier={launcherTier}
             inline
+            variant="grid"
             authUrl={identity?.isLoggedIn && identity?.tier !== 'soft' ? authUrl : undefined}
             enabledServices={activeConfig?.enabledServices}
           />


### PR DESCRIPTION
1. **Home page logo** — styled to match nav: amber 今 in a rounded box with amber/10 background, scaled up (16×16, text-4xl)

2. **Mobile launcher** — uses `variant='grid'` now, same 4-column icon grid as desktop. No more list-to-grid flip on resize.