### PR TITLE
feat(www): admin subscribers + newsletter (#669, #663)

### DIFF
--- a/apps/kernel/app/admin/newsletter/composer.tsx
+++ b/apps/kernel/app/admin/newsletter/composer.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface MailingList {
+  id: string;
+  name: string;
+  slug: string;
+  subscriber_count: number;
+}
+
+interface Props {
+  initialLists: MailingList[];
+  initialConnectionCount: number;
+  recentSends: Array<{
+    id: string;
+    subject: string;
+    audience_type: string;
+    audience_id: string | null;
+    recipient_count: number;
+    sent_at: string;
+  }>;
+}
+
+export default function NewsletterComposer({ initialLists, initialConnectionCount, recentSends }: Props) {
+  const [subject, setSubject] = useState('');
+  const [markdown, setMarkdown] = useState('');
+  const [audienceType, setAudienceType] = useState<'newsletter' | 'connections'>('newsletter');
+  const [selectedListId, setSelectedListId] = useState<string>(initialLists[0]?.id ?? '');
+  const [preview, setPreview] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [sendingTest, setSendingTest] = useState(false);
+  const [testEmail, setTestEmail] = useState('');
+  const [confirm, setConfirm] = useState(false);
+  const [result, setResult] = useState<{ sent: boolean; recipientCount: number } | null>(null);
+  const [error, setError] = useState('');
+
+  const selectedList = initialLists.find((l) => l.id === selectedListId);
+
+  const recipientCount =
+    audienceType === 'newsletter'
+      ? Number(selectedList?.subscriber_count ?? 0)
+      : initialConnectionCount;
+
+  async function handleSendTest() {
+    setSendingTest(true);
+    setError('');
+    try {
+      const res = await fetch('/api/admin/newsletter/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          subject,
+          markdown,
+          audienceType,
+          audienceId: audienceType === 'newsletter' ? selectedListId : undefined,
+          test: true,
+          testEmail: testEmail.trim() || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) setError(data.error ?? 'Test send failed');
+      else setResult({ sent: true, recipientCount: 1 });
+    } finally {
+      setSendingTest(false);
+    }
+  }
+
+  async function handleSend() {
+    setSending(true);
+    setError('');
+    try {
+      const res = await fetch('/api/admin/newsletter/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          subject,
+          markdown,
+          audienceType,
+          audienceId: audienceType === 'newsletter' ? selectedListId : undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) setError(data.error ?? 'Send failed');
+      else setResult({ sent: data.sent, recipientCount: data.recipientCount });
+    } finally {
+      setSending(false);
+      setConfirm(false);
+    }
+  }
+
+  function renderPreview(md: string): string {
+    return md
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/\n/g, '<br/>');
+  }
+
+  const canSend = subject.trim().length > 0 && markdown.trim().length > 0 && recipientCount > 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Composer */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Compose</h2>
+
+        <div className="space-y-4">
+          {/* Subject */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Subject</label>
+            <input
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Your newsletter subject…"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+
+          {/* Body */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Body (Markdown)</label>
+              <button
+                type="button"
+                onClick={() => setPreview((v) => !v)}
+                className="text-xs text-orange-600 dark:text-orange-400 hover:underline"
+              >
+                {preview ? 'Edit' : 'Preview'}
+              </button>
+            </div>
+            {preview ? (
+              <div
+                className="w-full min-h-48 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 px-3 py-2 text-sm whitespace-pre-wrap"
+                dangerouslySetInnerHTML={{ __html: renderPreview(markdown) }}
+              />
+            ) : (
+              <textarea
+                value={markdown}
+                onChange={(e) => setMarkdown(e.target.value)}
+                rows={12}
+                placeholder="Write your newsletter in Markdown…&#10;&#10;**Bold**, *italic*, and paragraphs are supported."
+                className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500 resize-y"
+              />
+            )}
+          </div>
+
+          {/* Audience */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Audience</label>
+            <div className="flex gap-2 mb-3">
+              {(['newsletter', 'connections'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setAudienceType(t)}
+                  className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+                    audienceType === t
+                      ? 'bg-orange-500 text-white'
+                      : 'border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  {t === 'newsletter' ? 'Newsletter' : 'Connections'}
+                </button>
+              ))}
+            </div>
+
+            {audienceType === 'newsletter' ? (
+              <div className="flex items-center gap-2">
+                <select
+                  value={selectedListId}
+                  onChange={(e) => setSelectedListId(e.target.value)}
+                  className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                >
+                  {initialLists.length === 0 && (
+                    <option value="">No lists available</option>
+                  )}
+                  {initialLists.map((l) => (
+                    <option key={l.id} value={l.id}>
+                      {l.name} ({Number(l.subscriber_count).toLocaleString()} subscribers)
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Send to all {initialConnectionCount.toLocaleString()} connection{initialConnectionCount !== 1 ? 's' : ''} with a contact email.
+              </p>
+            )}
+
+            <p className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
+              Recipients:{' '}
+              <span className="text-orange-600 dark:text-orange-400">
+                {recipientCount.toLocaleString()}
+              </span>
+            </p>
+          </div>
+
+          {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+          {result && (
+            <p className="text-sm text-green-600 dark:text-green-400">
+              {result.sent
+                ? `Sent to ${result.recipientCount.toLocaleString()} recipient${result.recipientCount !== 1 ? 's' : ''}.`
+                : 'No recipients found.'}
+            </p>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center gap-3 pt-2 flex-wrap">
+            <input
+              type="email"
+              placeholder="Test email address"
+              value={testEmail}
+              onChange={(e) => setTestEmail(e.target.value)}
+              className="w-56 px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-orange-500/50"
+            />
+            <button
+              type="button"
+              onClick={handleSendTest}
+              disabled={sendingTest || !subject.trim() || !markdown.trim()}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {sendingTest ? 'Sending test…' : 'Send Test'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirm(true)}
+              disabled={sending || !canSend}
+              className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-4 py-1.5 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {sending ? 'Sending…' : 'Send Newsletter'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Confirm dialog */}
+      {confirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-100 dark:border-gray-700 p-6 w-full max-w-sm">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Confirm Send</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+              This will send <strong>"{subject}"</strong> to{' '}
+              <strong>{recipientCount.toLocaleString()} recipient{recipientCount !== 1 ? 's' : ''}</strong>.
+              This cannot be undone.
+            </p>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setConfirm(false)}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSend}
+                disabled={sending}
+                className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+              >
+                {sending ? 'Sending…' : `Send to ${recipientCount.toLocaleString()}`}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Send History */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Send History</h2>
+        </div>
+        {recentSends.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">No sends yet.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Subject</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Audience</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Recipients</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Sent</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {recentSends.map((send) => (
+                  <tr key={send.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors">
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300 max-w-xs truncate">{send.subject}</td>
+                    <td className="px-4 py-3">
+                      <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
+                        {send.audience_type}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                      {Number(send.recipient_count).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      {send.sent_at ? new Date(send.sent_at).toLocaleString() : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/newsletter/page.tsx
+++ b/apps/kernel/app/admin/newsletter/page.tsx
@@ -1,0 +1,81 @@
+import { getClient } from '@imajin/db';
+import { getSession } from '@imajin/auth';
+import { redirect } from 'next/navigation';
+import NewsletterComposer from './composer';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) redirect('/admin');
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  if (!nodeRow) redirect('/admin');
+  return session;
+}
+
+export default async function AdminNewsletterPage() {
+  const session = await requireAdmin();
+
+  const lists = await sql`
+    SELECT
+      ml.id,
+      ml.name,
+      ml.slug,
+      COUNT(s.id) FILTER (WHERE s.status = 'subscribed') AS subscriber_count
+    FROM www.mailing_lists ml
+    LEFT JOIN www.subscriptions s ON s.mailing_list_id = ml.id
+    WHERE ml.owner_did IS NULL OR ml.owner_did = ${session.actingAs}
+    GROUP BY ml.id
+    ORDER BY ml.created_at ASC
+  `;
+
+  const [connRow] = await sql`
+    SELECT COUNT(*) AS total
+    FROM connections.connections
+    WHERE (did_a = ${session.actingAs} OR did_b = ${session.actingAs})
+    AND disconnected_at IS NULL
+  `;
+  const connectionCount = Number(connRow?.total ?? 0);
+
+  const recentSends = await sql`
+    SELECT id, subject, audience_type, audience_id, recipient_count, sent_at
+    FROM registry.newsletter_sends
+    WHERE sender_did = ${session.actingAs}
+    ORDER BY sent_at DESC
+    LIMIT 20
+  `;
+
+  return (
+    <div className="p-6 lg:p-8 max-w-4xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Newsletter</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Compose and send newsletters to subscribers or connections
+        </p>
+      </div>
+
+      <NewsletterComposer
+        initialLists={lists.map((l) => ({
+          id: l.id as string,
+          name: l.name as string,
+          slug: l.slug as string,
+          subscriber_count: Number(l.subscriber_count),
+        }))}
+        initialConnectionCount={connectionCount}
+        recentSends={recentSends.map((s) => ({
+          id: s.id as string,
+          subject: s.subject as string,
+          audience_type: s.audience_type as string,
+          audience_id: s.audience_id as string | null,
+          recipient_count: Number(s.recipient_count),
+          sent_at: s.sent_at ? new Date(s.sent_at as string).toISOString() : '',
+        }))}
+      />
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/subscribers/create-list.tsx
+++ b/apps/kernel/app/admin/subscribers/create-list.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function CreateList() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  function handleNameChange(v: string) {
+    setName(v);
+    setSlug(v.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setSaving(true);
+    try {
+      const res = await fetch('/api/admin/subscribers/lists', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, slug, description: description || undefined }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? 'Failed to create list');
+        return;
+      }
+      setOpen(false);
+      setName('');
+      setSlug('');
+      setDescription('');
+      router.refresh();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium"
+      >
+        + Create List
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-100 dark:border-gray-700 p-6 w-full max-w-md">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Create Mailing List</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(e) => handleNameChange(e.target.value)}
+              placeholder="e.g. Weekly Updates"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Slug</label>
+            <input
+              type="text"
+              required
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              placeholder="weekly-updates"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Description <span className="text-gray-400">(optional)</span>
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              placeholder="What this list is for…"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 resize-none"
+            />
+          </div>
+          {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+          <div className="flex gap-2 justify-end">
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            >
+              {saving ? 'Creating…' : 'Create List'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/subscribers/page.tsx
+++ b/apps/kernel/app/admin/subscribers/page.tsx
@@ -1,0 +1,358 @@
+import { getClient } from '@imajin/db';
+import { getSession } from '@imajin/auth';
+import { formatDistanceToNow } from 'date-fns';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import CreateList from './create-list';
+import SubscriberActions from './subscriber-actions';
+
+const sql = getClient();
+const PAGE_SIZE = 25;
+
+interface SearchParams {
+  q?: string;
+  list?: string;
+  verified?: string;
+  page?: string;
+}
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) redirect('/admin');
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  if (!nodeRow) redirect('/admin');
+  return session;
+}
+
+export default async function AdminSubscribersPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const session = await requireAdmin();
+  const params = await searchParams;
+  const q = params.q?.trim() ?? '';
+  const listSlug = params.list ?? '';
+  const verified = params.verified ?? '';
+  const page = Math.max(1, parseInt(params.page ?? '1', 10));
+  const offset = (page - 1) * PAGE_SIZE;
+
+  // Stats
+  const [statsRow] = await sql`
+    SELECT
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE c.is_verified = TRUE) AS verified,
+      COUNT(*) FILTER (WHERE c.is_verified = FALSE) AS unverified
+    FROM www.contacts c
+    JOIN www.subscriptions s ON c.id = s.contact_id
+    WHERE s.status = 'subscribed'
+  `;
+  const totalSubs = Number(statsRow?.total ?? 0);
+  const verifiedCount = Number(statsRow?.verified ?? 0);
+  const unverifiedCount = Number(statsRow?.unverified ?? 0);
+
+  // Mailing lists
+  const lists = await sql`
+    SELECT
+      ml.id,
+      ml.slug,
+      ml.name,
+      ml.description,
+      ml.is_active,
+      COUNT(s.id) FILTER (WHERE s.status = 'subscribed') AS subscriber_count
+    FROM www.mailing_lists ml
+    LEFT JOIN www.subscriptions s ON s.mailing_list_id = ml.id
+    WHERE ml.owner_did IS NULL OR ml.owner_did = ${session.actingAs}
+    GROUP BY ml.id
+    ORDER BY ml.created_at ASC
+  `;
+
+  // Subscribers query
+  const conditions: string[] = [];
+  const binds: (string | number)[] = [];
+  let idx = 1;
+
+  if (q) {
+    conditions.push(`c.email ILIKE $${idx}`);
+    binds.push(`%${q}%`);
+    idx++;
+  }
+  if (verified === 'true') {
+    conditions.push('c.is_verified = TRUE');
+  } else if (verified === 'false') {
+    conditions.push('c.is_verified = FALSE');
+  }
+  if (listSlug) {
+    conditions.push(`ml.slug = $${idx}`);
+    binds.push(listSlug);
+    idx++;
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const [countRow] = await sql.unsafe(
+    `SELECT COUNT(*) AS total
+     FROM www.contacts c
+     JOIN www.subscriptions s ON c.id = s.contact_id
+     JOIN www.mailing_lists ml ON ml.id = s.mailing_list_id
+     ${whereClause}`,
+    binds as string[]
+  );
+  const total = Number(countRow?.total ?? 0);
+
+  const rows = await sql.unsafe(
+    `SELECT
+       c.id,
+       c.email,
+       c.source,
+       c.is_verified,
+       c.verified_at,
+       s.status,
+       s.subscribed_at,
+       ml.slug AS list_slug,
+       ml.name AS list_name
+     FROM www.contacts c
+     JOIN www.subscriptions s ON c.id = s.contact_id
+     JOIN www.mailing_lists ml ON ml.id = s.mailing_list_id
+     ${whereClause}
+     ORDER BY s.subscribed_at DESC
+     LIMIT ${PAGE_SIZE} OFFSET ${offset}`,
+    binds as string[]
+  );
+
+  const hasNext = rows.length === PAGE_SIZE;
+  const hasPrev = page > 1;
+
+  function buildUrl(overrides: Partial<SearchParams>) {
+    const p: Record<string, string> = {};
+    if (q) p.q = q;
+    if (listSlug) p.list = listSlug;
+    if (verified) p.verified = verified;
+    p.page = String(page);
+    Object.assign(p, overrides);
+    return `/admin/subscribers?${new URLSearchParams(p).toString()}`;
+  }
+
+  return (
+    <div className="p-6 lg:p-8 max-w-6xl">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Subscribers</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Manage mailing lists and subscribers
+          </p>
+        </div>
+        <a
+          href={`/api/admin/subscribers/export${listSlug ? `?list=${listSlug}` : ''}`}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+        >
+          Export CSV
+        </a>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-4 mb-6">
+        {[
+          { label: 'Total Subscribers', value: totalSubs.toLocaleString() },
+          { label: 'Verified', value: verifiedCount.toLocaleString() },
+          { label: 'Unverified', value: unverifiedCount.toLocaleString() },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-4"
+          >
+            <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              {stat.label}
+            </p>
+            <p className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">{stat.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Mailing Lists */}
+      <div className="mb-8">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Mailing Lists</h2>
+          <CreateList />
+        </div>
+        {lists.length === 0 ? (
+          <p className="text-sm text-gray-400 dark:text-gray-500">No mailing lists yet.</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {lists.map((list) => (
+              <Link
+                key={list.id as string}
+                href={`/admin/subscribers?list=${list.slug}`}
+                className={`rounded-xl bg-white dark:bg-gray-800 shadow border p-4 transition-colors hover:border-orange-300 dark:hover:border-orange-700 ${
+                  listSlug === (list.slug as string)
+                    ? 'border-orange-500 dark:border-orange-500'
+                    : 'border-gray-100 dark:border-gray-700'
+                }`}
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-white text-sm">{list.name as string}</p>
+                    {list.description && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-2">
+                        {list.description as string}
+                      </p>
+                    )}
+                  </div>
+                  <span className="ml-2 text-xs bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 px-2 py-0.5 rounded-full font-medium whitespace-nowrap">
+                    {Number(list.subscriber_count).toLocaleString()}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-gray-400 dark:text-gray-600 font-mono">{list.slug as string}</p>
+              </Link>
+            ))}
+          </div>
+        )}
+        {listSlug && (
+          <div className="mt-2">
+            <Link href="/admin/subscribers" className="text-sm text-gray-500 dark:text-gray-400 hover:underline">
+              ← Show all lists
+            </Link>
+          </div>
+        )}
+      </div>
+
+      {/* Filters */}
+      <form method="GET" action="/admin/subscribers" className="mb-4 flex flex-wrap gap-2 items-center">
+        {listSlug && <input type="hidden" name="list" value={listSlug} />}
+        <input
+          type="search"
+          name="q"
+          defaultValue={q}
+          placeholder="Search email…"
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-52"
+        />
+        <select
+          name="verified"
+          defaultValue={verified}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+        >
+          <option value="">All</option>
+          <option value="true">Verified</option>
+          <option value="false">Unverified</option>
+        </select>
+        <button
+          type="submit"
+          className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium"
+        >
+          Filter
+        </button>
+        {(q || verified) && (
+          <Link
+            href={listSlug ? `/admin/subscribers?list=${listSlug}` : '/admin/subscribers'}
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+          >
+            Clear
+          </Link>
+        )}
+        <span className="ml-auto text-sm text-gray-500 dark:text-gray-400">
+          {total.toLocaleString()} subscriber{total !== 1 ? 's' : ''}
+        </span>
+      </form>
+
+      {/* Subscribers Table */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+        {rows.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+            No subscribers found
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Email</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Source</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Verified</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Subscribed</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Status</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">List</th>
+                  <th className="px-4 py-3" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {rows.map((row) => {
+                  const subscribedAt = row.subscribed_at ? new Date(row.subscribed_at as string) : null;
+                  const relTime = subscribedAt
+                    ? formatDistanceToNow(subscribedAt, { addSuffix: true })
+                    : '—';
+                  return (
+                    <tr key={`${row.id}-${row.list_slug}`} className="hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors">
+                      <td className="px-4 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">{row.email as string}</td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
+                          {row.source as string}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        {row.is_verified ? (
+                          <span className="text-green-600 dark:text-green-400">✓</span>
+                        ) : (
+                          <span className="text-gray-400 dark:text-gray-600">✗</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {relTime}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`text-xs px-2 py-0.5 rounded ${
+                          row.status === 'subscribed'
+                            ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400'
+                            : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+                        }`}>
+                          {row.status as string}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 font-mono">
+                        {row.list_slug as string}
+                      </td>
+                      <td className="px-4 py-3">
+                        <SubscriberActions
+                          id={row.id as string}
+                          email={row.email as string}
+                          isVerified={row.is_verified as boolean}
+                        />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      <div className="mt-4 flex items-center gap-3">
+        {hasPrev ? (
+          <Link href={buildUrl({ page: String(page - 1) })} className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">
+            ← Previous
+          </Link>
+        ) : (
+          <span className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-sm text-gray-400 dark:text-gray-600 cursor-not-allowed">
+            ← Previous
+          </span>
+        )}
+        <span className="text-sm text-gray-500 dark:text-gray-400">Page {page}</span>
+        {hasNext ? (
+          <Link href={buildUrl({ page: String(page + 1) })} className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">
+            Next →
+          </Link>
+        ) : (
+          <span className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-sm text-gray-400 dark:text-gray-600 cursor-not-allowed">
+            Next →
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/subscribers/subscriber-actions.tsx
+++ b/apps/kernel/app/admin/subscribers/subscriber-actions.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  id: string;
+  email: string;
+  isVerified: boolean;
+}
+
+export default function SubscriberActions({ id, email, isVerified }: Props) {
+  const router = useRouter();
+  const [deleting, setDeleting] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  async function handleDelete() {
+    setDeleting(true);
+    try {
+      await fetch(`/api/admin/subscribers/${id}`, { method: 'DELETE' });
+      router.refresh();
+    } finally {
+      setDeleting(false);
+      setShowConfirm(false);
+    }
+  }
+
+  async function handleResendVerify() {
+    setResending(true);
+    try {
+      await fetch(`/api/admin/subscribers/${id}/resend-verify`, { method: 'POST' });
+    } finally {
+      setResending(false);
+    }
+  }
+
+  if (showConfirm) {
+    return (
+      <div className="flex items-center gap-1 whitespace-nowrap">
+        <span className="text-xs text-gray-500 dark:text-gray-400">Delete {email}?</span>
+        <button
+          onClick={handleDelete}
+          disabled={deleting}
+          className="text-xs text-red-600 dark:text-red-400 hover:underline disabled:opacity-50"
+        >
+          {deleting ? 'Deleting…' : 'Confirm'}
+        </button>
+        <button
+          onClick={() => setShowConfirm(false)}
+          className="text-xs text-gray-500 dark:text-gray-400 hover:underline"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 whitespace-nowrap">
+      {!isVerified && (
+        <button
+          onClick={handleResendVerify}
+          disabled={resending}
+          className="text-xs text-blue-600 dark:text-blue-400 hover:underline disabled:opacity-50"
+        >
+          {resending ? 'Sending…' : 'Resend verify'}
+        </button>
+      )}
+      <button
+        onClick={() => setShowConfirm(true)}
+        className="text-xs text-red-600 dark:text-red-400 hover:underline"
+      >
+        Delete
+      </button>
+    </div>
+  );
+}

--- a/apps/kernel/app/api/admin/newsletter/audiences/route.ts
+++ b/apps/kernel/app/api/admin/newsletter/audiences/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function GET(_req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const lists = await sql`
+    SELECT
+      ml.id,
+      ml.name,
+      ml.slug,
+      COUNT(s.id) FILTER (WHERE s.status = 'subscribed') AS subscriber_count
+    FROM www.mailing_lists ml
+    LEFT JOIN www.subscriptions s ON s.mailing_list_id = ml.id
+    WHERE ml.owner_did IS NULL OR ml.owner_did = ${session.actingAs}
+    GROUP BY ml.id
+    ORDER BY ml.created_at ASC
+  `;
+
+  const [connRow] = await sql`
+    SELECT COUNT(*) AS total
+    FROM connections.connections
+    WHERE (did_a = ${session.actingAs} OR did_b = ${session.actingAs})
+    AND disconnected_at IS NULL
+  `;
+  const connectionCount = Number(connRow?.total ?? 0);
+
+  return NextResponse.json({ lists, connectionCount });
+}

--- a/apps/kernel/app/api/admin/newsletter/history/route.ts
+++ b/apps/kernel/app/api/admin/newsletter/history/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function GET(_req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const sends = await sql`
+    SELECT id, subject, audience_type, audience_id, recipient_count, sent_at
+    FROM registry.newsletter_sends
+    WHERE sender_did = ${session.actingAs}
+    ORDER BY sent_at DESC
+    LIMIT 20
+  `;
+
+  return NextResponse.json({ sends });
+}

--- a/apps/kernel/app/api/admin/newsletter/send/route.ts
+++ b/apps/kernel/app/api/admin/newsletter/send/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+import { sendEmail, renderBroadcastEmail } from '@imajin/email';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+async function sendBatch(emails: string[], subject: string, html: string, text: string) {
+  const BATCH_SIZE = 10;
+  for (let i = 0; i < emails.length; i += BATCH_SIZE) {
+    const batch = emails.slice(i, i + BATCH_SIZE);
+    await Promise.all(
+      batch.map((to) => sendEmail({ to, subject, html, text }))
+    );
+    if (i + BATCH_SIZE < emails.length) {
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await req.json() as {
+    subject: string;
+    markdown: string;
+    audienceType: 'newsletter' | 'connections';
+    audienceId?: string;
+    test?: boolean;
+    testEmail?: string;
+  };
+
+  const { subject, markdown, audienceType, audienceId, test, testEmail } = body;
+  if (!subject || !markdown || !audienceType) {
+    return NextResponse.json({ error: 'subject, markdown, and audienceType are required' }, { status: 400 });
+  }
+
+  const { html, text } = renderBroadcastEmail(markdown);
+
+  // Test mode: send to specified email or fall back to operator's profile email
+  if (test) {
+    let targetEmail = testEmail?.trim() || null;
+    if (!targetEmail) {
+      const [profile] = await sql`
+        SELECT contact_email FROM profile.profiles WHERE did = ${session.actingAs} LIMIT 1
+      `;
+      targetEmail = (profile?.contact_email as string | null) || null;
+    }
+    if (!targetEmail) {
+      return NextResponse.json({ error: 'No test email provided and no contact email on operator profile' }, { status: 400 });
+    }
+    await sendEmail({ to: targetEmail, subject: `[TEST] ${subject}`, html, text });
+    return NextResponse.json({ sent: true, recipientCount: 1, sendId: null });
+  }
+
+  let emails: string[] = [];
+
+  if (audienceType === 'newsletter') {
+    if (!audienceId) return NextResponse.json({ error: 'audienceId required for newsletter' }, { status: 400 });
+    const rows = await sql`
+      SELECT c.email
+      FROM www.contacts c
+      JOIN www.subscriptions s ON c.id = s.contact_id
+      WHERE s.mailing_list_id = ${audienceId}
+        AND s.status = 'subscribed'
+        AND c.is_verified = TRUE
+    `;
+    emails = rows.map((r) => r.email as string);
+  } else {
+    // connections mode
+    const rows = await sql`
+      SELECT DISTINCT
+        CASE
+          WHEN c.did_a = ${session.actingAs} THEN c.did_b
+          ELSE c.did_a
+        END AS connected_did
+      FROM connections.connections c
+      WHERE (c.did_a = ${session.actingAs} OR c.did_b = ${session.actingAs})
+        AND c.disconnected_at IS NULL
+    `;
+    const dids = rows.map((r) => r.connected_did as string).filter(Boolean);
+    if (dids.length > 0) {
+      const profileRows = await sql.unsafe(
+        `SELECT contact_email FROM profile.profiles WHERE did = ANY($1) AND contact_email IS NOT NULL`,
+        [dids]
+      );
+      emails = profileRows.map((r) => r.contact_email as string).filter(Boolean);
+    }
+  }
+
+  if (emails.length === 0) {
+    return NextResponse.json({ sent: false, recipientCount: 0, sendId: null, error: 'No recipients found' });
+  }
+
+  const sendId = `nws_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  // Record the send before dispatching (non-blocking send)
+  await sql`
+    INSERT INTO registry.newsletter_sends (id, sender_did, subject, audience_type, audience_id, recipient_count)
+    VALUES (${sendId}, ${session.actingAs}, ${subject}, ${audienceType}, ${audienceId ?? null}, ${emails.length})
+  `;
+
+  // Fire and forget
+  sendBatch(emails, subject, html, text).catch((err) => {
+    console.error('Newsletter batch send error:', err);
+  });
+
+  return NextResponse.json({ sent: true, recipientCount: emails.length, sendId });
+}

--- a/apps/kernel/app/api/admin/subscribers/[id]/resend-verify/route.ts
+++ b/apps/kernel/app/api/admin/subscribers/[id]/resend-verify/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+import { generateVerifyToken, verifyTokenExpiry } from '@/src/lib/www/subscribe-tokens';
+import { sendEmail } from '@imajin/email';
+import { verificationEmail, verificationEmailText } from '@/src/lib/www/verify-email-template';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+
+  const [contact] = await sql`
+    SELECT id, email, is_verified FROM www.contacts WHERE id = ${id} LIMIT 1
+  `;
+  if (!contact) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (contact.is_verified) return NextResponse.json({ error: 'Already verified' }, { status: 400 });
+
+  const email = contact.email as string;
+  const expiresAt = verifyTokenExpiry();
+  const token = generateVerifyToken(email, expiresAt);
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL ?? 'https://imajin.ai';
+  const verifyUrl = `${baseUrl}/subscribe/verify?email=${encodeURIComponent(email)}&token=${token}&expires=${expiresAt}`;
+
+  await sendEmail({
+    to: email,
+    subject: 'Confirm your email — Imajin',
+    html: verificationEmail(verifyUrl),
+    text: verificationEmailText(verifyUrl),
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/kernel/app/api/admin/subscribers/[id]/route.ts
+++ b/apps/kernel/app/api/admin/subscribers/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+
+  const [contact] = await sql`
+    SELECT id FROM www.contacts WHERE id = ${id} LIMIT 1
+  `;
+  if (!contact) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  // Unsubscribe all subscriptions then delete contact
+  await sql`
+    UPDATE www.subscriptions
+    SET status = 'unsubscribed', unsubscribed_at = NOW()
+    WHERE contact_id = ${id} AND status = 'subscribed'
+  `;
+  await sql`DELETE FROM www.contacts WHERE id = ${id}`;
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/kernel/app/api/admin/subscribers/export/route.ts
+++ b/apps/kernel/app/api/admin/subscribers/export/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function GET(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const listSlug = searchParams.get('list') ?? '';
+
+  const conditions: string[] = [];
+  const binds: string[] = [];
+  let idx = 1;
+
+  if (listSlug) {
+    conditions.push(`ml.slug = $${idx}`);
+    binds.push(listSlug);
+    idx++;
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const rows = await sql.unsafe(
+    `SELECT
+       c.email,
+       c.source,
+       c.is_verified,
+       c.verified_at,
+       s.status,
+       s.subscribed_at,
+       ml.slug AS list_slug,
+       ml.name AS list_name
+     FROM www.contacts c
+     JOIN www.subscriptions s ON c.id = s.contact_id
+     JOIN www.mailing_lists ml ON ml.id = s.mailing_list_id
+     ${whereClause}
+     ORDER BY s.subscribed_at DESC`,
+    binds
+  );
+
+  const header = 'email,source,is_verified,verified_at,status,subscribed_at,list_slug,list_name\n';
+  const csvRows = rows.map((r) => {
+    const fields = [
+      r.email,
+      r.source,
+      r.is_verified ? 'true' : 'false',
+      r.verified_at ? new Date(r.verified_at as string).toISOString() : '',
+      r.status,
+      r.subscribed_at ? new Date(r.subscribed_at as string).toISOString() : '',
+      r.list_slug,
+      `"${String(r.list_name).replace(/"/g, '""')}"`,
+    ];
+    return fields.join(',');
+  });
+
+  const csv = header + csvRows.join('\n');
+  const date = new Date().toISOString().slice(0, 10);
+
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename=subscribers-${date}.csv`,
+    },
+  });
+}

--- a/apps/kernel/app/api/admin/subscribers/lists/route.ts
+++ b/apps/kernel/app/api/admin/subscribers/lists/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+import { randomUUID } from 'crypto';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function GET(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const lists = await sql`
+    SELECT
+      ml.id,
+      ml.slug,
+      ml.name,
+      ml.description,
+      ml.is_active,
+      ml.owner_did,
+      ml.created_at,
+      COUNT(s.id) FILTER (WHERE s.status = 'subscribed') AS subscriber_count
+    FROM www.mailing_lists ml
+    LEFT JOIN www.subscriptions s ON s.mailing_list_id = ml.id
+    WHERE ml.owner_did IS NULL OR ml.owner_did = ${session.actingAs}
+    GROUP BY ml.id
+    ORDER BY ml.created_at ASC
+  `;
+
+  return NextResponse.json({ lists });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await req.json();
+  const { name, slug, description } = body as { name: string; slug: string; description?: string };
+
+  if (!name || !slug) return NextResponse.json({ error: 'name and slug are required' }, { status: 400 });
+
+  const id = randomUUID();
+  await sql`
+    INSERT INTO www.mailing_lists (id, slug, name, description, is_active, owner_did)
+    VALUES (${id}, ${slug}, ${name}, ${description ?? null}, TRUE, ${session.actingAs})
+  `;
+
+  return NextResponse.json({ ok: true, id });
+}

--- a/apps/kernel/app/api/admin/subscribers/route.ts
+++ b/apps/kernel/app/api/admin/subscribers/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+const PAGE_SIZE = 25;
+
+export async function GET(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q')?.trim() ?? '';
+  const verified = searchParams.get('verified');
+  const listSlug = searchParams.get('list') ?? '';
+  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10));
+  const offset = (page - 1) * PAGE_SIZE;
+
+  const conditions: string[] = [];
+  const binds: (string | number)[] = [];
+  let idx = 1;
+
+  if (q) {
+    conditions.push(`c.email ILIKE $${idx}`);
+    binds.push(`%${q}%`);
+    idx++;
+  }
+  if (verified === 'true') {
+    conditions.push(`c.is_verified = TRUE`);
+  } else if (verified === 'false') {
+    conditions.push(`c.is_verified = FALSE`);
+  }
+  if (listSlug) {
+    conditions.push(`ml.slug = $${idx}`);
+    binds.push(listSlug);
+    idx++;
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const countRows = await sql.unsafe(
+    `SELECT COUNT(*) AS total
+     FROM www.contacts c
+     JOIN www.subscriptions s ON c.id = s.contact_id
+     JOIN www.mailing_lists ml ON ml.id = s.mailing_list_id
+     ${whereClause}`,
+    binds as string[]
+  );
+  const total = Number(countRows[0]?.total ?? 0);
+
+  const rows = await sql.unsafe(
+    `SELECT
+       c.id,
+       c.email,
+       c.source,
+       c.is_verified,
+       c.verified_at,
+       c.created_at,
+       s.status,
+       s.subscribed_at,
+       ml.slug AS list_slug,
+       ml.name AS list_name
+     FROM www.contacts c
+     JOIN www.subscriptions s ON c.id = s.contact_id
+     JOIN www.mailing_lists ml ON ml.id = s.mailing_list_id
+     ${whereClause}
+     ORDER BY s.subscribed_at DESC
+     LIMIT ${PAGE_SIZE} OFFSET ${offset}`,
+    binds as string[]
+  );
+
+  return NextResponse.json({ subscribers: rows, total, page, pageSize: PAGE_SIZE });
+}

--- a/apps/kernel/drizzle/0011_add_mailing_list_owner_did.sql
+++ b/apps/kernel/drizzle/0011_add_mailing_list_owner_did.sql
@@ -1,0 +1,1 @@
+ALTER TABLE www.mailing_lists ADD COLUMN IF NOT EXISTS owner_did TEXT;

--- a/apps/kernel/drizzle/0012_add_newsletter_sends.sql
+++ b/apps/kernel/drizzle/0012_add_newsletter_sends.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS registry.newsletter_sends (
+  id TEXT PRIMARY KEY,
+  sender_did TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  audience_type TEXT NOT NULL,
+  audience_id TEXT,
+  recipient_count INTEGER NOT NULL DEFAULT 0,
+  sent_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/apps/kernel/drizzle/meta/0011_snapshot.json
+++ b/apps/kernel/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000011",
+  "prevId": "00000000-0000-0000-0000-000000000010",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/0012_snapshot.json
+++ b/apps/kernel/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000012",
+  "prevId": "00000000-0000-0000-0000-000000000011",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/_journal.json
+++ b/apps/kernel/drizzle/meta/_journal.json
@@ -78,6 +78,20 @@
       "when": 1744416000000,
       "tag": "0010_add_suspended_at",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1744502400000,
+      "tag": "0011_add_mailing_list_owner_did",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1744502400001,
+      "tag": "0012_add_newsletter_sends",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/kernel/src/db/schemas/registry.ts
+++ b/apps/kernel/src/db/schemas/registry.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, jsonb, index, boolean, pgSchema, unique, real } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, jsonb, index, boolean, pgSchema, unique, real, integer } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
 export const registrySchema = pgSchema('registry');
@@ -189,6 +189,19 @@ export const bumpMatches = registrySchema.table('bump_matches', {
 }, (table) => ({
   expiresNoConnectionIdx: index('idx_bump_matches_expires_no_connection').on(table.expiresAt).where(sql`connection_id IS NULL`),
 }));
+
+/**
+ * Newsletter sends — records of outbound newsletter/broadcast emails
+ */
+export const newsletterSends = registrySchema.table('newsletter_sends', {
+  id: text('id').primaryKey(),
+  senderDid: text('sender_did').notNull(),
+  subject: text('subject').notNull(),
+  audienceType: text('audience_type').notNull(), // 'newsletter' | 'connections'
+  audienceId: text('audience_id'), // mailing list id or null for connections
+  recipientCount: integer('recipient_count').notNull().default(0),
+  sentAt: timestamp('sent_at', { withTimezone: true }).defaultNow(),
+});
 
 // Types
 export type Node = typeof nodes.$inferSelect;

--- a/apps/kernel/src/db/schemas/www.ts
+++ b/apps/kernel/src/db/schemas/www.ts
@@ -27,6 +27,7 @@ export const mailingLists = wwwSchema.table('mailing_lists', {
   name: text('name').notNull(),
   description: text('description'),
   isActive: boolean('is_active').notNull().default(true),
+  ownerDid: text('owner_did'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({
   slugIdx: index('idx_www_mailing_lists_slug').on(table.slug),


### PR DESCRIPTION
## Summary

Subscriber management and newsletter compose/send for the admin console.

### Subscriber Management (#669)

**Subscribers page** (`/admin/subscribers`):
- Mailing list cards with subscriber counts, create new list
- Paginated subscriber table (25/page) with search, filter by verified/list
- Stats row: total, verified, unverified counts

**Actions:** delete subscriber, resend verification email

**CSV export:** `GET /api/admin/subscribers/export` — full subscriber list download

**Scoped:** `mailing_lists.owner_did` column — each scope owns its own lists (null = node-level)

### Newsletter Compose (#663)

**Composer** (`/admin/newsletter`):
- Subject + markdown textarea with preview toggle
- Dual audience picker: Newsletter lists (explicit subscribers) or Connections (graph-derived)
- Live recipient count
- Test send to any email address (input field + fallback to operator profile email)
- Send confirmation dialog
- Send history table below composer

**API routes:**
- `POST /api/admin/newsletter/send` — resolves audience, batched email send (10 at a time), records in newsletter_sends
- `GET /api/admin/newsletter/audiences` — lists + connection counts for acting-as DID
- `GET /api/admin/newsletter/history` — recent sends

### Schema Changes

- `www.mailing_lists` — added `owner_did TEXT` (migration 0011)
- `registry.newsletter_sends` — new table (migration 0012)
- 2 snapshots + journal entries

### Files (20 changed, +1,528 lines)

Closes #669, closes #663