### PR TITLE
feat(www): admin federation, storage, config, moderation (#670, #674, #667, #668)

### DIFF
--- a/apps/kernel/app/admin/config/config-form.tsx
+++ b/apps/kernel/app/admin/config/config-form.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+
+interface ConfigFormProps {
+  registrationMode: string;
+  maxIdentities: number;
+  maxStoragePerDidMb: number;
+}
+
+export function ConfigForm({ registrationMode, maxIdentities, maxStoragePerDidMb }: ConfigFormProps) {
+  const [regMode, setRegMode] = useState(registrationMode);
+  const [maxIds, setMaxIds] = useState(String(maxIdentities));
+  const [maxStorage, setMaxStorage] = useState(String(maxStoragePerDidMb));
+  const [saving, setSaving] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+
+  async function save(key: string, value: unknown) {
+    setSaving(key);
+    setSaved(null);
+    try {
+      const res = await fetch('/api/admin/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key, value }),
+      });
+      if (!res.ok) throw new Error('Failed');
+      setSaved(key);
+      setTimeout(() => setSaved(null), 2000);
+    } catch {
+      // no-op
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Registration Mode */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-6">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">Registration Mode</h2>
+        <div className="flex items-center gap-4">
+          <select
+            value={regMode}
+            onChange={(e) => setRegMode(e.target.value)}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            <option value="open">Open</option>
+            <option value="invite_only">Invite Only</option>
+            <option value="closed">Closed</option>
+          </select>
+          <button
+            onClick={() => save('registration_mode', regMode)}
+            disabled={saving === 'registration_mode'}
+            className="rounded-lg bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white px-4 py-2 text-sm font-medium"
+          >
+            {saving === 'registration_mode' ? 'Saving…' : saved === 'registration_mode' ? 'Saved!' : 'Save'}
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Controls who can register new identities on this node.
+        </p>
+      </div>
+
+      {/* Resource Limits */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-6">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">Resource Limits</h2>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+              Max Identities (0 = unlimited)
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                type="number"
+                min={0}
+                value={maxIds}
+                onChange={(e) => setMaxIds(e.target.value)}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-36"
+              />
+              <button
+                onClick={() => save('max_identities', Number(maxIds))}
+                disabled={saving === 'max_identities'}
+                className="rounded-lg bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white px-4 py-2 text-sm font-medium"
+              >
+                {saving === 'max_identities' ? 'Saving…' : saved === 'max_identities' ? 'Saved!' : 'Save'}
+              </button>
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+              Max Storage per DID (MB, 0 = unlimited)
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                type="number"
+                min={0}
+                value={maxStorage}
+                onChange={(e) => setMaxStorage(e.target.value)}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-36"
+              />
+              <button
+                onClick={() => save('max_storage_per_did_mb', Number(maxStorage))}
+                disabled={saving === 'max_storage_per_did_mb'}
+                className="rounded-lg bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white px-4 py-2 text-sm font-medium"
+              >
+                {saving === 'max_storage_per_did_mb' ? 'Saving…' : saved === 'max_storage_per_did_mb' ? 'Saved!' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/config/page.tsx
+++ b/apps/kernel/app/admin/config/page.tsx
@@ -1,0 +1,113 @@
+import { getClient } from '@imajin/db';
+import { ConfigForm } from './config-form';
+
+const sql = getClient();
+
+function formatBps(bps: number | null): string {
+  if (bps == null) return '—';
+  return `${(bps / 100).toFixed(2)}%`;
+}
+
+export default async function AdminConfigPage() {
+  const [relayConfig] = await sql`
+    SELECT did, imajin_did, node_fee_bps, buyer_credit_bps
+    FROM relay.relay_config
+    WHERE id = 'singleton'
+    LIMIT 1
+  `;
+
+  const [regModeRow] = await sql`
+    SELECT value FROM registry.node_config WHERE key = 'registration_mode'
+  `;
+  const [maxIdsRow] = await sql`
+    SELECT value FROM registry.node_config WHERE key = 'max_identities'
+  `;
+  const [maxStorageRow] = await sql`
+    SELECT value FROM registry.node_config WHERE key = 'max_storage_per_did_mb'
+  `;
+
+  const [profileRow] = await sql`
+    SELECT display_name FROM profile.profiles WHERE did = ${relayConfig?.imajin_did ?? ''} LIMIT 1
+  `;
+
+  const registrationMode = (regModeRow?.value as string | null) ?? 'invite_only';
+  const maxIdentities = Number(maxIdsRow?.value ?? 0);
+  const maxStoragePerDidMb = Number(maxStorageRow?.value ?? 0);
+
+  return (
+    <div className="p-6 lg:p-8 max-w-4xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Node Config</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Node identity, registration settings, and resource limits
+        </p>
+      </div>
+
+      {/* Node Identity (read-only) */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-6 mb-6">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+          Node Identity
+        </h2>
+        <dl className="space-y-3">
+          {profileRow?.display_name && (
+            <div>
+              <dt className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Node Name</dt>
+              <dd className="text-sm text-gray-900 dark:text-white font-medium">
+                {profileRow.display_name as string}
+              </dd>
+            </div>
+          )}
+          <div>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Imajin DID</dt>
+            <dd className="font-mono text-xs text-gray-900 dark:text-white break-all">
+              {relayConfig?.imajin_did ?? '—'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">DFOS DID</dt>
+            <dd className="font-mono text-xs text-gray-900 dark:text-white break-all">
+              {relayConfig?.did ?? '—'}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Fee Configuration (read-only) */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-6 mb-6">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+          Fee Configuration
+        </h2>
+        <dl className="grid grid-cols-2 gap-4">
+          <div>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Node Fee</dt>
+            <dd className="text-lg font-bold text-gray-900 dark:text-white">
+              {formatBps(relayConfig?.node_fee_bps as number | null)}
+            </dd>
+            <dd className="text-xs text-gray-400 dark:text-gray-500">
+              {relayConfig?.node_fee_bps ?? 0} bps
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-0.5">Buyer Credit</dt>
+            <dd className="text-lg font-bold text-gray-900 dark:text-white">
+              {formatBps(relayConfig?.buyer_credit_bps as number | null)}
+            </dd>
+            <dd className="text-xs text-gray-400 dark:text-gray-500">
+              {relayConfig?.buyer_credit_bps ?? 0} bps
+            </dd>
+          </div>
+        </dl>
+        <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+          Fee settings are configured at the relay level and cannot be changed here.
+        </p>
+      </div>
+
+      {/* Editable sections */}
+      <ConfigForm
+        registrationMode={registrationMode}
+        maxIdentities={maxIdentities}
+        maxStoragePerDidMb={maxStoragePerDidMb}
+      />
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/federation/page.tsx
+++ b/apps/kernel/app/admin/federation/page.tsx
@@ -1,0 +1,195 @@
+import { getClient } from '@imajin/db';
+import { formatDistanceToNow } from 'date-fns';
+
+const sql = getClient();
+
+function formatBps(bps: number | null): string {
+  if (bps == null) return '—';
+  return `${(bps / 100).toFixed(2)}%`;
+}
+
+export default async function AdminFederationPage() {
+  const [relayConfigRow] = await sql`
+    SELECT did, imajin_did, node_fee_bps, buyer_credit_bps, created_at
+    FROM relay.relay_config
+    WHERE id = 'singleton'
+    LIMIT 1
+  `;
+
+  const peers = await sql`
+    SELECT peer_url, cursor, updated_at
+    FROM relay.relay_peer_cursors
+    ORDER BY updated_at DESC NULLS LAST
+  `;
+
+  const [identityChainCount] = await sql`
+    SELECT COUNT(*) AS count FROM relay.relay_identity_chains
+  `;
+  const [contentChainCount] = await sql`
+    SELECT COUNT(*) AS count FROM relay.relay_content_chains
+  `;
+  const [operationCount] = await sql`
+    SELECT COUNT(*) AS count FROM relay.relay_operations
+  `;
+
+  const recentOps = await sql`
+    SELECT cid, chain_type, chain_id, created_at
+    FROM relay.relay_operations
+    ORDER BY created_at DESC
+    LIMIT 15
+  `;
+
+  return (
+    <div className="p-6 lg:p-8 max-w-6xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Federation</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Relay status, peer connections, and chain statistics
+        </p>
+      </div>
+
+      {/* Relay Status */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-6 mb-6">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+          Relay Status
+        </h2>
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-1">DFOS DID</dt>
+            <dd className="font-mono text-xs text-gray-900 dark:text-white break-all">
+              {relayConfigRow?.did ?? '—'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-1">Imajin DID</dt>
+            <dd className="font-mono text-xs text-gray-900 dark:text-white break-all">
+              {relayConfigRow?.imajin_did ?? '—'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-1">Relay Version</dt>
+            <dd className="text-sm text-gray-900 dark:text-white">@metalabel/dfos-web-relay 0.7.0</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-1">Conformance</dt>
+            <dd className="text-sm text-green-600 dark:text-green-400 font-semibold">100/100</dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* Chain Stats */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Identity Chains</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">
+            {Number(identityChainCount?.count ?? 0).toLocaleString()}
+          </p>
+        </div>
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Content Chains</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">
+            {Number(contentChainCount?.count ?? 0).toLocaleString()}
+          </p>
+        </div>
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Total Operations</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">
+            {Number(operationCount?.count ?? 0).toLocaleString()}
+          </p>
+        </div>
+      </div>
+
+      {/* Peer Nodes */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden mb-6">
+        <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Peer Nodes</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">{peers.length} configured</span>
+        </div>
+        {peers.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+            No peers configured
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Peer URL</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Last Synced</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Cursor</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {peers.map((peer) => (
+                  <tr key={peer.peer_url as string} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                    <td className="px-4 py-3 font-mono text-xs text-gray-900 dark:text-white">{peer.peer_url as string}</td>
+                    <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      {peer.updated_at
+                        ? formatDistanceToNow(new Date(peer.updated_at as Date), { addSuffix: true })
+                        : '—'}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+                      {peer.cursor ? String(peer.cursor).slice(0, 20) + '…' : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Recent Operations */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Recent Operations</h2>
+        </div>
+        {recentOps.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+            No operations found
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">CID</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Chain Type</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Chain ID</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {recentOps.map((op) => {
+                  const cid = op.cid as string;
+                  const chainId = op.chain_id as string;
+                  const createdAt = op.created_at as Date;
+                  return (
+                    <tr key={cid} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                      <td className="px-4 py-3 font-mono text-xs text-orange-600 dark:text-orange-400">
+                        {cid.slice(0, 12)}…
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
+                          {op.chain_type as string}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+                        {chainId.slice(0, 20)}…
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {createdAt
+                          ? formatDistanceToNow(new Date(createdAt), { addSuffix: true })
+                          : '—'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/moderation/create-flag.tsx
+++ b/apps/kernel/app/admin/moderation/create-flag.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export function CreateFlag() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [targetDid, setTargetDid] = useState('');
+  const [targetType, setTargetType] = useState('identity');
+  const [targetId, setTargetId] = useState('');
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await fetch('/api/admin/moderation/flags', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetDid, targetType, targetId, reason }),
+      });
+      setOpen(false);
+      setTargetDid('');
+      setTargetId('');
+      setReason('');
+      router.refresh();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 text-sm font-medium"
+      >
+        + Create Flag
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-6">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">Create Manual Flag</h3>
+      <form onSubmit={submit} className="space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target DID</label>
+          <input
+            required
+            type="text"
+            value={targetDid}
+            onChange={(e) => setTargetDid(e.target.value)}
+            placeholder="did:imajin:..."
+            className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target Type</label>
+            <select
+              value={targetType}
+              onChange={(e) => setTargetType(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            >
+              <option value="identity">Identity</option>
+              <option value="asset">Asset</option>
+              <option value="listing">Listing</option>
+              <option value="event">Event</option>
+              <option value="message">Message</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target ID</label>
+            <input
+              required
+              type="text"
+              value={targetId}
+              onChange={(e) => setTargetId(e.target.value)}
+              placeholder="ID of flagged content"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Reason</label>
+          <textarea
+            required
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={2}
+            placeholder="Reason for flagging"
+            className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white px-4 py-2 text-sm font-medium"
+          >
+            {submitting ? 'Submitting…' : 'Submit Flag'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/moderation/flag-actions.tsx
+++ b/apps/kernel/app/admin/moderation/flag-actions.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface FlagActionsProps {
+  flagId: string;
+  targetDid: string;
+}
+
+export function FlagActions({ flagId, targetDid }: FlagActionsProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState<string | null>(null);
+  const [resolution, setResolution] = useState('');
+
+  async function dismiss() {
+    setLoading('dismiss');
+    try {
+      await fetch(`/api/admin/moderation/flags/${flagId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'dismissed', resolution: resolution || 'Dismissed by operator' }),
+      });
+      router.refresh();
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function suspendTarget() {
+    setLoading('suspend');
+    try {
+      await fetch(`/api/admin/users/${encodeURIComponent(targetDid)}/suspend`, { method: 'POST' });
+      await fetch(`/api/admin/moderation/flags/${flagId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'actioned', resolution: resolution || 'Target suspended' }),
+      });
+      router.refresh();
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function removeContent() {
+    setLoading('remove');
+    try {
+      await fetch(`/api/admin/moderation/flags/${flagId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'actioned', resolution: resolution || 'Content removal logged' }),
+      });
+      router.refresh();
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      <input
+        type="text"
+        value={resolution}
+        onChange={(e) => setResolution(e.target.value)}
+        placeholder="Resolution note (optional)"
+        className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-orange-500"
+      />
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={dismiss}
+          disabled={!!loading}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+        >
+          {loading === 'dismiss' ? 'Dismissing…' : 'Dismiss'}
+        </button>
+        <button
+          onClick={suspendTarget}
+          disabled={!!loading}
+          className="rounded-lg bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white px-3 py-1.5 text-xs font-medium"
+        >
+          {loading === 'suspend' ? 'Suspending…' : 'Suspend Target'}
+        </button>
+        <button
+          onClick={removeContent}
+          disabled={!!loading}
+          className="rounded-lg bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white px-3 py-1.5 text-xs font-medium"
+        >
+          {loading === 'remove' ? 'Logging…' : 'Remove Content'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/moderation/page.tsx
+++ b/apps/kernel/app/admin/moderation/page.tsx
@@ -1,0 +1,164 @@
+import { getClient } from '@imajin/db';
+import { formatDistanceToNow } from 'date-fns';
+import { FlagActions } from './flag-actions';
+import { CreateFlag } from './create-flag';
+
+const sql = getClient();
+
+export default async function AdminModerationPage() {
+  const pendingFlags = await sql`
+    SELECT f.*, p.display_name AS reporter_name
+    FROM registry.flags f
+    LEFT JOIN profile.profiles p ON f.reporter_did = p.did
+    WHERE f.status = 'pending'
+    ORDER BY f.created_at DESC
+  `;
+
+  const auditLog = await sql`
+    SELECT m.*, p.display_name AS operator_name
+    FROM registry.moderation_log m
+    LEFT JOIN profile.profiles p ON m.operator_did = p.did
+    ORDER BY m.created_at DESC
+    LIMIT 25
+  `;
+
+  return (
+    <div className="p-6 lg:p-8 max-w-6xl">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Moderation</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Flag queue and moderation audit log
+          </p>
+        </div>
+        <CreateFlag />
+      </div>
+
+      {/* Flag Queue */}
+      <div className="mb-8">
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+          Pending Flags
+          {pendingFlags.length > 0 && (
+            <span className="ml-2 bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-400 px-2 py-0.5 rounded text-xs">
+              {pendingFlags.length}
+            </span>
+          )}
+        </h2>
+
+        {pendingFlags.length === 0 ? (
+          <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 px-6 py-10 text-center">
+            <p className="text-sm text-gray-400 dark:text-gray-500">No pending flags</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {pendingFlags.map((flag) => {
+              const flagId = flag.id as string;
+              const createdAt = flag.created_at as Date;
+              const reporterName = (flag.reporter_name ?? flag.reporter_did) as string;
+              return (
+                <div
+                  key={flagId}
+                  className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-xs bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-400 px-2 py-0.5 rounded font-medium">
+                          {flag.target_type as string}
+                        </span>
+                        <span className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                          {String(flag.target_id).slice(0, 24)}…
+                        </span>
+                      </div>
+                      <p className="text-sm font-medium text-gray-900 dark:text-white">
+                        {flag.reason as string}
+                      </p>
+                      <div className="text-xs text-gray-500 dark:text-gray-400 space-x-2">
+                        <span>Reporter: <span className="text-gray-700 dark:text-gray-300">{reporterName}</span></span>
+                        <span>·</span>
+                        <span>Target: <span className="font-mono">{String(flag.target_did).slice(0, 20)}…</span></span>
+                        <span>·</span>
+                        <span>{createdAt ? formatDistanceToNow(new Date(createdAt), { addSuffix: true }) : '—'}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <FlagActions flagId={flagId} targetDid={flag.target_did as string} />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Audit Log */}
+      <div>
+        <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+          Audit Log
+        </h2>
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+          {auditLog.length === 0 ? (
+            <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+              No moderation actions recorded
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                    <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Operator</th>
+                    <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Action</th>
+                    <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Target</th>
+                    <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Reason</th>
+                    <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">When</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                  {auditLog.map((entry) => {
+                    const id = entry.id as string;
+                    const createdAt = entry.created_at as Date;
+                    const operatorName = (entry.operator_name ?? entry.operator_did) as string;
+                    return (
+                      <tr key={id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                        <td className="px-4 py-3 text-xs text-gray-700 dark:text-gray-300">
+                          {operatorName}
+                        </td>
+                        <td className="px-4 py-3">
+                          <ActionBadge action={entry.action as string} />
+                        </td>
+                        <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+                          {String(entry.target_did).slice(0, 20)}…
+                        </td>
+                        <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 max-w-xs truncate">
+                          {(entry.reason as string | null) ?? '—'}
+                        </td>
+                        <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                          {createdAt ? formatDistanceToNow(new Date(createdAt), { addSuffix: true }) : '—'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ActionBadge({ action }: { action: string }) {
+  const styles: Record<string, string> = {
+    suspend: 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-400',
+    unsuspend: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400',
+    ban: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400',
+    warn: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400',
+    dismiss_flag: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+    remove_content: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400',
+  };
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded ${styles[action] ?? styles.dismiss_flag}`}>
+      {action.replace(/_/g, ' ')}
+    </span>
+  );
+}

--- a/apps/kernel/app/admin/storage/page.tsx
+++ b/apps/kernel/app/admin/storage/page.tsx
@@ -1,0 +1,239 @@
+import { getClient } from '@imajin/db';
+import { formatDistanceToNow } from 'date-fns';
+
+const sql = getClient();
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export default async function AdminStoragePage() {
+  const [totals] = await sql`
+    SELECT
+      COUNT(*) AS total_assets,
+      COALESCE(SUM(size), 0) AS total_size,
+      COUNT(DISTINCT owner_did) AS unique_uploaders
+    FROM media.assets
+    WHERE status != 'deleted'
+  `;
+
+  const topUploaders = await sql`
+    SELECT
+      a.owner_did,
+      COUNT(*) AS asset_count,
+      SUM(a.size) AS total_size,
+      p.display_name
+    FROM media.assets a
+    LEFT JOIN profile.profiles p ON a.owner_did = p.did
+    WHERE a.status != 'deleted'
+    GROUP BY a.owner_did, p.display_name
+    ORDER BY total_size DESC
+    LIMIT 10
+  `;
+
+  const recentAssets = await sql`
+    SELECT id, filename, mime_type, size, owner_did, created_at
+    FROM media.assets
+    WHERE status != 'deleted'
+    ORDER BY created_at DESC
+    LIMIT 20
+  `;
+
+  const orphans = await sql`
+    SELECT a.id, a.filename, a.mime_type, a.size, a.created_at
+    FROM media.assets a
+    LEFT JOIN media.asset_references r ON a.id = r.asset_id
+    WHERE r.id IS NULL
+      AND a.status != 'deleted'
+    ORDER BY a.created_at DESC
+    LIMIT 20
+  `;
+
+  const totalAssets = Number(totals?.total_assets ?? 0);
+  const totalSize = Number(totals?.total_size ?? 0);
+  const uniqueUploaders = Number(totals?.unique_uploaders ?? 0);
+
+  return (
+    <div className="p-6 lg:p-8 max-w-6xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Storage</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Media assets and storage usage
+        </p>
+      </div>
+
+      {/* Overview stats */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Total Assets</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">{totalAssets.toLocaleString()}</p>
+        </div>
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Total Size</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">{formatBytes(totalSize)}</p>
+        </div>
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-5">
+          <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Unique Uploaders</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-white">{uniqueUploaders.toLocaleString()}</p>
+        </div>
+      </div>
+
+      {/* Top Uploaders */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden mb-6">
+        <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Top Uploaders</h2>
+        </div>
+        {topUploaders.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">No assets yet</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Owner</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Assets</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Total Size</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {topUploaders.map((row) => {
+                  const ownerDid = row.owner_did as string;
+                  const displayName = row.display_name as string | null;
+                  return (
+                    <tr key={ownerDid} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                      <td className="px-4 py-3">
+                        {displayName && (
+                          <p className="text-sm text-gray-900 dark:text-white">{displayName}</p>
+                        )}
+                        <p className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                          {ownerDid.slice(0, 32)}…
+                        </p>
+                      </td>
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                        {Number(row.asset_count).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                        {formatBytes(Number(row.total_size ?? 0))}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Recent Assets */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden mb-6">
+        <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Recent Assets</h2>
+        </div>
+        {recentAssets.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">No assets yet</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Filename</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Type</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Size</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Owner</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Uploaded</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {recentAssets.map((asset) => {
+                  const id = asset.id as string;
+                  const createdAt = asset.created_at as Date;
+                  return (
+                    <tr key={id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                      <td className="px-4 py-3 font-mono text-xs text-gray-900 dark:text-white">
+                        {asset.filename ? String(asset.filename) : id.slice(0, 16) + '…'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
+                          {asset.mime_type as string}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-700 dark:text-gray-300">
+                        {formatBytes(Number(asset.size ?? 0))}
+                      </td>
+                      <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+                        {String(asset.owner_did).slice(0, 20)}…
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {createdAt
+                          ? formatDistanceToNow(new Date(createdAt), { addSuffix: true })
+                          : '—'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Orphan Detection */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Orphaned Assets</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {orphans.length} found (showing first 20)
+          </span>
+        </div>
+        {orphans.length === 0 ? (
+          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+            No orphaned assets found
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Filename</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Type</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Size</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Uploaded</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {orphans.map((asset) => {
+                  const id = asset.id as string;
+                  const createdAt = asset.created_at as Date;
+                  return (
+                    <tr key={id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                      <td className="px-4 py-3 font-mono text-xs text-gray-900 dark:text-white">
+                        {asset.filename ? String(asset.filename) : id.slice(0, 16) + '…'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="text-xs bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400 px-2 py-0.5 rounded">
+                          {asset.mime_type as string}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-700 dark:text-gray-300">
+                        {formatBytes(Number(asset.size ?? 0))}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {createdAt
+                          ? formatDistanceToNow(new Date(createdAt), { addSuffix: true })
+                          : '—'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/api/admin/config/route.ts
+++ b/apps/kernel/app/api/admin/config/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function GET() {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const [relayConfig] = await sql`
+    SELECT did, imajin_did, node_fee_bps, buyer_credit_bps, created_at
+    FROM relay.relay_config
+    WHERE id = 'singleton'
+    LIMIT 1
+  `;
+
+  const nodeConfigRows = await sql`
+    SELECT key, value FROM registry.node_config
+  `;
+
+  const nodeConfig: Record<string, unknown> = {};
+  for (const row of nodeConfigRows) {
+    nodeConfig[row.key as string] = row.value;
+  }
+
+  return NextResponse.json({ relayConfig, nodeConfig });
+}
+
+export async function PUT(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  if (!body?.key) {
+    return NextResponse.json({ error: 'key is required' }, { status: 400 });
+  }
+
+  const { key, value } = body;
+
+  await sql`
+    INSERT INTO registry.node_config (key, value, updated_at)
+    VALUES (${key}, ${JSON.stringify(value)}, NOW())
+    ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value, updated_at = NOW()
+  `;
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/kernel/app/api/admin/federation/peers/route.ts
+++ b/apps/kernel/app/api/admin/federation/peers/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function GET() {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const peers = await sql`
+    SELECT peer_url, cursor, updated_at
+    FROM relay.relay_peer_cursors
+    ORDER BY updated_at DESC NULLS LAST
+  `;
+
+  return NextResponse.json({ peers });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const url = body?.url?.trim();
+  if (!url) {
+    return NextResponse.json({ error: 'url is required' }, { status: 400 });
+  }
+
+  await sql`
+    INSERT INTO relay.relay_peer_cursors (peer_url, cursor, updated_at)
+    VALUES (${url}, '', NOW())
+    ON CONFLICT (peer_url) DO NOTHING
+  `;
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const url = new URL(req.url).searchParams.get('url');
+  if (!url) {
+    return NextResponse.json({ error: 'url query param required' }, { status: 400 });
+  }
+
+  await sql`
+    DELETE FROM relay.relay_peer_cursors WHERE peer_url = ${url}
+  `;
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/kernel/app/api/admin/moderation/flags/[id]/route.ts
+++ b/apps/kernel/app/api/admin/moderation/flags/[id]/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+function genId(prefix: string) {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = await req.json().catch(() => null);
+  const { status, resolution } = body ?? {};
+
+  if (!status || !['dismissed', 'actioned'].includes(status)) {
+    return NextResponse.json({ error: 'status must be dismissed or actioned' }, { status: 400 });
+  }
+
+  const [flag] = await sql`
+    SELECT * FROM registry.flags WHERE id = ${id} LIMIT 1
+  `;
+  if (!flag) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  await sql`
+    UPDATE registry.flags
+    SET status = ${status},
+        resolved_at = NOW(),
+        resolved_by = ${session.actingAs!},
+        resolution = ${resolution ?? null}
+    WHERE id = ${id}
+  `;
+
+  // Log to moderation_log
+  const action = status === 'dismissed' ? 'dismiss_flag' : 'remove_content';
+  const logId = genId('modlog');
+  await sql`
+    INSERT INTO registry.moderation_log (id, operator_did, action, target_did, target_type, target_id, reason, created_at)
+    VALUES (
+      ${logId},
+      ${session.actingAs!},
+      ${action},
+      ${flag.target_did as string},
+      ${flag.target_type as string},
+      ${flag.target_id as string},
+      ${resolution ?? null},
+      NOW()
+    )
+  `;
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/kernel/app/api/admin/moderation/flags/route.ts
+++ b/apps/kernel/app/api/admin/moderation/flags/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+function genId(prefix: string) {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
+}
+
+export async function GET(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const status = new URL(req.url).searchParams.get('status') ?? 'pending';
+
+  const flags = await sql`
+    SELECT f.*, p.display_name AS reporter_name
+    FROM registry.flags f
+    LEFT JOIN profile.profiles p ON f.reporter_did = p.did
+    WHERE f.status = ${status}
+    ORDER BY f.created_at DESC
+  `;
+
+  return NextResponse.json({ flags });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const { targetDid, targetType, targetId, reason } = body ?? {};
+
+  if (!targetDid || !targetType || !targetId || !reason) {
+    return NextResponse.json({ error: 'targetDid, targetType, targetId, reason are required' }, { status: 400 });
+  }
+
+  const id = genId('flag');
+  const reporterDid = session.actingAs!;
+
+  await sql`
+    INSERT INTO registry.flags (id, reporter_did, target_did, target_type, target_id, reason, status, created_at)
+    VALUES (${id}, ${reporterDid}, ${targetDid}, ${targetType}, ${targetId}, ${reason}, 'pending', NOW())
+  `;
+
+  return NextResponse.json({ ok: true, id });
+}

--- a/apps/kernel/app/api/admin/moderation/log/route.ts
+++ b/apps/kernel/app/api/admin/moderation/log/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSession } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+async function requireAdmin() {
+  const session = await getSession();
+  if (!session?.actingAs) return null;
+
+  const [nodeRow] = await sql`
+    SELECT group_did FROM auth.group_identities
+    WHERE group_did = ${session.actingAs}
+    AND scope = 'node'
+    LIMIT 1
+  `;
+  return nodeRow ? session : null;
+}
+
+export async function GET(req: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const limit = Math.min(100, Number(url.searchParams.get('limit') ?? '25'));
+  const offset = Number(url.searchParams.get('offset') ?? '0');
+
+  const entries = await sql`
+    SELECT m.*, p.display_name AS operator_name
+    FROM registry.moderation_log m
+    LEFT JOIN profile.profiles p ON m.operator_did = p.did
+    ORDER BY m.created_at DESC
+    LIMIT ${limit} OFFSET ${offset}
+  `;
+
+  return NextResponse.json({ entries });
+}

--- a/apps/kernel/drizzle/0013_add_node_config.sql
+++ b/apps/kernel/drizzle/0013_add_node_config.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS registry.node_config (
+  key TEXT PRIMARY KEY,
+  value JSONB NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/apps/kernel/drizzle/0014_add_moderation_tables.sql
+++ b/apps/kernel/drizzle/0014_add_moderation_tables.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS registry.flags (
+  id TEXT PRIMARY KEY,
+  reporter_did TEXT NOT NULL,
+  target_did TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  resolved_at TIMESTAMPTZ,
+  resolved_by TEXT,
+  resolution TEXT
+);
+
+CREATE TABLE IF NOT EXISTS registry.moderation_log (
+  id TEXT PRIMARY KEY,
+  operator_did TEXT NOT NULL,
+  action TEXT NOT NULL,
+  target_did TEXT NOT NULL,
+  target_type TEXT,
+  target_id TEXT,
+  reason TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/apps/kernel/drizzle/meta/0013_snapshot.json
+++ b/apps/kernel/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000013",
+  "prevId": "00000000-0000-0000-0000-000000000012",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/0014_snapshot.json
+++ b/apps/kernel/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000014",
+  "prevId": "00000000-0000-0000-0000-000000000013",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/_journal.json
+++ b/apps/kernel/drizzle/meta/_journal.json
@@ -92,6 +92,20 @@
       "when": 1744502400001,
       "tag": "0012_add_newsletter_sends",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1744588800000,
+      "tag": "0013_add_node_config",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1744588800001,
+      "tag": "0014_add_moderation_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/kernel/src/db/schemas/registry.ts
+++ b/apps/kernel/src/db/schemas/registry.ts
@@ -203,6 +203,52 @@ export const newsletterSends = registrySchema.table('newsletter_sends', {
   sentAt: timestamp('sent_at', { withTimezone: true }).defaultNow(),
 });
 
+/**
+ * Node configuration key-value store
+ */
+export const nodeConfig = registrySchema.table('node_config', {
+  key: text('key').primaryKey(),
+  value: jsonb('value').notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+});
+
+export type NodeConfig = typeof nodeConfig.$inferSelect;
+
+/**
+ * Content/identity flags submitted by users
+ */
+export const flags = registrySchema.table('flags', {
+  id: text('id').primaryKey(),
+  reporterDid: text('reporter_did').notNull(),
+  targetDid: text('target_did').notNull(),
+  targetType: text('target_type').notNull(), // 'identity' | 'asset' | 'listing' | 'event' | 'message'
+  targetId: text('target_id').notNull(),
+  reason: text('reason').notNull(),
+  status: text('status').notNull().default('pending'), // 'pending' | 'dismissed' | 'actioned'
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+  resolvedBy: text('resolved_by'),
+  resolution: text('resolution'),
+});
+
+export type Flag = typeof flags.$inferSelect;
+
+/**
+ * Audit log of moderation actions
+ */
+export const moderationLog = registrySchema.table('moderation_log', {
+  id: text('id').primaryKey(),
+  operatorDid: text('operator_did').notNull(),
+  action: text('action').notNull(), // 'suspend' | 'unsuspend' | 'warn' | 'remove_content' | 'dismiss_flag' | 'ban'
+  targetDid: text('target_did').notNull(),
+  targetType: text('target_type'),
+  targetId: text('target_id'),
+  reason: text('reason'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});
+
+export type ModerationLog = typeof moderationLog.$inferSelect;
+
 // Types
 export type Node = typeof nodes.$inferSelect;
 export type NewNode = typeof nodes.$inferInsert;


### PR DESCRIPTION
## Summary

Final four sections of the admin console Phase 1.

### Federation (#670) — `/admin/federation`
- Relay status card (DFOS DID, Imajin DID, version, conformance)
- Peer nodes table with last sync times
- Chain stats (identity chains, content chains, total operations)
- Recent operations log
- Add/remove peer API

### Storage (#674) — `/admin/storage`
- Overview stats (total assets, total size, unique uploaders)
- Top uploaders table (per-DID breakdown with sizes)
- Recent assets list
- Orphan detection (assets with no references)

### Config (#667) — `/admin/config`
- Node identity display (DFOS + Imajin DIDs)
- Registration mode (open/invite-only/closed) — editable, persisted to `registry.node_config`
- Fee configuration display (node fee + buyer credit bps)
- Resource limits (max identities, max storage per DID) — editable

### Moderation (#668) — `/admin/moderation`
- Pending flag queue with action buttons (dismiss/suspend/remove)
- Manual flag creation form
- Audit log of all moderation actions
- Ties into user suspend from #665

### Schema Changes
- `registry.node_config` — key-value config table (migration 0013)
- `registry.flags` + `registry.moderation_log` — moderation infrastructure (migration 0014)

### Files (18 changed, +1,470 lines)

Closes #670, closes #674, closes #667, closes #668