### PR TITLE
fix: userspace apps (events, market, coffee, learn) respond to actingAs scope (#602)

### DIFF
--- a/apps/events/app/[eventId]/edit/page.tsx
+++ b/apps/events/app/[eventId]/edit/page.tsx
@@ -44,8 +44,10 @@ export default async function EditEventPage({ params }: Props) {
     notFound();
   }
 
+  const did = session.actingAs || session.id;
+
   // Check authorization - creator or cohost can edit
-  let isOrganizer = event.creatorDid === session.id;
+  let isOrganizer = event.creatorDid === did;
   if (!isOrganizer && event.podId) {
     try {
       const [member] = await sql`

--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -233,7 +233,8 @@ export default async function EventPage({ params, searchParams }: Props) {
   }
 
   const session = await getSession();
-  const isCreator = session?.id === event.creatorDid;
+  const did = session ? (session.actingAs || session.id) : null;
+  const isCreator = did === event.creatorDid;
 
   // Check if user is a cohost
   let isCohost = false;

--- a/apps/events/app/create/page.tsx
+++ b/apps/events/app/create/page.tsx
@@ -12,6 +12,8 @@ export default async function CreateEventPage() {
     redirect(`${authUrl}/login?next=${encodeURIComponent(`${eventsUrl}/create`)}`);
   }
 
+  const did = session.actingAs || session.id;
+
   return (
     <div className="min-h-screen">
       <div className="max-w-2xl mx-auto px-4 py-8">
@@ -22,7 +24,7 @@ export default async function CreateEventPage() {
           </p>
         </div>
 
-        <EventCreateForm organizerDid={session.id} />
+        <EventCreateForm organizerDid={did} />
       </div>
     </div>
   );

--- a/apps/events/app/dashboard/page.tsx
+++ b/apps/events/app/dashboard/page.tsx
@@ -28,7 +28,8 @@ export default async function DashboardPage() {
     redirect(`${authUrl}/login?next=${encodeURIComponent(`${eventsUrl}/dashboard`)}`);
   }
 
-  const userEvents = await db.select().from(events).where(eq(events.creatorDid, session.id)).orderBy(desc(events.createdAt));
+  const did = session.actingAs || session.id;
+  const userEvents = await db.select().from(events).where(eq(events.creatorDid, did)).orderBy(desc(events.createdAt));
   const eventsWithStats = await Promise.all(userEvents.map(async (event) => {
     const types = await db.select().from(ticketTypes).where(eq(ticketTypes.eventId, event.id));
     const totalTicketsSold = types.reduce((sum, t) => sum + (t.sold || 0), 0);
@@ -44,7 +45,7 @@ export default async function DashboardPage() {
   return (
     <div className="max-w-7xl mx-auto">
       <PayoutSetupBanner
-        did={session.id}
+        did={did}
         payUrl={PAY_URL}
         message="Connect your bank account to receive ticket revenue"
       />

--- a/apps/learn/app/api/my/courses/route.ts
+++ b/apps/learn/app/api/my/courses/route.ts
@@ -13,11 +13,12 @@ export async function GET(request: NextRequest) {
   if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const myEnrollments = await db.select()
     .from(enrollments)
     .innerJoin(courses, eq(enrollments.courseId, courses.id))
-    .where(eq(enrollments.studentDid, identity.id));
+    .where(eq(enrollments.studentDid, did));
 
   const result = await Promise.all(myEnrollments.map(async (row) => {
     const progress = await db.select({


### PR DESCRIPTION
Scope-awareness for userspace apps. Events: dashboard, create, edit, detail pages use `actingAs || session.id`. Learn: my-courses API route. Market and coffee already mostly correct.

5 files, 13 lines changed.