### PR TITLE
feat(auth): node identity bootstrap (#675)

### DIFF
--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/check-in/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/check-in/route.ts
@@ -5,7 +5,18 @@ import { getClient } from '@imajin/db';
 
 const sql = getClient();
 
-const platformDid = process.env.RELAY_DID || process.env.AUTH_DID || '';
+let _nodeDid: string | undefined;
+async function getNodeDid(): Promise<string> {
+  if (_nodeDid !== undefined) return _nodeDid;
+  try {
+    const [row] = await sql`SELECT imajin_did FROM relay.relay_config WHERE id = 'singleton' LIMIT 1`;
+    _nodeDid = (row?.imajin_did as string | null) || process.env.RELAY_DID || '';
+  } catch {
+    _nodeDid = process.env.RELAY_DID || '';
+  }
+  if (!_nodeDid) console.warn('[check-in] No node DID found in relay.relay_config or RELAY_DID');
+  return _nodeDid;
+}
 
 /**
  * Fire-and-forget hard verification check for a DID.
@@ -48,8 +59,9 @@ async function triggerHardEligibilityCheck(did: string): Promise<void> {
 
   if (!upgraded) return;
 
+  const nodeDid = await getNodeDid();
   emitAttestation({
-    issuer_did: platformDid,
+    issuer_did: nodeDid,
     subject_did: did,
     type: 'identity.verified.hard',
     context_id: did,

--- a/apps/kernel/app/auth/api/register/route.ts
+++ b/apps/kernel/app/auth/api/register/route.ts
@@ -5,6 +5,7 @@ import { didFromPublicKey, verifySignature } from '@/src/lib/auth/crypto';
 import { createSessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
 import { rateLimit, getClientIP } from '@/src/lib/kernel/rate-limit';
 import { generateId } from '@/src/lib/kernel/utils';
+import { getNodeDid } from '@/src/lib/kernel/node-identity';
 import { emitAttestation } from '@imajin/auth';
 import { notify } from '@imajin/notify';
 import { sendEmail } from '@imajin/email';
@@ -256,7 +257,7 @@ export async function POST(request: NextRequest) {
     // Emit identity.verified.preliminary → triggers 100 MJN emission
     // Key-based registrations are preliminary by definition (proved key ownership).
     // checkPreliminaryEligibility only fires for 'soft' tier, so we emit directly here.
-    const platformDid = process.env.RELAY_DID || process.env.AUTH_DID || '';
+    const platformDid = await getNodeDid();
     emitAttestation({
       issuer_did: platformDid,
       subject_did: identity.id,

--- a/apps/kernel/drizzle/0009_add_node_imajin_did.sql
+++ b/apps/kernel/drizzle/0009_add_node_imajin_did.sql
@@ -1,0 +1,2 @@
+-- Add imajin_did column to relay_config for node identity bootstrap (#675)
+ALTER TABLE relay.relay_config ADD COLUMN IF NOT EXISTS imajin_did TEXT;

--- a/apps/kernel/drizzle/meta/0009_snapshot.json
+++ b/apps/kernel/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000009",
+  "prevId": "00000000-0000-0000-0000-000000000008",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/_journal.json
+++ b/apps/kernel/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1744329600003,
       "tag": "0008_add_scope_did_to_onboard_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1744329600004,
+      "tag": "0009_add_node_imajin_did",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/kernel/src/db/schemas/relay.ts
+++ b/apps/kernel/src/db/schemas/relay.ts
@@ -82,6 +82,7 @@ export const relayConfig = relaySchema.table('relay_config', {
   nodeFeeBps: integer('node_fee_bps').default(50),
   buyerCreditBps: integer('buyer_credit_bps').default(25),
   nodeOperatorDid: text('node_operator_did'),
+  imajinDid: text('imajin_did'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 });
 

--- a/apps/kernel/src/lib/auth/emit-session-attestation.ts
+++ b/apps/kernel/src/lib/auth/emit-session-attestation.ts
@@ -2,6 +2,7 @@ import { db, attestations } from "@/src/db";
 import { canonicalize, crypto as authCrypto } from "@imajin/auth";
 import type { AttestationType } from "@imajin/auth";
 import { computeCid } from "@imajin/cid";
+import { getNodeDid } from "@/src/lib/kernel/node-identity";
 
 function genId(prefix: string): string {
   return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
@@ -19,9 +20,9 @@ export async function emitSessionAttestation(params: {
     return;
   }
 
-  const platformDid = process.env.PLATFORM_DID;
+  const platformDid = await getNodeDid();
   if (!platformDid) {
-    console.warn("Session attestation skipped: PLATFORM_DID not set");
+    console.warn("Session attestation skipped: node DID not set");
     return;
   }
 

--- a/apps/kernel/src/lib/kernel/node-identity.ts
+++ b/apps/kernel/src/lib/kernel/node-identity.ts
@@ -1,0 +1,36 @@
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+let cachedNodeDid: string | undefined;
+
+/**
+ * Returns this node's did:imajin DID.
+ * Reads relay.relay_config.imajin_did from DB (cached for process lifetime).
+ * Falls back to RELAY_DID env var, then empty string with a warning.
+ */
+export async function getNodeDid(): Promise<string> {
+  if (cachedNodeDid !== undefined) return cachedNodeDid;
+
+  try {
+    const [row] = await sql`
+      SELECT imajin_did FROM relay.relay_config WHERE id = 'singleton' LIMIT 1
+    `;
+    if (row?.imajin_did) {
+      cachedNodeDid = row.imajin_did as string;
+      return cachedNodeDid;
+    }
+  } catch (err) {
+    console.warn('[node-identity] Could not read relay.relay_config:', err);
+  }
+
+  const fallback = process.env.RELAY_DID;
+  if (fallback) {
+    cachedNodeDid = fallback;
+    return cachedNodeDid;
+  }
+
+  console.warn('[node-identity] No node DID found in relay.relay_config or RELAY_DID env');
+  cachedNodeDid = '';
+  return '';
+}

--- a/apps/kernel/src/lib/kernel/verification.ts
+++ b/apps/kernel/src/lib/kernel/verification.ts
@@ -2,8 +2,7 @@ import { db } from '@/src/db';
 import { identities, attestations, connections } from '@/src/db';
 import { emitAttestation } from '@imajin/auth';
 import { eq, or, and, isNull, count, sql } from 'drizzle-orm';
-
-const platformDid = process.env.RELAY_DID || process.env.AUTH_DID || '';
+import { getNodeDid } from '@/src/lib/kernel/node-identity';
 
 /**
  * Checks whether a DID is eligible for preliminary verification.
@@ -54,8 +53,9 @@ export async function checkPreliminaryEligibility(did: string): Promise<void> {
 
   if (!upgraded) return; // Already upgraded by concurrent event
 
+  const nodeDid = await getNodeDid();
   emitAttestation({
-    issuer_did: platformDid,
+    issuer_did: nodeDid,
     subject_did: did,
     type: 'identity.verified.preliminary',
     context_id: did,
@@ -121,8 +121,9 @@ export async function checkHardEligibility(did: string): Promise<void> {
 
   if (!upgraded) return; // Already upgraded by concurrent event
 
+  const nodeDid = await getNodeDid();
   emitAttestation({
-    issuer_did: platformDid,
+    issuer_did: nodeDid,
     subject_did: did,
     type: 'identity.verified.hard',
     context_id: did,

--- a/scripts/bootstrap-node-identity.ts
+++ b/scripts/bootstrap-node-identity.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env tsx
+/**
+ * Node identity bootstrap (#675)
+ *
+ * Generates an Ed25519 keypair, creates a did:imajin DID for this node,
+ * inserts the node identity into the DB, and wires it into relay.relay_config.
+ *
+ * Usage:
+ *   cd apps/kernel
+ *   npx tsx ../../scripts/bootstrap-node-identity.ts
+ *
+ * Idempotent: if relay_config.imajin_did is already set, exits with the existing DID.
+ *
+ * Env vars:
+ *   NODE_NAME          — display name for the node (default: 'Imajin Node')
+ *   NODE_OPERATOR_DID  — DID of the operator to grant owner role
+ *   DATABASE_URL       — required
+ *   MFA_ENCRYPTION_KEY — optional; falls back to dev key for private key encryption
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import postgres from 'postgres';
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha2.js';
+import bs58 from 'bs58';
+import { createHash, randomBytes, createCipheriv } from 'crypto';
+
+// Configure ed25519 to use sha512 (required by @noble/ed25519 v2+)
+ed.etc.sha512Sync = (...m) => sha512(ed.etc.concatBytes(...m));
+
+// ---------------------------------------------------------------------------
+// Load .env.local (same pattern as backfill-emissions.ts)
+// ---------------------------------------------------------------------------
+try {
+  const envPath = resolve(process.cwd(), '.env.local');
+  const envContent = readFileSync(envPath, 'utf-8');
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    let val = trimmed.slice(eqIdx + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (!process.env[key]) process.env[key] = val;
+  }
+} catch {
+  // No .env.local — rely on environment
+}
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('DATABASE_URL not set. Run from apps/kernel/ directory.');
+  process.exit(1);
+}
+
+const sql = postgres(DATABASE_URL);
+
+// ---------------------------------------------------------------------------
+// Crypto helpers (inlined to avoid path alias issues in script context)
+// ---------------------------------------------------------------------------
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function didFromPublicKey(publicKeyBytes: Uint8Array): string {
+  const encoded = bs58.encode(publicKeyBytes);
+  return `did:imajin:${encoded}`;
+}
+
+function encryptSecret(plaintext: string): string {
+  const keyHex = process.env.MFA_ENCRYPTION_KEY;
+  const key = keyHex
+    ? Buffer.from(keyHex, 'hex')
+    : createHash('sha256').update('dev-mfa-encryption-key-imajin').digest();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+function genId(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log('\nNode Identity Bootstrap (#675)\n');
+
+  // Check idempotency — if imajin_did already set, skip
+  const [existing] = await sql`
+    SELECT imajin_did FROM relay.relay_config WHERE id = 'singleton' LIMIT 1
+  `;
+
+  if (existing?.imajin_did) {
+    console.log('Node identity already bootstrapped.');
+    console.log('  Node DID:', existing.imajin_did);
+    await sql.end();
+    return;
+  }
+
+  const nodeName = process.env.NODE_NAME || 'Imajin Node';
+  const operatorDid = process.env.NODE_OPERATOR_DID || null;
+
+  // 1. Generate Ed25519 keypair
+  const privateKeyBytes = ed.utils.randomPrivateKey();
+  const publicKeyBytes = await ed.getPublicKeyAsync(privateKeyBytes);
+  const privateKeyHex = bytesToHex(privateKeyBytes);
+  const publicKeyHex = bytesToHex(publicKeyBytes);
+  const nodeDid = didFromPublicKey(publicKeyBytes);
+
+  console.log('Generated node DID:', nodeDid);
+
+  // 2. Insert into auth.identities (type='node', tier='established')
+  await sql`
+    INSERT INTO auth.identities (id, type, public_key, name, tier, created_at, updated_at)
+    VALUES (
+      ${nodeDid},
+      'node',
+      ${publicKeyHex},
+      ${nodeName},
+      'established',
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT (id) DO NOTHING
+  `;
+  console.log('  Inserted auth.identities');
+
+  // 3. Store encrypted private key in auth.stored_keys
+  const encryptedKey = encryptSecret(privateKeyHex);
+  await sql`
+    INSERT INTO auth.stored_keys (id, did, encrypted_key, salt, key_derivation, created_at)
+    VALUES (
+      ${genId('key')},
+      ${nodeDid},
+      ${encryptedKey},
+      'server-side',
+      'aes-256-gcm',
+      NOW()
+    )
+    ON CONFLICT (did) DO NOTHING
+  `;
+  console.log('  Stored encrypted private key in auth.stored_keys');
+
+  // 4. Update relay.relay_config with imajin_did (and optionally node_operator_did)
+  if (operatorDid) {
+    await sql`
+      UPDATE relay.relay_config
+      SET imajin_did = ${nodeDid}, node_operator_did = ${operatorDid}
+      WHERE id = 'singleton'
+    `;
+    console.log('  Updated relay.relay_config (imajin_did + node_operator_did)');
+  } else {
+    await sql`
+      UPDATE relay.relay_config
+      SET imajin_did = ${nodeDid}
+      WHERE id = 'singleton'
+    `;
+    console.log('  Updated relay.relay_config (imajin_did)');
+  }
+
+  // 5. Insert into auth.group_identities (scope='node')
+  await sql`
+    INSERT INTO auth.group_identities (group_did, scope, created_by, created_at)
+    VALUES (${nodeDid}, 'node', ${nodeDid}, NOW())
+    ON CONFLICT (group_did) DO NOTHING
+  `;
+  console.log('  Inserted auth.group_identities');
+
+  // 6. If NODE_OPERATOR_DID set, insert into auth.group_controllers
+  if (operatorDid) {
+    await sql`
+      INSERT INTO auth.group_controllers (group_did, controller_did, role, added_at)
+      VALUES (${nodeDid}, ${operatorDid}, 'owner', NOW())
+      ON CONFLICT DO NOTHING
+    `;
+    console.log('  Inserted auth.group_controllers (operator as owner)');
+  }
+
+  // 7. Insert into profile.profiles
+  await sql`
+    INSERT INTO profile.profiles (did, display_name, display_type, handle, created_at, updated_at)
+    VALUES (${nodeDid}, ${nodeName}, 'human', NULL, NOW(), NOW())
+    ON CONFLICT (did) DO NOTHING
+  `;
+  console.log('  Inserted profile.profiles');
+
+  console.log('\nDone. Node DID:', nodeDid);
+  if (operatorDid) {
+    console.log('Operator DID:', operatorDid);
+  }
+
+  await sql.end();
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Gives the node a proper `did:imajin:` identity. Foundation for the admin console (#259) and all node-level operations.

### What changed

**New: `relay.relay_config.imajin_did` column** (migration 0009)
- Stores the node's `did:imajin:` alongside its existing `did:dfos:`

**New: `scripts/bootstrap-node-identity.ts`**
- Generates Ed25519 keypair, creates `did:imajin:` for the node
- Inserts into `auth.identities` (type=node, tier=established)
- Stores encrypted private key in `auth.stored_keys`
- Registers as group entity (`auth.group_identities`, scope=node)
- Registers operator as controller (`auth.group_controllers`, role=owner)
- Creates node profile in `profile.profiles`
- Idempotent — skips if `imajin_did` already set
- Usage: `cd apps/kernel && NODE_OPERATOR_DID=did:imajin:88k... npx tsx ../../scripts/bootstrap-node-identity.ts`

**New: `apps/kernel/src/lib/kernel/node-identity.ts`**
- `getNodeDid()` — reads from DB (cached for process lifetime), falls back to `RELAY_DID` env var

**Fixed: attestation issuer references**
- `verification.ts` — `RELAY_DID || AUTH_DID || ''` → `getNodeDid()`
- `register/route.ts` — same
- `emit-session-attestation.ts` — `PLATFORM_DID` → `getNodeDid()` (sessions are node-level)
- `check-in/route.ts` — local `getNodeDid()` (events app can't import from kernel)
- Removed all `AUTH_DID` references (dead code, never set)

### Three identity layers (clarified)

| Layer | Scope | Actable? |
|-------|-------|----------|
| **PLATFORM_DID** | Imajin network (all nodes) | Never |
| **Node DID** | This node | Yes — operator acts-as node for admin |
| **User DIDs** | Individuals | Yes (self) |

### Post-merge

Run migration on dev + prod:
```sql
ALTER TABLE relay.relay_config ADD COLUMN IF NOT EXISTS imajin_did TEXT;
```

Run bootstrap on prod:
```bash
cd apps/kernel && NODE_NAME="jin.imajin.ai" NODE_OPERATOR_DID="did:imajin:88kPYWwv5YFrQwAteEmSndbbHWvzePJ1zNSxpBCCNWXU" npx tsx ../../scripts/bootstrap-node-identity.ts
```

Closes #675