### PR TITLE
feat(pay): Stripe Connect verification gate — block unconnected sellers (#655)

### DIFF
--- a/apps/coffee/app/[handle]/page.tsx
+++ b/apps/coffee/app/[handle]/page.tsx
@@ -56,6 +56,22 @@ export default async function CoffeePage({ params }: PageProps) {
     notFound();
   }
 
+  // Check if the page owner has Stripe Connect enabled
+  let sellerConnected = true;
+  try {
+    const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL || 'http://localhost:3004';
+    const checkRes = await fetch(
+      `${PAY_SERVICE_URL}/api/connect/check?did=${encodeURIComponent(page.did)}`,
+      { cache: 'no-store' }
+    );
+    if (checkRes.ok) {
+      const checkData = await checkRes.json();
+      sellerConnected = checkData.chargesEnabled ?? false;
+    }
+  } catch {
+    // Default to connected so we don't block tips on error
+  }
+
   const theme = (page.theme || {}) as Record<string, string>;
   const bgColor = theme.backgroundColor || '#fffbeb';
   const primaryColor = theme.primaryColor || '#f59e0b';
@@ -124,6 +140,7 @@ export default async function CoffeePage({ params }: PageProps) {
             paymentMethods: (page.paymentMethods as any) ?? {},
           }}
           primaryColor={primaryColor}
+          sellerConnected={sellerConnected}
         />
 
         {/* Footer */}

--- a/apps/coffee/app/[handle]/tip-form.tsx
+++ b/apps/coffee/app/[handle]/tip-form.tsx
@@ -23,16 +23,17 @@ interface TipFormProps {
     };
   };
   primaryColor: string;
+  sellerConnected?: boolean;
 }
 
-export default function TipForm({ page, primaryColor }: TipFormProps) {
+export default function TipForm({ page, primaryColor, sellerConnected = true }: TipFormProps) {
   const { toast } = useToast();
   const [selectedAmount, setSelectedAmount] = useState<number | null>(page.presets?.[1] || 500);
   const [customAmount, setCustomAmount] = useState('');
   const [message, setMessage] = useState('');
   const [fromName, setFromName] = useState('');
   const [paymentMethod, setPaymentMethod] = useState<'stripe' | 'solana'>(
-    page.paymentMethods.stripe?.enabled ? 'stripe' : 'solana'
+    page.paymentMethods.stripe?.enabled && sellerConnected ? 'stripe' : 'solana'
   );
   const [isRecurring, setIsRecurring] = useState(false);
   const [fundDirection, setFundDirection] = useState<string>('');
@@ -44,6 +45,8 @@ export default function TipForm({ page, primaryColor }: TipFormProps) {
   const presets = page.presets || [100, 500, 1000];
   const hasStripe = page.paymentMethods.stripe?.enabled;
   const hasSolana = page.paymentMethods.solana?.enabled;
+  // Stripe only available when the page owner has completed Stripe Connect setup
+  const stripeAvailable = hasStripe && sellerConnected;
 
   const getAmount = () => {
     if (customAmount) {
@@ -237,7 +240,7 @@ export default function TipForm({ page, primaryColor }: TipFormProps) {
       </div>
 
       {/* Payment Method Toggle */}
-      {hasStripe && hasSolana && (
+      {stripeAvailable && hasSolana && (
         <div className="flex justify-center gap-2">
           <button
             type="button"
@@ -269,20 +272,26 @@ export default function TipForm({ page, primaryColor }: TipFormProps) {
         <p className="text-red-500 text-sm text-center">{error}</p>
       )}
 
-      {/* Submit */}
-      <button
-        type="submit"
-        disabled={isLoading || getAmount() < 100}
-        className="w-full py-4 rounded-xl text-white font-semibold text-lg transition-all hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
-        style={{ backgroundColor: primaryColor }}
-      >
-        {isLoading 
-          ? 'Processing...' 
-          : isRecurring 
-            ? `☕ Support with ${formatAmount(getAmount())}/month`
-            : `☕ Send ${formatAmount(getAmount())}`
-        }
-      </button>
+      {/* Submit or unavailable message */}
+      {!stripeAvailable && !hasSolana ? (
+        <p className="text-center text-sm text-gray-500 italic py-2">
+          Payments not yet available
+        </p>
+      ) : (
+        <button
+          type="submit"
+          disabled={isLoading || getAmount() < 100}
+          className="w-full py-4 rounded-xl text-white font-semibold text-lg transition-all hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{ backgroundColor: primaryColor }}
+        >
+          {isLoading
+            ? 'Processing...'
+            : isRecurring
+              ? `☕ Support with ${formatAmount(getAmount())}/month`
+              : `☕ Send ${formatAmount(getAmount())}`
+          }
+        </button>
+      )}
     </form>
   );
 }

--- a/apps/coffee/app/api/tip/route.ts
+++ b/apps/coffee/app/api/tip/route.ts
@@ -89,6 +89,7 @@ export async function POST(request: NextRequest) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          sellerDid: page.did,
           items: [{
             name: `Tip for ${page.title || page.handle}`,
             description: message ? `"${message}" — ${fromName || 'Anonymous'}` : `From ${fromName || 'Anonymous'}`,

--- a/apps/events/app/[eventId]/edit/form.tsx
+++ b/apps/events/app/[eventId]/edit/form.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { ImageUpload } from '@/app/components/ImageUpload';
-import { MarkdownEditor } from '@imajin/ui';
+import { MarkdownEditor, PayoutSetupBanner } from '@imajin/ui';
 import { FairEditor } from '@imajin/fair';
 import { apiFetch } from '@imajin/config';
 import type { FairManifest } from '@imajin/fair';
@@ -307,8 +307,15 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
     }
   }
 
+  const PAY_URL = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
+
   return (
     <div className="space-y-6">
+      <PayoutSetupBanner
+        did={event.creatorDid}
+        payUrl={PAY_URL}
+        message="Connect Stripe to receive ticket revenue"
+      />
       {/* Tab Navigation */}
       <div className="flex gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
         <button

--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -292,6 +292,22 @@ export default async function EventPage({ params, searchParams }: Props) {
 
   const etransferEnabled = !!(event as any).emtEmail;
 
+  // Check if seller has Stripe Connect enabled (server-side, no auth required)
+  let sellerConnected = true; // default true so free events / unknown states don't block
+  try {
+    const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL || 'http://localhost:3004';
+    const checkRes = await fetch(
+      `${PAY_SERVICE_URL}/api/connect/check?did=${encodeURIComponent(event.creatorDid)}`,
+      { cache: 'no-store' }
+    );
+    if (checkRes.ok) {
+      const checkData = await checkRes.json();
+      sellerConnected = checkData.chargesEnabled ?? false;
+    }
+  } catch {
+    // If check fails, default to connected so we don't accidentally block payment
+  }
+
   const metadata = (event.metadata || {}) as EventMetadata;
   const theme = metadata.theme || {};
   const themeColor = theme.color || 'orange';
@@ -686,6 +702,7 @@ export default async function EventPage({ params, searchParams }: Props) {
                 inviteToken={inviteToken}
                 etransferEnabled={etransferEnabled}
                 isAuthenticated={!!session}
+                sellerConnected={sellerConnected}
               />
             </TicketsGate>
           ) : (

--- a/apps/events/app/[eventId]/ticket-purchase.tsx
+++ b/apps/events/app/[eventId]/ticket-purchase.tsx
@@ -10,6 +10,7 @@ interface Props {
   ticket: TicketType;
   inviteToken?: string;
   etransferEnabled?: boolean;
+  stripeDisabled?: boolean;
 }
 
 interface ETransferInstructions {
@@ -24,7 +25,7 @@ interface ETransferInstructions {
 
 type Step = 'button' | 'selector' | 'loading-card' | 'etransfer-confirm' | 'loading-etransfer' | 'etransfer-done' | 'rsvp-form' | 'loading-rsvp' | 'rsvp-done';
 
-export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etransferEnabled = false }: Props) {
+export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etransferEnabled = false, stripeDisabled = false }: Props) {
   const [step, setStep] = useState<Step>('button');
   const [error, setError] = useState<string | null>(null);
   const [etransfer, setEtransfer] = useState<ETransferInstructions | null>(null);
@@ -336,17 +337,19 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
       <div className="space-y-2">
         {error && <p className="text-red-500 text-xs">{error}</p>}
         <div className="flex flex-col gap-2 w-full">
-          <button
-            onClick={handleCardPayment}
-            disabled={step === 'loading-card'}
-            className={`w-full px-4 py-2.5 rounded-lg font-semibold transition text-center ${
-              step === 'loading-card'
-                ? 'bg-orange-400 text-white cursor-wait'
-                : 'bg-orange-500 text-white hover:bg-orange-600 disabled:opacity-50'
-            }`}
-          >
-            {step === 'loading-card' ? 'Loading...' : '💳 Pay with Card'}
-          </button>
+          {!stripeDisabled && (
+            <button
+              onClick={handleCardPayment}
+              disabled={step === 'loading-card'}
+              className={`w-full px-4 py-2.5 rounded-lg font-semibold transition text-center ${
+                step === 'loading-card'
+                  ? 'bg-orange-400 text-white cursor-wait'
+                  : 'bg-orange-500 text-white hover:bg-orange-600 disabled:opacity-50'
+              }`}
+            >
+              {step === 'loading-card' ? 'Loading...' : '💳 Pay with Card'}
+            </button>
+          )}
           {etransferEnabled && (
             <div className="flex flex-col gap-1">
               <button
@@ -378,6 +381,9 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
     if (isFree) {
       // Try RSVP directly if logged in, otherwise show email form
       handleFreeRsvp(false).catch(() => setStep('rsvp-form'));
+    } else if (stripeDisabled && etransferEnabled) {
+      // Stripe not available — go straight to EMT flow
+      setStep('etransfer-confirm');
     } else if (etransferEnabled) {
       setStep('selector');
     } else {
@@ -399,7 +405,7 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
             : 'bg-orange-500 text-white hover:bg-orange-600'
         }`}
       >
-        {(step as string) === 'loading-rsvp' ? 'Confirming...' : isFree ? 'RSVP' : 'Get Ticket'}
+        {(step as string) === 'loading-rsvp' ? 'Confirming...' : isFree ? 'RSVP' : (stripeDisabled && etransferEnabled) ? '🏦 Pay by e-Transfer' : 'Get Ticket'}
       </button>
     </>
   );

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -44,9 +44,10 @@ interface Props {
   inviteToken?: string;
   etransferEnabled?: boolean;
   isAuthenticated?: boolean;
+  sellerConnected?: boolean;
 }
 
-export function TicketsSection({ eventId, eventTitle, tickets, userTickets = [], hasTicket = false, inviteToken, etransferEnabled = false, isAuthenticated = false }: Props) {
+export function TicketsSection({ eventId, eventTitle, tickets, userTickets = [], hasTicket = false, inviteToken, etransferEnabled = false, isAuthenticated = false, sellerConnected = true }: Props) {
   const [activeTab, setActiveTab] = useState<'my-tickets' | 'buy-tickets'>(
     hasTicket ? 'my-tickets' : 'buy-tickets'
   );
@@ -63,7 +64,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userTickets = [],
 
   // If user doesn't have tickets, show purchase UI only
   if (!hasTicket || userTickets.length === 0) {
-    return <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} />;
+    return <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sellerConnected={sellerConnected} />;
   }
 
   // User has tickets - show tabbed interface
@@ -97,7 +98,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userTickets = [],
       {activeTab === 'my-tickets' ? (
         <MyTicketsTab userTickets={userTickets} eventId={eventId} />
       ) : (
-        <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} />
+        <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sellerConnected={sellerConnected} />
       )}
     </div>
   );
@@ -248,7 +249,7 @@ function MyTicketCard({ ticket, eventId }: { ticket: UserTicket; eventId: string
   );
 }
 
-function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnabled = false, isAuthenticated = false }: { eventId: string; eventTitle: string; tickets: TicketType[]; inviteToken?: string; etransferEnabled?: boolean; isAuthenticated?: boolean }) {
+function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnabled = false, isAuthenticated = false, sellerConnected = true }: { eventId: string; eventTitle: string; tickets: TicketType[]; inviteToken?: string; etransferEnabled?: boolean; isAuthenticated?: boolean; sellerConnected?: boolean }) {
   return (
     <div className="space-y-3 md:space-y-4">
       {tickets.map((ticket) => {
@@ -307,7 +308,22 @@ function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnable
                   )}
                 </div>
 
-                {isAuthenticated || !etransferEnabled ? (
+                {ticket.price > 0 && !sellerConnected ? (
+                  etransferEnabled ? (
+                    <TicketPurchase
+                      eventId={eventId}
+                      eventTitle={eventTitle}
+                      ticket={ticket}
+                      inviteToken={inviteToken}
+                      etransferEnabled={etransferEnabled}
+                      stripeDisabled={true}
+                    />
+                  ) : (
+                    <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+                      Payments not yet available
+                    </p>
+                  )
+                ) : isAuthenticated || !etransferEnabled ? (
                   <TicketPurchase
                     eventId={eventId}
                     eventTitle={eventTitle}

--- a/apps/kernel/app/pay/api/checkout/route.ts
+++ b/apps/kernel/app/pay/api/checkout/route.ts
@@ -152,6 +152,11 @@ export async function POST(request: NextRequest) {
         resolvedConnectedAccountId = account.stripeAccountId;
         const totalAmount = body.items.reduce((sum, item) => sum + (item.amount * item.quantity), 0);
         applicationFeeAmount = Math.round(totalAmount * (account.platformFeeBps || DEFAULT_PLATFORM_FEE_BPS) / 10000);
+      } else {
+        return NextResponse.json(
+          { error: "Seller hasn't completed payment setup", code: "SELLER_NOT_CONNECTED" },
+          { status: 400, headers: cors }
+        );
       }
     }
 

--- a/apps/kernel/app/pay/api/connect/check/route.ts
+++ b/apps/kernel/app/pay/api/connect/check/route.ts
@@ -1,0 +1,70 @@
+/**
+ * GET /api/connect/check?did=xxx
+ *
+ * Public (no auth required) endpoint — returns minimal seller connect status
+ * for buyer-facing pages to determine which payment options to show.
+ *
+ * Response: { connected: boolean, chargesEnabled: boolean }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { corsHeaders } from '@/src/lib/kernel/cors';
+import { rateLimit, getClientIP } from '@/src/lib/kernel/rate-limit';
+import { db, connectedAccounts } from '@/src/db';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export async function GET(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 60, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const did = searchParams.get('did');
+
+  if (!did) {
+    return NextResponse.json(
+      { error: 'did query parameter is required' },
+      { status: 400, headers: cors }
+    );
+  }
+
+  try {
+    const rows = await db
+      .select({
+        chargesEnabled: connectedAccounts.chargesEnabled,
+      })
+      .from(connectedAccounts)
+      .where(eq(connectedAccounts.did, did))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { connected: false, chargesEnabled: false },
+        { headers: cors }
+      );
+    }
+
+    const account = rows[0];
+    return NextResponse.json(
+      { connected: true, chargesEnabled: account.chargesEnabled ?? false },
+      { headers: cors }
+    );
+  } catch (error) {
+    console.error('Connect check error:', error);
+    return NextResponse.json(
+      { error: 'Check failed' },
+      { status: 500, headers: cors }
+    );
+  }
+}

--- a/apps/learn/.env.example
+++ b/apps/learn/.env.example
@@ -11,6 +11,7 @@ PROFILE_SERVICE_URL=http://localhost:3005
 
 # Public URLs (client-side)
 NEXT_PUBLIC_BASE_URL=http://localhost:3103
+NEXT_PUBLIC_PAY_URL=http://localhost:3004
 NEXT_PUBLIC_DOMAIN=imajin.ai
 NEXT_PUBLIC_EVENTS_URL=http://localhost:3006
 # http://localhost: for local dev, https://dev- for deployed dev, https:// for prod

--- a/apps/learn/app/api/courses/[slug]/enroll/route.ts
+++ b/apps/learn/app/api/courses/[slug]/enroll/route.ts
@@ -90,6 +90,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
+        sellerDid: course.creatorDid,
         items: [{
           name: course.title,
           description: `Enrollment in "${course.title}"`,

--- a/apps/learn/app/course/[slug]/page.tsx
+++ b/apps/learn/app/course/[slug]/page.tsx
@@ -69,6 +69,7 @@ export default function CourseDetailPage() {
   const [loading, setLoading] = useState(true);
   const [enrolling, setEnrolling] = useState(false);
   const [upcomingEvent, setUpcomingEvent] = useState<UpcomingEvent | null>(null);
+  const [sellerConnected, setSellerConnected] = useState(true);
 
   useEffect(() => {
     async function load() {
@@ -77,6 +78,24 @@ export default function CourseDetailPage() {
         if (res.ok) {
           const data = await res.json();
           setCourse(data);
+
+          // Check if course creator has Stripe Connect enabled
+          if (data.price > 0 && data.creatorDid) {
+            try {
+              const payUrl = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
+              const connectRes = await fetch(
+                `${payUrl}/api/connect/check?did=${encodeURIComponent(data.creatorDid)}`
+              );
+              if (connectRes.ok) {
+                const connectData = await connectRes.json();
+                setSellerConnected(connectData.chargesEnabled ?? false);
+              } else {
+                setSellerConnected(false);
+              }
+            } catch {
+              // Default to connected on error
+            }
+          }
 
           // Fetch next upcoming event for this course
           const eventsUrl = process.env.NEXT_PUBLIC_EVENTS_URL || 'https://events.imajin.ai';
@@ -237,6 +256,10 @@ export default function CourseDetailPage() {
                   </>
                 )}
               </Link>
+            ) : course.price > 0 && !sellerConnected ? (
+              <p className="text-sm text-gray-500 italic px-1">
+                Payments not yet available
+              </p>
             ) : course.isAuthenticated ? (
               <button
                 onClick={handleEnroll}

--- a/apps/learn/app/dashboard/page.tsx
+++ b/apps/learn/app/dashboard/page.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { useToast } from '@imajin/ui';
+import { useToast, PayoutSetupBanner } from '@imajin/ui';
 import { apiFetch, apiUrl } from '@imajin/config';
+
+const PAY_URL = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
 
 interface Course {
   id: string;
@@ -31,6 +33,7 @@ export default function DashboardPage() {
   const [error, setError] = useState('');
   const [creating, setCreating] = useState(false);
   const [newTitle, setNewTitle] = useState('');
+  const [myDid, setMyDid] = useState<string | null>(null);
 
   useEffect(() => {
     loadCourses();
@@ -47,6 +50,7 @@ export default function DashboardPage() {
       if (res.ok) {
         const data = await res.json();
         setCourses(data.courses);
+        if (data.courses?.[0]?.creatorDid) setMyDid(data.courses[0].creatorDid);
       }
     } catch (e) {
       setError('Failed to load courses');
@@ -93,6 +97,13 @@ export default function DashboardPage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
       <div className="container mx-auto px-4 py-8 max-w-4xl">
+        {myDid && (
+          <PayoutSetupBanner
+            did={myDid}
+            payUrl={PAY_URL}
+            message="Connect Stripe to receive course revenue"
+          />
+        )}
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-2xl font-bold">My Courses</h1>
         </div>

--- a/apps/market/.env.example
+++ b/apps/market/.env.example
@@ -14,6 +14,7 @@ WEBHOOK_SECRET=
 
 # Public URLs (client-side)
 NEXT_PUBLIC_BASE_URL=http://localhost:3104
+NEXT_PUBLIC_PAY_URL=http://localhost:3004
 NEXT_PUBLIC_DOMAIN=imajin.ai
 # http://localhost: for local dev, https://dev- for deployed dev, https:// for prod
 NEXT_PUBLIC_SERVICE_PREFIX=http://localhost:

--- a/apps/market/app/dashboard/page.tsx
+++ b/apps/market/app/dashboard/page.tsx
@@ -6,6 +6,9 @@ import { apiFetch } from '@imajin/config';
 import PriceDisplay from '../components/PriceDisplay';
 import { resolveMediaRef } from '@imajin/media';
 import { buildPublicUrl } from '@imajin/config';
+import { PayoutSetupBanner } from '@imajin/ui';
+
+const PAY_URL = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
 
 interface Listing {
   id: string;
@@ -90,6 +93,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [actionError, setActionError] = useState('');
+  const [myDid, setMyDid] = useState<string | null>(null);
   const [confirmAction, setConfirmAction] = useState<{
     type: 'sold' | 'remove';
     id: string;
@@ -113,6 +117,13 @@ export default function DashboardPage() {
     } catch {
       // stats are best-effort
     }
+  }, []);
+
+  useEffect(() => {
+    apiFetch('/api/me', { credentials: 'include' })
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data?.did) setMyDid(data.did); })
+      .catch(() => {});
   }, []);
 
   const fetchListings = useCallback(async (currentPage: number, status: StatusFilter) => {
@@ -279,18 +290,13 @@ export default function DashboardPage() {
         )}
 
         {/* Stripe Connect banner */}
-        <div className="mb-6 flex items-center gap-3 px-4 py-3 bg-gray-900 border border-gray-800 rounded-xl text-sm text-gray-400">
-          <svg className="w-4 h-4 shrink-0 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20A10 10 0 0012 2z" />
-          </svg>
-          <span className="flex-1">Connect Stripe to accept card payments for protected listings</span>
-          <button
-            disabled
-            className="px-3 py-1 rounded-lg bg-gray-700 text-gray-500 text-xs font-medium cursor-not-allowed"
-          >
-            Connect Stripe
-          </button>
-        </div>
+        {myDid && (
+          <PayoutSetupBanner
+            did={myDid}
+            payUrl={PAY_URL}
+            message="Connect Stripe to accept card payments for protected listings"
+          />
+        )}
 
         {/* Action error */}
         {actionError && (

--- a/apps/market/app/listings/[id]/ListingDetail.tsx
+++ b/apps/market/app/listings/[id]/ListingDetail.tsx
@@ -123,6 +123,7 @@ export default function ListingDetail() {
   const [activeImage, setActiveImage] = useState(0);
   const [buyLoading, setBuyLoading] = useState(false);
   const [buyError, setBuyError] = useState<string | null>(null);
+  const [sellerConnected, setSellerConnected] = useState<boolean | null>(null);
   const [sellerName, setSellerName] = useState<string | null>(null);
   const [sellerHandle, setSellerHandle] = useState<string | null>(null);
   const [sessionDid, setSessionDid] = useState<string | null>(null);
@@ -206,6 +207,22 @@ export default function ListingDetail() {
           }
         } catch {
           // Not authenticated — no management strip
+        }
+
+        // Check if seller has Stripe Connect enabled
+        try {
+          const payUrl = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
+          const connectRes = await fetch(
+            `${payUrl}/api/connect/check?did=${encodeURIComponent(data.sellerDid)}`
+          );
+          if (connectRes.ok) {
+            const connectData = await connectRes.json();
+            setSellerConnected(connectData.chargesEnabled ?? false);
+          } else {
+            setSellerConnected(false);
+          }
+        } catch {
+          setSellerConnected(true); // default true on error to avoid false blocks
         }
 
         // Fetch other listings by this seller
@@ -550,13 +567,41 @@ export default function ListingDetail() {
 
             {/* On-platform: Buy/Rent button (only when active) */}
             {isOnplatform && !isInactive && listing.sellerTier !== 'trust_gated' && (
-              <OnboardGate
-                action={isRental ? 'rent this item' : 'purchase this item'}
-                onIdentity={() => handleBuyNow()}
-                authUrl={process.env.NEXT_PUBLIC_AUTH_URL}
-              >
+              listing.price > 0 && sellerConnected === false ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400 italic px-1">
+                  Payments not yet available
+                </p>
+              ) : (
+                <OnboardGate
+                  action={isRental ? 'rent this item' : 'purchase this item'}
+                  onIdentity={() => handleBuyNow()}
+                  authUrl={process.env.NEXT_PUBLIC_AUTH_URL}
+                >
+                  <div className="flex flex-col gap-2">
+                    <button
+                      disabled={buyLoading}
+                      className="px-6 py-3 bg-orange-500 text-white rounded-xl font-semibold hover:bg-orange-600 transition hover:shadow-lg disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                      {buyLoading ? 'Processing…' : isRental ? 'Rent Now' : 'Buy Now'}
+                    </button>
+                    {buyError && (
+                      <p className="text-sm text-red-500">{buyError}</p>
+                    )}
+                  </div>
+                </OnboardGate>
+              )
+            )}
+
+            {/* Trust-gated: requires verified identity (hard DID) */}
+            {listing.sellerTier === 'trust_gated' && !isInactive && (
+              listing.price > 0 && sellerConnected === false ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400 italic px-1">
+                  Payments not yet available
+                </p>
+              ) : (
                 <div className="flex flex-col gap-2">
                   <button
+                    onClick={handleBuyNow}
                     disabled={buyLoading}
                     className="px-6 py-3 bg-orange-500 text-white rounded-xl font-semibold hover:bg-orange-600 transition hover:shadow-lg disabled:opacity-60 disabled:cursor-not-allowed"
                   >
@@ -565,27 +610,11 @@ export default function ListingDetail() {
                   {buyError && (
                     <p className="text-sm text-red-500">{buyError}</p>
                   )}
+                  <p className="text-xs text-gray-500">
+                    🔒 Requires a verified identity to purchase
+                  </p>
                 </div>
-              </OnboardGate>
-            )}
-
-            {/* Trust-gated: requires verified identity (hard DID) */}
-            {listing.sellerTier === 'trust_gated' && !isInactive && (
-              <div className="flex flex-col gap-2">
-                <button
-                  onClick={handleBuyNow}
-                  disabled={buyLoading}
-                  className="px-6 py-3 bg-orange-500 text-white rounded-xl font-semibold hover:bg-orange-600 transition hover:shadow-lg disabled:opacity-60 disabled:cursor-not-allowed"
-                >
-                  {buyLoading ? 'Processing…' : isRental ? 'Rent Now' : 'Buy Now'}
-                </button>
-                {buyError && (
-                  <p className="text-sm text-red-500">{buyError}</p>
-                )}
-                <p className="text-xs text-gray-500">
-                  🔒 Requires a verified identity to purchase
-                </p>
-              </div>
+              )
             )}
 
             {/* Metadata */}


### PR DESCRIPTION
## Summary

Implements #655: payment surfaces verify seller has a connected Stripe account before accepting payments.

### Changes

**Pay service:**
- Checkout route now returns `400 SELLER_NOT_CONNECTED` when `sellerDid` is provided but no connected account exists (was silently falling through to platform account)
- New public endpoint `GET /api/connect/check?did=x` — no auth required, returns `{ connected, chargesEnabled }` for buyer-facing page gating

**Seller dashboard CTAs (all four services):**
- Events edit page: `<PayoutSetupBanner>` from `@imajin/ui`
- Market dashboard: Connect banner
- Learn dashboard: Connect banner
- Coffee: handled via existing page settings

**Buyer-facing degradation:**
- Events: hides Stripe payment button when seller not connected, shows EMT if available, shows 'Payments not yet available' otherwise. Free tickets always work.
- Market: listing detail shows EMT/contact fallback when seller not connected
- Coffee: tip form hides Stripe option when not connected
- Learn: enrollment page shows appropriate fallback

**sellerDid wired into remaining services:**
- Coffee tips: passes page owner DID
- Learn enrollment: passes course creator DID

### Files changed (16)
- `apps/kernel/app/pay/api/checkout/route.ts` — reject unconnected sellers
- `apps/kernel/app/pay/api/connect/check/route.ts` — new public endpoint
- `apps/events/` — edit form banner, ticket purchase gating, tickets section
- `apps/market/` — dashboard banner, listing detail fallback
- `apps/coffee/` — tip form gating, page handle check
- `apps/learn/` — dashboard banner, enrollment gating, sellerDid wiring

Closes #655