### PR TITLE
feat(www): admin console scaffolding (#664)

### DIFF
--- a/apps/kernel/app/admin/admin-nav.tsx
+++ b/apps/kernel/app/admin/admin-nav.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface NavItem {
+  label: string;
+  href: string;
+  icon: string;
+}
+
+interface AdminNavProps {
+  navItems: NavItem[];
+  mobile?: boolean;
+  nodeName?: string;
+}
+
+export default function AdminNav({ navItems, mobile = false, nodeName }: AdminNavProps) {
+  const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const isActive = (href: string) => {
+    if (href === '/admin') return pathname === '/admin';
+    return pathname.startsWith(href);
+  };
+
+  const linkClass = (href: string) =>
+    `flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+      isActive(href)
+        ? 'bg-orange-500 text-white'
+        : 'text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white'
+    }`;
+
+  if (mobile) {
+    return (
+      <>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-base">🖥️</span>
+            <span className="font-semibold text-gray-900 dark:text-white text-sm truncate max-w-[160px]">
+              {nodeName || 'Admin Console'}
+            </span>
+          </div>
+          <button
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="p-2 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
+            aria-label="Toggle menu"
+          >
+            {menuOpen ? '✕' : '☰'}
+          </button>
+        </div>
+
+        {menuOpen && (
+          <div className="mt-3 pb-2 border-t border-gray-200 dark:border-gray-700 pt-3 space-y-1">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={linkClass(item.href)}
+                onClick={() => setMenuOpen(false)}
+              >
+                <span>{item.icon}</span>
+                <span>{item.label}</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <ul className="space-y-1">
+      {navItems.map((item) => (
+        <li key={item.href}>
+          <Link href={item.href} className={linkClass(item.href)}>
+            <span>{item.icon}</span>
+            <span>{item.label}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/kernel/app/admin/layout.tsx
+++ b/apps/kernel/app/admin/layout.tsx
@@ -1,0 +1,106 @@
+import { redirect } from 'next/navigation';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+import Link from 'next/link';
+import AdminNav from './admin-nav';
+
+const sql = getClient();
+
+const NAV_ITEMS = [
+  { label: 'Overview', href: '/admin', icon: '📊' },
+  { label: 'Users', href: '/admin/users', icon: '👥' },
+  { label: 'Subscribers', href: '/admin/subscribers', icon: '📬' },
+  { label: 'Newsletter', href: '/admin/newsletter', icon: '📰' },
+  { label: 'Services', href: '/admin/services', icon: '⚙️' },
+  { label: 'Federation', href: '/admin/federation', icon: '🌐' },
+  { label: 'Storage', href: '/admin/storage', icon: '💾' },
+  { label: 'Config', href: '/admin/config', icon: '🔧' },
+  { label: 'Moderation', href: '/admin/moderation', icon: '🛡️' },
+];
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+
+  if (!session?.actingAs) {
+    redirect('/');
+  }
+
+  // Verify actingAs is a node-scope group DID
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+
+  if (!nodeRow) {
+    redirect('/');
+  }
+
+  const nodeDid: string = session.actingAs;
+
+  // Fetch node profile display name
+  const [profileRow] = await sql`
+    SELECT display_name FROM profile.profiles
+    WHERE did = ${nodeDid}
+    LIMIT 1
+  `;
+
+  const nodeName: string = (profileRow?.display_name as string) || 'Node';
+  const nodeDidShort = `${nodeDid.slice(0, 16)}…${nodeDid.slice(-6)}`;
+
+  return (
+    <div className="flex min-h-screen bg-white dark:bg-gray-900">
+      {/* Sidebar */}
+      <div className="hidden md:flex md:flex-col md:w-64 md:fixed md:inset-y-0 bg-gray-100 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700">
+        {/* Node identity header */}
+        <div className="px-4 py-5 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-lg">🖥️</span>
+            <span className="font-semibold text-gray-900 dark:text-white truncate text-sm">
+              {nodeName}
+            </span>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate">
+            {nodeDidShort}
+          </p>
+          <span className="mt-2 inline-block text-xs bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-400 px-2 py-0.5 rounded-full font-medium">
+            Admin Console
+          </span>
+        </div>
+
+        {/* Nav */}
+        <nav className="flex-1 px-3 py-4 overflow-y-auto">
+          <AdminNav navItems={NAV_ITEMS} />
+        </nav>
+
+        {/* Footer */}
+        <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700">
+          <Link
+            href="/"
+            className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+          >
+            <span>←</span>
+            <span>Back to site</span>
+          </Link>
+        </div>
+      </div>
+
+      {/* Mobile header */}
+      <div className="md:hidden fixed top-0 left-0 right-0 z-20 bg-gray-100 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-3">
+        <AdminNav navItems={NAV_ITEMS} mobile nodeName={nodeName} />
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 md:ml-64">
+        <main className="md:pt-0 pt-14 min-h-screen">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/page.tsx
+++ b/apps/kernel/app/admin/page.tsx
@@ -1,0 +1,165 @@
+import { getClient } from '@imajin/db';
+import { formatDistanceToNow } from 'date-fns';
+
+const sql = getClient();
+
+interface StatCard {
+  label: string;
+  value: string | number;
+  subtitle?: string;
+  icon: string;
+}
+
+function StatCardUI({ label, value, subtitle, icon }: StatCard) {
+  return (
+    <div className="rounded-xl bg-white dark:bg-gray-800 p-6 shadow border border-gray-100 dark:border-gray-700">
+      <div className="flex items-start justify-between">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</p>
+          <p className="mt-1 text-3xl font-bold text-gray-900 dark:text-white truncate">
+            {value}
+          </p>
+          {subtitle && (
+            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500 truncate">{subtitle}</p>
+          )}
+        </div>
+        <span className="text-2xl ml-3">{icon}</span>
+      </div>
+    </div>
+  );
+}
+
+export default async function AdminOverviewPage() {
+  // --- Stats queries ---
+  const [identityCountRow] = await sql`
+    SELECT COUNT(*) AS total FROM auth.identities
+  `;
+
+  const tierRows = await sql`
+    SELECT tier, COUNT(*) AS count
+    FROM auth.identities
+    GROUP BY tier
+  `;
+
+  const tierMap: Record<string, number> = {};
+  for (const row of tierRows) {
+    tierMap[row.tier as string] = Number(row.count);
+  }
+
+  const tierSubtitle = [
+    tierMap['soft'] ? `${tierMap['soft']} soft` : null,
+    tierMap['preliminary'] ? `${tierMap['preliminary']} preliminary` : null,
+    tierMap['established'] ? `${tierMap['established']} established` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  const [sessionCountRow] = await sql`
+    SELECT COUNT(*) AS total
+    FROM auth.attestations
+    WHERE type = 'session.created'
+    AND issued_at > NOW() - INTERVAL '24 hours'
+  `;
+
+  const [subscriberCountRow] = await sql`
+    SELECT COUNT(*) AS total
+    FROM www.contacts
+    WHERE is_verified = true
+  `;
+
+  // --- Recent attestations ---
+  const recentAttestations = await sql`
+    SELECT id, type, subject_did, issued_at
+    FROM auth.attestations
+    ORDER BY issued_at DESC
+    LIMIT 10
+  `;
+
+  const stats: StatCard[] = [
+    {
+      label: 'Total Identities',
+      value: Number(identityCountRow?.total ?? 0).toLocaleString(),
+      subtitle: tierSubtitle || undefined,
+      icon: '🪪',
+    },
+    {
+      label: 'Active Sessions (24h)',
+      value: Number(sessionCountRow?.total ?? 0).toLocaleString(),
+      icon: '🔑',
+    },
+    {
+      label: 'Subscribers',
+      value: Number(subscriberCountRow?.total ?? 0).toLocaleString(),
+      subtitle: 'verified emails',
+      icon: '📬',
+    },
+    {
+      label: 'Services',
+      value: '15',
+      subtitle: '9 kernel · 6 userspace',
+      icon: '⚙️',
+    },
+  ];
+
+  return (
+    <div className="p-6 lg:p-8 max-w-6xl">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Overview</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Node health and activity at a glance
+        </p>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-10">
+        {stats.map((stat) => (
+          <StatCardUI key={stat.label} {...stat} />
+        ))}
+      </div>
+
+      {/* Recent attestations */}
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Recent Attestations
+        </h2>
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+          {recentAttestations.length === 0 ? (
+            <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+              No attestations yet
+            </p>
+          ) : (
+            <div className="divide-y divide-gray-100 dark:divide-gray-700">
+              {recentAttestations.map((att) => {
+                const subjectDid = att.subject_did as string;
+                const shortDid = `${subjectDid.slice(0, 18)}…${subjectDid.slice(-6)}`;
+                const issuedAt = att.issued_at as Date;
+                const relativeTime = issuedAt
+                  ? formatDistanceToNow(new Date(issuedAt), { addSuffix: true })
+                  : '—';
+
+                return (
+                  <div
+                    key={att.id as string}
+                    className="flex items-center justify-between px-6 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <span className="inline-block text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2 py-0.5 rounded font-mono mr-3">
+                        {att.type as string}
+                      </span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">
+                        {shortDid}
+                      </span>
+                    </div>
+                    <span className="text-xs text-gray-400 dark:text-gray-500 ml-4 whitespace-nowrap">
+                      {relativeTime}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/api/admin/verify/route.ts
+++ b/apps/kernel/app/api/admin/verify/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+export async function GET(request: NextRequest) {
+  const authResult = await requireAuth(request);
+
+  if (!authResult || 'error' in authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { identity } = authResult;
+
+  if (!identity.actingAs) {
+    return NextResponse.json({ error: 'Forbidden: no acting-as scope' }, { status: 403 });
+  }
+
+  // Verify actingAs is a node-scope group DID
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${identity.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+
+  if (!nodeRow) {
+    return NextResponse.json({ error: 'Forbidden: not a node scope' }, { status: 403 });
+  }
+
+  const nodeDid = identity.actingAs;
+
+  const [profileRow] = await sql`
+    SELECT display_name FROM profile.profiles
+    WHERE did = ${nodeDid}
+    LIMIT 1
+  `;
+
+  const nodeName: string = (profileRow?.display_name as string) || 'Node';
+
+  return NextResponse.json({ authorized: true, nodeDid, nodeName });
+}


### PR DESCRIPTION
## Summary

Admin console route scaffolding — layout, auth gate, navigation, and overview dashboard.

### What's new

**`/admin` route group** with server-side auth gate:
- Layout checks `session.actingAs` is a `scope = 'node'` group DID
- Redirects to `/` if not authorized (no acting-as, or not a node scope)
- Sidebar with node name + DID, 9 nav sections, "Back to site" link
- Mobile responsive with hamburger menu

**Overview dashboard** (`/admin`):
- Total identities (with tier breakdown: soft · preliminary · established)
- Active sessions in last 24h (from session.created attestations)
- Verified subscriber count
- Service count (9 kernel · 6 userspace)
- Recent attestations list (last 10, with relative timestamps)

**Admin verify endpoint** (`GET /api/admin/verify`):
- For client components that need admin auth checks
- Returns `{ authorized, nodeDid, nodeName }` or 401/403

### Files

- `apps/kernel/app/admin/layout.tsx` — server layout + auth gate
- `apps/kernel/app/admin/admin-nav.tsx` — client nav with active states
- `apps/kernel/app/admin/page.tsx` — overview dashboard
- `apps/kernel/app/api/admin/verify/route.ts` — auth verify endpoint

### Prerequisites

- #675 (node identity bootstrap) must be run first — the admin console requires acting-as a node DID
- Migration 0009 must be applied

### Next

Sub-section pages (users, subscribers, newsletter, etc.) will be added in subsequent PRs.

Closes #664