### PR TITLE
feat(auth): identity scopes + stub business identities (#346, #653)

### DIFF
--- a/apps/kernel/app/admin/layout.tsx
+++ b/apps/kernel/app/admin/layout.tsx
@@ -31,11 +31,11 @@ export default async function AdminLayout({
     redirect('/');
   }
 
-  // Verify actingAs is a node-scope group DID
+  // Verify actingAs is a node identity
   const [nodeRow] = await sql`
-    SELECT group_did FROM auth.group_identities
-    WHERE group_did = ${session.actingAs}
-    AND scope = 'node'
+    SELECT id FROM auth.identities
+    WHERE id = ${session.actingAs}
+    AND scope = 'actor' AND subtype = 'node'
     LIMIT 1
   `;
 

--- a/apps/kernel/app/admin/layout.tsx
+++ b/apps/kernel/app/admin/layout.tsx
@@ -31,15 +31,9 @@ export default async function AdminLayout({
     redirect('/');
   }
 
-  // Verify actingAs is a node identity
-  const [nodeRow] = await sql`
-    SELECT id FROM auth.identities
-    WHERE id = ${session.actingAs}
-    AND scope = 'actor' AND subtype = 'node'
-    LIMIT 1
-  `;
-
-  if (!nodeRow) {
+  // Verify actingAs is the node DID
+  const nodeDid_ = process.env.NODE_DID;
+  if (!nodeDid_ || session.actingAs !== nodeDid_) {
     redirect('/');
   }
 

--- a/apps/kernel/app/admin/newsletter/page.tsx
+++ b/apps/kernel/app/admin/newsletter/page.tsx
@@ -9,9 +9,9 @@ async function requireAdmin() {
   const session = await getSession();
   if (!session?.actingAs) redirect('/admin');
   const [nodeRow] = await sql`
-    SELECT group_did FROM auth.group_identities
-    WHERE group_did = ${session.actingAs}
-    AND scope = 'node'
+    SELECT id FROM auth.identities
+    WHERE id = ${session.actingAs}
+    AND scope = 'actor' AND subtype = 'node'
     LIMIT 1
   `;
   if (!nodeRow) redirect('/admin');

--- a/apps/kernel/app/admin/newsletter/page.tsx
+++ b/apps/kernel/app/admin/newsletter/page.tsx
@@ -8,13 +8,8 @@ const sql = getClient();
 async function requireAdmin() {
   const session = await getSession();
   if (!session?.actingAs) redirect('/admin');
-  const [nodeRow] = await sql`
-    SELECT id FROM auth.identities
-    WHERE id = ${session.actingAs}
-    AND scope = 'actor' AND subtype = 'node'
-    LIMIT 1
-  `;
-  if (!nodeRow) redirect('/admin');
+  const nodeDid = process.env.NODE_DID;
+  if (!nodeDid || session.actingAs !== nodeDid) redirect('/admin');
   return session;
 }
 

--- a/apps/kernel/app/admin/subscribers/page.tsx
+++ b/apps/kernel/app/admin/subscribers/page.tsx
@@ -19,13 +19,8 @@ interface SearchParams {
 async function requireAdmin() {
   const session = await getSession();
   if (!session?.actingAs) redirect('/admin');
-  const [nodeRow] = await sql`
-    SELECT id FROM auth.identities
-    WHERE id = ${session.actingAs}
-    AND scope = 'actor' AND subtype = 'node'
-    LIMIT 1
-  `;
-  if (!nodeRow) redirect('/admin');
+  const nodeDid = process.env.NODE_DID;
+  if (!nodeDid || session.actingAs !== nodeDid) redirect('/admin');
   return session;
 }
 

--- a/apps/kernel/app/admin/subscribers/page.tsx
+++ b/apps/kernel/app/admin/subscribers/page.tsx
@@ -20,9 +20,9 @@ async function requireAdmin() {
   const session = await getSession();
   if (!session?.actingAs) redirect('/admin');
   const [nodeRow] = await sql`
-    SELECT group_did FROM auth.group_identities
-    WHERE group_did = ${session.actingAs}
-    AND scope = 'node'
+    SELECT id FROM auth.identities
+    WHERE id = ${session.actingAs}
+    AND scope = 'actor' AND subtype = 'node'
     LIMIT 1
   `;
   if (!nodeRow) redirect('/admin');

--- a/apps/kernel/app/admin/users/[did]/page.tsx
+++ b/apps/kernel/app/admin/users/[did]/page.tsx
@@ -24,7 +24,7 @@ export default async function AdminUserDetailPage({
 
   // Profile
   const [profile] = await sql`
-    SELECT display_name, display_type, bio, avatar, avatar_asset_id
+    SELECT display_name, bio, avatar, avatar_asset_id
     FROM profile.profiles
     WHERE did = ${decodedDid}
     LIMIT 1
@@ -134,7 +134,6 @@ export default async function AdminUserDetailPage({
           {profile ? (
             <div className="space-y-2 text-sm">
               <Row label="Display Name" value={profile.display_name as string | null} />
-              <Row label="Display Type" value={profile.display_type as string | null} />
               <Row label="Bio" value={profile.bio as string | null} />
               <Row label="Avatar" value={profile.avatar as string | null} mono />
             </div>

--- a/apps/kernel/app/admin/users/[did]/page.tsx
+++ b/apps/kernel/app/admin/users/[did]/page.tsx
@@ -15,7 +15,7 @@ export default async function AdminUserDetailPage({
 
   // Identity
   const [identity] = await sql`
-    SELECT id, handle, name, type, tier, public_key, suspended_at, created_at
+    SELECT id, handle, name, scope, subtype, tier, public_key, suspended_at, created_at
     FROM auth.identities
     WHERE id = ${decodedDid}
     LIMIT 1
@@ -89,7 +89,7 @@ export default async function AdminUserDetailPage({
               )}
               <TierBadge tier={identity.tier as string} />
               <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
-                {identity.type as string}
+                {identity.scope as string}{identity.subtype ? `/${identity.subtype as string}` : ''}
               </span>
             </div>
             <p className="font-mono text-xs text-gray-500 dark:text-gray-400 break-all mb-1">

--- a/apps/kernel/app/api/admin/verify/route.ts
+++ b/apps/kernel/app/api/admin/verify/route.ts
@@ -17,11 +17,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Forbidden: no acting-as scope' }, { status: 403 });
   }
 
-  // Verify actingAs is a node-scope group DID
+  // Verify actingAs is a node identity
   const [nodeRow] = await sql`
-    SELECT group_did FROM auth.group_identities
-    WHERE group_did = ${identity.actingAs}
-    AND scope = 'node'
+    SELECT id FROM auth.identities
+    WHERE id = ${identity.actingAs}
+    AND scope = 'actor' AND subtype = 'node'
     LIMIT 1
   `;
 

--- a/apps/kernel/app/api/admin/verify/route.ts
+++ b/apps/kernel/app/api/admin/verify/route.ts
@@ -17,19 +17,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Forbidden: no acting-as scope' }, { status: 403 });
   }
 
-  // Verify actingAs is a node identity
-  const [nodeRow] = await sql`
-    SELECT id FROM auth.identities
-    WHERE id = ${identity.actingAs}
-    AND scope = 'actor' AND subtype = 'node'
-    LIMIT 1
-  `;
-
-  if (!nodeRow) {
-    return NextResponse.json({ error: 'Forbidden: not a node scope' }, { status: 403 });
+  // Verify actingAs is the node DID
+  const nodeDid = process.env.NODE_DID;
+  if (!nodeDid || identity.actingAs !== nodeDid) {
+    return NextResponse.json({ error: 'Forbidden: not the node operator' }, { status: 403 });
   }
-
-  const nodeDid = identity.actingAs;
 
   const [profileRow] = await sql`
     SELECT display_name FROM profile.profiles

--- a/apps/kernel/app/auth/api/authenticate/route.ts
+++ b/apps/kernel/app/auth/api/authenticate/route.ts
@@ -112,7 +112,8 @@ export async function POST(request: NextRequest) {
       expiresAt: expiresAt.toISOString(),
       identity: {
         id: identity.id,
-        type: identity.type,
+        scope: identity.scope,
+        subtype: identity.subtype,
         name: identity.name,
       },
     });

--- a/apps/kernel/app/auth/api/groups/[groupDid]/controllers/[controllerDid]/route.ts
+++ b/apps/kernel/app/auth/api/groups/[groupDid]/controllers/[controllerDid]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, groupControllers } from '@/src/db';
+import { db, identityMembers } from '@/src/db';
 import { eq, and, isNull } from 'drizzle-orm';
 import { requireAuth, emitAttestation } from '@imajin/auth';
 import { createLogger } from '@imajin/logger';
@@ -23,13 +23,13 @@ export async function DELETE(
   const { groupDid, controllerDid } = await params;
 
   const [callerMembership] = await db
-    .select({ role: groupControllers.role })
-    .from(groupControllers)
+    .select({ role: identityMembers.role })
+    .from(identityMembers)
     .where(
       and(
-        eq(groupControllers.groupDid, groupDid),
-        eq(groupControllers.controllerDid, caller.id),
-        isNull(groupControllers.removedAt)
+        eq(identityMembers.identityDid, groupDid),
+        eq(identityMembers.memberDid, caller.id),
+        isNull(identityMembers.removedAt)
       )
     )
     .limit(1);
@@ -44,13 +44,13 @@ export async function DELETE(
 
   // Check target's role
   const [targetMembership] = await db
-    .select({ role: groupControllers.role })
-    .from(groupControllers)
+    .select({ role: identityMembers.role })
+    .from(identityMembers)
     .where(
       and(
-        eq(groupControllers.groupDid, groupDid),
-        eq(groupControllers.controllerDid, controllerDid),
-        isNull(groupControllers.removedAt)
+        eq(identityMembers.identityDid, groupDid),
+        eq(identityMembers.memberDid, controllerDid),
+        isNull(identityMembers.removedAt)
       )
     )
     .limit(1);
@@ -65,12 +65,12 @@ export async function DELETE(
 
   try {
     await db
-      .update(groupControllers)
+      .update(identityMembers)
       .set({ removedAt: new Date() })
       .where(
         and(
-          eq(groupControllers.groupDid, groupDid),
-          eq(groupControllers.controllerDid, controllerDid)
+          eq(identityMembers.identityDid, groupDid),
+          eq(identityMembers.memberDid, controllerDid)
         )
       );
 
@@ -112,16 +112,16 @@ export async function GET(
   try {
     const [membership] = await db
       .select({
-        role: groupControllers.role,
-        removedAt: groupControllers.removedAt,
-        allowedServices: groupControllers.allowedServices,
+        role: identityMembers.role,
+        removedAt: identityMembers.removedAt,
+        allowedServices: identityMembers.allowedServices,
       })
-      .from(groupControllers)
+      .from(identityMembers)
       .where(
         and(
-          eq(groupControllers.groupDid, groupDid),
-          eq(groupControllers.controllerDid, controllerDid),
-          isNull(groupControllers.removedAt)
+          eq(identityMembers.identityDid, groupDid),
+          eq(identityMembers.memberDid, controllerDid),
+          isNull(identityMembers.removedAt)
         )
       )
       .limit(1);

--- a/apps/kernel/app/auth/api/groups/[groupDid]/controllers/route.ts
+++ b/apps/kernel/app/auth/api/groups/[groupDid]/controllers/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, groupControllers } from '@/src/db';
+import { db, identityMembers } from '@/src/db';
 import { eq, and, isNull } from 'drizzle-orm';
 import { requireAuth, emitAttestation } from '@imajin/auth';
 import { createLogger } from '@imajin/logger';
@@ -25,13 +25,13 @@ export async function POST(
   const { groupDid } = await params;
 
   const [callerMembership] = await db
-    .select({ role: groupControllers.role })
-    .from(groupControllers)
+    .select({ role: identityMembers.role })
+    .from(identityMembers)
     .where(
       and(
-        eq(groupControllers.groupDid, groupDid),
-        eq(groupControllers.controllerDid, caller.id),
-        isNull(groupControllers.removedAt)
+        eq(identityMembers.identityDid, groupDid),
+        eq(identityMembers.memberDid, caller.id),
+        isNull(identityMembers.removedAt)
       )
     )
     .limit(1);
@@ -66,12 +66,12 @@ export async function POST(
   try {
     // Check if controller was previously removed (soft delete)
     const [existing] = await db
-      .select({ removedAt: groupControllers.removedAt, role: groupControllers.role })
-      .from(groupControllers)
+      .select({ removedAt: identityMembers.removedAt, role: identityMembers.role })
+      .from(identityMembers)
       .where(
         and(
-          eq(groupControllers.groupDid, groupDid),
-          eq(groupControllers.controllerDid, did)
+          eq(identityMembers.identityDid, groupDid),
+          eq(identityMembers.memberDid, did)
         )
       )
       .limit(1);
@@ -83,18 +83,18 @@ export async function POST(
     if (existing && existing.removedAt) {
       // Reactivate
       await db
-        .update(groupControllers)
+        .update(identityMembers)
         .set({ removedAt: null, role, allowedServices, addedBy: caller.id, addedAt: new Date() })
         .where(
           and(
-            eq(groupControllers.groupDid, groupDid),
-            eq(groupControllers.controllerDid, did)
+            eq(identityMembers.identityDid, groupDid),
+            eq(identityMembers.memberDid, did)
           )
         );
     } else {
-      await db.insert(groupControllers).values({
-        groupDid,
-        controllerDid: did,
+      await db.insert(identityMembers).values({
+        identityDid: groupDid,
+        memberDid: did,
         role,
         allowedServices,
         addedBy: caller.id,
@@ -110,7 +110,7 @@ export async function POST(
       payload: { role },
     }).catch((err) => log.error({ err: String(err) }, '[groups] Attestation failed (non-fatal)'));
 
-    return NextResponse.json({ ok: true, groupDid, controllerDid: did, role }, { status: 201 });
+    return NextResponse.json({ ok: true, identityDid: groupDid, memberDid: did, role }, { status: 201 });
   } catch (error) {
     log.error({ err: String(error) }, '[groups] Add controller error');
     return NextResponse.json({ error: 'Failed to add controller' }, { status: 500 });

--- a/apps/kernel/app/auth/api/groups/[groupDid]/route.ts
+++ b/apps/kernel/app/auth/api/groups/[groupDid]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, identities, groupIdentities, groupControllers, profiles } from '@/src/db';
+import { db, identities, groupControllers, profiles } from '@/src/db';
 import { eq, and, isNull } from 'drizzle-orm';
 import { requireAuth } from '@imajin/auth';
 import { createLogger } from '@imajin/logger';
 
 const log = createLogger('kernel');
-const VALID_SCOPES = ['org', 'community', 'family'];
+const VALID_SCOPES = ['business', 'community', 'family'];
 
 /**
  * GET /api/groups/[groupDid]
@@ -40,18 +40,22 @@ export async function GET(
       return NextResponse.json({ error: 'Not a controller of this group' }, { status: 403 });
     }
 
+    const [ownerRow] = await db
+      .select({ controllerDid: groupControllers.controllerDid, addedAt: groupControllers.addedAt })
+      .from(groupControllers)
+      .where(and(eq(groupControllers.groupDid, groupDid), eq(groupControllers.role, 'owner'), isNull(groupControllers.removedAt)))
+      .limit(1);
+
     const [group] = await db
       .select({
-        groupDid: groupIdentities.groupDid,
-        scope: groupIdentities.scope,
-        createdBy: groupIdentities.createdBy,
-        createdAt: groupIdentities.createdAt,
+        groupDid: identities.id,
+        scope: identities.scope,
+        createdAt: identities.createdAt,
         name: identities.name,
         handle: identities.handle,
       })
-      .from(groupIdentities)
-      .innerJoin(identities, eq(groupIdentities.groupDid, identities.id))
-      .where(eq(groupIdentities.groupDid, groupDid))
+      .from(identities)
+      .where(eq(identities.id, groupDid))
       .limit(1);
 
     if (!group) {
@@ -73,7 +77,7 @@ export async function GET(
         )
       );
 
-    return NextResponse.json({ ...group, controllers });
+    return NextResponse.json({ ...group, createdBy: ownerRow?.controllerDid ?? null, controllers });
   } catch (error) {
     log.error({ err: String(error) }, '[groups] Get error');
     return NextResponse.json({ error: 'Failed to get group' }, { status: 500 });
@@ -144,9 +148,9 @@ export async function PATCH(
 
     if (scope) {
       await db
-        .update(groupIdentities)
-        .set({ scope })
-        .where(eq(groupIdentities.groupDid, groupDid));
+        .update(identities)
+        .set({ scope, updatedAt: new Date() })
+        .where(eq(identities.id, groupDid));
     }
 
     return NextResponse.json({ ok: true });

--- a/apps/kernel/app/auth/api/groups/[groupDid]/route.ts
+++ b/apps/kernel/app/auth/api/groups/[groupDid]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, identities, groupControllers, profiles } from '@/src/db';
+import { db, identities, identityMembers, profiles } from '@/src/db';
 import { eq, and, isNull } from 'drizzle-orm';
 import { requireAuth } from '@imajin/auth';
 import { createLogger } from '@imajin/logger';
@@ -25,13 +25,13 @@ export async function GET(
   try {
     // Check caller is active controller
     const [membership] = await db
-      .select({ role: groupControllers.role })
-      .from(groupControllers)
+      .select({ role: identityMembers.role })
+      .from(identityMembers)
       .where(
         and(
-          eq(groupControllers.groupDid, groupDid),
-          eq(groupControllers.controllerDid, caller.id),
-          isNull(groupControllers.removedAt)
+          eq(identityMembers.identityDid, groupDid),
+          eq(identityMembers.memberDid, caller.id),
+          isNull(identityMembers.removedAt)
         )
       )
       .limit(1);
@@ -41,9 +41,9 @@ export async function GET(
     }
 
     const [ownerRow] = await db
-      .select({ controllerDid: groupControllers.controllerDid, addedAt: groupControllers.addedAt })
-      .from(groupControllers)
-      .where(and(eq(groupControllers.groupDid, groupDid), eq(groupControllers.role, 'owner'), isNull(groupControllers.removedAt)))
+      .select({ controllerDid: identityMembers.memberDid, addedAt: identityMembers.addedAt })
+      .from(identityMembers)
+      .where(and(eq(identityMembers.identityDid, groupDid), eq(identityMembers.role, 'owner'), isNull(identityMembers.removedAt)))
       .limit(1);
 
     const [group] = await db
@@ -64,16 +64,16 @@ export async function GET(
 
     const controllers = await db
       .select({
-        controllerDid: groupControllers.controllerDid,
-        role: groupControllers.role,
-        addedBy: groupControllers.addedBy,
-        addedAt: groupControllers.addedAt,
+        controllerDid: identityMembers.memberDid,
+        role: identityMembers.role,
+        addedBy: identityMembers.addedBy,
+        addedAt: identityMembers.addedAt,
       })
-      .from(groupControllers)
+      .from(identityMembers)
       .where(
         and(
-          eq(groupControllers.groupDid, groupDid),
-          isNull(groupControllers.removedAt)
+          eq(identityMembers.identityDid, groupDid),
+          isNull(identityMembers.removedAt)
         )
       );
 
@@ -100,13 +100,13 @@ export async function PATCH(
   const { groupDid } = await params;
 
   const [membership] = await db
-    .select({ role: groupControllers.role })
-    .from(groupControllers)
+    .select({ role: identityMembers.role })
+    .from(identityMembers)
     .where(
       and(
-        eq(groupControllers.groupDid, groupDid),
-        eq(groupControllers.controllerDid, caller.id),
-        isNull(groupControllers.removedAt)
+        eq(identityMembers.identityDid, groupDid),
+        eq(identityMembers.memberDid, caller.id),
+        isNull(identityMembers.removedAt)
       )
     )
     .limit(1);

--- a/apps/kernel/app/auth/api/groups/route.ts
+++ b/apps/kernel/app/auth/api/groups/route.ts
@@ -3,7 +3,7 @@ import { db, identities, storedKeys, identityMembers, profiles } from '@/src/db'
 import { eq, and, isNull } from 'drizzle-orm';
 import { requireAuth } from '@imajin/auth';
 import { generateKeypair } from '@imajin/auth';
-import { didFromPublicKey } from '@/src/lib/auth/crypto';
+import { didFromPublicKey, encryptPrivateKey } from '@/src/lib/auth/crypto';
 import { emitAttestation } from '@imajin/auth';
 import { createLogger } from '@imajin/logger';
 
@@ -14,40 +14,6 @@ type GroupScope = typeof VALID_SCOPES[number];
 
 function genId(prefix: string): string {
   return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
-}
-
-async function encryptPrivateKey(privateKeyHex: string): Promise<{ encryptedKey: string; salt: string }> {
-  const secret = process.env.GROUP_KEY_ENCRYPTION_SECRET;
-  if (!secret) throw new Error('GROUP_KEY_ENCRYPTION_SECRET not set');
-
-  const saltBytes = crypto.getRandomValues(new Uint8Array(16));
-  const salt = Buffer.from(saltBytes).toString('base64');
-
-  const keyMaterial = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(secret),
-    { name: 'PBKDF2' },
-    false,
-    ['deriveKey']
-  );
-  const derivedKey = await crypto.subtle.deriveKey(
-    { name: 'PBKDF2', salt: saltBytes, iterations: 100_000, hash: 'SHA-256' },
-    keyMaterial,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt']
-  );
-
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const plaintext = new TextEncoder().encode(privateKeyHex);
-  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, derivedKey, plaintext);
-
-  // Prepend IV to ciphertext
-  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
-  combined.set(iv);
-  combined.set(new Uint8Array(ciphertext), iv.length);
-
-  return { encryptedKey: Buffer.from(combined).toString('base64'), salt };
 }
 
 /**

--- a/apps/kernel/app/auth/api/groups/route.ts
+++ b/apps/kernel/app/auth/api/groups/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, identities, storedKeys, groupControllers, profiles } from '@/src/db';
+import { db, identities, storedKeys, identityMembers, profiles } from '@/src/db';
 import { eq, and, isNull } from 'drizzle-orm';
 import { requireAuth } from '@imajin/auth';
 import { generateKeypair } from '@imajin/auth';
@@ -134,9 +134,9 @@ export async function POST(request: NextRequest) {
     });
 
     // Add creator as owner
-    await db.insert(groupControllers).values({
-      groupDid,
-      controllerDid: caller.id,
+    await db.insert(identityMembers).values({
+      identityDid: groupDid,
+      memberDid: caller.id,
       role: 'owner',
       addedBy: caller.id,
     });
@@ -184,18 +184,18 @@ export async function GET(request: NextRequest) {
   try {
     const rows = await db
       .select({
-        groupDid: groupControllers.groupDid,
-        role: groupControllers.role,
+        groupDid: identityMembers.identityDid,
+        role: identityMembers.role,
         scope: identities.scope,
         name: identities.name,
         handle: identities.handle,
       })
-      .from(groupControllers)
-      .innerJoin(identities, eq(groupControllers.groupDid, identities.id))
+      .from(identityMembers)
+      .innerJoin(identities, eq(identityMembers.identityDid, identities.id))
       .where(
         and(
-          eq(groupControllers.controllerDid, caller.id),
-          isNull(groupControllers.removedAt)
+          eq(identityMembers.memberDid, caller.id),
+          isNull(identityMembers.removedAt)
         )
       );
 

--- a/apps/kernel/app/auth/api/groups/route.ts
+++ b/apps/kernel/app/auth/api/groups/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, identities, storedKeys, groupIdentities, groupControllers, profiles } from '@/src/db';
+import { db, identities, storedKeys, groupControllers, profiles } from '@/src/db';
 import { eq, and, isNull } from 'drizzle-orm';
 import { requireAuth } from '@imajin/auth';
 import { generateKeypair } from '@imajin/auth';
@@ -9,7 +9,7 @@ import { createLogger } from '@imajin/logger';
 
 const log = createLogger('kernel');
 
-const VALID_SCOPES = ['org', 'community', 'family'] as const;
+const VALID_SCOPES = ['business', 'community', 'family'] as const;
 type GroupScope = typeof VALID_SCOPES[number];
 
 function genId(prefix: string): string {
@@ -104,6 +104,8 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    const validatedScope = scope as GroupScope;
+
     // Generate Ed25519 keypair server-side
     const { privateKey, publicKey } = generateKeypair();
     const groupDid = didFromPublicKey(publicKey);
@@ -115,7 +117,7 @@ export async function POST(request: NextRequest) {
     // Store identity
     await db.insert(identities).values({
       id: groupDid,
-      type: scope,  // 'org' | 'community' | 'family'
+      scope: validatedScope,
       publicKey,
       handle: handle || null,
       name: name.trim().slice(0, 100),
@@ -129,13 +131,6 @@ export async function POST(request: NextRequest) {
       encryptedKey,
       salt,
       keyDerivation: 'pbkdf2',
-    });
-
-    // Store group identity record
-    await db.insert(groupIdentities).values({
-      groupDid,
-      scope: scope as GroupScope,
-      createdBy: caller.id,
     });
 
     // Add creator as owner
@@ -153,7 +148,6 @@ export async function POST(request: NextRequest) {
         displayName: name.trim().slice(0, 100),
         handle: handle || null,
         bio: description || null,
-        displayType: scope,
       }).onConflictDoNothing();
     } catch (err) {
       log.error({ err: String(err) }, '[groups] Profile creation failed (non-fatal)');
@@ -192,12 +186,11 @@ export async function GET(request: NextRequest) {
       .select({
         groupDid: groupControllers.groupDid,
         role: groupControllers.role,
-        scope: groupIdentities.scope,
+        scope: identities.scope,
         name: identities.name,
         handle: identities.handle,
       })
       .from(groupControllers)
-      .innerJoin(groupIdentities, eq(groupControllers.groupDid, groupIdentities.groupDid))
       .innerJoin(identities, eq(groupControllers.groupDid, identities.id))
       .where(
         and(

--- a/apps/kernel/app/auth/api/identity/[did]/route.ts
+++ b/apps/kernel/app/auth/api/identity/[did]/route.ts
@@ -29,7 +29,8 @@ export async function GET(
       .select({
         id: identities.id,
         publicKey: identities.publicKey,
-        type: identities.type,
+        scope: identities.scope,
+        subtype: identities.subtype,
         tier: identities.tier,
       })
       .from(identities)
@@ -49,7 +50,8 @@ export async function GET(
       {
         did: identity.id,
         publicKey: identity.publicKey,
-        type: identity.type,
+        scope: identity.scope,
+        subtype: identity.subtype,
         tier: identity.tier,
         ...(chain ? { dfosDid: chain.dfosDid } : {}),
       },

--- a/apps/kernel/app/auth/api/identity/[did]/verify/route.ts
+++ b/apps/kernel/app/auth/api/identity/[did]/verify/route.ts
@@ -30,7 +30,8 @@ export async function GET(
       .select({
         id: identities.id,
         publicKey: identities.publicKey,
-        type: identities.type,
+        scope: identities.scope,
+        subtype: identities.subtype,
         tier: identities.tier,
       })
       .from(identities)

--- a/apps/kernel/app/auth/api/identity/present-chain/route.ts
+++ b/apps/kernel/app/auth/api/identity/present-chain/route.ts
@@ -57,7 +57,8 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
     if (existing) {
       const token = await createSessionToken({
         sub: existing.imajinDid,
-        type: existing.type,
+        scope: existing.scope || 'actor',
+        subtype: existing.subtype || undefined,
         tier: existing.tier as 'soft' | 'preliminary' | 'established',
       });
 
@@ -76,7 +77,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
 
     // 3. Check if the public key is already registered locally (same key, no chain yet)
     const [existingByKey] = await db
-      .select({ id: identities.id, type: identities.type, tier: identities.tier })
+      .select({ id: identities.id, scope: identities.scope, subtype: identities.subtype, tier: identities.tier })
       .from(identities)
       .where(eq(identities.publicKey, publicKeyHex))
       .limit(1);
@@ -91,7 +92,8 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
 
       const token = await createSessionToken({
         sub: existingByKey.id,
-        type: existingByKey.type,
+        scope: existingByKey.scope || 'actor',
+        subtype: existingByKey.subtype || undefined,
         tier: existingByKey.tier as 'soft' | 'preliminary' | 'established',
       });
 
@@ -115,7 +117,8 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
       .insert(identities)
       .values({
         id: imajinDid,
-        type: 'human',
+        scope: 'actor',
+        subtype: 'human',
         publicKey: publicKeyHex,
         tier: 'preliminary', // chain proves keypair, not standing on this network
       })
@@ -141,7 +144,8 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
     // 5. Create session
     const token = await createSessionToken({
       sub: identity.id,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype || undefined,
       tier: 'preliminary',
     });
 

--- a/apps/kernel/app/auth/api/login/mfa/route.ts
+++ b/apps/kernel/app/auth/api/login/mfa/route.ts
@@ -112,7 +112,8 @@ export async function POST(request: NextRequest) {
     const token = await createSessionToken({
       sub: identity.id,
       handle: identity.handle || undefined,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype || undefined,
       name: identity.name || undefined,
       tier: (identity.tier as 'soft' | 'preliminary' | 'established') || 'preliminary',
     });
@@ -121,7 +122,8 @@ export async function POST(request: NextRequest) {
     const response = NextResponse.json({
       did: identity.id,
       handle: identity.handle,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype,
       name: identity.name,
     }, { headers: cors });
 

--- a/apps/kernel/app/auth/api/login/verify/route.ts
+++ b/apps/kernel/app/auth/api/login/verify/route.ts
@@ -147,7 +147,8 @@ export async function POST(request: NextRequest) {
     const token = await createSessionToken({
       sub: identity.id,
       handle: identity.handle || undefined,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype || undefined,
       name: identity.name || undefined,
       tier: (identity.tier as 'soft' | 'preliminary' | 'established') || 'preliminary',
     });
@@ -157,7 +158,8 @@ export async function POST(request: NextRequest) {
     const response = NextResponse.json({
       did: identity.id,
       handle: identity.handle,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype,
       name: identity.name,
       dfosChainLinked,
     });

--- a/apps/kernel/app/auth/api/lookup/[id]/route.ts
+++ b/apps/kernel/app/auth/api/lookup/[id]/route.ts
@@ -35,7 +35,8 @@ export async function GET(
     const [identity] = await db
       .select({
         id: identities.id,
-        type: identities.type,
+        scope: identities.scope,
+        subtype: identities.subtype,
         handle: identities.handle,
         name: identities.name,
         avatarUrl: identities.avatarUrl,
@@ -59,7 +60,8 @@ export async function GET(
       did: identity.id,
       handle: identity.handle,
       name: identity.name,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype,
       tier: identity.tier,
       avatarUrl: identity.avatarUrl,
       metadata: identity.metadata,

--- a/apps/kernel/app/auth/api/magic/route.ts
+++ b/apps/kernel/app/auth/api/magic/route.ts
@@ -151,7 +151,8 @@ export async function GET(request: NextRequest) {
         .insert(identities)
         .values({
           id: ownerDid,
-          type: 'human',
+          scope: 'actor',
+          subtype: 'human',
           publicKey: `soft_${ownerDid}`, // Placeholder for soft identities
           metadata: { tier: 'soft', source: 'magic_link' },
         })
@@ -163,7 +164,8 @@ export async function GET(request: NextRequest) {
     // Create session token
     const sessionToken = await createSessionToken({
       sub: ownerDid,
-      type: 'human',
+      scope: 'actor',
+      subtype: 'human',
       tier: identityTier,
       handle: identity.handle || undefined,
       name: identity.name || undefined,

--- a/apps/kernel/app/auth/api/onboard/generate/route.ts
+++ b/apps/kernel/app/auth/api/onboard/generate/route.ts
@@ -9,7 +9,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { db, identities, credentials, groupControllers, profiles } from '@/src/db';
+import { db, identities, credentials, identityMembers, profiles } from '@/src/db';
 import { didFromPublicKey } from '@/src/lib/auth/crypto';
 import { createSessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
 import { emitAttestation } from '@imajin/auth';
@@ -110,16 +110,16 @@ export async function POST(request: NextRequest) {
     if (scopeDid && typeof scopeDid === 'string') {
       try {
         const [existingMember] = await db
-          .select({ removedAt: groupControllers.removedAt })
-          .from(groupControllers)
-          .where(and(eq(groupControllers.groupDid, scopeDid), eq(groupControllers.controllerDid, did)))
+          .select({ removedAt: identityMembers.removedAt })
+          .from(identityMembers)
+          .where(and(eq(identityMembers.identityDid, scopeDid), eq(identityMembers.memberDid, did)))
           .limit(1);
         if (!existingMember) {
-          await db.insert(groupControllers).values({ groupDid: scopeDid, controllerDid: did, role: 'member', addedBy: scopeDid });
+          await db.insert(identityMembers).values({ identityDid: scopeDid, memberDid: did, role: 'member', addedBy: scopeDid });
         } else if (existingMember.removedAt) {
-          await db.update(groupControllers)
+          await db.update(identityMembers)
             .set({ removedAt: null, role: 'member', addedBy: scopeDid, addedAt: new Date() })
-            .where(and(eq(groupControllers.groupDid, scopeDid), eq(groupControllers.controllerDid, did)));
+            .where(and(eq(identityMembers.identityDid, scopeDid), eq(identityMembers.memberDid, did)));
         }
       } catch (err) {
         log.error({ err: String(err) }, '[onboard/generate] Forest member add failed (non-fatal)');

--- a/apps/kernel/app/auth/api/onboard/generate/route.ts
+++ b/apps/kernel/app/auth/api/onboard/generate/route.ts
@@ -67,7 +67,8 @@ export async function POST(request: NextRequest) {
         .insert(identities)
         .values({
           id: did,
-          type: 'human',
+          scope: 'actor',
+          subtype: 'human',
           publicKey,
           name: name?.trim().slice(0, 100) || null,
           tier: 'soft',
@@ -90,7 +91,8 @@ export async function POST(request: NextRequest) {
     const tier = (identity.tier || 'soft') as 'soft' | 'preliminary' | 'established';
     const sessionToken = await createSessionToken({
       sub: did,
-      type: 'human',
+      scope: 'actor',
+      subtype: 'human',
       tier,
       handle: identity.handle || undefined,
       name: identity.name || undefined,
@@ -133,7 +135,6 @@ export async function POST(request: NextRequest) {
         await db.insert(profiles).values({
           did,
           displayName: name?.trim().slice(0, 100) || 'Anonymous',
-          displayType: 'human',
         }).onConflictDoNothing();
       } catch (err) {
         log.error({ err: String(err) }, '[onboard/generate] Profile creation failed (non-fatal)');

--- a/apps/kernel/app/auth/api/onboard/verify/route.ts
+++ b/apps/kernel/app/auth/api/onboard/verify/route.ts
@@ -93,7 +93,8 @@ export async function GET(request: NextRequest) {
               const identityTier = (identity.tier || 'soft') as 'soft' | 'preliminary' | 'established';
               const sessionToken = await createSessionToken({
                 sub: existingCred.did,
-                type: 'human',
+                scope: 'actor',
+                subtype: 'human',
                 tier: identityTier,
                 handle: identity.handle || undefined,
                 name: identity.name || undefined,
@@ -163,7 +164,8 @@ export async function GET(request: NextRequest) {
         .insert(identities)
         .values({
           id: did,
-          type: 'human',
+          scope: 'actor',
+          subtype: 'human',
           publicKey: placeholderKey,
           handle: null,
           name: record.name || null,
@@ -195,7 +197,8 @@ export async function GET(request: NextRequest) {
     const identityTier = (identity.tier || 'soft') as 'soft' | 'preliminary' | 'established';
     const sessionToken = await createSessionToken({
       sub: did,
-      type: 'human',
+      scope: 'actor',
+      subtype: 'human',
       tier: identityTier,
       handle: identity.handle || undefined,
       name: identity.name || undefined,

--- a/apps/kernel/app/auth/api/onboard/verify/route.ts
+++ b/apps/kernel/app/auth/api/onboard/verify/route.ts
@@ -6,7 +6,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/src/db';
-import { onboardTokens, identities, credentials, groupControllers } from '@/src/db';
+import { onboardTokens, identities, credentials, identityMembers } from '@/src/db';
 import { createSessionToken, getSessionCookieOptions, verifySessionToken } from '@/src/lib/auth/jwt';
 import { emitSessionAttestation } from '@/src/lib/auth/emit-session-attestation';
 import { emitAttestation } from '@imajin/auth';
@@ -222,16 +222,16 @@ export async function GET(request: NextRequest) {
       // Add as forest member directly (same-app operation)
       try {
         const [existing] = await db
-          .select({ removedAt: groupControllers.removedAt })
-          .from(groupControllers)
-          .where(and(eq(groupControllers.groupDid, scopeDid), eq(groupControllers.controllerDid, did)))
+          .select({ removedAt: identityMembers.removedAt })
+          .from(identityMembers)
+          .where(and(eq(identityMembers.identityDid, scopeDid), eq(identityMembers.memberDid, did)))
           .limit(1);
         if (!existing) {
-          await db.insert(groupControllers).values({ groupDid: scopeDid, controllerDid: did, role: 'member', addedBy: scopeDid });
+          await db.insert(identityMembers).values({ identityDid: scopeDid, memberDid: did, role: 'member', addedBy: scopeDid });
         } else if (existing.removedAt) {
-          await db.update(groupControllers)
+          await db.update(identityMembers)
             .set({ removedAt: null, role: 'member', addedBy: scopeDid, addedAt: new Date() })
-            .where(and(eq(groupControllers.groupDid, scopeDid), eq(groupControllers.controllerDid, did)));
+            .where(and(eq(identityMembers.identityDid, scopeDid), eq(identityMembers.memberDid, did)));
         }
       } catch (err) {
         log.error({ err: String(err) }, '[onboard/verify] Forest member add failed (non-fatal)');

--- a/apps/kernel/app/auth/api/register/route.ts
+++ b/apps/kernel/app/auth/api/register/route.ts
@@ -26,7 +26,8 @@ const events = createEmitter('kernel');
  *   publicKey: string (hex),
  *   handle?: string,
  *   name?: string,
- *   type: 'human' | 'agent' | 'presence' | 'org' | 'device' | 'service',
+ *   scope?: 'actor' | 'family' | 'community' | 'business' (default: 'actor'),
+ *   subtype?: string (default: 'human' for actor scope),
  *   signature: string (hex) - signs the payload,
  *   inviteCode?: string - required for new registrations
  * }
@@ -43,7 +44,9 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { publicKey, handle, name, type, signature, inviteCode, email, phone, optInUpdates } = body;
+    const { publicKey, handle, name, scope: rawScope, subtype: rawSubtype, signature, inviteCode, email, phone, optInUpdates } = body;
+    const scope = rawScope || 'actor';
+    const subtype = rawSubtype || (scope === 'actor' ? 'human' : null);
 
     // Validate required fields
     if (!publicKey || typeof publicKey !== 'string') {
@@ -53,11 +56,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Valid identity types
-    const validTypes = ['human', 'agent', 'presence', 'org', 'device', 'service', 'event'];
-    if (!type || !validTypes.includes(type)) {
+    // Valid identity scopes
+    const VALID_SCOPES = ['actor', 'family', 'community', 'business'];
+    if (!VALID_SCOPES.includes(scope)) {
       return NextResponse.json(
-        { error: `type required: ${validTypes.join(', ')}` },
+        { error: `scope must be one of: ${VALID_SCOPES.join(', ')}` },
         { status: 400 }
       );
     }
@@ -85,19 +88,22 @@ export async function POST(request: NextRequest) {
       publicKey,
       handle,
       name,
-      type,
+      scope,
+      subtype,
       timestamp: Math.floor(Date.now() / 1000),
     });
 
     // For registration, we accept any recent timestamp (within 5 minutes)
     // In production, you'd want stricter timestamp validation
-    
+
     const isValid = await verifySignature(payloadToSign, signature, publicKey);
     if (!isValid) {
-      // Also try without timestamp for simpler clients
-      const simplePayload = JSON.stringify({ publicKey, handle, name, type });
+      // Also try without timestamp for simpler clients (and legacy type-based payloads)
+      const simplePayload = JSON.stringify({ publicKey, handle, name, scope, subtype });
       const isValidSimple = await verifySignature(simplePayload, signature, publicKey);
-      if (!isValidSimple) {
+      const legacyPayload = JSON.stringify({ publicKey, handle, name, type: rawSubtype || 'human' });
+      const isValidLegacy = !isValidSimple && await verifySignature(legacyPayload, signature, publicKey);
+      if (!isValidSimple && !isValidLegacy) {
         return NextResponse.json(
           { error: 'Invalid signature' },
           { status: 401 }
@@ -136,7 +142,8 @@ export async function POST(request: NextRequest) {
         const token = await createSessionToken({
           sub: existing[0].id,
           handle: existing[0].handle || undefined,
-          type: existing[0].type,
+          scope: existing[0].scope,
+          subtype: existing[0].subtype || undefined,
           name: existing[0].name || undefined,
           tier: (existing[0].tier as 'soft' | 'preliminary' | 'established') || 'preliminary',
         });
@@ -145,7 +152,8 @@ export async function POST(request: NextRequest) {
         const response = NextResponse.json({
           did: existing[0].id,
           handle: existing[0].handle,
-          type: existing[0].type,
+          scope: existing[0].scope,
+          subtype: existing[0].subtype,
           created: false,
           message: 'Identity already exists',
           dfosChainLinked: existingDfosLinked,
@@ -165,7 +173,7 @@ export async function POST(request: NextRequest) {
     // Require invite code for new registrations (skip in dev with DISABLE_INVITE_GATE=true)
     // Service-to-service registrations (events, agents, etc.) bypass the invite gate
     const inviteGateDisabled = process.env.NEXT_PUBLIC_DISABLE_INVITE_GATE === 'true';
-    const isServiceRegistration = type && type !== 'human';
+    const isServiceRegistration = scope !== 'actor' || (subtype && subtype !== 'human');
     let inviteData: { fromDid: string; fromHandle?: string } | null = null;
 
     if (!isServiceRegistration && inviteCode) {
@@ -202,7 +210,8 @@ export async function POST(request: NextRequest) {
       .insert(identities)
       .values({
         id: did,
-        type,
+        scope,
+        subtype: subtype || null,
         publicKey,
         handle: handle || null,
         name: name?.trim().slice(0, 100) || null,
@@ -231,7 +240,8 @@ export async function POST(request: NextRequest) {
     const token = await createSessionToken({
       sub: identity.id,
       handle: identity.handle || undefined,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype || undefined,
       name: identity.name || undefined,
       tier: 'preliminary', // registrations with public keys are preliminary DIDs
     });
@@ -241,7 +251,8 @@ export async function POST(request: NextRequest) {
     const response = NextResponse.json({
       did: identity.id,
       handle: identity.handle,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype,
       created: true,
       inviteAccepted: false,
       dfosChainLinked,
@@ -249,7 +260,7 @@ export async function POST(request: NextRequest) {
 
     response.cookies.set(cookieConfig.name, token, cookieConfig.options);
 
-    events.emit({ action: 'identity.register', did: identity.id, payload: { identityType: type, tier: 'preliminary' } });
+    events.emit({ action: 'identity.register', did: identity.id, payload: { scope: identity.scope, subtype: identity.subtype, tier: 'preliminary' } });
 
     // Emit identity.created attestation → triggers 10 MJN emission
     emitAttestation({
@@ -258,7 +269,7 @@ export async function POST(request: NextRequest) {
       type: 'identity.created',
       context_id: identity.id,
       context_type: 'identity',
-      payload: { tier: 'preliminary', type: identity.type },
+      payload: { tier: 'preliminary', scope: identity.scope, subtype: identity.subtype },
     }).catch((err) => log.error({ err: String(err) }, '[register] Attestation (identity.created) error (non-fatal)'));
 
     // Emit identity.verified.preliminary → triggers 100 MJN emission
@@ -271,16 +282,14 @@ export async function POST(request: NextRequest) {
       type: 'identity.verified.preliminary',
       context_id: identity.id,
       context_type: 'identity',
-      payload: { tier: 'preliminary', type: identity.type },
+      payload: { tier: 'preliminary', scope: identity.scope, subtype: identity.subtype },
     }).catch((err) => log.error({ err: String(err) }, '[register] Attestation (identity.verified.preliminary) error (non-fatal)'));
 
     // Create profile row so the user is visible/discoverable
     try {
-      const displayType = ['human', 'agent', 'presence'].includes(type) ? type : 'human';
       await db.insert(profiles).values({
         did: identity.id,
         displayName: name?.trim().slice(0, 100) || handle || 'Anonymous',
-        displayType,
         handle: handle || null,
         contactEmail: email?.trim() || null,
         phone: phone?.trim() || null,
@@ -451,7 +460,8 @@ export async function POST(request: NextRequest) {
         const acceptedResponse = NextResponse.json({
           did: identity.id,
           handle: identity.handle,
-          type: identity.type,
+          scope: identity.scope,
+          subtype: identity.subtype,
           created: true,
           inviteAccepted: true,
           dfosChainLinked,

--- a/apps/kernel/app/auth/api/session/act-as/route.ts
+++ b/apps/kernel/app/auth/api/session/act-as/route.ts
@@ -2,12 +2,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { corsHeaders } from '@imajin/config';
 import { withLogger } from '@imajin/logger';
 import { requireAuth } from '@imajin/auth';
-import { db, groupControllers } from '@/src/db';
-import { eq, and, isNull } from 'drizzle-orm';
+import { db, identityMembers } from '@/src/db';
+import { eq, and, isNull, inArray } from 'drizzle-orm';
 
 export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
 }
+
+const ACT_AS_ROLES = ['owner', 'admin'];
 
 export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
   const cors = corsHeaders(request);
@@ -35,19 +37,20 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
   }
 
   try {
-    const controllers = await db
-      .select({ controllerDid: groupControllers.controllerDid })
-      .from(groupControllers)
+    const members = await db
+      .select({ memberDid: identityMembers.memberDid })
+      .from(identityMembers)
       .where(
         and(
-          eq(groupControllers.groupDid, did),
-          eq(groupControllers.controllerDid, caller.id),
-          isNull(groupControllers.removedAt)
+          eq(identityMembers.identityDid, did),
+          eq(identityMembers.memberDid, caller.id),
+          inArray(identityMembers.role, ACT_AS_ROLES),
+          isNull(identityMembers.removedAt)
         )
       )
       .limit(1);
 
-    if (controllers.length === 0) {
+    if (members.length === 0) {
       return NextResponse.json(
         { error: 'Not authorized to act as this identity' },
         { status: 403, headers: cors }

--- a/apps/kernel/app/auth/api/session/route.ts
+++ b/apps/kernel/app/auth/api/session/route.ts
@@ -57,7 +57,8 @@ export const GET = withLogger('kernel', async (request: NextRequest, { log }) =>
     return NextResponse.json({
       did: session.sub,
       handle: identity[0].handle || session.handle,
-      type: identity[0].type || session.type,
+      scope: identity[0].scope || session.scope,
+      subtype: identity[0].subtype || session.subtype || undefined,
       name: identity[0].name || session.name,
       role: metadata.role || 'member',
       tier,

--- a/apps/kernel/app/auth/api/session/soft/route.ts
+++ b/apps/kernel/app/auth/api/session/soft/route.ts
@@ -93,7 +93,8 @@ export async function POST(request: NextRequest) {
         .insert(identities)
         .values({
           id: did,
-          type: 'human',
+          scope: 'actor',
+          subtype: 'human',
           publicKey: placeholderKey,
           handle: null,
           name: name?.trim() || null,
@@ -118,7 +119,8 @@ export async function POST(request: NextRequest) {
     const token = await createSessionToken({
       sub: identity[0].id,
       handle: identity[0].handle || undefined,
-      type: identity[0].type,
+      scope: identity[0].scope,
+      subtype: identity[0].subtype || undefined,
       name: identity[0].name || undefined,
       tier: 'soft',
     });
@@ -127,7 +129,8 @@ export async function POST(request: NextRequest) {
     const response = NextResponse.json({
       did: identity[0].id,
       handle: identity[0].handle,
-      type: identity[0].type,
+      scope: identity[0].scope,
+      subtype: identity[0].subtype,
       name: identity[0].name,
       tier: 'soft',
     }, { headers: cors });

--- a/apps/kernel/app/auth/api/validate/route.ts
+++ b/apps/kernel/app/auth/api/validate/route.ts
@@ -63,7 +63,8 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
       valid: true,
       identity: {
         id: identity.id,
-        type: identity.type,
+        scope: identity.scope,
+        subtype: identity.subtype,
         name: identity.name,
         metadata: identity.metadata,
       },

--- a/apps/kernel/app/auth/api/verify/route.ts
+++ b/apps/kernel/app/auth/api/verify/route.ts
@@ -44,7 +44,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
       });
     }
 
-    const { from, type } = message;
+    const { from } = message;
 
     // Get identity from database
     const [identity] = await db
@@ -57,14 +57,6 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
       return NextResponse.json({
         valid: false,
         error: 'Identity not found',
-      });
-    }
-
-    // Verify type matches
-    if (identity.type !== type) {
-      return NextResponse.json({
-        valid: false,
-        error: 'Type mismatch',
       });
     }
 
@@ -82,7 +74,8 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
       valid: true,
       identity: {
         id: identity.id,
-        type: identity.type,
+        scope: identity.scope,
+        subtype: identity.subtype,
         name: identity.name,
         metadata: identity.metadata,
       },

--- a/apps/kernel/app/auth/components/IdentityDetail.tsx
+++ b/apps/kernel/app/auth/components/IdentityDetail.tsx
@@ -70,7 +70,7 @@ export default async function IdentityDetail({ did }: Props) {
           <span className="text-white font-medium">{attCount}</span>{' '}
           {attCount === 1 ? 'attestation' : 'attestations'}
         </span>
-        <span className="text-zinc-600 capitalize">{identity.type}</span>
+        <span className="text-zinc-600 capitalize">{identity.scope}{identity.subtype ? `/${identity.subtype}` : ''}</span>
       </div>
 
       {identity.createdAt && (

--- a/apps/kernel/app/auth/components/IdentitySwitcher.tsx
+++ b/apps/kernel/app/auth/components/IdentitySwitcher.tsx
@@ -3,13 +3,10 @@
 import { useIdentities } from '@imajin/ui';
 
 function scopeIcon(scope: string): string {
-  if (scope === 'community') return '🏛️';
-  if (scope === 'org') return '🏢';
+  if (scope === 'community') return '🌐';
+  if (scope === 'business') return '🏢';
   if (scope === 'family') return '👨‍👩‍👦';
-  if (scope === 'node') return '🖥️';
-  if (scope === 'agent') return '🤖';
-  if (scope === 'device') return '📱';
-  return '👥';
+  return '👤';
 }
 
 interface Props {
@@ -125,10 +122,10 @@ export default function IdentitySwitcher({
           <span className="text-base leading-none">+</span> Create Community Identity
         </a>
         <a
-          href="/auth/groups/new?scope=org"
+          href="/auth/groups/new?scope=business"
           className="flex items-center gap-2 px-3 py-2 text-xs text-zinc-500 hover:text-zinc-300 transition-colors rounded-lg no-underline"
         >
-          <span className="text-base leading-none">+</span> Create Organization
+          <span className="text-base leading-none">+</span> Create Business Identity
         </a>
       </div>
     </div>

--- a/apps/kernel/app/auth/components/PlacesMaintained.tsx
+++ b/apps/kernel/app/auth/components/PlacesMaintained.tsx
@@ -1,0 +1,85 @@
+import { db, identityMembers, profiles } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import Link from 'next/link';
+
+interface Props {
+  sessionDid: string;
+}
+
+/**
+ * Server component — lists stubs the current user maintains.
+ */
+export default async function PlacesMaintained({ sessionDid }: Props) {
+  let rows: Array<{
+    did: string;
+    name: string;
+    handle: string | null;
+    claimStatus: string | null;
+  }> = [];
+
+  try {
+    rows = await db
+      .select({
+        did: identityMembers.identityDid,
+        name: profiles.displayName,
+        handle: profiles.handle,
+        claimStatus: profiles.claimStatus,
+      })
+      .from(identityMembers)
+      .innerJoin(profiles, eq(profiles.did, identityMembers.identityDid))
+      .where(
+        and(
+          eq(identityMembers.memberDid, sessionDid),
+          eq(identityMembers.role, 'maintainer'),
+          isNull(identityMembers.removedAt)
+        )
+      );
+  } catch {
+    // Non-fatal — render nothing on DB error
+    return null;
+  }
+
+  return (
+    <div className="mt-4 border-t border-gray-800 pt-4">
+      <h2 className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-2 px-1">
+        Places I Maintain
+      </h2>
+
+      {rows.length === 0 ? (
+        <p className="px-3 py-2 text-xs text-zinc-600">No places yet.</p>
+      ) : (
+        <div className="space-y-0.5">
+          {rows.map((row) => (
+            <Link
+              key={row.did}
+              href={row.handle ? `/profile/${row.handle}` : `/profile/${row.did}`}
+              className="flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-zinc-800/60 transition-colors no-underline"
+            >
+              <span className="text-lg leading-none">🏢</span>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium text-white truncate">{row.name}</div>
+                {row.handle && (
+                  <div className="text-xs text-zinc-500 truncate">@{row.handle}</div>
+                )}
+              </div>
+              {row.claimStatus === 'unclaimed' && (
+                <span className="text-[10px] px-1.5 py-0.5 bg-amber-900/30 border border-amber-700/50 rounded text-amber-400 shrink-0">
+                  unclaimed
+                </span>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-2">
+        <Link
+          href="/profile/api/stubs/new"
+          className="flex items-center gap-2 px-3 py-2 text-xs text-zinc-500 hover:text-zinc-300 transition-colors rounded-lg no-underline"
+        >
+          <span className="text-base leading-none">+</span> Add a Place
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/components/PlacesMaintained.tsx
+++ b/apps/kernel/app/auth/components/PlacesMaintained.tsx
@@ -6,9 +6,6 @@ interface Props {
   sessionDid: string;
 }
 
-/**
- * Server component — lists stubs the current user maintains.
- */
 export default async function PlacesMaintained({ sessionDid }: Props) {
   let rows: Array<{
     did: string;

--- a/apps/kernel/app/auth/components/PlacesMaintained.tsx
+++ b/apps/kernel/app/auth/components/PlacesMaintained.tsx
@@ -35,7 +35,6 @@ export default async function PlacesMaintained({ sessionDid }: Props) {
         )
       );
   } catch {
-    // Non-fatal — render nothing on DB error
     return null;
   }
 

--- a/apps/kernel/app/auth/components/PlacesMaintained.tsx
+++ b/apps/kernel/app/auth/components/PlacesMaintained.tsx
@@ -74,7 +74,7 @@ export default async function PlacesMaintained({ sessionDid }: Props) {
 
       <div className="mt-2">
         <Link
-          href="/profile/api/stubs/new"
+          href="/auth/stubs/new"
           className="flex items-center gap-2 px-3 py-2 text-xs text-zinc-500 hover:text-zinc-300 transition-colors rounded-lg no-underline"
         >
           <span className="text-base leading-none">+</span> Add a Place

--- a/apps/kernel/app/auth/login/components/KeyAuthTab.tsx
+++ b/apps/kernel/app/auth/login/components/KeyAuthTab.tsx
@@ -83,7 +83,7 @@ async function loginWithKeypair(privateKeyHex: string): Promise<LoginResult> {
   }
 
   // Fallback: register (for new identities or if challenge fails)
-  const payload = JSON.stringify({ publicKey: publicKeyHex, type: 'human' });
+  const payload = JSON.stringify({ publicKey: publicKeyHex, scope: 'actor', subtype: 'human' });
   const msgBytes = new TextEncoder().encode(payload);
   const signatureBytes = await ed.signAsync(msgBytes, privateKeyBytes);
   const signature = Array.from(signatureBytes).map(b => b.toString(16).padStart(2, '0')).join('');
@@ -99,7 +99,7 @@ async function loginWithKeypair(privateKeyHex: string): Promise<LoginResult> {
   const authResponse = await fetch('/auth/api/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ publicKey: publicKeyHex, type: 'human', signature, dfosChain }),
+    body: JSON.stringify({ publicKey: publicKeyHex, scope: 'actor', subtype: 'human', signature, dfosChain }),
   });
 
   if (!authResponse.ok) {

--- a/apps/kernel/app/auth/page.tsx
+++ b/apps/kernel/app/auth/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import IdentitySwitcher from './components/IdentitySwitcher';
 import IdentityDetail from './components/IdentityDetail';
 import AttestationList from './components/AttestationList';
+import PlacesMaintained from './components/PlacesMaintained';
 
 interface SearchParams {
   type?: string;
@@ -76,6 +77,7 @@ export default async function AuthPage({ searchParams }: { searchParams: SearchP
             personalName={personalName}
             personalHandle={personalHandle}
           />
+          <PlacesMaintained sessionDid={sessionDid} />
         </div>
       </div>
 

--- a/apps/kernel/app/auth/register/page.tsx
+++ b/apps/kernel/app/auth/register/page.tsx
@@ -77,7 +77,8 @@ function RegisterPage() {
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
   const [optInUpdates, setOptInUpdates] = useState(false);
-  const [type, setType] = useState<'human' | 'agent'>('human');
+  const [scope] = useState<string>('actor');
+  const [subtype] = useState<string>('human');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [inviteInfo, setInviteInfo] = useState<InviteInfo | null>(null);
@@ -132,7 +133,8 @@ function RegisterPage() {
         publicKey: keypair.publicKey,
         handle: handle.toLowerCase(),
         name,
-        type,
+        scope,
+        subtype,
       };
       
       const signature = await sign(JSON.stringify(payload), keypair.privateKey);
@@ -404,14 +406,13 @@ function RegisterPage() {
           )}
 
           <div>
-            <label className="block text-sm font-medium mb-1">Type</label>
+            <label className="block text-sm font-medium mb-1">Account Type</label>
             <select
-              value={type}
-              onChange={(e) => setType(e.target.value as 'human' | 'agent')}
+              value={subtype}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+              disabled
             >
               <option value="human">👤 Human</option>
-              <option value="agent">🤖 Agent</option>
             </select>
           </div>
           

--- a/apps/kernel/app/auth/stubs/new/page.tsx
+++ b/apps/kernel/app/auth/stubs/new/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+
+const CATEGORY_PRESETS = ['café', 'restaurant', 'shop', 'venue', 'studio', 'bar', 'gallery', 'gym'];
+
+export default function NewStubPage() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('');
+  const [location, setLocation] = useState('');
+  const [handle, setHandle] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch('/profile/api/stubs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          name: name.trim(),
+          category: category.trim() || undefined,
+          location: location.trim() || undefined,
+          handle: handle.trim() || undefined,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Failed to create place');
+        return;
+      }
+
+      // Redirect to the new stub's profile
+      const dest = data.handle ? `/profile/${data.handle}` : `/profile/${data.did}`;
+      router.push(dest);
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="max-w-lg mx-auto py-8">
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8">
+        <h1 className="text-2xl font-bold text-white mb-1">Add a Place</h1>
+        <p className="text-zinc-400 text-sm mb-6">
+          Create a community-maintained stub for a business that isn&apos;t on Imajin yet.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* Name */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Name <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Rosetta Café"
+              maxLength={100}
+              required
+              className="w-full bg-zinc-900 border border-gray-700 rounded-lg px-4 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors"
+            />
+          </div>
+
+          {/* Category */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Category
+            </label>
+            <div className="flex flex-wrap gap-2 mb-2">
+              {CATEGORY_PRESETS.map((preset) => (
+                <button
+                  key={preset}
+                  type="button"
+                  onClick={() => setCategory(category === preset ? '' : preset)}
+                  className={`px-3 py-1 rounded-full text-xs border transition-colors ${
+                    category === preset
+                      ? 'bg-amber-500/20 border-amber-500/50 text-amber-400'
+                      : 'bg-zinc-900 border-gray-700 text-zinc-400 hover:border-gray-500'
+                  }`}
+                >
+                  {preset}
+                </button>
+              ))}
+            </div>
+            <input
+              type="text"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              placeholder="or type your own…"
+              maxLength={100}
+              className="w-full bg-zinc-900 border border-gray-700 rounded-lg px-4 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors"
+            />
+          </div>
+
+          {/* Location */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Location
+            </label>
+            <input
+              type="text"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="e.g. 123 Main St, Portland OR"
+              maxLength={200}
+              className="w-full bg-zinc-900 border border-gray-700 rounded-lg px-4 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors"
+            />
+          </div>
+
+          {/* Handle */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Handle <span className="text-zinc-600">(optional)</span>
+            </label>
+            <div className="relative">
+              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 text-sm">@</span>
+              <input
+                type="text"
+                value={handle}
+                onChange={(e) => setHandle(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
+                placeholder="rosetta_cafe"
+                maxLength={30}
+                pattern="[a-z0-9_]{3,30}"
+                className="w-full bg-zinc-900 border border-gray-700 rounded-lg pl-8 pr-4 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors"
+              />
+            </div>
+            <p className="mt-1 text-xs text-zinc-600">3–30 lowercase letters, numbers, or underscores</p>
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-400 bg-red-900/20 border border-red-800/40 rounded-lg px-4 py-3">
+              {error}
+            </p>
+          )}
+
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="flex-1 px-4 py-2.5 bg-zinc-900 border border-gray-700 rounded-lg text-zinc-400 hover:text-white hover:border-gray-500 transition-colors text-sm font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !name.trim()}
+              className="flex-1 px-4 py-2.5 bg-amber-500 hover:bg-amber-400 disabled:bg-amber-900/40 disabled:text-amber-700 text-black font-semibold rounded-lg transition-colors text-sm"
+            >
+              {submitting ? 'Creating…' : 'Add Place'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/chat/api/session/route.ts
+++ b/apps/kernel/app/chat/api/session/route.ts
@@ -32,7 +32,7 @@ export const GET = withLogger('kernel', async (request, { log }) => {
 
     if (!profile) {
       return NextResponse.json({
-        identity: { id: did, type: session.type }
+        identity: { id: did, scope: session.scope, subtype: session.subtype }
       });
     }
 
@@ -41,7 +41,8 @@ export const GET = withLogger('kernel', async (request, { log }) => {
         id: did,
         handle: profile.handle || session.handle,
         name: profile.displayName || session.name,
-        type: profile.displayType || session.type,
+        scope: session.scope,
+        subtype: session.subtype || undefined,
       }
     });
   } catch (error) {

--- a/apps/kernel/app/chat/components/NewChatModal.tsx
+++ b/apps/kernel/app/chat/components/NewChatModal.tsx
@@ -29,7 +29,7 @@ import { conversationPath } from '@/src/lib/chat/conversation-did';
 
 const SERVICE_PREFIX = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
-const CONNECTIONS_URL = buildPublicUrl('connections', SERVICE_PREFIX, DOMAIN);
+const CONNECTIONS_URL = '/connections';
 const AUTH_URL = buildPublicUrl('auth', SERVICE_PREFIX, DOMAIN);
 
 interface Connection {

--- a/apps/kernel/app/chat/components/NewChatModal.tsx
+++ b/apps/kernel/app/chat/components/NewChatModal.tsx
@@ -47,6 +47,9 @@ function displayName(conn: Connection): string {
   return conn.did.slice(0, 24) + '...';
 }
 
+// Module-level cache — survives modal open/close cycles within the same page session
+let _connectionsCache: { did: string; connections: Connection[] } | null = null;
+
 export function NewChatModal({ onClose }: { onClose: () => void }) {
   const router = useRouter();
   const { identity } = useIdentity();
@@ -63,6 +66,15 @@ export function NewChatModal({ onClose }: { onClose: () => void }) {
   const [groupName, setGroupName] = useState('');
 
   useEffect(() => {
+    if (!identity?.did) return;
+
+    // Return cached connections if we already fetched for this identity
+    if (_connectionsCache && _connectionsCache.did === identity.did) {
+      setConnections(_connectionsCache.connections);
+      setLoading(false);
+      return;
+    }
+
     async function loadConnections() {
       try {
         const connRes = await fetch(`${CONNECTIONS_URL}/api/connections`, {
@@ -99,7 +111,9 @@ export function NewChatModal({ onClose }: { onClose: () => void }) {
             seen.set(conn.did, conn);
           }
         }
-        setConnections(Array.from(seen.values()));
+        const result = Array.from(seen.values());
+        _connectionsCache = { did: identity!.did, connections: result };
+        setConnections(result);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load connections');
       } finally {
@@ -108,7 +122,7 @@ export function NewChatModal({ onClose }: { onClose: () => void }) {
     }
 
     loadConnections();
-  }, [identity]);
+  }, [identity?.did]);
 
   async function startDm(connection: Connection) {
     if (!identity) return;

--- a/apps/kernel/app/chat/components/NewChatModal.tsx
+++ b/apps/kernel/app/chat/components/NewChatModal.tsx
@@ -29,7 +29,7 @@ import { conversationPath } from '@/src/lib/chat/conversation-did';
 
 const SERVICE_PREFIX = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
 const DOMAIN = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
-const CONNECTIONS_URL = '/connections';
+const CONNECTIONS_URL = buildPublicUrl('connections');
 const AUTH_URL = buildPublicUrl('auth', SERVICE_PREFIX, DOMAIN);
 
 interface Connection {

--- a/apps/kernel/app/chat/conversations/[type]/[slug]/page.tsx
+++ b/apps/kernel/app/chat/conversations/[type]/[slug]/page.tsx
@@ -284,7 +284,7 @@ function DIDConversationView({ did }: { did: string }) {
   // Use same-origin proxy for access checks (cross-origin cookie forwarding is unreliable)
   const authUrl = '/chat';  // kernel: access route is at /chat/api/access/[did]
   const mediaUrl = MEDIA_URL;
-  const connectionsUrl = `${SERVICE_PREFIX}connections.${DOMAIN}`;
+  const connectionsUrl = '/connections';
 
   const displayName =
     convName ||

--- a/apps/kernel/app/chat/conversations/[type]/[slug]/page.tsx
+++ b/apps/kernel/app/chat/conversations/[type]/[slug]/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useIdentity, LoginPrompt } from '@/src/contexts/IdentityContext';
 import { Chat, ChatProvider, useDidNames } from '@imajin/chat';
 import { useToast } from '@imajin/ui';
+import { buildPublicUrl } from '@imajin/config';
 
 // Inline DID parser (avoids importing Node.js crypto in client bundle)
 function parseConvDid(did: string): { type: string; slug?: string } {
@@ -284,7 +285,7 @@ function DIDConversationView({ did }: { did: string }) {
   // Use same-origin proxy for access checks (cross-origin cookie forwarding is unreliable)
   const authUrl = '/chat';  // kernel: access route is at /chat/api/access/[did]
   const mediaUrl = MEDIA_URL;
-  const connectionsUrl = '/connections';
+  const connectionsUrl = buildPublicUrl('connections');
 
   const displayName =
     convName ||

--- a/apps/kernel/app/media/page.tsx
+++ b/apps/kernel/app/media/page.tsx
@@ -16,7 +16,8 @@ export default async function Page() {
 
   const identity: Identity = {
     id: session.did,
-    type: session.type as Identity["type"],
+    scope: session.scope,
+    subtype: session.subtype,
     name: session.name,
     handle: session.handle,
     tier: session.tier as Identity["tier"],

--- a/apps/kernel/app/page.tsx
+++ b/apps/kernel/app/page.tsx
@@ -15,20 +15,23 @@ async function getNetworkStats() {
 
     const [humans] = await sql`
       SELECT COUNT(*)::int as count
-      FROM profile.profiles
-      WHERE display_type = 'human'
+      FROM profile.profiles p
+      JOIN auth.identities i ON i.id = p.did
+      WHERE i.scope = 'actor' AND i.subtype = 'human'
     `;
 
     const [businesses] = await sql`
       SELECT COUNT(*)::int as count
-      FROM profile.profiles
-      WHERE display_type = 'org'
+      FROM profile.profiles p
+      JOIN auth.identities i ON i.id = p.did
+      WHERE i.scope IN ('business', 'community', 'family')
     `;
 
     const [presences] = await sql`
       SELECT COUNT(*)::int as count
-      FROM profile.profiles
-      WHERE display_type IN ('presence', 'agent', 'device', 'service')
+      FROM profile.profiles p
+      JOIN auth.identities i ON i.id = p.did
+      WHERE i.scope = 'actor' AND i.subtype IN ('presence', 'agent', 'device')
     `;
 
     return {

--- a/apps/kernel/app/pay/api/connect/onboard/route.ts
+++ b/apps/kernel/app/pay/api/connect/onboard/route.ts
@@ -38,10 +38,10 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
   }
   const { identity } = authResult;
 
-  // Must be a human (hard DID), not an agent
-  if (identity.type !== 'human') {
+  // Must be an actor (human), not a group identity
+  if (identity.scope !== 'actor') {
     return NextResponse.json(
-      { error: 'Forbidden - only human accounts can onboard to Stripe Connect' },
+      { error: 'Forbidden - only actor accounts can onboard to Stripe Connect' },
       { status: 403, headers: cors }
     );
   }

--- a/apps/kernel/app/profile/[handle]/page.tsx
+++ b/apps/kernel/app/profile/[handle]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import { SESSION_COOKIE_NAME } from '@imajin/config';
+import { SESSION_COOKIE_NAME, buildPublicUrl } from '@imajin/config';
 import { db, profiles, follows, connections, identityMembers } from '@/src/db';
 import { getClient } from '@imajin/db';
 import { eq, count, and, isNull } from 'drizzle-orm';
@@ -228,7 +228,7 @@ export default async function ProfilePage({ params }: PageProps) {
             </p>
             {!viewerDid && (
               <a
-                href={`${process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://'}auth.${process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai'}/login`}
+                href={`${buildPublicUrl('auth')}/login`}
                 className="inline-block mt-4 px-6 py-2 bg-[#F59E0B] text-black rounded-lg hover:bg-[#D97706] transition font-medium text-sm"
               >
                 Login to see more

--- a/apps/kernel/app/profile/[handle]/page.tsx
+++ b/apps/kernel/app/profile/[handle]/page.tsx
@@ -3,9 +3,9 @@ import { cookies } from 'next/headers';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import { SESSION_COOKIE_NAME } from '@imajin/config';
-import { db, profiles, follows, connections } from '@/src/db';
+import { db, profiles, follows, connections, identityMembers } from '@/src/db';
 import { getClient } from '@imajin/db';
-import { eq, count } from 'drizzle-orm';
+import { eq, count, and, isNull } from 'drizzle-orm';
 import { getSessionFromCookies } from '@/src/lib/kernel/session';
 import { Avatar } from '../components/Avatar';
 import { FollowButton } from '../components/FollowButton';
@@ -39,6 +39,7 @@ interface Profile {
   featureToggles?: FeatureToggles;
   createdAt: string;
   metadata?: Record<string, string>;
+  claimStatus?: string | null;
 }
 
 interface ProfileCounts {
@@ -248,6 +249,43 @@ export default async function ProfilePage({ params }: PageProps) {
   const [chainRow] = await authSql`SELECT did FROM auth.identity_chains WHERE did = ${profile.did} LIMIT 1`.catch(() => []);
   const chainVerified = !!chainRow;
 
+  // Stub metadata for unclaimed business profiles
+  let maintainerCount = 0;
+  let isMaintainer = false;
+  if (identityScope === 'business' && profile.claimStatus === 'unclaimed') {
+    try {
+      const [{ value: mc }] = await db
+        .select({ value: count() })
+        .from(identityMembers)
+        .where(
+          and(
+            eq(identityMembers.identityDid, profile.did),
+            eq(identityMembers.role, 'maintainer'),
+            isNull(identityMembers.removedAt)
+          )
+        );
+      maintainerCount = mc;
+
+      if (viewerDid && !isSelf) {
+        const [maintainerRow] = await db
+          .select({ identityDid: identityMembers.identityDid })
+          .from(identityMembers)
+          .where(
+            and(
+              eq(identityMembers.identityDid, profile.did),
+              eq(identityMembers.memberDid, viewerDid),
+              eq(identityMembers.role, 'maintainer'),
+              isNull(identityMembers.removedAt)
+            )
+          )
+          .limit(1);
+        isMaintainer = !!maintainerRow;
+      }
+    } catch {
+      // Non-fatal
+    }
+  }
+
   // Fetch counts, follow status, and links in parallel
   const [counts, isFollowing, links] = await Promise.all([
     getProfileCounts(profile.did),
@@ -273,7 +311,7 @@ export default async function ProfilePage({ params }: PageProps) {
         )}
 
         {/* Type badge & Identity Tier */}
-        <div className="flex gap-2 justify-center mb-4">
+        <div className="flex gap-2 justify-center mb-4 flex-wrap">
           <span className="inline-block px-3 py-1 bg-gray-900 border border-gray-800 rounded-full text-sm text-gray-300">
             {typeLabel}
           </span>
@@ -287,7 +325,35 @@ export default async function ProfilePage({ params }: PageProps) {
               ⛓ Chain Verified
             </span>
           )}
+          {identityScope === 'business' && profile.claimStatus === 'unclaimed' && (
+            <span className="inline-block px-3 py-1 bg-sky-900/30 border border-sky-700/50 rounded-full text-sm text-sky-400">
+              🤝 Community-maintained
+            </span>
+          )}
         </div>
+
+        {/* Unclaimed stub — maintainer info + join CTA */}
+        {identityScope === 'business' && profile.claimStatus === 'unclaimed' && (
+          <div className="mb-4 bg-sky-950/30 border border-sky-800/40 rounded-xl px-4 py-3 text-sm text-sky-300">
+            <p className="mb-1">
+              This place is community-maintained.{' '}
+              <span className="text-sky-400 font-medium">{maintainerCount} maintainer{maintainerCount !== 1 ? 's' : ''}</span> keeping it up to date.
+            </p>
+            {viewerDid && !isMaintainer && (
+              <form action={`/profile/api/stubs/${encodeURIComponent(profile.did)}/join`} method="POST">
+                <button
+                  type="submit"
+                  className="mt-2 px-4 py-1.5 bg-sky-700 hover:bg-sky-600 text-white rounded-lg text-xs font-medium transition-colors"
+                >
+                  Help maintain this place
+                </button>
+              </form>
+            )}
+            {viewerDid && isMaintainer && (
+              <p className="mt-1 text-xs text-sky-500">You are a maintainer of this place.</p>
+            )}
+          </div>
+        )}
 
         {/* Counts & Follow Button */}
         <div className="mb-6 flex flex-col items-center gap-3">

--- a/apps/kernel/app/profile/[handle]/page.tsx
+++ b/apps/kernel/app/profile/[handle]/page.tsx
@@ -31,7 +31,6 @@ interface Profile {
   did: string;
   handle?: string;
   displayName: string;
-  displayType: 'human' | 'presence' | 'agent' | 'device' | 'org' | 'event' | 'service';
   bio?: string;
   avatar?: string;
   email?: string;
@@ -125,6 +124,33 @@ async function getLinks(linksHandle: string): Promise<LinkItem[]> {
   } catch { return []; }
 }
 
+function getScopeEmoji(scope: string, subtype: string | null): string {
+  if (scope === 'actor') {
+    const map: Record<string, string> = { human: '👤', agent: '🤖', device: '📱', presence: '🟠' };
+    return map[subtype ?? 'human'] ?? '👤';
+  }
+  const map: Record<string, string> = { business: '🏢', family: '👨‍👩‍👧‍👦', community: '🌐' };
+  return map[scope] ?? '👤';
+}
+
+function getScopeLabel(scope: string, subtype: string | null): string {
+  if (scope === 'actor') {
+    const map: Record<string, string> = {
+      human: '👤 Human',
+      agent: '🤖 Agent',
+      device: '📱 Device',
+      presence: '🟠 Presence',
+    };
+    return map[subtype ?? 'human'] ?? '👤 Human';
+  }
+  const map: Record<string, string> = {
+    business: '🏢 Business',
+    family: '👨‍👩‍👧‍👦 Family',
+    community: '🌐 Community',
+  };
+  return map[scope] ?? scope;
+}
+
 // Generate dynamic metadata for OG/Twitter cards
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { handle } = await params;
@@ -136,20 +162,19 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     };
   }
 
-  const typeEmoji: Record<string, string> = {
-    human: '👤',
-    presence: '🟠',
-    agent: '🤖',
-    device: '📱',
-    org: '🏢',
-    event: '📅',
-    service: '⚙️',
-  };
+  // Fetch identity scope+subtype for metadata
+  const authSqlMeta = getClient();
+  const [idRowMeta] = await authSqlMeta`
+    SELECT scope, subtype FROM auth.identities WHERE id = ${profile.did} LIMIT 1
+  `.catch(() => []);
+  const metaScope: string = idRowMeta?.scope ?? 'actor';
+  const metaSubtype: string | null = idRowMeta?.subtype ?? null;
+  const emoji = getScopeEmoji(metaScope, metaSubtype);
 
   const displayHandle = profile.handle ? `@${profile.handle}` : handle;
   const description = profile.bio
     ? profile.bio.slice(0, 200) + (profile.bio.length > 200 ? '...' : '')
-    : `${typeEmoji[profile.displayType]} ${profile.displayType} on the Imajin network`;
+    : `${emoji} ${metaSubtype ?? metaScope} on the Imajin network`;
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://profile.imajin.ai';
   const url = `${baseUrl}/${handle}`;
@@ -158,7 +183,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     title: `${profile.displayName} (${displayHandle})`,
     description,
     openGraph: {
-      title: `${profile.displayName} ${typeEmoji[profile.displayType]}`,
+      title: `${profile.displayName} ${emoji}`,
       description,
       url,
       siteName: 'Imajin Profiles',
@@ -167,7 +192,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: profile.avatar?.startsWith('http') ? 'summary_large_image' : 'summary',
-      title: `${profile.displayName} ${typeEmoji[profile.displayType]}`,
+      title: `${profile.displayName} ${emoji}`,
       description,
       images: profile.avatar?.startsWith('http') ? [profile.avatar] : undefined,
     },
@@ -214,19 +239,11 @@ export default async function ProfilePage({ params }: PageProps) {
     );
   }
 
-  const typeLabels: Record<string, string> = {
-    human: '👤 Human',
-    presence: '🟠 Presence',
-    agent: '🤖 Agent',
-    device: '📱 Device',
-    org: '🏢 Organization',
-    event: '📅 Event',
-    service: '⚙️ Service',
-  };
-  const typeLabel = typeLabels[profile.displayType];
-
   const authSql = getClient();
-  const [identityRow] = await authSql`SELECT tier FROM auth.identities WHERE id = ${profile.did} LIMIT 1`.catch(() => []);
+  const [identityRow] = await authSql`SELECT tier, scope, subtype FROM auth.identities WHERE id = ${profile.did} LIMIT 1`.catch(() => []);
+  const identityScope: string = identityRow?.scope ?? 'actor';
+  const identitySubtype: string | null = identityRow?.subtype ?? null;
+  const typeLabel = getScopeLabel(identityScope, identitySubtype);
   const isSoftDID = identityRow?.tier === 'soft';
   const [chainRow] = await authSql`SELECT did FROM auth.identity_chains WHERE did = ${profile.did} LIMIT 1`.catch(() => []);
   const chainVerified = !!chainRow;

--- a/apps/kernel/app/profile/api/forest/[groupDid]/config/route.ts
+++ b/apps/kernel/app/profile/api/forest/[groupDid]/config/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, forestConfig, groupControllers } from '@/src/db';
+import { db, forestConfig, identityMembers } from '@/src/db';
 import { eq, and, isNull } from 'drizzle-orm';
 import { requireAuth } from '@imajin/auth';
 import { SERVICES } from '@imajin/config';
@@ -16,13 +16,13 @@ async function verifyController(
 ): Promise<{ valid: boolean; role?: string }> {
   try {
     const [membership] = await db
-      .select({ role: groupControllers.role })
-      .from(groupControllers)
+      .select({ role: identityMembers.role })
+      .from(identityMembers)
       .where(
         and(
-          eq(groupControllers.groupDid, groupDid),
-          eq(groupControllers.controllerDid, callerDid),
-          isNull(groupControllers.removedAt)
+          eq(identityMembers.identityDid, groupDid),
+          eq(identityMembers.memberDid, callerDid),
+          isNull(identityMembers.removedAt)
         )
       )
       .limit(1);

--- a/apps/kernel/app/profile/api/profile/[id]/route.ts
+++ b/apps/kernel/app/profile/api/profile/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha2.js';
-import { db, profiles, connections } from '@/src/db';
+import { db, profiles, connections, identityMembers } from '@/src/db';
 import { requireAuth } from '@imajin/auth';
 import { corsOptions, corsHeaders } from "@/src/lib/kernel/cors";
-import { eq, or, and, isNull } from 'drizzle-orm';
+import { eq, or, and, isNull, count } from 'drizzle-orm';
 import { getSessionFromCookies } from '@/src/lib/kernel/session';
 import { createLogger } from '@imajin/logger';
 import { createEmitter } from '@imajin/events';
@@ -127,13 +127,46 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Gate contact info: only visible to self or connections
     const result: Record<string, any> = { ...profile };
+    let viewerDid: string | null = null;
     if (profile.contactEmail || profile.phone) {
-      const viewerDid = await getViewerDid(request);
+      viewerDid = await getViewerDid(request);
       const isSelf = viewerDid === profile.did;
       const connected = viewerDid && !isSelf ? await checkConnected(viewerDid, profile.did) : false;
       if (!isSelf && !connected) {
         delete result.contactEmail;
         delete result.phone;
+      }
+    }
+
+    // Stub metadata for business profiles
+    if (profile.claimStatus) {
+      const [{ value: maintainerCount }] = await db
+        .select({ value: count() })
+        .from(identityMembers)
+        .where(
+          and(
+            eq(identityMembers.identityDid, profile.did),
+            eq(identityMembers.role, 'maintainer'),
+            isNull(identityMembers.removedAt)
+          )
+        );
+      result.maintainerCount = maintainerCount;
+
+      if (!viewerDid) viewerDid = await getViewerDid(request);
+      if (viewerDid) {
+        const [isMaintainerRow] = await db
+          .select({ identityDid: identityMembers.identityDid })
+          .from(identityMembers)
+          .where(
+            and(
+              eq(identityMembers.identityDid, profile.did),
+              eq(identityMembers.memberDid, viewerDid),
+              eq(identityMembers.role, 'maintainer'),
+              isNull(identityMembers.removedAt)
+            )
+          )
+          .limit(1);
+        result.isMaintainer = !!isMaintainerRow;
       }
     }
 

--- a/apps/kernel/app/profile/api/profile/[id]/route.ts
+++ b/apps/kernel/app/profile/api/profile/[id]/route.ts
@@ -192,7 +192,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     const body = JSON.parse(bodyText);
-    const { displayName, displayType, avatar, avatarAssetId, bio, email, phone, visibility, feature_toggles } = body;
+    const { displayName, avatar, avatarAssetId, bio, email, phone, visibility, feature_toggles } = body;
 
     // Build update object
     const updates: Record<string, any> = {
@@ -200,12 +200,6 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     };
 
     if (displayName !== undefined) updates.displayName = displayName;
-    if (displayType !== undefined) {
-      if (!['human', 'agent', 'presence'].includes(displayType)) {
-        return NextResponse.json({ error: 'displayType must be human, agent, or presence' }, { status: 400, headers: cors });
-      }
-      updates.displayType = displayType;
-    }
     if (avatar !== undefined) updates.avatar = avatar;
     if (avatarAssetId !== undefined) updates.avatarAssetId = avatarAssetId;
     if (bio !== undefined) updates.bio = bio;

--- a/apps/kernel/app/profile/api/profile/route.ts
+++ b/apps/kernel/app/profile/api/profile/route.ts
@@ -18,15 +18,11 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
 
   try {
     const body = await request.json();
-    const { displayName, displayType, avatar, avatarAssetId, bio, handle, metadata, email, phone, optInUpdates } = body;
+    const { displayName, avatar, avatarAssetId, bio, handle, metadata, email, phone, optInUpdates } = body;
 
     // Validate required fields
     if (!displayName) {
       return errorResponse('displayName is required');
-    }
-
-    if (!displayType || !['human', 'agent', 'presence'].includes(displayType)) {
-      return errorResponse('displayType must be human, agent, or presence');
     }
 
     // Validate handle format if provided
@@ -58,7 +54,6 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
     const result = await db.insert(profiles).values({
       did: identity.id,
       displayName,
-      displayType,
       avatar: avatar || null,
       avatarAssetId: avatarAssetId || null,
       bio: bio || null,

--- a/apps/kernel/app/profile/api/profile/search/route.ts
+++ b/apps/kernel/app/profile/api/profile/search/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest } from 'next/server';
 import { db, profiles } from '@/src/db';
 import { jsonResponse, errorResponse } from '@/src/lib/kernel/utils';
-import { ilike, eq, or, sql, type SQL } from 'drizzle-orm';
+import { ilike, or, sql, type SQL } from 'drizzle-orm';
 import { withLogger } from '@imajin/logger';
 
 /**
  * GET /api/profile/search - Search profiles
- * 
+ *
  * Query params:
- * - q: search query (searches displayName and bio)
- * - type: filter by displayType (human, agent, presence)
+ * - q: search query (searches displayName and handle)
  * - limit: max results (default 20, max 100)
  * - offset: pagination offset
  */
@@ -17,7 +16,6 @@ export const GET = withLogger('kernel', async (request: NextRequest, { log }) =>
   const searchParams = request.nextUrl.searchParams;
 
   const q = searchParams.get('q');
-  const type = searchParams.get('type');
   const limit = Math.min(parseInt(searchParams.get('limit') || '20'), 100);
   const offset = parseInt(searchParams.get('offset') || '0');
 
@@ -26,19 +24,12 @@ export const GET = withLogger('kernel', async (request: NextRequest, { log }) =>
     const conditions: SQL[] = [];
 
     if (q) {
-      // Simple search on displayName and bio
+      // Simple search on displayName and handle
       const searchCondition = or(
         ilike(profiles.handle, `%${q}%`),
         ilike(profiles.displayName, `%${q}%`),
       );
       if (searchCondition) conditions.push(searchCondition);
-    }
-
-    if (type) {
-      if (!['human', 'agent', 'presence'].includes(type)) {
-        return errorResponse('Invalid type filter');
-      }
-      conditions.push(eq(profiles.displayType, type));
     }
 
     // Execute query

--- a/apps/kernel/app/profile/api/register/route.ts
+++ b/apps/kernel/app/profile/api/register/route.ts
@@ -115,11 +115,10 @@ export async function POST(request: NextRequest) {
       return errorResponse('Profile already exists for this public key', 409);
     }
 
-    // Create profile with 'human' as default display type
+    // Create profile
     const result = await db.insert(profiles).values({
       did,
       displayName,
-      displayType: 'human',
       avatar: avatar || null,
       bio: bio || null,
       handle: handle || null,

--- a/apps/kernel/app/profile/api/soft-register/route.ts
+++ b/apps/kernel/app/profile/api/soft-register/route.ts
@@ -67,7 +67,6 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
     await db.insert(profiles).values({
       did,
       displayName,
-      displayType: 'human',
       metadata: {
         isGuest: true,
         email: email || undefined,

--- a/apps/kernel/app/profile/api/stubs/[did]/join/route.ts
+++ b/apps/kernel/app/profile/api/stubs/[did]/join/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, identityMembers, profiles } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import { requireAuth } from '@imajin/auth';
+import { createLogger } from '@imajin/logger';
+
+const log = createLogger('kernel');
+
+interface RouteParams {
+  params: Promise<{ did: string }>;
+}
+
+/**
+ * POST /api/stubs/:did/join
+ * Join as a maintainer of an unclaimed stub.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { did } = await params;
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+
+  try {
+    // Verify stub exists and is unclaimed
+    const stub = await db.query.profiles.findFirst({
+      where: (p, { eq }) => eq(p.did, did),
+    });
+
+    if (!stub) {
+      return NextResponse.json({ error: 'Stub not found' }, { status: 404 });
+    }
+    if (stub.claimStatus !== 'unclaimed') {
+      return NextResponse.json({ error: 'This place has already been claimed' }, { status: 409 });
+    }
+
+    // Check caller isn't already a member
+    const [existing] = await db
+      .select({ identityDid: identityMembers.identityDid })
+      .from(identityMembers)
+      .where(
+        and(
+          eq(identityMembers.identityDid, did),
+          eq(identityMembers.memberDid, caller.id),
+          isNull(identityMembers.removedAt)
+        )
+      )
+      .limit(1);
+
+    if (existing) {
+      return NextResponse.json({ error: 'Already a maintainer of this place' }, { status: 409 });
+    }
+
+    // Insert maintainer membership
+    await db.insert(identityMembers).values({
+      identityDid: did,
+      memberDid: caller.id,
+      role: 'maintainer',
+      addedBy: caller.id,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    log.error({ err: String(error) }, '[stubs/join] Error');
+    return NextResponse.json({ error: 'Failed to join stub' }, { status: 500 });
+  }
+}

--- a/apps/kernel/app/profile/api/stubs/mine/route.ts
+++ b/apps/kernel/app/profile/api/stubs/mine/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, identityMembers, profiles } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import { requireAuth } from '@imajin/auth';
+import { createLogger } from '@imajin/logger';
+
+const log = createLogger('kernel');
+
+/**
+ * GET /api/stubs/mine
+ * List stubs the authenticated caller maintains.
+ */
+export async function GET(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+
+  try {
+    const rows = await db
+      .select({
+        did: identityMembers.identityDid,
+        role: identityMembers.role,
+        name: profiles.displayName,
+        handle: profiles.handle,
+        metadata: profiles.metadata,
+        claimStatus: profiles.claimStatus,
+      })
+      .from(identityMembers)
+      .innerJoin(profiles, eq(profiles.did, identityMembers.identityDid))
+      .where(
+        and(
+          eq(identityMembers.memberDid, caller.id),
+          eq(identityMembers.role, 'maintainer'),
+          isNull(identityMembers.removedAt)
+        )
+      );
+
+    return NextResponse.json(rows);
+  } catch (error) {
+    log.error({ err: String(error) }, '[stubs/mine] List error');
+    return NextResponse.json({ error: 'Failed to list maintained stubs' }, { status: 500 });
+  }
+}

--- a/apps/kernel/app/profile/api/stubs/route.ts
+++ b/apps/kernel/app/profile/api/stubs/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, identities, storedKeys, identityMembers, profiles, attestations } from '@/src/db';
+import { eq, and, isNull, count } from 'drizzle-orm';
+import { requireAuth } from '@imajin/auth';
+import { generateKeypair } from '@imajin/auth';
+import { didFromPublicKey, encryptPrivateKey } from '@/src/lib/auth/crypto';
+import { emitAttestation } from '@imajin/auth';
+import { createLogger } from '@imajin/logger';
+
+const log = createLogger('kernel');
+
+const MAX_STUBS_PER_ACTOR = 10;
+
+function genId(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
+}
+
+/**
+ * POST /api/stubs
+ * Create a stub business identity.
+ * Only actor-scoped identities (humans) can create stubs.
+ */
+export async function POST(request: NextRequest) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+  const { identity: caller } = authResult;
+
+  // Only actors can create stubs
+  if (caller.scope !== 'actor') {
+    return NextResponse.json({ error: 'Only actor identities can create stubs' }, { status: 403 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { name, subtype, handle, location, category } = body as {
+    name?: string;
+    subtype?: string;
+    handle?: string;
+    location?: string;
+    category?: string;
+  };
+
+  if (!name || typeof name !== 'string' || !name.trim()) {
+    return NextResponse.json({ error: 'name required' }, { status: 400 });
+  }
+  if (handle && !/^[a-z0-9_]{3,30}$/.test(handle)) {
+    return NextResponse.json(
+      { error: 'Handle must be 3-30 lowercase letters, numbers, or underscores' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Rate limit: max MAX_STUBS_PER_ACTOR stubs per actor
+    const [{ value: stubCount }] = await db
+      .select({ value: count() })
+      .from(identityMembers)
+      .where(
+        and(
+          eq(identityMembers.memberDid, caller.id),
+          eq(identityMembers.role, 'maintainer'),
+          isNull(identityMembers.removedAt)
+        )
+      );
+    if (stubCount >= MAX_STUBS_PER_ACTOR) {
+      return NextResponse.json(
+        { error: `Maximum of ${MAX_STUBS_PER_ACTOR} maintained places reached` },
+        { status: 429 }
+      );
+    }
+
+    // Check handle uniqueness
+    if (handle) {
+      const existing = await db
+        .select({ id: identities.id })
+        .from(identities)
+        .where(eq(identities.handle, handle))
+        .limit(1);
+      if (existing.length > 0) {
+        return NextResponse.json({ error: 'Handle already taken' }, { status: 409 });
+      }
+    }
+
+    // Generate Ed25519 keypair server-side
+    const { privateKey, publicKey } = generateKeypair();
+    const stubDid = didFromPublicKey(publicKey);
+
+    // Encrypt and store private key
+    const { encryptedKey, salt } = await encryptPrivateKey(privateKey);
+    const keyId = genId('key');
+
+    const trimmedName = name.trim().slice(0, 100);
+
+    // Store identity
+    await db.insert(identities).values({
+      id: stubDid,
+      scope: 'business',
+      subtype: (subtype as string) || null,
+      publicKey,
+      handle: handle || null,
+      name: trimmedName,
+      tier: 'preliminary',
+    });
+
+    // Store encrypted private key
+    await db.insert(storedKeys).values({
+      id: keyId,
+      did: stubDid,
+      encryptedKey,
+      salt,
+      keyDerivation: 'pbkdf2',
+    });
+
+    // Create profile
+    const metadata: Record<string, string> = {};
+    if (location) metadata.location = String(location).slice(0, 200);
+    if (category) metadata.category = String(category).slice(0, 100);
+
+    await db.insert(profiles).values({
+      did: stubDid,
+      displayName: trimmedName,
+      handle: handle || null,
+      metadata,
+      claimStatus: 'unclaimed',
+    }).onConflictDoNothing();
+
+    // Add creator as maintainer (not owner — no act-as)
+    await db.insert(identityMembers).values({
+      identityDid: stubDid,
+      memberDid: caller.id,
+      role: 'maintainer',
+      addedBy: caller.id,
+    });
+
+    // Emit attestation (fire-and-forget)
+    emitAttestation({
+      issuer_did: caller.id,
+      subject_did: stubDid,
+      type: 'stub.created',
+      context_id: stubDid,
+      context_type: 'stub',
+      payload: { name: trimmedName, handle: handle || null, category: category || null },
+    }).catch((err) => log.error({ err: String(err) }, '[stubs] Attestation failed (non-fatal)'));
+
+    return NextResponse.json(
+      { did: stubDid, name: trimmedName, handle: handle || null, scope: 'business', claimStatus: 'unclaimed' },
+      { status: 201 }
+    );
+  } catch (error) {
+    log.error({ err: String(error) }, '[stubs] Create error');
+    return NextResponse.json({ error: 'Failed to create stub' }, { status: 500 });
+  }
+}

--- a/apps/kernel/app/profile/context/IdentityContext.tsx
+++ b/apps/kernel/app/profile/context/IdentityContext.tsx
@@ -150,7 +150,8 @@ export function IdentityProvider({ children }: { children: ReactNode }) {
         publicKey: publicKeyHex,
         handle: profile.handle || undefined,
         name: profile.displayName,
-        type: 'human',
+        scope: 'actor',
+        subtype: 'human',
       });
       const msgBytes = new TextEncoder().encode(payload);
       const signatureBytes = await ed.signAsync(msgBytes, privateKeyBytes);
@@ -163,7 +164,8 @@ export function IdentityProvider({ children }: { children: ReactNode }) {
           publicKey: publicKeyHex,
           handle: profile.handle || undefined,
           name: profile.displayName,
-          type: 'human',
+          scope: 'actor',
+          subtype: 'human',
           signature,
         }),
       });

--- a/apps/kernel/app/profile/edit/page.tsx
+++ b/apps/kernel/app/profile/edit/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import * as ed from '@noble/ed25519';
+import { buildPublicUrl } from '@imajin/config';
 import { useIdentity } from '../context/IdentityContext';
 import { ImageUpload } from '../components/ImageUpload';
 
@@ -66,8 +67,7 @@ export default function EditProfilePage() {
     if (identityLoading) return;
 
     if (!isLoggedIn || !did) {
-      const authUrl = `${process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://'}auth.${process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai'}`;
-      window.location.href = `${authUrl}/login?next=${encodeURIComponent(window.location.href)}`;
+      window.location.href = `${buildPublicUrl('auth')}/login?next=${encodeURIComponent(window.location.href)}`;
       return;
     }
 

--- a/apps/kernel/app/profile/edit/page.tsx
+++ b/apps/kernel/app/profile/edit/page.tsx
@@ -20,7 +20,6 @@ interface Profile {
   did: string;
   handle?: string;
   displayName: string;
-  displayType: string;
   bio?: string;
   avatar?: string;
   contactEmail?: string;

--- a/apps/kernel/app/profile/login/page.tsx
+++ b/apps/kernel/app/profile/login/page.tsx
@@ -1,8 +1,8 @@
 import { redirect } from "next/navigation";
+import { buildPublicUrl } from "@imajin/config";
 
 export default function LoginRedirect({ searchParams }: { searchParams: { next?: string } }) {
-  const authDomain = process.env.NEXT_PUBLIC_AUTH_URL ||
-    `${process.env.NEXT_PUBLIC_SERVICE_PREFIX || "https://"}auth.${process.env.NEXT_PUBLIC_DOMAIN || "imajin.ai"}`;
+  const authUrl = buildPublicUrl('auth');
   const next = searchParams.next ? `?next=${encodeURIComponent(searchParams.next)}` : "";
-  redirect(`${authDomain}/login${next}`);
+  redirect(`${authUrl}/login${next}`);
 }

--- a/apps/kernel/app/profile/register/page.tsx
+++ b/apps/kernel/app/profile/register/page.tsx
@@ -190,7 +190,8 @@ function RegisterPage() {
         publicKey: keypair.publicKey,
         handle: handle || undefined,
         name: displayName,
-        type: 'human',
+        scope: 'actor',
+        subtype: 'human',
       });
       const msgBytes = new TextEncoder().encode(payload);
       const privateKeyBytes = new Uint8Array(keypair.privateKey.match(/.{2}/g)!.map(byte => parseInt(byte, 16)));
@@ -205,7 +206,8 @@ function RegisterPage() {
           publicKey: keypair.publicKey,
           handle: handle || undefined,
           name: displayName,
-          type: 'human',
+          scope: 'actor',
+          subtype: 'human',
           signature,
           inviteCode: inviteCode || undefined,
         }),

--- a/apps/kernel/app/project/page.tsx
+++ b/apps/kernel/app/project/page.tsx
@@ -20,20 +20,23 @@ async function getNetworkStats() {
 
     const [presences] = await sql`
       SELECT COUNT(*)::int as count
-      FROM profile.profiles
-      WHERE display_type IN ('presence', 'agent', 'device', 'service')
+      FROM profile.profiles p
+      JOIN auth.identities i ON i.id = p.did
+      WHERE i.scope = 'actor' AND i.subtype IN ('presence', 'agent', 'device')
     `;
 
     const [humans] = await sql`
       SELECT COUNT(*)::int as count
-      FROM profile.profiles
-      WHERE display_type = 'human'
+      FROM profile.profiles p
+      JOIN auth.identities i ON i.id = p.did
+      WHERE i.scope = 'actor' AND i.subtype = 'human'
     `;
 
     const [businesses] = await sql`
       SELECT COUNT(*)::int as count
-      FROM profile.profiles
-      WHERE display_type = 'org'
+      FROM profile.profiles p
+      JOIN auth.identities i ON i.id = p.did
+      WHERE i.scope IN ('business', 'community', 'family')
     `;
 
     const [lightningProfiles] = await sql`

--- a/apps/kernel/drizzle/0017_identity_scopes.sql
+++ b/apps/kernel/drizzle/0017_identity_scopes.sql
@@ -1,0 +1,24 @@
+-- Migration 0017: Identity scopes (#346)
+-- Consolidates identities.type + group_identities.scope into scope + subtype on identities.
+-- group_identities will be dropped in the follow-up migration (0018, WO2).
+
+-- Step 1: Add new columns
+ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS scope TEXT;
+ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS subtype TEXT;
+
+-- Step 2: Backfill scope + subtype from existing type
+UPDATE auth.identities SET scope = 'actor', subtype = type WHERE type IN ('human', 'agent', 'presence', 'node');
+UPDATE auth.identities SET scope = 'business' WHERE type = 'org';
+UPDATE auth.identities SET scope = 'community' WHERE type = 'community';
+UPDATE auth.identities SET scope = 'family' WHERE type = 'family';
+-- Any remaining nulls: default to actor
+UPDATE auth.identities SET scope = 'actor' WHERE scope IS NULL;
+
+-- Step 3: Make scope NOT NULL now that it is backfilled
+ALTER TABLE auth.identities ALTER COLUMN scope SET NOT NULL;
+
+-- Step 4: Drop old type column
+ALTER TABLE auth.identities DROP COLUMN IF EXISTS type;
+
+-- Step 5: Index on scope
+CREATE INDEX IF NOT EXISTS idx_identities_scope ON auth.identities (scope);

--- a/apps/kernel/drizzle/0018_drop_display_type_and_group_identities.sql
+++ b/apps/kernel/drizzle/0018_drop_display_type_and_group_identities.sql
@@ -1,0 +1,12 @@
+-- Migration 0018: Drop profiles.display_type + auth.group_identities (#346 WO2)
+-- profile.display_type is superseded by auth.identities.scope + subtype (see 0017).
+-- group_identities table was already stopped from receiving new writes in WO1; drop it now.
+
+-- Drop display_type column (index is dropped automatically by PostgreSQL)
+ALTER TABLE profile.profiles DROP COLUMN IF EXISTS display_type;
+
+-- Explicitly drop the index in case it survived in some environments
+DROP INDEX IF EXISTS profile.idx_profiles_display_type;
+
+-- Drop group_identities table (no longer written to after WO1)
+DROP TABLE IF EXISTS auth.group_identities;

--- a/apps/kernel/drizzle/0019_rename_group_controllers_to_identity_members.sql
+++ b/apps/kernel/drizzle/0019_rename_group_controllers_to_identity_members.sql
@@ -1,0 +1,13 @@
+-- Migration 0019: Rename group_controllers → identity_members
+-- Renames table + columns to be scope-neutral; prepares for #653 (role stubs)
+
+-- Rename table (stays in auth schema)
+ALTER TABLE auth.group_controllers RENAME TO identity_members;
+
+-- Rename columns to be scope-neutral
+ALTER TABLE auth.identity_members RENAME COLUMN group_did TO identity_did;
+ALTER TABLE auth.identity_members RENAME COLUMN controller_did TO member_did;
+
+-- Rename indexes
+ALTER INDEX IF EXISTS idx_group_controllers_pk RENAME TO idx_identity_members_pk;
+ALTER INDEX IF EXISTS idx_group_controllers_controller RENAME TO idx_identity_members_member;

--- a/apps/kernel/drizzle/0020_stub_business_identities.sql
+++ b/apps/kernel/drizzle/0020_stub_business_identities.sql
@@ -1,0 +1,5 @@
+-- Stub tracking on profiles
+ALTER TABLE profile.profiles ADD COLUMN IF NOT EXISTS claimed_by TEXT;        -- owner DID, null = unclaimed stub
+ALTER TABLE profile.profiles ADD COLUMN IF NOT EXISTS claim_status TEXT;       -- 'unclaimed' | 'pending' | 'claimed'
+
+CREATE INDEX IF NOT EXISTS idx_profiles_claim_status ON profile.profiles (claim_status) WHERE claim_status IS NOT NULL;

--- a/apps/kernel/drizzle/meta/0017_snapshot.json
+++ b/apps/kernel/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000017",
+  "prevId": "00000000-0000-0000-0000-000000000016",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/0018_snapshot.json
+++ b/apps/kernel/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000018",
+  "prevId": "00000000-0000-0000-0000-000000000017",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/0019_snapshot.json
+++ b/apps/kernel/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000019",
+  "prevId": "00000000-0000-0000-0000-000000000018",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/0020_snapshot.json
+++ b/apps/kernel/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000020",
+  "prevId": "00000000-0000-0000-0000-000000000019",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/_journal.json
+++ b/apps/kernel/drizzle/meta/_journal.json
@@ -120,6 +120,34 @@
       "when": 1744675200001,
       "tag": "0016_add_system_events",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1744761600000,
+      "tag": "0017_identity_scopes",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1744761600001,
+      "tag": "0018_drop_display_type_and_group_identities",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1744761600002,
+      "tag": "0019_rename_group_controllers_to_identity_members",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1744761600003,
+      "tag": "0020_stub_business_identities",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/kernel/src/contexts/IdentityContext.tsx
+++ b/apps/kernel/src/contexts/IdentityContext.tsx
@@ -6,7 +6,8 @@ import { buildPublicUrl } from '@imajin/config';
 export interface Identity {
   did: string;
   handle?: string;
-  type: string;
+  scope: string;
+  subtype?: string;
   name?: string;
 }
 
@@ -37,12 +38,13 @@ export function IdentityProvider({ children }: { children: ReactNode }) {
         const res = await fetch('/auth/api/session');
         if (res.ok) {
           const data = await res.json();
-          // Session API returns { identity: { id, handle, name, type } }
+          // Session API returns { identity: { id, handle, name, scope, subtype } }
           const raw = data.identity || data;
           setIdentity({
             did: raw.did || raw.id,
             handle: raw.handle,
-            type: raw.type || 'human',
+            scope: raw.scope || 'actor',
+            subtype: raw.subtype || undefined,
             name: raw.name,
           });
         } else {

--- a/apps/kernel/src/db/schemas/auth.ts
+++ b/apps/kernel/src/db/schemas/auth.ts
@@ -191,16 +191,6 @@ export const devices = authSchema.table('devices', {
 }));
 
 /**
- * Group Identities — multi-controller DIDs for orgs, communities, families
- */
-export const groupIdentities = authSchema.table('group_identities', {
-  groupDid: text('group_did').primaryKey(),               // references identities.id
-  scope: text('scope').notNull(),                         // 'org' | 'community' | 'family'
-  createdBy: text('created_by').notNull(),                // DID of creator
-  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
-});
-
-/**
  * Group Controllers — members that control a group DID
  */
 export const groupControllers = authSchema.table('group_controllers', {
@@ -234,7 +224,5 @@ export type MfaMethod = typeof mfaMethods.$inferSelect;
 export type NewMfaMethod = typeof mfaMethods.$inferInsert;
 export type Device = typeof devices.$inferSelect;
 export type NewDevice = typeof devices.$inferInsert;
-export type GroupIdentity = typeof groupIdentities.$inferSelect;
-export type NewGroupIdentity = typeof groupIdentities.$inferInsert;
 export type GroupController = typeof groupControllers.$inferSelect;
 export type NewGroupController = typeof groupControllers.$inferInsert;

--- a/apps/kernel/src/db/schemas/auth.ts
+++ b/apps/kernel/src/db/schemas/auth.ts
@@ -14,7 +14,8 @@ export const authSchema = pgSchema('auth');
  */
 export const identities = authSchema.table('identities', {
   id: text('id').primaryKey(),                    // did:imajin:xxx
-  type: text('type').notNull(),                   // 'human' | 'agent'
+  scope: text('scope').notNull(),                 // 'actor' | 'family' | 'community' | 'business'
+  subtype: text('subtype'),                       // scope-dependent: 'human' | 'agent' | 'device' | etc.
   publicKey: text('public_key').notNull().unique(),
   handle: text('handle').unique(),                // @username (unique, optional)
   name: text('name'),                             // Display name

--- a/apps/kernel/src/db/schemas/auth.ts
+++ b/apps/kernel/src/db/schemas/auth.ts
@@ -191,19 +191,19 @@ export const devices = authSchema.table('devices', {
 }));
 
 /**
- * Group Controllers — members that control a group DID
+ * Identity Members — members of a group/collective identity
  */
-export const groupControllers = authSchema.table('group_controllers', {
-  groupDid: text('group_did').notNull(),
-  controllerDid: text('controller_did').notNull(),
-  role: text('role').notNull().default('member'),         // 'owner' | 'admin' | 'member'
+export const identityMembers = authSchema.table('identity_members', {
+  identityDid: text('identity_did').notNull(),
+  memberDid: text('member_did').notNull(),
+  role: text('role').notNull().default('member'),         // 'owner' | 'admin' | 'maintainer' | 'member' | ...
   allowedServices: text('allowed_services').array(),      // null = full access, ['events','pay'] = restricted
   addedBy: text('added_by'),
   addedAt: timestamp('added_at', { withTimezone: true }).defaultNow(),
   removedAt: timestamp('removed_at', { withTimezone: true }),
 }, (table) => ({
-  pk: index('idx_group_controllers_pk').on(table.groupDid, table.controllerDid),
-  controllerIdx: index('idx_group_controllers_controller').on(table.controllerDid),
+  pk: index('idx_identity_members_pk').on(table.identityDid, table.memberDid),
+  memberIdx: index('idx_identity_members_member').on(table.memberDid),
 }));
 
 // Types
@@ -224,5 +224,5 @@ export type MfaMethod = typeof mfaMethods.$inferSelect;
 export type NewMfaMethod = typeof mfaMethods.$inferInsert;
 export type Device = typeof devices.$inferSelect;
 export type NewDevice = typeof devices.$inferInsert;
-export type GroupController = typeof groupControllers.$inferSelect;
-export type NewGroupController = typeof groupControllers.$inferInsert;
+export type IdentityMember = typeof identityMembers.$inferSelect;
+export type NewIdentityMember = typeof identityMembers.$inferInsert;

--- a/apps/kernel/src/db/schemas/profile.ts
+++ b/apps/kernel/src/db/schemas/profile.ts
@@ -19,7 +19,6 @@ export const profiles = profileSchema.table('profiles', {
   did: text('did').primaryKey(),                              // did:imajin:xxx
   handle: text('handle').unique(),                            // unique handle (e.g., "jin", "ryan")
   displayName: text('display_name').notNull(),
-  displayType: text('display_type').notNull(),                // 'human' | 'agent' | 'device' | 'org' | 'event' | 'service'
   avatar: text('avatar'),                                     // URL or emoji
   avatarAssetId: text('avatar_asset_id'),                     // asset_xxx from media service
   bio: text('bio'),
@@ -34,7 +33,6 @@ export const profiles = profileSchema.table('profiles', {
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({
   handleIdx: index('idx_profiles_handle').on(table.handle),
-  displayTypeIdx: index('idx_profiles_display_type').on(table.displayType),
 }));
 
 /**

--- a/apps/kernel/src/db/schemas/profile.ts
+++ b/apps/kernel/src/db/schemas/profile.ts
@@ -31,8 +31,11 @@ export const profiles = profileSchema.table('profiles', {
   featureToggles: jsonb('feature_toggles').$type<FeatureToggles>().notNull().default({}),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  claimedBy: text('claimed_by'),                              // owner DID, null = unclaimed stub
+  claimStatus: text('claim_status'),                          // 'unclaimed' | 'pending' | 'claimed'
 }, (table) => ({
   handleIdx: index('idx_profiles_handle').on(table.handle),
+  claimStatusIdx: index('idx_profiles_claim_status').on(table.claimStatus),
 }));
 
 /**

--- a/apps/kernel/src/lib/auth/crypto.ts
+++ b/apps/kernel/src/lib/auth/crypto.ts
@@ -62,6 +62,43 @@ export function generateChallenge(): string {
   return bytesToHex(bytes);
 }
 
+/**
+ * Encrypt a private key using AES-256-GCM with PBKDF2 key derivation.
+ * Uses GROUP_KEY_ENCRYPTION_SECRET env var as the master secret.
+ */
+export async function encryptPrivateKey(privateKeyHex: string): Promise<{ encryptedKey: string; salt: string }> {
+  const secret = process.env.GROUP_KEY_ENCRYPTION_SECRET;
+  if (!secret) throw new Error('GROUP_KEY_ENCRYPTION_SECRET not set');
+
+  const saltBytes = crypto.getRandomValues(new Uint8Array(16));
+  const salt = Buffer.from(saltBytes).toString('base64');
+
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey']
+  );
+  const derivedKey = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: saltBytes, iterations: 100_000, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt']
+  );
+
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = new TextEncoder().encode(privateKeyHex);
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, derivedKey, plaintext);
+
+  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+  combined.set(iv);
+  combined.set(new Uint8Array(ciphertext), iv.length);
+
+  return { encryptedKey: Buffer.from(combined).toString('base64'), salt };
+}
+
 // Hex utilities
 function hexToBytes(hex: string): Uint8Array {
   const bytes = new Uint8Array(hex.length / 2);

--- a/apps/kernel/src/lib/auth/dfos.ts
+++ b/apps/kernel/src/lib/auth/dfos.ts
@@ -190,7 +190,8 @@ export async function getIdentityByDfosDid(dfosDid: string) {
   const [identity] = await db
     .select({
       id: identities.id,
-      type: identities.type,
+      scope: identities.scope,
+      subtype: identities.subtype,
       tier: identities.tier,
     })
     .from(identities)
@@ -202,7 +203,8 @@ export async function getIdentityByDfosDid(dfosDid: string) {
   return {
     imajinDid: identity.id,
     dfosDid: chain.dfosDid,
-    type: identity.type,
+    scope: identity.scope,
+    subtype: identity.subtype,
     tier: identity.tier,
   };
 }

--- a/apps/kernel/src/lib/auth/jwt.ts
+++ b/apps/kernel/src/lib/auth/jwt.ts
@@ -69,7 +69,8 @@ function getKeyPair(): Promise<KeyPair> {
 export interface SessionPayload {
   sub: string;      // DID
   handle?: string;  // @username
-  type: string;     // identity type
+  scope: string;    // 'actor' | 'family' | 'community' | 'business'
+  subtype?: string; // scope-dependent: 'human' | 'agent' | 'device' | etc.
   name?: string;
   tier?: 'soft' | 'preliminary' | 'established'; // identity tier
   keyId?: string;   // which key created this session
@@ -84,7 +85,8 @@ export async function createSessionToken(payload: SessionPayload): Promise<strin
 
   const jwt = await new jose.SignJWT({
     handle: payload.handle,
-    type: payload.type,
+    scope: payload.scope,
+    subtype: payload.subtype,
     name: payload.name,
     tier: payload.tier || 'soft',
     ...(payload.keyId ? { keyId: payload.keyId } : {}),
@@ -116,7 +118,8 @@ export async function verifySessionToken(token: string): Promise<SessionPayload 
     return {
       sub: payload.sub as string,
       handle: payload.handle as string | undefined,
-      type: payload.type as string,
+      scope: (payload.scope as string) || 'actor',
+      subtype: payload.subtype as string | undefined,
       name: payload.name as string | undefined,
       tier,
       keyId: payload.keyId as string | undefined,

--- a/apps/kernel/src/lib/kernel/lookup.ts
+++ b/apps/kernel/src/lib/kernel/lookup.ts
@@ -6,7 +6,8 @@ const log = createLogger('kernel');
 
 export interface IdentityLookup {
   did: string;
-  type: string;
+  scope: string;
+  subtype: string | null;
   handle: string | null;
   name: string | null;
   avatarUrl: string | null;
@@ -25,7 +26,8 @@ export async function lookupIdentity(did: string): Promise<IdentityLookup | null
     const [identity] = await db
       .select({
         id: identities.id,
-        type: identities.type,
+        scope: identities.scope,
+        subtype: identities.subtype,
         handle: identities.handle,
         name: identities.name,
         avatarUrl: identities.avatarUrl,
@@ -41,7 +43,8 @@ export async function lookupIdentity(did: string): Promise<IdentityLookup | null
 
     return {
       did: identity.id,
-      type: identity.type,
+      scope: identity.scope,
+      subtype: identity.subtype,
       handle: identity.handle,
       name: identity.name,
       avatarUrl: identity.avatarUrl,

--- a/apps/kernel/src/lib/kernel/session.ts
+++ b/apps/kernel/src/lib/kernel/session.ts
@@ -8,7 +8,8 @@ const log = createLogger('kernel');
 export interface KernelSession {
   did: string;
   handle?: string;
-  type: string;
+  scope: string;
+  subtype?: string;
   name?: string;
   role: string;
   tier: string;
@@ -59,7 +60,8 @@ export async function getSessionFromCookies(cookieHeader: string | null): Promis
     return {
       did: session.sub,
       handle: identity[0].handle || session.handle || undefined,
-      type: identity[0].type || session.type,
+      scope: identity[0].scope || session.scope,
+      subtype: identity[0].subtype || session.subtype || undefined,
       name: identity[0].name || session.name || undefined,
       role: (metadata.role as string) || 'member',
       tier,

--- a/apps/kernel/src/lib/kernel/verification.ts
+++ b/apps/kernel/src/lib/kernel/verification.ts
@@ -39,7 +39,7 @@ export async function checkPreliminaryEligibility(did: string): Promise<void> {
     .where(
       and(
         isNull(connections.disconnectedAt),
-        eq(identities.type, 'human'),
+        eq(identities.scope, 'actor'),
         or(eq(identities.tier, 'preliminary'), eq(identities.tier, 'established'))
       )
     )
@@ -100,7 +100,7 @@ export async function checkHardEligibility(did: string): Promise<void> {
         and(eq(connections.didB, did), eq(identities.id, connections.didA))
       )
     )
-    .where(and(isNull(connections.disconnectedAt), eq(identities.type, 'human')));
+    .where(and(isNull(connections.disconnectedAt), eq(identities.scope, 'actor')));
 
   if (total < 25) return;
 

--- a/docs/work-orders/wo-346-identity-scopes.md
+++ b/docs/work-orders/wo-346-identity-scopes.md
@@ -1,0 +1,521 @@
+# Work Order: Identity Scopes (#346)
+
+**Goal:** Consolidate three redundant identity classification systems into two fields on `auth.identities`: `scope` + `subtype`. Drop `group_identities` table and `profiles.displayType` column.
+
+**Current state (3 sources of truth):**
+| Column | Table | Values |
+|--------|-------|--------|
+| `identities.type` | auth | `human`, `agent`, `org`, `community`, `family` |
+| `group_identities.scope` | auth | `org`, `community`, `family` |
+| `profiles.displayType` | profile | `human`, `agent`, `device`, `org`, `event`, `service`, `presence` |
+
+**Target state (1 source of truth):**
+| Column | Table | Values |
+|--------|-------|--------|
+| `identities.scope` | auth | `actor`, `family`, `community`, `business` |
+| `identities.subtype` | auth | scope-dependent (e.g. `human`, `agent`, `device`, `cafe`, `inc`, `club`) |
+
+**Branch:** `feat/346-identity-scopes` from `main`
+
+**Critical path:**
+```
+WO1 (schema migration + auth code) → WO2 (profile + UI + drop group_identities)
+```
+
+WO1 must land first — WO2 depends on `scope`/`subtype` columns existing and auth code using them.
+
+---
+
+## Work Order 1: Schema Migration + Auth Layer
+
+**Estimated effort:** 1-2 hours (agent)
+**Blocks:** WO2
+
+### 1. Migration SQL
+
+Create new migration in `apps/kernel/src/db/migrations/` (next available number). All DDL must be idempotent.
+
+```sql
+-- Step 1: Add new columns
+ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS scope TEXT;
+ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS subtype TEXT;
+
+-- Step 2: Backfill scope + subtype from existing type
+UPDATE auth.identities SET scope = 'actor', subtype = type WHERE type IN ('human', 'agent', 'presence');
+UPDATE auth.identities SET scope = 'business' WHERE type = 'org';
+UPDATE auth.identities SET scope = 'community' WHERE type = 'community';
+UPDATE auth.identities SET scope = 'family' WHERE type = 'family';
+-- Groups don't have subtypes yet — null is fine
+
+-- Step 3: Make scope NOT NULL now that it's backfilled
+-- (Do this as a separate statement after backfill)
+ALTER TABLE auth.identities ALTER COLUMN scope SET NOT NULL;
+
+-- Step 4: Drop old type column
+ALTER TABLE auth.identities DROP COLUMN IF EXISTS type;
+
+-- Step 5: Index on scope
+CREATE INDEX IF NOT EXISTS idx_identities_scope ON auth.identities (scope);
+```
+
+### 2. Schema Definition
+
+Update `apps/kernel/src/db/schemas/auth.ts`:
+
+```ts
+// identities table — CHANGE:
+// Remove:  type: text('type').notNull(),
+// Add:
+scope: text('scope').notNull(),          // 'actor' | 'family' | 'community' | 'business'
+subtype: text('subtype'),                // scope-dependent: 'human' | 'agent' | 'device' | 'cafe' | etc.
+```
+
+Update exported types (`Identity`, `NewIdentity`) — these auto-derive from the table, so just verify they look right.
+
+### 3. Auth Code Changes (~30 references)
+
+**Registration (`auth/api/register/route.ts`):**
+- `type: 'human'` → `scope: 'actor', subtype: 'human'`
+- Validation: accept `scope` + `subtype` in request body (default: `scope: 'actor', subtype: 'human'`)
+- The JSDoc comment on line 29 lists old types — update it
+
+**Group creation (`auth/api/groups/route.ts`):**
+- `VALID_SCOPES`: `['org', 'community', 'family']` → `['business', 'community', 'family']`
+- Identity insert: `type: scope` → `scope: validatedScope, subtype: body.subtype || null`
+- Remove `group_identities` insert entirely (table is being dropped in WO2)
+- Keep `groupControllers` insert as-is
+
+**Group read (`auth/api/groups/[groupDid]/route.ts`):**
+- Read `scope` from `identities` table instead of `groupIdentities`
+- Remove `groupIdentities` from the join
+- `createdBy`: read from `groupControllers` where `role = 'owner'` instead of `groupIdentities.createdBy`
+
+**Group list (`auth/api/groups/route.ts` GET):**
+- Join `groupControllers` → `identities` directly, read `identities.scope`
+- Remove `groupIdentities` from the join
+
+**Onboarding (`auth/api/onboard/generate/route.ts`, `onboard/verify/route.ts`):**
+- `type: 'human'` → `scope: 'actor', subtype: 'human'`
+
+**Magic link (`auth/api/magic/route.ts`):**
+- `type: 'human'` → `scope: 'actor', subtype: 'human'`
+
+**Soft session (`auth/api/session/soft/route.ts`):**
+- `type: 'human'` → `scope: 'actor', subtype: 'human'`
+
+**Node registration (`registry/api/node/register/route.ts`, `node/heartbeat/route.ts`):**
+- `type: 'agent'` → `scope: 'actor', subtype: 'agent'`
+
+**Identity endpoints (`auth/api/identity/*/route.ts`):**
+- Any `identities.type` selections → `identities.scope` + `identities.subtype`
+
+**Verification/lookup (`src/lib/kernel/verification.ts`, `src/lib/kernel/lookup.ts`):**
+- `eq(identities.type, 'human')` → `eq(identities.scope, 'actor')` (all current actors are human)
+
+**DFOS integration (`src/lib/auth/dfos.ts`):**
+- `type: identities.type` → `scope: identities.scope, subtype: identities.subtype`
+
+**Client-side contexts (`src/contexts/IdentityContext.tsx`, `profile/context/IdentityContext.tsx`):**
+- `type: raw.type || 'human'` → `scope: raw.scope || 'actor', subtype: raw.subtype || 'human'`
+
+**requireAuth (`packages/auth/src/require-auth.ts`):**
+- `type: data.type` → `scope: data.scope, subtype: data.subtype`
+- Return shape: `identity.scope` and `identity.subtype` instead of `identity.type`
+
+**Pay connect (`pay/api/connect/onboard/route.ts`):**
+- `identity.type !== 'human'` → `identity.scope !== 'actor'` (or check subtype if you want to restrict to humans only)
+
+**Key auth tab (`auth/login/components/KeyAuthTab.tsx`):**
+- `type: 'human'` → `scope: 'actor', subtype: 'human'`
+
+**Profile registration UI (`profile/register/page.tsx`):**
+- `type: 'human'` → `scope: 'actor', subtype: 'human'`
+
+**Bootstrap node script (`scripts/bootstrap-node-identity.ts`):**
+- Update if it references `type`
+
+### 4. Validation Rules
+
+```ts
+const VALID_SCOPES = ['actor', 'family', 'community', 'business'] as const;
+
+// Subtype validation is scope-dependent, application-layer only
+const VALID_ACTOR_SUBTYPES = ['human', 'agent', 'device'] as const;
+// Business, family, community subtypes: open text for now, no validation
+```
+
+### 5. Tests
+
+If any existing tests reference `type: 'human'` or `type: 'agent'`, update to `scope`/`subtype`.
+
+### Done Criteria
+- [ ] Migration runs cleanly (dev DB)
+- [ ] `identities` table has `scope` + `subtype`, no `type` column
+- [ ] All auth routes create identities with `scope` + `subtype`
+- [ ] Group creation no longer inserts into `group_identities`
+- [ ] `requireAuth()` returns `scope` + `subtype` on the identity object
+- [ ] No TypeScript errors (`pnpm --filter @imajin/kernel build` succeeds)
+
+---
+
+## Work Order 2: Profile Layer + Drop group_identities
+
+**Estimated effort:** 1-2 hours (agent)
+**Depends on:** WO1 merged to feature branch
+
+### 1. Drop `profiles.displayType`
+
+**Migration SQL:**
+```sql
+-- Drop displayType column from profiles
+ALTER TABLE profile.profiles DROP COLUMN IF EXISTS display_type;
+
+-- Drop the index on it
+DROP INDEX IF EXISTS profile.idx_profiles_display_type;
+```
+
+**Schema (`apps/kernel/src/db/schemas/profile.ts`):**
+- Remove `displayType` column definition
+- Remove `displayTypeIdx` index definition
+
+### 2. Drop `group_identities` Table
+
+**Migration SQL:**
+```sql
+DROP TABLE IF EXISTS auth.group_identities;
+```
+
+**Schema (`apps/kernel/src/db/schemas/auth.ts`):**
+- Remove `groupIdentities` table definition
+- Remove `GroupIdentity` and `NewGroupIdentity` type exports
+
+**DB barrel export (`apps/kernel/src/db/index.ts` or equivalent):**
+- Remove `groupIdentities` from exports
+
+### 3. Profile Code Changes (~34 displayType references)
+
+**Dashboard pages (`app/page.tsx`, `app/project/page.tsx`):**
+- Raw SQL `WHERE display_type = 'human'` → join to `auth.identities` and filter `WHERE scope = 'actor'`
+- Same for `'org'` → `scope IN ('business', 'community', 'family')` or just `scope != 'actor'`
+- Agent/device/service counts → `WHERE scope = 'actor' AND subtype != 'human'`
+
+**Profile display (`profile/[handle]/page.tsx`):**
+- `profile.displayType` → join identity to get `scope` + `subtype`
+- `typeEmoji` / `typeLabels` maps: key by scope+subtype instead of displayType
+- Meta descriptions using displayType → use scope+subtype
+
+**Profile edit (`profile/edit/page.tsx`):**
+- Remove `displayType` from the type definition
+
+**Profile API routes:**
+- `POST /api/profile` — remove `displayType` from request body, don't insert it
+- `PATCH /api/profile/[id]` — remove displayType update logic
+- `GET /api/profile/search` — filter by scope (joined from identities) instead of displayType
+- `POST /api/soft-register` — remove `displayType: 'human'` from insert
+- `POST /api/register` — remove `displayType: 'human'` from insert
+
+**Group creation (`auth/api/groups/route.ts`):**
+- Profile insert: remove `displayType: scope` — column no longer exists
+
+**Chat session (`chat/api/session/route.ts`):**
+- `profile.displayType` → derive from identity scope+subtype
+
+**Admin pages:**
+- `admin/users/[did]/page.tsx` — remove `display_type` from SQL select + UI
+- `admin/subscribers/page.tsx` — raw SQL referencing `group_identities` → check `identities.scope != 'actor'`
+- `admin/newsletter/page.tsx` — same
+- `admin/layout.tsx` — same
+- `api/admin/verify/route.ts` — same
+
+**`packages/auth/src/require-admin.ts`:**
+- Raw SQL `SELECT group_did FROM auth.group_identities` → `SELECT id FROM auth.identities WHERE scope != 'actor'`
+- Adjust the admin check logic accordingly
+
+### 4. Profile Queries Helper (optional but recommended)
+
+Since many places now need scope+subtype from identity joined to profile, consider a shared query fragment:
+
+```ts
+// In a shared location (e.g. src/lib/kernel/identity.ts)
+export function identityLabel(scope: string, subtype: string | null): string {
+  if (subtype) return subtype; // 'human', 'cafe', etc.
+  return scope; // fallback to scope name
+}
+
+export const scopeEmoji: Record<string, string> = {
+  actor: '👤',
+  family: '👨‍👩‍👧‍👦',
+  community: '🌐',
+  business: '🏢',
+};
+```
+
+### Done Criteria
+- [ ] `profiles` table has no `display_type` column
+- [ ] `group_identities` table dropped
+- [ ] All 34 displayType references removed/replaced
+- [ ] All 6 group_identities references removed/replaced
+- [ ] Admin pages still work (scope checks via identities table)
+- [ ] Profile pages render correctly with scope+subtype
+- [ ] No TypeScript errors (`pnpm --filter @imajin/kernel build` succeeds)
+
+---
+
+## Work Order 3: Rename groupControllers → identityMembers + Gate Act-As
+
+**Estimated effort:** 1-2 hours (agent)
+**Depends on:** WO1 + WO2 committed on feature branch
+
+### Why
+
+`group_controllers` conflates two things: control (act-as) and membership. The table has `role: 'owner' | 'admin' | 'member'` but every row grants act-as access — the `act-as` route doesn't check role. Renaming + role-gating fixes this and prepares the table for #653 (stubs add `maintainer`, `contributor` roles).
+
+### 1. Migration SQL
+
+```sql
+-- Rename table
+ALTER TABLE auth.group_controllers RENAME TO auth.identity_members;
+
+-- Rename columns to be scope-neutral
+ALTER TABLE auth.identity_members RENAME COLUMN group_did TO identity_did;
+ALTER TABLE auth.identity_members RENAME COLUMN controller_did TO member_did;
+
+-- Rename indexes
+ALTER INDEX IF EXISTS idx_group_controllers_pk RENAME TO idx_identity_members_pk;
+ALTER INDEX IF EXISTS idx_group_controllers_controller RENAME TO idx_identity_members_member;
+```
+
+### 2. Schema Definition
+
+Update `apps/kernel/src/db/schemas/auth.ts`:
+
+```ts
+// Rename groupControllers → identityMembers
+export const identityMembers = authSchema.table('identity_members', {
+  identityDid: text('identity_did').notNull(),
+  memberDid: text('member_did').notNull(),
+  role: text('role').notNull().default('member'),         // 'owner' | 'admin' | 'maintainer' | 'member' | ...
+  allowedServices: text('allowed_services').array(),
+  addedBy: text('added_by'),
+  addedAt: timestamp('added_at', { withTimezone: true }).defaultNow(),
+  removedAt: timestamp('removed_at', { withTimezone: true }),
+}, (table) => ({
+  pk: index('idx_identity_members_pk').on(table.identityDid, table.memberDid),
+  memberIdx: index('idx_identity_members_member').on(table.memberDid),
+}));
+
+export type IdentityMember = typeof identityMembers.$inferSelect;
+export type NewIdentityMember = typeof identityMembers.$inferInsert;
+```
+
+Remove old `groupControllers` + `GroupController` / `NewGroupController` types.
+
+### 3. Act-As Role Gate
+
+In `auth/api/session/act-as/route.ts`, add role check:
+
+```ts
+const ACT_AS_ROLES = ['owner', 'admin'];
+
+// In the query:
+.where(
+  and(
+    eq(identityMembers.identityDid, did),
+    eq(identityMembers.memberDid, caller.id),
+    inArray(identityMembers.role, ACT_AS_ROLES),
+    isNull(identityMembers.removedAt)
+  )
+)
+```
+
+### 4. Code Changes (~90 references across 9 files)
+
+All references to `groupControllers` → `identityMembers`, `groupDid` → `identityDid`, `controllerDid` → `memberDid`:
+
+**Files:**
+- `apps/kernel/src/db/schemas/auth.ts` — schema definition
+- `apps/kernel/src/db/index.ts` — barrel export
+- `apps/kernel/app/auth/api/groups/route.ts` — group creation (insert member as owner)
+- `apps/kernel/app/auth/api/groups/[groupDid]/route.ts` — group detail + update
+- `apps/kernel/app/auth/api/groups/[groupDid]/controllers/route.ts` — list/add controllers
+- `apps/kernel/app/auth/api/groups/[groupDid]/controllers/[controllerDid]/route.ts` — remove/update controller
+- `apps/kernel/app/auth/api/session/act-as/route.ts` — act-as switching (+ add role gate)
+- `apps/kernel/app/auth/api/onboard/generate/route.ts` — scope join on onboard
+- `apps/kernel/app/auth/api/onboard/verify/route.ts` — scope join on verify
+- `apps/kernel/app/profile/api/forest/[groupDid]/config/route.ts` — forest config access check
+
+**Optional:** Rename the `controllers/` route directories to `members/` for consistency. If too disruptive, leave the URL paths and just change the internal references.
+
+### 5. Identity Hub Scope Switcher
+
+The identity hub lists groups you can act-as. Verify it filters by `role IN ('owner', 'admin')` so members don't see groups in their scope switcher. Check:
+- `apps/kernel/app/auth/` — any component that lists "my identities" for the switcher
+
+### Done Criteria
+- [ ] `group_controllers` table renamed to `identity_members`
+- [ ] Columns renamed: `group_did` → `identity_did`, `controller_did` → `member_did`
+- [ ] Act-as route gates on `role IN ('owner', 'admin')`
+- [ ] All 90 `groupControllers` references updated
+- [ ] Schema types updated (`IdentityMember`, `NewIdentityMember`)
+- [ ] No TypeScript errors (`pnpm --filter @imajin/kernel build` succeeds)
+- [ ] Commit with descriptive message referencing #346
+
+---
+
+## Work Order 4: Stub Business Identities (#653 core primitive)
+
+**Estimated effort:** 2-3 hours (agent)
+**Depends on:** WO1-WO3 committed on feature branch
+
+### Goal
+
+Any authenticated user can create a **stub** — an unclaimed business identity that the community maintains until the real owner arrives. This is the cold-start engine: customers build a business's presence before the business signs up.
+
+A stub is a normal `scope: 'business'` identity where `claimed_by` is null. The creator becomes `role: 'maintainer'` (not owner/admin — no act-as). A separate "Places I Maintain" section surfaces these.
+
+### 1. Schema Changes
+
+**Migration 0020 (`apps/kernel/drizzle/0020_stub_business_identities.sql`):**
+
+```sql
+-- Stub tracking on profiles
+ALTER TABLE profile.profiles ADD COLUMN IF NOT EXISTS claimed_by TEXT;        -- owner DID, null = unclaimed stub
+ALTER TABLE profile.profiles ADD COLUMN IF NOT EXISTS claim_status TEXT;       -- 'unclaimed' | 'pending' | 'claimed'
+
+CREATE INDEX IF NOT EXISTS idx_profiles_claim_status ON profile.profiles (claim_status) WHERE claim_status IS NOT NULL;
+```
+
+**Update `apps/kernel/src/db/schemas/profile.ts`:**
+
+Add to the `profiles` table definition:
+```ts
+claimedBy: text('claimed_by'),                              // owner DID, null = unclaimed stub
+claimStatus: text('claim_status'),                          // 'unclaimed' | 'pending' | 'claimed'
+```
+
+### 2. API Endpoints
+
+**New: `POST /api/stubs` (`apps/kernel/app/profile/api/stubs/route.ts`)**
+
+Create a stub business identity. Flow:
+1. Validate request: `name` required, optional `subtype` (default `null`), optional `handle`, `location` (jsonb in metadata), `category`
+2. Create identity: `scope: 'business'`, `subtype: body.subtype || null` — use the same keypair generation + encryption as groups route (`auth/api/groups/route.ts`)
+3. Create profile: `displayName`, `handle`, `bio`, `metadata: { location, category }`, `claimStatus: 'unclaimed'`
+4. Add creator as maintainer: `identity_members` with `role: 'maintainer'`
+5. Emit attestation: `type: 'stub.created'`
+6. Return `{ did, name, handle, scope: 'business', claimStatus: 'unclaimed' }`
+
+Reuse the `encryptPrivateKey` helper from groups route — extract it to a shared location if not already shared (e.g. `src/lib/auth/crypto.ts`).
+
+**New: `GET /api/stubs/mine` (`apps/kernel/app/profile/api/stubs/mine/route.ts`)**
+
+List stubs the caller maintains:
+```sql
+SELECT im.identity_did, im.role, p.display_name, p.handle, p.metadata, p.claim_status
+FROM auth.identity_members im
+JOIN profile.profiles p ON p.did = im.identity_did
+WHERE im.member_did = :callerDid
+  AND im.role = 'maintainer'
+  AND im.removed_at IS NULL
+```
+
+Return array of `{ did, name, handle, metadata, claimStatus, role }`.
+
+**Extend: `GET /api/profile/[id]` response**
+
+When fetching a business profile, include:
+- `claimStatus` — from profiles table
+- `maintainerCount` — count of `identity_members` where `role = 'maintainer'` for this DID
+- `isMaintainer` — if authenticated caller is a maintainer of this stub
+
+### 3. UI Components
+
+**New: "Places I Maintain" section in Identity Hub (`apps/kernel/app/auth/page.tsx`)**
+
+Below the identity switcher / identity detail area, add a section:
+- Header: "Places I Maintain" (only shows if user has any maintainer roles)
+- List of stubs with name, category (from metadata), claim status badge
+- Each item links to the stub's profile page (`/profile/[handle]`)
+- "Add a place" button that opens the stub creation flow
+
+This section is NOT in the scope switcher — maintainers cannot act-as stubs.
+
+**New: Stub Creation Form**
+
+Simple form accessible from "Add a place" button:
+- Name (required)
+- Category (optional — text input or common presets like café, restaurant, shop, venue, studio)
+- Location (optional — text input, stored in profile metadata)
+- Handle (optional)
+- Submit → `POST /api/stubs`
+
+Can be a modal or a new page at `/auth/stubs/new`. Keep it simple.
+
+**Extend: Profile page (`apps/kernel/app/profile/[handle]/page.tsx`)**
+
+For unclaimed business profiles:
+- Show "Community-maintained" badge near the name
+- Show maintainer count: "Maintained by N people"
+- If viewer is authenticated: "Suggest an edit" link (placeholder — just a visual for now, edit flow is #653 follow-up)
+- If viewer is authenticated + not already a maintainer: "Help maintain this place" button → adds them as maintainer via new endpoint
+
+**New: `POST /api/stubs/[did]/join` (`apps/kernel/app/profile/api/stubs/[did]/join/route.ts`)**
+
+Join as maintainer of an unclaimed stub:
+1. Verify stub exists and `claim_status = 'unclaimed'`
+2. Check caller isn't already a member
+3. Insert into `identity_members` with `role: 'maintainer'`
+4. Return `{ ok: true }`
+
+### 4. IdentitySwitcher Update
+
+The `IdentitySwitcher` component at `apps/kernel/app/auth/components/IdentitySwitcher.tsx` has stale scope icons. Update:
+```ts
+function scopeIcon(scope: string): string {
+  if (scope === 'community') return '🌐';
+  if (scope === 'business') return '🏢';
+  if (scope === 'family') return '👨‍👩‍👧‍👦';
+  return '👤';
+}
+```
+
+Remove `org`, `node`, `agent`, `device` cases — those are subtypes now, not scopes. The switcher only shows identities you can act-as (owner/admin), which are always scoped identities.
+
+### 5. Validation
+
+- Only `scope: 'actor'` identities (humans) can create stubs — agents/devices cannot
+- Handle uniqueness check (same as groups route)
+- Stub creation rate limit: consider max 10 stubs per actor (application-layer, not DB constraint) — implement as a count check before insert
+
+### Done Criteria
+- [ ] Migration 0020 adds `claimed_by` + `claim_status` to profiles
+- [ ] `POST /api/stubs` creates business identity + profile + maintainer membership
+- [ ] `GET /api/stubs/mine` returns caller's maintained stubs
+- [ ] `POST /api/stubs/[did]/join` allows joining as maintainer
+- [ ] `GET /api/profile/[id]` includes claim status + maintainer count for business profiles
+- [ ] "Places I Maintain" section visible in identity hub when user has stubs
+- [ ] Stub creation form works (modal or page)
+- [ ] Profile page shows community-maintained badge for unclaimed stubs
+- [ ] IdentitySwitcher scope icons updated for new scope values
+- [ ] `encryptPrivateKey` extracted to shared location (not duplicated)
+- [ ] No TypeScript errors (`pnpm --filter @imajin/kernel build` succeeds)
+- [ ] Commits reference both #346 and #653
+
+---
+
+## Agent Instructions (all WOs)
+
+**Repo:** `/home/veteze/.openclaw/workspace/imajin-ai`
+**Branch:** Create `feat/346-identity-scopes` from `main`
+
+Before starting:
+1. Read `apps/kernel/src/db/schemas/auth.ts` and `apps/kernel/src/db/schemas/profile.ts` for current schema
+2. Read `packages/auth/src/require-auth.ts` for identity return shape
+3. `grep -rn 'identities.type\|\.type.*human\|group_identities\|groupIdentities\|displayType\|display_type' apps/kernel/ packages/ --include="*.ts" --include="*.tsx" | grep -v node_modules | grep -v .next` to find all references
+
+Key rules:
+- All migration DDL must be idempotent (`IF NOT EXISTS`, `IF EXISTS`)
+- Do NOT edit code on the server
+- Run `pnpm --filter @imajin/kernel build` to verify no TypeScript errors before committing
+- Commit with descriptive messages referencing #346
+- When done, append a summary to `memory/2026-04-12.md`

--- a/packages/auth/src/require-admin.ts
+++ b/packages/auth/src/require-admin.ts
@@ -24,9 +24,9 @@ export async function requireAdmin() {
   if (!session?.actingAs) return null;
 
   const [nodeRow] = await sql`
-    SELECT group_did FROM auth.group_identities
-    WHERE group_did = ${session.actingAs}
-    AND scope = 'node'
+    SELECT id FROM auth.identities
+    WHERE id = ${session.actingAs}
+    AND scope = 'actor' AND subtype = 'node'
     LIMIT 1
   `;
 

--- a/packages/auth/src/require-admin.ts
+++ b/packages/auth/src/require-admin.ts
@@ -7,8 +7,11 @@ const sql = getClient();
  * Shared requireAdmin helper — extracted from the copy-pasted pattern
  * in apps/kernel/app/api/admin/**\/route.ts.
  *
- * Verifies the active session's actingAs DID is a node-scope group identity.
+ * Verifies the active session's actingAs DID matches the node DID (NODE_DID env var).
  * Returns the session if the caller is an admin, null otherwise.
+ *
+ * Future: scoped admin views where any non-actor identity gets filtered access
+ * based on its scope (community sees its own newsletter/telemetry, etc.).
  *
  * Usage:
  *   import { requireAdmin } from '@imajin/auth';
@@ -23,12 +26,8 @@ export async function requireAdmin() {
   const session = await getSession();
   if (!session?.actingAs) return null;
 
-  const [nodeRow] = await sql`
-    SELECT id FROM auth.identities
-    WHERE id = ${session.actingAs}
-    AND scope = 'actor' AND subtype = 'node'
-    LIMIT 1
-  `;
+  const nodeDid = process.env.NODE_DID;
+  if (!nodeDid) return null;
 
-  return nodeRow ? session : null;
+  return session.actingAs === nodeDid ? session : null;
 }

--- a/packages/auth/src/require-auth.ts
+++ b/packages/auth/src/require-auth.ts
@@ -48,7 +48,8 @@ async function validateSessionCookie(
     const data = await response.json();
     const identity: Identity = {
       id: data.did || data.identity?.did || data.identity?.id,
-      type: data.type || data.identity?.type || "human",
+      scope: data.scope || data.identity?.scope || "actor",
+      subtype: data.subtype || data.identity?.subtype || undefined,
       name: data.name || data.identity?.name,
       handle: data.handle || data.identity?.handle,
       tier: data.tier || data.identity?.tier || "soft",

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -82,7 +82,8 @@ export async function getSession(options?: SessionOptions): Promise<Identity | n
 
     const identity: Identity = {
       id: callerDid,
-      type: data.type || "human",
+      scope: data.scope || "actor",
+      subtype: data.subtype || undefined,
       name: data.name,
       handle: data.handle,
       tier: data.tier || "soft",

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -1,6 +1,7 @@
 export interface Identity {
   id: string;
-  type: "human" | "agent" | "presence";
+  scope: string;                // 'actor' | 'family' | 'community' | 'business'
+  subtype?: string;             // scope-dependent: 'human' | 'agent' | 'device' | etc.
   name?: string;
   handle?: string;
   tier?: "soft" | "preliminary" | "established";
@@ -18,7 +19,8 @@ export interface AuthError {
   status: number;
 }
 
-export type IdentityType = "human" | "agent";
+export type IdentityScope = "actor" | "family" | "community" | "business";
+export type IdentityType = "human" | "agent"; // used in SignedMessage only — not identity table
 
 export interface Keypair {
   privateKey: string; // 64-char hex (32 bytes)

--- a/packages/chat/src/hooks/useDidNames.ts
+++ b/packages/chat/src/hooks/useDidNames.ts
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useChatConfig } from '../ChatProvider';
 
 /**
  * Resolves DIDs to display names via auth lookup.
  * Nicknames (from connections service) take priority over auth names.
  * Caches results and deduplicates in-flight requests.
+ * Only re-fetches when the set of DIDs actually changes.
  */
 export function useDidNames(dids: string[]): Record<string, string> {
   const { chatUrl, connectionsUrl } = useChatConfig();
@@ -14,6 +15,12 @@ export function useDidNames(dids: string[]): Record<string, string> {
   const pendingRef = useRef(new Set<string>());
   const cacheRef = useRef<Record<string, string>>({});
   const nicknameCacheRef = useRef<Record<string, string>>({});
+
+  // Stable key: only changes when the actual set of DIDs changes
+  const didsKey = useMemo(() => {
+    const sorted = Array.from(new Set(dids)).sort();
+    return sorted.join(',');
+  }, [dids]);
 
   const resolve = useCallback(async (did: string) => {
     if (cacheRef.current[did] || pendingRef.current.has(did)) return;
@@ -40,15 +47,22 @@ export function useDidNames(dids: string[]): Record<string, string> {
     }
   }, [chatUrl]);
 
+  // Resolve auth names — only for DIDs not already cached
   useEffect(() => {
-    const uniqueDids = Array.from(new Set(dids));
-    uniqueDids.forEach(resolve);
-  }, [dids, resolve]);
+    const uniqueDids = didsKey.split(',').filter(Boolean);
+    const uncached = uniqueDids.filter(did => !cacheRef.current[did]);
+    uncached.forEach(resolve);
+  }, [didsKey, resolve]);
 
+  // Resolve nicknames — batch, only when DIDs change
   useEffect(() => {
     if (!connectionsUrl) return;
-    const uniqueDids = Array.from(new Set(dids));
+    const uniqueDids = didsKey.split(',').filter(Boolean);
     if (uniqueDids.length === 0) return;
+
+    // Skip if all nicknames already cached
+    const uncached = uniqueDids.filter(did => !(did in nicknameCacheRef.current));
+    if (uncached.length === 0) return;
 
     (async () => {
       try {
@@ -56,16 +70,20 @@ export function useDidNames(dids: string[]): Record<string, string> {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ dids: uniqueDids }),
+          body: JSON.stringify({ dids: uncached }),
         });
         if (res.ok) {
           const data = await res.json();
           const fetched: Record<string, string> = data.nicknames ?? {};
           let changed = false;
           for (const [did, nickname] of Object.entries(fetched)) {
-            if (nickname && nicknameCacheRef.current[did] !== nickname) {
-              nicknameCacheRef.current[did] = nickname;
-              changed = true;
+            nicknameCacheRef.current[did] = nickname || '';
+            if (nickname) changed = true;
+          }
+          // Mark DIDs with no nickname as resolved (empty string) to avoid re-fetching
+          for (const did of uncached) {
+            if (!(did in nicknameCacheRef.current)) {
+              nicknameCacheRef.current[did] = '';
             }
           }
           if (changed) {
@@ -76,7 +94,7 @@ export function useDidNames(dids: string[]): Record<string, string> {
         // Graceful fallback — auth names still resolve
       }
     })();
-  }, [dids, connectionsUrl]);
+  }, [didsKey, connectionsUrl]);
 
   // Nickname wins over auth name
   const merged: Record<string, string> = { ...cacheRef.current, ...names };

--- a/packages/config/src/services.ts
+++ b/packages/config/src/services.ts
@@ -156,18 +156,14 @@ export function buildPublicUrl(
     return port ? `http://localhost:${port}` : `http://localhost:3000`;
   }
 
-  // Kernel services live at /{name} on the same domain, not as subdomains.
-  // Only fall through to subdomain construction for federated apps (events, coffee, etc.)
-  // unless explicit prefix/domain args were passed (caller knows what they want).
+  // All services live at /{name} on the same domain (single-node architecture).
+  // Subdomain construction is legacy — only used if explicit prefix/domain args
+  // are passed (e.g. generating external links for a different node).
   if (!servicePrefix && !domain) {
-    const svc = SERVICES.find((s) => s.name === name);
-    if (svc?.category === "kernel") {
-      // "kernel" itself is the root, others are /{name}
-      return name === "kernel" ? "" : `/${name}`;
-    }
+    return name === "kernel" ? "" : `/${name}`;
   }
 
-  // Extract env prefix: "https://dev-" → "dev", "https://" → undefined
+  // Explicit prefix/domain passed — caller wants a full URL (e.g. cross-node links)
   const match = p.replace(/^https?:\/\//, "").replace(/-$/, "") || undefined;
   return getPublicUrl(name, { prefix: match, domain: d });
 }

--- a/packages/config/src/services.ts
+++ b/packages/config/src/services.ts
@@ -156,6 +156,17 @@ export function buildPublicUrl(
     return port ? `http://localhost:${port}` : `http://localhost:3000`;
   }
 
+  // Kernel services live at /{name} on the same domain, not as subdomains.
+  // Only fall through to subdomain construction for federated apps (events, coffee, etc.)
+  // unless explicit prefix/domain args were passed (caller knows what they want).
+  if (!servicePrefix && !domain) {
+    const svc = SERVICES.find((s) => s.name === name);
+    if (svc?.category === "kernel") {
+      // "kernel" itself is the root, others are /{name}
+      return name === "kernel" ? "" : `/${name}`;
+    }
+  }
+
   // Extract env prefix: "https://dev-" → "dev", "https://" → undefined
   const match = p.replace(/^https?:\/\//, "").replace(/-$/, "") || undefined;
   return getPublicUrl(name, { prefix: match, domain: d });

--- a/scripts/bootstrap-node-identity.ts
+++ b/scripts/bootstrap-node-identity.ts
@@ -121,11 +121,12 @@ async function main() {
 
   console.log('Generated node DID:', nodeDid);
 
-  // 2. Insert into auth.identities (type='node', tier='established')
+  // 2. Insert into auth.identities (scope='actor', subtype='node', tier='established')
   await sql`
-    INSERT INTO auth.identities (id, type, public_key, name, tier, created_at, updated_at)
+    INSERT INTO auth.identities (id, scope, subtype, public_key, name, tier, created_at, updated_at)
     VALUES (
       ${nodeDid},
+      'actor',
       'node',
       ${publicKeyHex},
       ${nodeName},


### PR DESCRIPTION
## Summary

Consolidates three redundant identity classification systems into two fields on `auth.identities`: **scope** + **subtype**. Then builds stub business identities on top as the first feature using the new model.

### Identity Scopes (#346)

**Problem:** Identity type was stored 3 ways — `identities.type`, `group_identities.scope`, `profiles.displayType` — with inconsistent enums and no single source of truth.

**Solution:** Two columns on `identities`:
- **`scope`** — `actor | family | community | business` (the 4 protocol scopes from the README matrix)
- **`subtype`** — scope-dependent (`human`, `agent`, `device`, `cafe`, `inc`, etc.)

**Changes:**
- `identities.type` → `identities.scope` + `identities.subtype` (migration 0017)
- Dropped `profiles.displayType` column (migration 0018)
- Dropped `auth.group_identities` table — fully redundant (migration 0018)
- Renamed `group_controllers` → `identity_members`, `group_did` → `identity_did`, `controller_did` → `member_did` (migration 0019)
- **Act-as role gate:** only `owner`/`admin` roles can act-as a group identity (was ungated — any member could act-as)
- Updated ~90 code references across auth, profile, admin, chat, pay, packages/auth

### Stub Business Identities (#653 core primitive)

Any authenticated user can create a **stub** — an unclaimed business identity the community maintains until the real owner arrives. Cold-start engine for business onboarding.

- `POST /api/stubs` — create stub (scope: business, role: maintainer, not owner)
- `GET /api/stubs/mine` — list your maintained stubs
- `POST /api/stubs/[did]/join` — join as maintainer
- Extended `GET /api/profile/[id]` with `claimStatus`, `maintainerCount`, `isMaintainer`
- "Places I Maintain" section in identity hub
- Stub creation form at `/auth/stubs/new`
- Community-maintained badge on unclaimed business profile pages
- Extracted `encryptPrivateKey` to shared `src/lib/auth/crypto.ts`
- Max 10 stubs per actor (rate limit)

### Migrations (run in order)

| # | What |
|---|------|
| 0017 | Add `scope` + `subtype` to identities, drop `type` |
| 0018 | Drop `profiles.display_type`, drop `auth.group_identities` |
| 0019 | Rename `group_controllers` → `identity_members` |
| 0020 | Add `claimed_by` + `claim_status` to profiles |

### Not in scope (follow-up)

- Consensus edit model (grace period, auto-approve)
- Owner claim flow + admin review queue
- Business-specific profile fields (hours, etc.)

Closes #346
Refs #653