### PR TITLE
feat(www): admin users + service health (#665, #666)

### DIFF
--- a/apps/coffee/app/api/health/route.ts
+++ b/apps/coffee/app/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'coffee',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/dykil/app/api/health/route.ts
+++ b/apps/dykil/app/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'dykil',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/events/app/api/health/route.ts
+++ b/apps/events/app/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'events',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/kernel/app/admin/services/page.tsx
+++ b/apps/kernel/app/admin/services/page.tsx
@@ -1,0 +1,155 @@
+import { getSession } from '@imajin/auth';
+import { redirect } from 'next/navigation';
+import ServicesRefresh from './refresh';
+
+interface ServiceHealth {
+  name: string;
+  label: string;
+  group: 'kernel' | 'userspace';
+  status: 'healthy' | 'degraded' | 'down';
+  responseTime: number | null;
+  version?: string;
+  build?: string;
+  checkedAt: string;
+}
+
+async function fetchHealth(): Promise<{ services: ServiceHealth[]; checkedAt: string } | null> {
+  const port = process.env.PORT ?? '7000';
+  try {
+    const res = await fetch(`http://localhost:${port}/api/admin/services/health`, {
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+export default async function AdminServicesPage() {
+  const session = await getSession();
+  if (!session?.actingAs) redirect('/');
+
+  const data = await fetchHealth();
+
+  const kernelServices = data?.services.filter((s) => s.group === 'kernel') ?? [];
+  const userspaceServices = data?.services.filter((s) => s.group === 'userspace') ?? [];
+
+  return (
+    <div className="p-6 lg:p-8 max-w-6xl">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Services</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {data
+              ? `Last checked ${new Date(data.checkedAt).toLocaleTimeString()}`
+              : 'Health check unavailable'}
+          </p>
+        </div>
+        <ServicesRefresh />
+      </div>
+
+      {!data ? (
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-8 text-center">
+          <p className="text-gray-500 dark:text-gray-400 text-sm">
+            Could not fetch service health. Check admin authentication.
+          </p>
+        </div>
+      ) : (
+        <>
+          <ServiceSection title="Kernel Services" services={kernelServices} />
+          <ServiceSection title="Userspace Services" services={userspaceServices} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function ServiceSection({
+  title,
+  services,
+}: {
+  title: string;
+  services: ServiceHealth[];
+}) {
+  if (services.length === 0) return null;
+
+  const healthyCount = services.filter((s) => s.status === 'healthy').length;
+  const total = services.length;
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-3 mb-3">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+          {title}
+        </h2>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {healthyCount}/{total} healthy
+        </span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {services.map((svc) => (
+          <ServiceCard key={svc.name} service={svc} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ServiceCard({ service }: { service: ServiceHealth }) {
+  const statusConfig = {
+    healthy: {
+      indicator: '🟢',
+      label: 'Healthy',
+      textClass: 'text-green-700 dark:text-green-400',
+      bgClass: 'bg-green-50 dark:bg-green-900/20',
+    },
+    degraded: {
+      indicator: '🟡',
+      label: 'Degraded',
+      textClass: 'text-yellow-700 dark:text-yellow-400',
+      bgClass: 'bg-yellow-50 dark:bg-yellow-900/20',
+    },
+    down: {
+      indicator: '🔴',
+      label: 'Down',
+      textClass: 'text-red-700 dark:text-red-400',
+      bgClass: 'bg-red-50 dark:bg-red-900/20',
+    },
+  };
+
+  const config = statusConfig[service.status];
+
+  return (
+    <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-4">
+      <div className="flex items-start justify-between mb-2">
+        <div>
+          <h3 className="font-semibold text-gray-900 dark:text-white text-sm">{service.label}</h3>
+          <span className="text-xs text-gray-500 dark:text-gray-400 capitalize">{service.name}</span>
+        </div>
+        <span
+          className={`text-xs px-2 py-0.5 rounded-full font-medium ${config.bgClass} ${config.textClass}`}
+        >
+          {service.group === 'kernel' ? 'Kernel' : 'Userspace'}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-base leading-none">{config.indicator}</span>
+        <span className={`text-sm font-medium ${config.textClass}`}>{config.label}</span>
+        {service.responseTime !== null && (
+          <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+            {service.responseTime}ms
+          </span>
+        )}
+      </div>
+
+      {service.version && (
+        <p className="mt-2 text-xs text-gray-400 dark:text-gray-500 font-mono">
+          v{service.version}
+          {service.build && service.build !== 'dev' ? ` (${service.build.slice(0, 7)})` : ''}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/services/refresh.tsx
+++ b/apps/kernel/app/admin/services/refresh.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function ServicesRefresh() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function handleRefresh() {
+    setLoading(true);
+    router.refresh();
+    // Give a moment for the refresh to register visually
+    await new Promise((r) => setTimeout(r, 500));
+    setLoading(false);
+  }
+
+  return (
+    <button
+      onClick={handleRefresh}
+      disabled={loading}
+      className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+    >
+      {loading ? 'Refreshing…' : '↻ Refresh'}
+    </button>
+  );
+}

--- a/apps/kernel/app/admin/users/[did]/actions.tsx
+++ b/apps/kernel/app/admin/users/[did]/actions.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface UserActionsProps {
+  did: string;
+  currentTier: string;
+  isSuspended: boolean;
+}
+
+export default function UserActions({ did, currentTier, isSuspended }: UserActionsProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const encodedDid = encodeURIComponent(did);
+
+  async function handleSuspend() {
+    const action = isSuspended ? 'unsuspend' : 'suspend';
+    const confirmed = window.confirm(
+      isSuspended
+        ? 'Unsuspend this user? They will regain access.'
+        : 'Suspend this user? They will lose access immediately.'
+    );
+    if (!confirmed) return;
+
+    setLoading('suspend');
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/users/${encodedDid}/suspend`, { method: 'POST' });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? `Failed to ${action}`);
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function handleUpgradeTier(tier: 'preliminary' | 'established') {
+    const confirmed = window.confirm(`Upgrade tier to "${tier}"? This will emit a verification attestation.`);
+    if (!confirmed) return;
+
+    setLoading('tier');
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/users/${encodedDid}/upgrade-tier`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tier }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? 'Failed to upgrade tier');
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  const upgradableToTiers: Array<'preliminary' | 'established'> = [];
+  if (currentTier === 'soft') upgradableToTiers.push('preliminary');
+  if (currentTier === 'soft' || currentTier === 'preliminary') upgradableToTiers.push('established');
+
+  return (
+    <div className="flex flex-col items-end gap-2 shrink-0">
+      {error && (
+        <p className="text-xs text-red-600 dark:text-red-400 max-w-48 text-right">{error}</p>
+      )}
+
+      <div className="flex gap-2 flex-wrap justify-end">
+        {upgradableToTiers.map((tier) => (
+          <button
+            key={tier}
+            onClick={() => handleUpgradeTier(tier)}
+            disabled={loading !== null}
+            className="rounded-lg border border-orange-500 text-orange-600 dark:text-orange-400 hover:bg-orange-50 dark:hover:bg-orange-900/20 px-3 py-1.5 text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading === 'tier' ? 'Upgrading…' : `→ ${tier}`}
+          </button>
+        ))}
+
+        <button
+          onClick={handleSuspend}
+          disabled={loading !== null}
+          className={`rounded-lg px-3 py-1.5 text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
+            isSuspended
+              ? 'border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+              : 'bg-red-600 hover:bg-red-700 text-white border border-transparent'
+          }`}
+        >
+          {loading === 'suspend'
+            ? isSuspended
+              ? 'Unsuspending…'
+              : 'Suspending…'
+            : isSuspended
+            ? 'Unsuspend'
+            : 'Suspend'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/users/[did]/page.tsx
+++ b/apps/kernel/app/admin/users/[did]/page.tsx
@@ -1,0 +1,340 @@
+import { getClient } from '@imajin/db';
+import { formatDistanceToNow } from 'date-fns';
+import { notFound } from 'next/navigation';
+import UserActions from './actions';
+
+const sql = getClient();
+
+export default async function AdminUserDetailPage({
+  params,
+}: {
+  params: Promise<{ did: string }>;
+}) {
+  const { did } = await params;
+  const decodedDid = decodeURIComponent(did);
+
+  // Identity
+  const [identity] = await sql`
+    SELECT id, handle, name, type, tier, public_key, suspended_at, created_at
+    FROM auth.identities
+    WHERE id = ${decodedDid}
+    LIMIT 1
+  `;
+  if (!identity) notFound();
+
+  // Profile
+  const [profile] = await sql`
+    SELECT display_name, display_type, bio, avatar, avatar_asset_id
+    FROM profile.profiles
+    WHERE did = ${decodedDid}
+    LIMIT 1
+  `;
+
+  // Balance
+  const [balance] = await sql`
+    SELECT cash_amount, credit_amount, currency
+    FROM pay.balances
+    WHERE did = ${decodedDid}
+    LIMIT 1
+  `;
+
+  // Connections count
+  const [connCount] = await sql`
+    SELECT COUNT(*) AS total
+    FROM connections.connections
+    WHERE (did_a = ${decodedDid} OR did_b = ${decodedDid})
+    AND disconnected_at IS NULL
+  `;
+
+  // Recent attestations
+  const attestations = await sql`
+    SELECT id, type, issuer_did, subject_did, attestation_status, issued_at
+    FROM auth.attestations
+    WHERE subject_did = ${decodedDid} OR issuer_did = ${decodedDid}
+    ORDER BY issued_at DESC
+    LIMIT 15
+  `;
+
+  // Recent transactions
+  const transactions = await sql`
+    SELECT id, type, service, amount, currency, from_did, to_did, status, created_at
+    FROM pay.transactions
+    WHERE to_did = ${decodedDid} OR from_did = ${decodedDid}
+    ORDER BY created_at DESC
+    LIMIT 10
+  `;
+
+  const isSuspended = !!identity.suspended_at;
+  const publicKey = identity.public_key as string;
+  const shortKey = publicKey ? `${publicKey.slice(0, 20)}…${publicKey.slice(-8)}` : '—';
+  const createdAt = identity.created_at as Date;
+  const relTime = createdAt
+    ? formatDistanceToNow(new Date(createdAt), { addSuffix: true })
+    : '—';
+
+  return (
+    <div className="p-6 lg:p-8 max-w-5xl">
+      {/* Header card */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-6 mb-6">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-3 flex-wrap mb-2">
+              <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+                {identity.handle ? `@${identity.handle as string}` : (identity.name as string | null) ?? 'Unknown'}
+              </h1>
+              {isSuspended && (
+                <span className="text-xs bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400 px-2 py-0.5 rounded-full font-medium">
+                  Suspended
+                </span>
+              )}
+              <TierBadge tier={identity.tier as string} />
+              <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
+                {identity.type as string}
+              </span>
+            </div>
+            <p className="font-mono text-xs text-gray-500 dark:text-gray-400 break-all mb-1">
+              {identity.id as string}
+            </p>
+            {identity.name && (
+              <p className="text-sm text-gray-600 dark:text-gray-300">{identity.name as string}</p>
+            )}
+          </div>
+          <UserActions
+            did={decodedDid}
+            currentTier={identity.tier as string}
+            isSuspended={isSuspended}
+          />
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+          <div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Public Key</p>
+            <p className="font-mono text-xs text-gray-700 dark:text-gray-300">{shortKey}</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Created</p>
+            <p className="text-xs text-gray-700 dark:text-gray-300">{relTime}</p>
+          </div>
+          {isSuspended && (
+            <div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Suspended</p>
+              <p className="text-xs text-red-600 dark:text-red-400">
+                {formatDistanceToNow(new Date(identity.suspended_at as Date), { addSuffix: true })}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 2-col grid: Profile + Balance + Connections */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+        {/* Profile */}
+        <div className="lg:col-span-2 rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Profile</h2>
+          {profile ? (
+            <div className="space-y-2 text-sm">
+              <Row label="Display Name" value={profile.display_name as string | null} />
+              <Row label="Display Type" value={profile.display_type as string | null} />
+              <Row label="Bio" value={profile.bio as string | null} />
+              <Row label="Avatar" value={profile.avatar as string | null} mono />
+            </div>
+          ) : (
+            <p className="text-sm text-gray-400 dark:text-gray-500">No profile</p>
+          )}
+        </div>
+
+        {/* Balance + Connections */}
+        <div className="space-y-4">
+          <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Balance</h2>
+            {balance ? (
+              <div className="space-y-1 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-gray-500 dark:text-gray-400">Cash</span>
+                  <span className="font-medium text-gray-900 dark:text-white font-mono">
+                    {balance.cash_amount as string} {balance.currency as string}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-500 dark:text-gray-400">Credit</span>
+                  <span className="font-medium text-gray-900 dark:text-white font-mono">
+                    {balance.credit_amount as string} {balance.currency as string}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400 dark:text-gray-500">No balance</p>
+            )}
+          </div>
+
+          <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Connections</h2>
+            <p className="text-3xl font-bold text-gray-900 dark:text-white">
+              {Number(connCount?.total ?? 0).toLocaleString()}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">active connections</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Attestations */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden mb-6">
+        <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Recent Attestations</h2>
+        </div>
+        {attestations.length === 0 ? (
+          <p className="px-5 py-6 text-sm text-gray-400 dark:text-gray-500 text-center">None</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50">
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Type</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Role</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Counterpart</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Status</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Issued</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {attestations.map((att) => {
+                  const isSubject = att.subject_did === decodedDid;
+                  const counterpart = isSubject
+                    ? (att.issuer_did as string)
+                    : (att.subject_did as string);
+                  const shortCounterpart = `${counterpart.slice(0, 16)}…${counterpart.slice(-6)}`;
+                  const issuedAt = att.issued_at as Date;
+                  return (
+                    <tr key={att.id as string} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                      <td className="px-4 py-2.5">
+                        <span className="font-mono bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-1.5 py-0.5 rounded">
+                          {att.type as string}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5 text-gray-600 dark:text-gray-400">
+                        {isSubject ? 'subject' : 'issuer'}
+                      </td>
+                      <td className="px-4 py-2.5 font-mono text-gray-500 dark:text-gray-400">
+                        {shortCounterpart}
+                      </td>
+                      <td className="px-4 py-2.5 text-gray-600 dark:text-gray-400">
+                        {att.attestation_status as string}
+                      </td>
+                      <td className="px-4 py-2.5 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {issuedAt
+                          ? formatDistanceToNow(new Date(issuedAt), { addSuffix: true })
+                          : '—'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Transactions */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+        <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Recent Transactions</h2>
+        </div>
+        {transactions.length === 0 ? (
+          <p className="px-5 py-6 text-sm text-gray-400 dark:text-gray-500 text-center">None</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50">
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Type</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Amount</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">From</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">To</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Status</th>
+                  <th className="text-left px-4 py-2 text-gray-500 dark:text-gray-400 font-medium">Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {transactions.map((tx) => {
+                  const fromDid = tx.from_did as string | null;
+                  const toDid = tx.to_did as string;
+                  const shortFrom = fromDid ? `${fromDid.slice(0, 12)}…` : 'external';
+                  const shortTo = `${toDid.slice(0, 12)}…`;
+                  const createdAt = tx.created_at as Date;
+                  return (
+                    <tr key={tx.id as string} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                      <td className="px-4 py-2.5">
+                        <span className="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-1.5 py-0.5 rounded">
+                          {tx.type as string}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5 font-mono font-medium text-gray-900 dark:text-white">
+                        {tx.amount as string} {tx.currency as string}
+                      </td>
+                      <td className="px-4 py-2.5 font-mono text-gray-500 dark:text-gray-400">{shortFrom}</td>
+                      <td className="px-4 py-2.5 font-mono text-gray-500 dark:text-gray-400">{shortTo}</td>
+                      <td className="px-4 py-2.5">
+                        <StatusBadge status={tx.status as string} />
+                      </td>
+                      <td className="px-4 py-2.5 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {createdAt
+                          ? formatDistanceToNow(new Date(createdAt), { addSuffix: true })
+                          : '—'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex gap-2">
+      <span className="text-gray-500 dark:text-gray-400 w-28 shrink-0">{label}</span>
+      <span className={`text-gray-700 dark:text-gray-300 break-all ${mono ? 'font-mono text-xs' : ''}`}>
+        {value ?? <span className="text-gray-400 dark:text-gray-600">—</span>}
+      </span>
+    </div>
+  );
+}
+
+function TierBadge({ tier }: { tier: string }) {
+  const styles: Record<string, string> = {
+    soft: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+    preliminary: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400',
+    established: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400',
+  };
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${styles[tier] ?? styles.soft}`}>
+      {tier}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    completed: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400',
+    pending: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400',
+    failed: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400',
+    refunded: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+  };
+  return (
+    <span className={`px-1.5 py-0.5 rounded text-xs ${styles[status] ?? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'}`}>
+      {status}
+    </span>
+  );
+}

--- a/apps/kernel/app/admin/users/page.tsx
+++ b/apps/kernel/app/admin/users/page.tsx
@@ -1,0 +1,262 @@
+import { getClient } from '@imajin/db';
+import { formatDistanceToNow } from 'date-fns';
+import Link from 'next/link';
+
+const sql = getClient();
+const PAGE_SIZE = 25;
+
+interface SearchParams {
+  q?: string;
+  tier?: string;
+  type?: string;
+  page?: string;
+}
+
+export default async function AdminUsersPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const q = params.q?.trim() ?? '';
+  const tier = params.tier ?? '';
+  const type = params.type ?? '';
+  const page = Math.max(1, parseInt(params.page ?? '1', 10));
+  const offset = (page - 1) * PAGE_SIZE;
+
+  // Build filter conditions
+  const conditions: string[] = [];
+  const binds: (string | number)[] = [];
+  let idx = 1;
+
+  if (q) {
+    conditions.push(`(i.handle ILIKE $${idx} OR i.name ILIKE $${idx} OR p.display_name ILIKE $${idx})`);
+    binds.push(`%${q}%`);
+    idx++;
+  }
+  if (tier) {
+    conditions.push(`i.tier = $${idx}`);
+    binds.push(tier);
+    idx++;
+  }
+  if (type) {
+    conditions.push(`i.type = $${idx}`);
+    binds.push(type);
+    idx++;
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const countRows = await sql.unsafe(
+    `SELECT COUNT(*) AS total
+     FROM auth.identities i
+     LEFT JOIN profile.profiles p ON i.id = p.did
+     ${whereClause}`,
+    binds as string[]
+  );
+  const total = Number(countRows[0]?.total ?? 0);
+
+  const rows = await sql.unsafe(
+    `SELECT
+       i.id,
+       i.handle,
+       i.name,
+       i.type,
+       i.tier,
+       i.suspended_at,
+       i.created_at,
+       p.display_name
+     FROM auth.identities i
+     LEFT JOIN profile.profiles p ON i.id = p.did
+     ${whereClause}
+     ORDER BY i.created_at DESC
+     LIMIT ${PAGE_SIZE} OFFSET ${offset}`,
+    binds as string[]
+  );
+
+  const hasNext = rows.length === PAGE_SIZE;
+  const hasPrev = page > 1;
+
+  function buildUrl(overrides: Partial<SearchParams>) {
+    const p: Record<string, string> = {};
+    if (q) p.q = q;
+    if (tier) p.tier = tier;
+    if (type) p.type = type;
+    p.page = String(page);
+    Object.assign(p, overrides);
+    const qs = new URLSearchParams(p).toString();
+    return `/admin/users?${qs}`;
+  }
+
+  return (
+    <div className="p-6 lg:p-8 max-w-6xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Users</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {total.toLocaleString()} total identities
+        </p>
+      </div>
+
+      {/* Filters */}
+      <form method="GET" action="/admin/users" className="mb-4 flex flex-wrap gap-2 items-center">
+        <input
+          type="search"
+          name="q"
+          defaultValue={q}
+          placeholder="Search handle or name…"
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-52"
+        />
+        <select
+          name="tier"
+          defaultValue={tier}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+        >
+          <option value="">All tiers</option>
+          <option value="soft">Soft</option>
+          <option value="preliminary">Preliminary</option>
+          <option value="established">Established</option>
+        </select>
+        <select
+          name="type"
+          defaultValue={type}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+        >
+          <option value="">All types</option>
+          <option value="human">Human</option>
+          <option value="agent">Agent</option>
+          <option value="event">Event</option>
+          <option value="service">Service</option>
+          <option value="node">Node</option>
+        </select>
+        <button
+          type="submit"
+          className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium"
+        >
+          Filter
+        </button>
+        {(q || tier || type) && (
+          <Link
+            href="/admin/users"
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+          >
+            Clear
+          </Link>
+        )}
+      </form>
+
+      {/* Table */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+        {rows.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+            No users found
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Handle</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Name</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Type</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Tier</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {rows.map((row) => {
+                  const did = row.id as string;
+                  const handle = row.handle as string | null;
+                  const name = (row.display_name ?? row.name) as string | null;
+                  const createdAt = row.created_at as Date;
+                  const isSuspended = !!row.suspended_at;
+                  const relTime = createdAt
+                    ? formatDistanceToNow(new Date(createdAt), { addSuffix: true })
+                    : '—';
+
+                  return (
+                    <tr
+                      key={did}
+                      className="hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors"
+                    >
+                      <td className="px-4 py-3">
+                        <Link
+                          href={`/admin/users/${encodeURIComponent(did)}`}
+                          className="font-mono text-orange-600 dark:text-orange-400 hover:underline text-xs"
+                        >
+                          {handle ? `@${handle}` : did.slice(0, 20) + '…'}
+                        </Link>
+                        {isSuspended && (
+                          <span className="ml-2 text-xs bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400 px-1.5 py-0.5 rounded">
+                            suspended
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                        {name ?? <span className="text-gray-400 dark:text-gray-600">—</span>}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
+                          {row.type as string}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <TierBadge tier={row.tier as string} />
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {relTime}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      <div className="mt-4 flex items-center gap-3">
+        {hasPrev ? (
+          <Link
+            href={buildUrl({ page: String(page - 1) })}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            ← Previous
+          </Link>
+        ) : (
+          <span className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-sm text-gray-400 dark:text-gray-600 cursor-not-allowed">
+            ← Previous
+          </span>
+        )}
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          Page {page}
+        </span>
+        {hasNext ? (
+          <Link
+            href={buildUrl({ page: String(page + 1) })}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Next →
+          </Link>
+        ) : (
+          <span className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-sm text-gray-400 dark:text-gray-600 cursor-not-allowed">
+            Next →
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TierBadge({ tier }: { tier: string }) {
+  const styles: Record<string, string> = {
+    soft: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+    preliminary: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400',
+    established: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400',
+  };
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded ${styles[tier] ?? styles.soft}`}>
+      {tier}
+    </span>
+  );
+}

--- a/apps/kernel/app/api/admin/services/health/route.ts
+++ b/apps/kernel/app/api/admin/services/health/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+import { buildPublicUrl } from '@imajin/config';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+interface ServiceHealth {
+  name: string;
+  label: string;
+  group: 'kernel' | 'userspace';
+  status: 'healthy' | 'degraded' | 'down';
+  responseTime: number | null;
+  version?: string;
+  build?: string;
+  checkedAt: string;
+}
+
+const KERNEL_SERVICES = [
+  { name: 'auth', label: 'Auth', path: '/auth/api/health' },
+  { name: 'pay', label: 'Pay', path: '/pay/api/health' },
+  { name: 'profile', label: 'Profile', path: '/profile/api/health' },
+  { name: 'connections', label: 'Connections', path: '/connections/api/health' },
+  { name: 'chat', label: 'Chat', path: '/chat/api/health' },
+  { name: 'media', label: 'Media', path: '/media/api/health' },
+  { name: 'notify', label: 'Notify', path: '/notify/api/health' },
+  { name: 'registry', label: 'Registry', path: '/registry/api/health' },
+  { name: 'www', label: 'WWW', path: '/api/health' },
+];
+
+const USERSPACE_SERVICES = [
+  { name: 'events', label: 'Events' },
+  { name: 'market', label: 'Market' },
+  { name: 'coffee', label: 'Coffee' },
+  { name: 'learn', label: 'Learn' },
+  { name: 'links', label: 'Links' },
+  { name: 'dykil', label: 'Surveys' },
+];
+
+interface CacheEntry {
+  data: { services: ServiceHealth[]; checkedAt: string };
+  expiresAt: number;
+}
+let cache: CacheEntry | null = null;
+
+async function checkKernelService(
+  svc: (typeof KERNEL_SERVICES)[number]
+): Promise<ServiceHealth> {
+  const port = process.env.PORT ?? '7000';
+  const url = `http://localhost:${port}${svc.path}`;
+  const checkedAt = new Date().toISOString();
+  const start = Date.now();
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    clearTimeout(timeout);
+    const responseTime = Date.now() - start;
+
+    let version: string | undefined;
+    let build: string | undefined;
+    try {
+      const data = await res.json();
+      version = data.version;
+      build = data.build;
+    } catch {
+      // ignore parse errors
+    }
+
+    const status = !res.ok ? 'down' : responseTime > 2000 ? 'degraded' : 'healthy';
+    return { name: svc.name, label: svc.label, group: 'kernel', status, responseTime, version, build, checkedAt };
+  } catch {
+    const responseTime = Date.now() - start;
+    return {
+      name: svc.name,
+      label: svc.label,
+      group: 'kernel',
+      status: 'down',
+      responseTime: responseTime < 3000 ? responseTime : null,
+      checkedAt,
+    };
+  }
+}
+
+async function checkUserspaceService(
+  svc: (typeof USERSPACE_SERVICES)[number]
+): Promise<ServiceHealth> {
+  const envKey = `${svc.name.toUpperCase()}_URL`;
+  const url = (process.env[envKey] ?? buildPublicUrl(svc.name)) + '/api/health';
+  const checkedAt = new Date().toISOString();
+  const start = Date.now();
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch(url, {
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    clearTimeout(timeout);
+    const responseTime = Date.now() - start;
+
+    let version: string | undefined;
+    let build: string | undefined;
+    try {
+      const data = await res.json();
+      version = data.version;
+      build = data.build;
+    } catch {
+      // ignore parse errors
+    }
+
+    const status = !res.ok ? 'down' : responseTime > 2000 ? 'degraded' : 'healthy';
+    return { name: svc.name, label: svc.label, group: 'userspace', status, responseTime, version, build, checkedAt };
+  } catch {
+    const responseTime = Date.now() - start;
+    return {
+      name: svc.name,
+      label: svc.label,
+      group: 'userspace',
+      status: 'down',
+      responseTime: responseTime < 3000 ? responseTime : null,
+      checkedAt,
+    };
+  }
+}
+
+export async function GET() {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Return cached result if fresh
+  if (cache && cache.expiresAt > Date.now()) {
+    return NextResponse.json(cache.data);
+  }
+
+  const [kernelResults, userspaceResults] = await Promise.all([
+    Promise.all(KERNEL_SERVICES.map(checkKernelService)),
+    Promise.all(USERSPACE_SERVICES.map(checkUserspaceService)),
+  ]);
+
+  const services = [...kernelResults, ...userspaceResults];
+  const checkedAt = new Date().toISOString();
+  const result = { services, checkedAt };
+
+  cache = { data: result, expiresAt: Date.now() + 30_000 };
+
+  return NextResponse.json(result);
+}

--- a/apps/kernel/app/api/admin/users/[did]/suspend/route.ts
+++ b/apps/kernel/app/api/admin/users/[did]/suspend/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { did } = await params;
+  const decodedDid = decodeURIComponent(did);
+
+  const [identity] = await sql`
+    SELECT id, suspended_at FROM auth.identities WHERE id = ${decodedDid} LIMIT 1
+  `;
+  if (!identity) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const isSuspended = !!identity.suspended_at;
+
+  if (isSuspended) {
+    await sql`
+      UPDATE auth.identities
+      SET suspended_at = NULL, updated_at = NOW()
+      WHERE id = ${decodedDid}
+    `;
+  } else {
+    await sql`
+      UPDATE auth.identities
+      SET suspended_at = NOW(), updated_at = NOW()
+      WHERE id = ${decodedDid}
+    `;
+  }
+
+  return NextResponse.json({ ok: true, suspended: !isSuspended });
+}

--- a/apps/kernel/app/api/admin/users/[did]/upgrade-tier/route.ts
+++ b/apps/kernel/app/api/admin/users/[did]/upgrade-tier/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession, emitAttestation } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+import { getNodeDid } from '@/src/lib/kernel/node-identity';
+
+const sql = getClient();
+
+const VALID_TIERS = ['preliminary', 'established'] as const;
+type Tier = (typeof VALID_TIERS)[number];
+
+const TIER_ATTESTATION_TYPE: Record<Tier, string> = {
+  preliminary: 'identity.verified.preliminary',
+  established: 'identity.verified.hard',
+};
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { did } = await params;
+  const decodedDid = decodeURIComponent(did);
+
+  let body: { tier?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const tier = body.tier as Tier;
+  if (!VALID_TIERS.includes(tier)) {
+    return NextResponse.json({ error: 'Invalid tier. Must be preliminary or established.' }, { status: 400 });
+  }
+
+  const [identity] = await sql`
+    SELECT id, tier FROM auth.identities WHERE id = ${decodedDid} LIMIT 1
+  `;
+  if (!identity) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  await sql`
+    UPDATE auth.identities
+    SET tier = ${tier}, updated_at = NOW()
+    WHERE id = ${decodedDid}
+  `;
+
+  const issuerDid = await getNodeDid();
+  if (issuerDid) {
+    await emitAttestation({
+      issuer_did: issuerDid,
+      subject_did: decodedDid,
+      type: TIER_ATTESTATION_TYPE[tier],
+      context_id: decodedDid,
+      context_type: 'identity',
+    });
+  }
+
+  return NextResponse.json({ ok: true, tier });
+}

--- a/apps/kernel/app/api/health/route.ts
+++ b/apps/kernel/app/api/health/route.ts
@@ -84,6 +84,8 @@ export async function GET() {
 
   return NextResponse.json({
     status: anyDown ? 'degraded' : allUp ? 'operational' : 'degraded',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
     services: checks,
   });

--- a/apps/kernel/app/auth/api/health/route.ts
+++ b/apps/kernel/app/auth/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'auth',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/kernel/app/chat/api/health/route.ts
+++ b/apps/kernel/app/chat/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'chat',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/kernel/app/connections/api/health/route.ts
+++ b/apps/kernel/app/connections/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'connections',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/kernel/app/media/api/health/route.ts
+++ b/apps/kernel/app/media/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'media',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/kernel/app/notify/api/health/route.ts
+++ b/apps/kernel/app/notify/api/health/route.ts
@@ -7,5 +7,11 @@ export async function OPTIONS(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   const cors = corsHeaders(request);
-  return NextResponse.json({ ok: true, service: 'notify' }, { headers: cors });
+  return NextResponse.json({
+    ok: true,
+    status: 'ok',
+    service: 'notify',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
+  }, { headers: cors });
 }

--- a/apps/kernel/app/pay/api/health/route.ts
+++ b/apps/kernel/app/pay/api/health/route.ts
@@ -17,6 +17,8 @@ export async function GET() {
     return NextResponse.json({
       status: allHealthy ? 'healthy' : 'degraded',
       providers: health,
+      version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+      build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
       timestamp: new Date().toISOString(),
     }, {
       status: allHealthy ? 200 : 503,

--- a/apps/kernel/app/profile/api/health/route.ts
+++ b/apps/kernel/app/profile/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'profile',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/kernel/app/registry/api/health/route.ts
+++ b/apps/kernel/app/registry/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'registry',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/kernel/drizzle/0010_add_suspended_at.sql
+++ b/apps/kernel/drizzle/0010_add_suspended_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS suspended_at TIMESTAMPTZ;

--- a/apps/kernel/drizzle/meta/0010_snapshot.json
+++ b/apps/kernel/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000010",
+  "prevId": "00000000-0000-0000-0000-000000000009",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/_journal.json
+++ b/apps/kernel/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1744329600004,
       "tag": "0009_add_node_imajin_did",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1744416000000,
+      "tag": "0010_add_suspended_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/kernel/src/db/schemas/auth.ts
+++ b/apps/kernel/src/db/schemas/auth.ts
@@ -26,6 +26,7 @@ export const identities = authSchema.table('identities', {
   contactEmail: text('contact_email'),                  // billing/notification email from Stripe or onboard
   keyRoles: jsonb('key_roles').$type<KeyRoles | null>(), // null = single key in all roles
   metadata: jsonb('metadata').default({}),
+  suspendedAt: timestamp('suspended_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({

--- a/apps/learn/app/api/health/route.ts
+++ b/apps/learn/app/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'learn',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/links/app/api/health/route.ts
+++ b/apps/links/app/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'links',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }

--- a/apps/market/app/api/health/route.ts
+++ b/apps/market/app/api/health/route.ts
@@ -4,6 +4,8 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     service: 'market',
+    version: process.env.NEXT_PUBLIC_VERSION || '0.0.0',
+    build: process.env.NEXT_PUBLIC_BUILD_HASH || 'dev',
     timestamp: new Date().toISOString(),
   });
 }


### PR DESCRIPTION
## Summary

User management and service health dashboard for the admin console.

### User Management (#665)

**User list** (`/admin/users`):
- Paginated table (25/page) with search by handle/name
- Filter by tier (soft/preliminary/established) and type (human/agent/event/service/node)
- Click through to detail page

**User detail** (`/admin/users/[did]`):
- Identity info, profile, MJN balance (credit + cash)
- Connection count, recent attestations (last 15), recent transactions (last 10)

**User actions:**
- Suspend/unsuspend — toggles `suspended_at` on identity
- Upgrade tier — promotes to preliminary/established with attestation emission via node DID
- Confirmation dialogs on all actions

**Schema:** `suspended_at` column on `auth.identities` (migration 0010)

### Service Health (#666)

**Health dashboard** (`/admin/services`):
- Grid of 15 service cards grouped by kernel (9) and userspace (6)
- Status: 🟢 healthy / 🟡 degraded / 🔴 down
- Response time display, version + build info
- 30s server-side cache, refresh button

**Health endpoint upgrades:**
- All 15 health endpoints now return version + build hash
- Kernel: auth, pay, profile, connections, chat, media, notify, registry, www
- Userspace: events, market, coffee, learn, links, dykil

### Files (27 changed)

- `apps/kernel/app/admin/users/page.tsx` — user list
- `apps/kernel/app/admin/users/[did]/page.tsx` — user detail
- `apps/kernel/app/admin/users/[did]/actions.tsx` — suspend/upgrade UI
- `apps/kernel/app/admin/services/page.tsx` — service health grid
- `apps/kernel/app/admin/services/refresh.tsx` — refresh button
- `apps/kernel/app/api/admin/users/[did]/suspend/route.ts`
- `apps/kernel/app/api/admin/users/[did]/upgrade-tier/route.ts`
- `apps/kernel/app/api/admin/services/health/route.ts`
- `apps/kernel/drizzle/0010_add_suspended_at.sql` + snapshot + journal
- All 15 health endpoint files updated

Closes #665, closes #666