### PR TITLE
feat(profile): scope-specific profile pages — actor, business, community, family

### DIFF
--- a/apps/kernel/app/profile/[handle]/page.tsx
+++ b/apps/kernel/app/profile/[handle]/page.tsx
@@ -1,181 +1,37 @@
 import { notFound } from 'next/navigation';
-import { cookies } from 'next/headers';
-import Link from 'next/link';
 import type { Metadata } from 'next';
-import { SESSION_COOKIE_NAME, buildPublicUrl } from '@imajin/config';
-import { db, profiles, follows, connections, identityMembers } from '@/src/db';
-import { getClient } from '@imajin/db';
-import { eq, count, and, isNull } from 'drizzle-orm';
-import { getSessionFromCookies } from '@/src/lib/kernel/session';
-import { Avatar } from '../components/Avatar';
-import { FollowButton } from '../components/FollowButton';
-import { AskButton } from '../components/AskButton';
-import { MarketItems } from '../components/MarketItems';
-import { UpcomingEvents } from '../components/UpcomingEvents';
+import {
+  getViewerDid,
+  getProfile,
+  getProfileCounts,
+  getFollowStatus,
+  isConnected,
+  getLinks,
+  getIdentityInfo,
+  getMaintainerInfo,
+} from '../lib/profile-data';
+import { getScopeEmoji } from '../lib/profile-utils';
+import { GatedProfile } from '../components/GatedProfile';
+import { ActorProfile } from '../components/profiles/ActorProfile';
 
 interface PageProps {
   params: Promise<{ handle: string }>;
 }
 
-interface FeatureToggles {
-  inference_enabled?: boolean;
-  show_market_items?: boolean;
-  show_events?: boolean;
-  links?: string | null;
-  coffee?: string | null;
-  dykil?: string | null;
-  learn?: string | null;
-}
-
-interface Profile {
-  did: string;
-  handle?: string;
-  displayName: string;
-  bio?: string;
-  avatar?: string;
-  email?: string;
-  phone?: string;
-  contactEmail?: string;
-  featureToggles?: FeatureToggles;
-  createdAt: string;
-  metadata?: Record<string, string>;
-  claimStatus?: string | null;
-}
-
-interface ProfileCounts {
-  followers: number;
-  following: number;
-  connections: number;
-}
-
-interface LinkItem {
-  title: string;
-  url: string;
-  description?: string;
-}
-
-async function getViewerDid(): Promise<string | null> {
-  try {
-    const cookieStore = await cookies();
-    const session = cookieStore.get(SESSION_COOKIE_NAME);
-    if (!session?.value) return null;
-    const kernelSession = await getSessionFromCookies(`${SESSION_COOKIE_NAME}=${session.value}`);
-    return kernelSession?.did ?? null;
-  } catch { return null; }
-}
-
-async function isConnected(viewerDid: string, targetDid: string): Promise<boolean> {
-  try {
-    const [connDidA, connDidB] = [viewerDid, targetDid].sort((a, b) => a.localeCompare(b));
-    const row = await db.query.connections.findFirst({
-      where: (c, { eq, and, isNull }) => and(
-        eq(c.didA, connDidA),
-        eq(c.didB, connDidB),
-        isNull(c.disconnectedAt)
-      ),
-    });
-    return !!row;
-  } catch { return false; }
-}
-
-async function getProfile(handle: string): Promise<Profile | null> {
-  const row = await db.query.profiles.findFirst({
-    where: (profiles, { eq, or }) => or(eq(profiles.did, handle), eq(profiles.handle, handle)),
-  });
-  return row as unknown as Profile | null;
-}
-
-async function getProfileCounts(profileDid: string): Promise<ProfileCounts> {
-  try {
-    const [followersResult] = await db.select({ count: count() }).from(follows).where(eq(follows.followedDid, profileDid));
-    const [followingResult] = await db.select({ count: count() }).from(follows).where(eq(follows.followerDid, profileDid));
-    const sql = getClient();
-    const [connectionsResult] = await sql`
-      SELECT count(*)::int as count
-      FROM connections.connections
-      WHERE (did_a = ${profileDid} OR did_b = ${profileDid})
-        AND disconnected_at IS NULL
-    `;
-    return {
-      followers: Number(followersResult.count),
-      following: Number(followingResult.count),
-      connections: connectionsResult?.count ?? 0,
-    };
-  } catch { return { followers: 0, following: 0, connections: 0 }; }
-}
-
-async function getFollowStatus(viewerDid: string, targetDid: string): Promise<boolean> {
-  const existingFollow = await db.query.follows.findFirst({
-    where: (follows, { eq, and }) => and(eq(follows.followerDid, viewerDid), eq(follows.followedDid, targetDid)),
-  });
-  return !!existingFollow;
-}
-
-async function getLinks(linksHandle: string): Promise<LinkItem[]> {
-  const linksServiceUrl = process.env.LINKS_SERVICE_URL;
-  if (!linksServiceUrl) return [];
-  try {
-    const res = await fetch(
-      `${linksServiceUrl}/api/pages/${encodeURIComponent(linksHandle)}/links`,
-      { cache: 'no-store' }
-    );
-    if (!res.ok) return [];
-    const data = await res.json();
-    return Array.isArray(data) ? data : (data.links || []);
-  } catch { return []; }
-}
-
-function getScopeEmoji(scope: string, subtype: string | null): string {
-  if (scope === 'actor') {
-    const map: Record<string, string> = { human: '👤', agent: '🤖', device: '📱', presence: '🟠' };
-    return map[subtype ?? 'human'] ?? '👤';
-  }
-  const map: Record<string, string> = { business: '🏢', family: '👨‍👩‍👧‍👦', community: '🌐' };
-  return map[scope] ?? '👤';
-}
-
-function getScopeLabel(scope: string, subtype: string | null): string {
-  if (scope === 'actor') {
-    const map: Record<string, string> = {
-      human: '👤 Human',
-      agent: '🤖 Agent',
-      device: '📱 Device',
-      presence: '🟠 Presence',
-    };
-    return map[subtype ?? 'human'] ?? '👤 Human';
-  }
-  const map: Record<string, string> = {
-    business: '🏢 Business',
-    family: '👨‍👩‍👧‍👦 Family',
-    community: '🌐 Community',
-  };
-  return map[scope] ?? scope;
-}
-
-// Generate dynamic metadata for OG/Twitter cards
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { handle } = await params;
   const profile = await getProfile(handle);
 
   if (!profile) {
-    return {
-      title: 'Profile Not Found',
-    };
+    return { title: 'Profile Not Found' };
   }
 
-  // Fetch identity scope+subtype for metadata
-  const authSqlMeta = getClient();
-  const [idRowMeta] = await authSqlMeta`
-    SELECT scope, subtype FROM auth.identities WHERE id = ${profile.did} LIMIT 1
-  `.catch(() => []);
-  const metaScope: string = idRowMeta?.scope ?? 'actor';
-  const metaSubtype: string | null = idRowMeta?.subtype ?? null;
-  const emoji = getScopeEmoji(metaScope, metaSubtype);
-
+  const identity = await getIdentityInfo(profile.did);
+  const emoji = getScopeEmoji(identity.scope, identity.subtype);
   const displayHandle = profile.handle ? `@${profile.handle}` : handle;
   const description = profile.bio
     ? profile.bio.slice(0, 200) + (profile.bio.length > 200 ? '...' : '')
-    : `${emoji} ${metaSubtype ?? metaScope} on the Imajin network`;
+    : `${emoji} ${identity.subtype ?? identity.scope} on the Imajin network`;
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://profile.imajin.ai';
   const url = `${baseUrl}/${handle}`;
@@ -208,274 +64,41 @@ export default async function ProfilePage({ params }: PageProps) {
     notFound();
   }
 
-  // Trust gating: only show full profile to self or connections
   const viewerDid = await getViewerDid();
   const isSelf = viewerDid === profile.did;
   const connected = viewerDid && !isSelf ? await isConnected(viewerDid, profile.did) : false;
 
   if (!isSelf && !connected) {
-    return (
-      <div className="max-w-lg mx-auto text-center py-16">
-        <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8">
-          <div className="mb-4 flex justify-center">
-            <Avatar avatar={profile.avatar} displayName={profile.displayName} size="lg" />
-          </div>
-          <h1 className="text-2xl font-bold mb-1 text-white">{profile.displayName}</h1>
-          {profile.handle && <p className="text-gray-400 mb-4">@{profile.handle}</p>}
-          <div className="py-6 border-t border-gray-800 mt-4">
-            <p className="text-gray-500 text-sm">
-              🔒 This profile is only visible to connections.
-            </p>
-            {!viewerDid && (
-              <a
-                href={`${buildPublicUrl('auth')}/login`}
-                className="inline-block mt-4 px-6 py-2 bg-[#F59E0B] text-black rounded-lg hover:bg-[#D97706] transition font-medium text-sm"
-              >
-                Login to see more
-              </a>
-            )}
-          </div>
-        </div>
-      </div>
-    );
+    return <GatedProfile profile={profile} viewerDid={viewerDid} />;
   }
 
-  const authSql = getClient();
-  const [identityRow] = await authSql`SELECT tier, scope, subtype FROM auth.identities WHERE id = ${profile.did} LIMIT 1`.catch(() => []);
-  const identityScope: string = identityRow?.scope ?? 'actor';
-  const identitySubtype: string | null = identityRow?.subtype ?? null;
-  const typeLabel = getScopeLabel(identityScope, identitySubtype);
-  const isSoftDID = identityRow?.tier === 'soft';
-  const [chainRow] = await authSql`SELECT did FROM auth.identity_chains WHERE did = ${profile.did} LIMIT 1`.catch(() => []);
-  const chainVerified = !!chainRow;
-
-  // Stub metadata for unclaimed business profiles
-  let maintainerCount = 0;
-  let isMaintainer = false;
-  if (identityScope === 'business' && profile.claimStatus === 'unclaimed') {
-    try {
-      const [{ value: mc }] = await db
-        .select({ value: count() })
-        .from(identityMembers)
-        .where(
-          and(
-            eq(identityMembers.identityDid, profile.did),
-            eq(identityMembers.role, 'maintainer'),
-            isNull(identityMembers.removedAt)
-          )
-        );
-      maintainerCount = mc;
-
-      if (viewerDid && !isSelf) {
-        const [maintainerRow] = await db
-          .select({ identityDid: identityMembers.identityDid })
-          .from(identityMembers)
-          .where(
-            and(
-              eq(identityMembers.identityDid, profile.did),
-              eq(identityMembers.memberDid, viewerDid),
-              eq(identityMembers.role, 'maintainer'),
-              isNull(identityMembers.removedAt)
-            )
-          )
-          .limit(1);
-        isMaintainer = !!maintainerRow;
-      }
-    } catch {
-      // Non-fatal
-    }
-  }
-
-  // Fetch counts, follow status, and links in parallel
-  const [counts, isFollowing, links] = await Promise.all([
+  const [identity, counts, isFollowing, links] = await Promise.all([
+    getIdentityInfo(profile.did),
     getProfileCounts(profile.did),
     viewerDid && !isSelf ? getFollowStatus(viewerDid, profile.did) : Promise.resolve(false),
     profile.featureToggles?.links ? getLinks(profile.featureToggles.links) : Promise.resolve([]),
   ]);
 
-  const servicePrefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
-  const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
+  let maintainerInfo: { count: number; isMaintainer: boolean } | undefined;
+  if (identity.scope === 'business' && profile.claimStatus === 'unclaimed') {
+    maintainerInfo = await getMaintainerInfo(profile.did, isSelf ? null : viewerDid);
+  }
 
-  return (
-    <div className="max-w-lg mx-auto">
-      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8 text-center">
-        {/* Avatar */}
-        <div className="mb-4 flex justify-center">
-          <Avatar avatar={profile.avatar} displayName={profile.displayName} size="lg" />
-        </div>
+  const viewer = {
+    viewerDid,
+    isSelf,
+    isConnected: !!connected,
+    isFollowing: isFollowing as boolean,
+  };
 
-        {/* Name & Handle */}
-        <h1 className="text-2xl font-bold mb-1 text-white">{profile.displayName}</h1>
-        {profile.handle && (
-          <p className="text-gray-400 mb-2">@{profile.handle}</p>
-        )}
+  const props = { profile, identity, viewer, counts, links, maintainerInfo };
 
-        {/* Type badge & Identity Tier */}
-        <div className="flex gap-2 justify-center mb-4 flex-wrap">
-          <span className="inline-block px-3 py-1 bg-gray-900 border border-gray-800 rounded-full text-sm text-gray-300">
-            {typeLabel}
-          </span>
-          {isSoftDID && (
-            <span className="inline-block px-3 py-1 bg-amber-900/30 border border-amber-700/50 rounded-full text-sm text-amber-400">
-              ⚡ Quick Profile
-            </span>
-          )}
-          {chainVerified && (
-            <span className="inline-block px-3 py-1 bg-emerald-900/30 border border-emerald-700/50 rounded-full text-sm text-emerald-400">
-              ⛓ Chain Verified
-            </span>
-          )}
-          {identityScope === 'business' && profile.claimStatus === 'unclaimed' && (
-            <span className="inline-block px-3 py-1 bg-sky-900/30 border border-sky-700/50 rounded-full text-sm text-sky-400">
-              🤝 Community-maintained
-            </span>
-          )}
-        </div>
-
-        {/* Unclaimed stub — maintainer info + join CTA */}
-        {identityScope === 'business' && profile.claimStatus === 'unclaimed' && (
-          <div className="mb-4 bg-sky-950/30 border border-sky-800/40 rounded-xl px-4 py-3 text-sm text-sky-300">
-            <p className="mb-1">
-              This place is community-maintained.{' '}
-              <span className="text-sky-400 font-medium">{maintainerCount} maintainer{maintainerCount !== 1 ? 's' : ''}</span> keeping it up to date.
-            </p>
-            {viewerDid && !isMaintainer && (
-              <form action={`/profile/api/stubs/${encodeURIComponent(profile.did)}/join`} method="POST">
-                <button
-                  type="submit"
-                  className="mt-2 px-4 py-1.5 bg-sky-700 hover:bg-sky-600 text-white rounded-lg text-xs font-medium transition-colors"
-                >
-                  Help maintain this place
-                </button>
-              </form>
-            )}
-            {viewerDid && isMaintainer && (
-              <p className="mt-1 text-xs text-sky-500">You are a maintainer of this place.</p>
-            )}
-          </div>
-        )}
-
-        {/* Counts & Follow Button */}
-        <div className="mb-6 flex flex-col items-center gap-3">
-          <p className="text-sm text-gray-400">
-            <span className="text-white font-medium">{counts.followers}</span> followers
-            {' · '}
-            <span className="text-white font-medium">{counts.following}</span> following
-            {' · '}
-            <span className="text-white font-medium">{counts.connections}</span> connections
-          </p>
-          {viewerDid && !isSelf && (
-            <FollowButton targetDid={profile.did} initialFollowing={isFollowing} />
-          )}
-        </div>
-
-        {/* Bio */}
-        {profile.bio && (
-          <p className="text-gray-300 mb-6">
-            {profile.bio}
-          </p>
-        )}
-
-        {/* Info note for invited members viewing their own profile */}
-        {isSoftDID && isSelf && (
-          <p className="mb-6 text-xs text-gray-500 border border-gray-800 rounded-lg px-4 py-3">
-            Invited members can claim a handle and download backup keys
-          </p>
-        )}
-
-        {/* Contact Info (only visible to self/connections — API strips for others) */}
-        {(profile.contactEmail || profile.phone) && (
-          <div className="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg p-4 text-left">
-            <p className="text-xs text-gray-500 mb-2 text-center">📇 Contact</p>
-            {profile.contactEmail && (
-              <p className="text-sm text-gray-300 mb-1">
-                <span className="text-gray-500">✉️</span>{' '}
-                <a href={`mailto:${profile.contactEmail}`} className="text-[#F59E0B] hover:underline">
-                  {profile.contactEmail}
-                </a>
-              </p>
-            )}
-            {profile.phone && (
-              <p className="text-sm text-gray-300">
-                <span className="text-gray-500">📱</span>{' '}
-                <a href={`tel:${profile.phone}`} className="text-[#F59E0B] hover:underline">
-                  {profile.phone}
-                </a>
-              </p>
-            )}
-          </div>
-        )}
-
-        {/* Action buttons — single row */}
-        <div className="flex justify-center gap-3 mb-6 flex-wrap">
-          <AskButton
-            targetDid={profile.did}
-            targetName={profile.displayName}
-            targetHandle={profile.handle}
-            inferenceEnabled={!!profile.featureToggles?.inference_enabled}
-            canAsk={!!viewerDid}
-          />
-          {profile.featureToggles?.links && (
-            <a
-              href={`${process.env.NEXT_PUBLIC_LINKS_URL || `${servicePrefix}links.${domain}`}/${profile.featureToggles.links}`}
-              className="px-4 py-2 bg-gray-900 border border-gray-800 rounded-lg hover:bg-gray-800 transition text-white text-sm font-medium"
-            >
-              🔗 Links
-            </a>
-          )}
-          {profile.featureToggles?.coffee && (
-            <a
-              href={`${process.env.NEXT_PUBLIC_COFFEE_URL || `${servicePrefix}coffee.${domain}`}/${profile.featureToggles.coffee}`}
-              className="px-4 py-2 bg-[#F59E0B]/10 border-[#F59E0B]/30 text-[#F59E0B] rounded-lg hover:bg-[#F59E0B]/20 transition border text-sm font-medium"
-            >
-              ☕ Tip Me
-            </a>
-          )}
-        </div>
-
-        {/* Expanded links list (when links service has items) */}
-        {links.length > 0 && (
-          <div className="mb-6 space-y-2">
-            {links.map((link, i) => (
-              <a
-                key={i}
-                href={link.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg hover:bg-gray-800 transition text-left"
-              >
-                <p className="text-white text-sm font-medium">{link.title}</p>
-                {link.description && (
-                  <p className="text-gray-500 text-xs mt-0.5">{link.description}</p>
-                )}
-              </a>
-            ))}
-          </div>
-        )}
-
-        {/* Upcoming events */}
-        {profile.featureToggles?.show_events && (
-          <UpcomingEvents did={profile.did} servicePrefix={servicePrefix} domain={domain} viewerDid={viewerDid} />
-        )}
-
-        {/* Market items */}
-        {profile.featureToggles?.show_market_items && (
-          <MarketItems did={profile.did} handle={profile.handle} servicePrefix={servicePrefix} domain={domain} />
-        )}
-
-        {/* Member since */}
-        <p className="text-xs text-gray-500 mt-4">
-          Member since {new Date(profile.createdAt).toLocaleDateString('en-US', {
-            month: 'long',
-            year: 'numeric'
-          })}
-        </p>
-      </div>
-
-      {/* DID */}
-      <p className="text-center text-xs text-gray-500 mt-4 font-mono break-all">
-        {profile.did}
-      </p>
-    </div>
-  );
+  switch (identity.scope) {
+    case 'actor':
+    case 'business':
+    case 'community':
+    case 'family':
+    default:
+      return <ActorProfile {...props} />;
+  }
 }

--- a/apps/kernel/app/profile/[handle]/page.tsx
+++ b/apps/kernel/app/profile/[handle]/page.tsx
@@ -8,11 +8,11 @@ import {
   isConnected,
   getLinks,
   getIdentityInfo,
-  getMaintainerInfo,
 } from '../lib/profile-data';
 import { getScopeEmoji } from '../lib/profile-utils';
 import { GatedProfile } from '../components/GatedProfile';
 import { ActorProfile } from '../components/profiles/ActorProfile';
+import { BusinessProfile } from '../components/profiles/BusinessProfile';
 
 interface PageProps {
   params: Promise<{ handle: string }>;
@@ -79,11 +79,6 @@ export default async function ProfilePage({ params }: PageProps) {
     profile.featureToggles?.links ? getLinks(profile.featureToggles.links) : Promise.resolve([]),
   ]);
 
-  let maintainerInfo: { count: number; isMaintainer: boolean } | undefined;
-  if (identity.scope === 'business' && profile.claimStatus === 'unclaimed') {
-    maintainerInfo = await getMaintainerInfo(profile.did, isSelf ? null : viewerDid);
-  }
-
   const viewer = {
     viewerDid,
     isSelf,
@@ -91,11 +86,12 @@ export default async function ProfilePage({ params }: PageProps) {
     isFollowing: isFollowing as boolean,
   };
 
-  const props = { profile, identity, viewer, counts, links, maintainerInfo };
+  const props = { profile, identity, viewer, counts, links };
 
   switch (identity.scope) {
-    case 'actor':
     case 'business':
+      return <BusinessProfile {...props} />;
+    case 'actor':
     case 'community':
     case 'family':
     default:

--- a/apps/kernel/app/profile/[handle]/page.tsx
+++ b/apps/kernel/app/profile/[handle]/page.tsx
@@ -13,6 +13,8 @@ import { getScopeEmoji } from '../lib/profile-utils';
 import { GatedProfile } from '../components/GatedProfile';
 import { ActorProfile } from '../components/profiles/ActorProfile';
 import { BusinessProfile } from '../components/profiles/BusinessProfile';
+import { CommunityProfile } from '../components/profiles/CommunityProfile';
+import { FamilyProfile } from '../components/profiles/FamilyProfile';
 
 interface PageProps {
   params: Promise<{ handle: string }>;
@@ -91,9 +93,11 @@ export default async function ProfilePage({ params }: PageProps) {
   switch (identity.scope) {
     case 'business':
       return <BusinessProfile {...props} />;
-    case 'actor':
     case 'community':
+      return <CommunityProfile {...props} />;
     case 'family':
+      return <FamilyProfile {...props} />;
+    case 'actor':
     default:
       return <ActorProfile {...props} />;
   }

--- a/apps/kernel/app/profile/components/BusinessDetails.tsx
+++ b/apps/kernel/app/profile/components/BusinessDetails.tsx
@@ -1,0 +1,53 @@
+interface BusinessDetailsProps {
+  metadata?: Record<string, unknown>;
+}
+
+export function BusinessDetails({ metadata }: BusinessDetailsProps) {
+  if (!metadata) return null;
+
+  const location = metadata.location as string | undefined;
+  const phone = metadata.phone as string | undefined;
+  const website = metadata.website as string | undefined;
+  const category = metadata.category as string | undefined;
+
+  if (!location && !phone && !website && !category) return null;
+
+  return (
+    <div className="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg p-4 text-left">
+      <p className="text-xs text-gray-500 mb-2 text-center">🏢 Business Info</p>
+      {category && (
+        <p className="text-sm text-gray-300 mb-1">
+          <span className="text-gray-500">🏷️</span>{' '}
+          <span>{category}</span>
+        </p>
+      )}
+      {location && (
+        <p className="text-sm text-gray-300 mb-1">
+          <span className="text-gray-500">📍</span>{' '}
+          <span>{location}</span>
+        </p>
+      )}
+      {phone && (
+        <p className="text-sm text-gray-300 mb-1">
+          <span className="text-gray-500">📞</span>{' '}
+          <a href={`tel:${phone}`} className="text-[#F59E0B] hover:underline">
+            {phone}
+          </a>
+        </p>
+      )}
+      {website && (
+        <p className="text-sm text-gray-300">
+          <span className="text-gray-500">🌐</span>{' '}
+          <a
+            href={website.startsWith('http') ? website : `https://${website}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#F59E0B] hover:underline"
+          >
+            {website}
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/ContactCard.tsx
+++ b/apps/kernel/app/profile/components/ContactCard.tsx
@@ -1,0 +1,30 @@
+interface ContactCardProps {
+  contactEmail?: string;
+  phone?: string;
+}
+
+export function ContactCard({ contactEmail, phone }: ContactCardProps) {
+  if (!contactEmail && !phone) return null;
+
+  return (
+    <div className="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg p-4 text-left">
+      <p className="text-xs text-gray-500 mb-2 text-center">📇 Contact</p>
+      {contactEmail && (
+        <p className="text-sm text-gray-300 mb-1">
+          <span className="text-gray-500">✉️</span>{' '}
+          <a href={`mailto:${contactEmail}`} className="text-[#F59E0B] hover:underline">
+            {contactEmail}
+          </a>
+        </p>
+      )}
+      {phone && (
+        <p className="text-sm text-gray-300">
+          <span className="text-gray-500">📱</span>{' '}
+          <a href={`tel:${phone}`} className="text-[#F59E0B] hover:underline">
+            {phone}
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/ForestServices.tsx
+++ b/apps/kernel/app/profile/components/ForestServices.tsx
@@ -1,0 +1,35 @@
+import { SERVICES } from '@imajin/config';
+import { buildServiceUrl } from '../lib/profile-utils';
+
+interface ForestServicesProps {
+  enabledServices: string[];
+  handle?: string;
+}
+
+export function ForestServices({ enabledServices, handle }: ForestServicesProps) {
+  if (!enabledServices || enabledServices.length === 0) return null;
+
+  const services = enabledServices
+    .map((name) => SERVICES.find((s) => s.name === name))
+    .filter(Boolean) as typeof SERVICES[number][];
+
+  if (services.length === 0) return null;
+
+  return (
+    <div className="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg p-4">
+      <p className="text-xs text-gray-500 mb-3 text-center">Services</p>
+      <div className="flex flex-wrap justify-center gap-2">
+        {services.map((svc) => (
+          <a
+            key={svc.name}
+            href={handle ? `${buildServiceUrl(svc.name)}/${handle}` : buildServiceUrl(svc.name)}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg hover:bg-gray-700 transition text-sm text-white"
+          >
+            <span>{svc.icon}</span>
+            <span>{svc.label}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/GatedProfile.tsx
+++ b/apps/kernel/app/profile/components/GatedProfile.tsx
@@ -1,0 +1,35 @@
+import { buildPublicUrl } from '@imajin/config';
+import { Avatar } from './Avatar';
+import type { ProfileData } from '../lib/types';
+
+interface GatedProfileProps {
+  profile: ProfileData;
+  viewerDid: string | null;
+}
+
+export function GatedProfile({ profile, viewerDid }: GatedProfileProps) {
+  return (
+    <div className="max-w-lg mx-auto text-center py-16">
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8">
+        <div className="mb-4 flex justify-center">
+          <Avatar avatar={profile.avatar} displayName={profile.displayName} size="lg" />
+        </div>
+        <h1 className="text-2xl font-bold mb-1 text-white">{profile.displayName}</h1>
+        {profile.handle && <p className="text-gray-400 mb-4">@{profile.handle}</p>}
+        <div className="py-6 border-t border-gray-800 mt-4">
+          <p className="text-gray-500 text-sm">
+            🔒 This profile is only visible to connections.
+          </p>
+          {!viewerDid && (
+            <a
+              href={`${buildPublicUrl('auth')}/login`}
+              className="inline-block mt-4 px-6 py-2 bg-[#F59E0B] text-black rounded-lg hover:bg-[#D97706] transition font-medium text-sm"
+            >
+              Login to see more
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/JoinButton.tsx
+++ b/apps/kernel/app/profile/components/JoinButton.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+
+interface JoinButtonProps {
+  identityDid: string;
+  viewerDid: string | null;
+  initialMemberRole: string | null;
+}
+
+export function JoinButton({ identityDid, viewerDid, initialMemberRole }: JoinButtonProps) {
+  const [memberRole, setMemberRole] = useState(initialMemberRole);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!viewerDid) {
+    return (
+      <div className="mb-6">
+        <button
+          disabled
+          className="px-6 py-2 bg-gray-900 border border-gray-800 rounded-lg text-gray-500 text-sm cursor-not-allowed"
+        >
+          Sign in to join
+        </button>
+      </div>
+    );
+  }
+
+  if (memberRole) {
+    return (
+      <div className="mb-6">
+        <div className="px-6 py-2 bg-gray-900/50 border border-gray-800 rounded-lg text-gray-400 text-sm inline-block">
+          ✓ You&apos;re a {memberRole}
+        </div>
+      </div>
+    );
+  }
+
+  async function handleJoin() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/profile/api/stubs/${encodeURIComponent(identityDid)}/join`, {
+        method: 'POST',
+      });
+      if (res.ok) {
+        setMemberRole('member');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || 'Failed to join');
+      }
+    } catch {
+      setError('Failed to join');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mb-6">
+      <button
+        onClick={handleJoin}
+        disabled={loading}
+        className="px-6 py-2 bg-[#F59E0B]/10 border border-[#F59E0B]/30 text-[#F59E0B] rounded-lg hover:bg-[#F59E0B]/20 transition text-sm font-medium disabled:opacity-50"
+      >
+        {loading ? 'Joining...' : '+ Join Community'}
+      </button>
+      {error && <p className="text-red-400 text-xs mt-2">{error}</p>}
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/MarketItems.tsx
+++ b/apps/kernel/app/profile/components/MarketItems.tsx
@@ -5,8 +5,7 @@ import { useState, useEffect } from 'react';
 interface MarketItemsProps {
   did: string;
   handle?: string;
-  servicePrefix: string;
-  domain: string;
+  marketBaseUrl?: string;
 }
 
 interface Listing {
@@ -24,11 +23,11 @@ function formatPrice(amount: number, currency: string) {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(value);
 }
 
-export function MarketItems({ did, handle, servicePrefix, domain }: MarketItemsProps) {
+export function MarketItems({ did, handle, marketBaseUrl }: MarketItemsProps) {
   const [listings, setListings] = useState<Listing[] | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const marketBase = process.env.NEXT_PUBLIC_MARKET_URL || `${servicePrefix}market.${domain}`;
+  const marketBase = marketBaseUrl || process.env.NEXT_PUBLIC_MARKET_URL || '/market';
 
   useEffect(() => {
     fetch(`${marketBase}/api/listings?seller_did=${encodeURIComponent(did)}&status=active&limit=8`)

--- a/apps/kernel/app/profile/components/MemberList.tsx
+++ b/apps/kernel/app/profile/components/MemberList.tsx
@@ -1,0 +1,120 @@
+import { getMembersByRole } from '../lib/profile-data';
+import { Avatar } from './Avatar';
+
+interface MemberListProps {
+  identityDid: string;
+  roleFilter?: string;
+  grouped?: boolean;
+  showCount?: boolean;
+  title?: string;
+}
+
+const ROLE_HEADERS: Record<string, string> = {
+  owner: '👑 Owners',
+  admin: '🛡️ Admins',
+  member: '👥 Members',
+  maintainer: '🔧 Maintainers',
+};
+
+export async function MemberList({
+  identityDid,
+  roleFilter,
+  grouped = false,
+  showCount = false,
+  title = 'Members',
+}: MemberListProps) {
+  const allMembers = await getMembersByRole(identityDid);
+  const members = roleFilter
+    ? allMembers.filter((m) => m.role === roleFilter)
+    : allMembers;
+
+  const sectionTitle = roleFilter
+    ? (ROLE_HEADERS[roleFilter] ?? `${roleFilter}s`)
+    : title;
+
+  if (members.length === 0) {
+    return (
+      <div className="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg p-4 text-center">
+        <p className="text-xs text-gray-500">No members yet</p>
+      </div>
+    );
+  }
+
+  if (grouped && !roleFilter) {
+    const byRole: Record<string, typeof members> = {};
+    for (const m of members) {
+      if (!byRole[m.role]) byRole[m.role] = [];
+      byRole[m.role].push(m);
+    }
+    const roleOrder = ['owner', 'admin', 'maintainer', 'member'];
+    const sortedRoles = [
+      ...roleOrder.filter((r) => byRole[r]),
+      ...Object.keys(byRole).filter((r) => !roleOrder.includes(r)),
+    ];
+
+    return (
+      <div className="mb-6 space-y-4">
+        {sortedRoles.map((role) => (
+          <div key={role} className="bg-gray-900/50 border border-gray-800 rounded-lg p-4">
+            <p className="text-xs text-gray-500 mb-3 text-center">
+              {ROLE_HEADERS[role] ?? role}
+              {showCount && (
+                <span className="ml-1 text-gray-600">({byRole[role].length})</span>
+              )}
+            </p>
+            <div className="space-y-2">
+              {byRole[role].map((m) => (
+                <MemberRow key={m.did} member={m} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg p-4">
+      <p className="text-xs text-gray-500 mb-3 text-center">
+        {sectionTitle}
+        {showCount && (
+          <span className="ml-1 text-gray-600">({members.length})</span>
+        )}
+      </p>
+      <div className="space-y-2">
+        {members.map((m) => (
+          <MemberRow key={m.did} member={m} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MemberRow({ member }: { member: { did: string; displayName: string; handle?: string; avatar?: string } }) {
+  const initials = member.displayName
+    .split(' ')
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-shrink-0">
+        {member.avatar ? (
+          <Avatar avatar={member.avatar} displayName={member.displayName} size="sm" />
+        ) : (
+          <div className="w-8 h-8 rounded-full flex items-center justify-center bg-gray-800 border border-gray-700 text-xs font-medium text-gray-400">
+            {initials || '?'}
+          </div>
+        )}
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm text-white font-medium truncate">{member.displayName}</p>
+        {member.handle && (
+          <p className="text-xs text-gray-500 truncate">@{member.handle}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/ProfileStats.tsx
+++ b/apps/kernel/app/profile/components/ProfileStats.tsx
@@ -1,0 +1,27 @@
+import { FollowButton } from './FollowButton';
+import type { ProfileCounts } from '../lib/types';
+
+interface ProfileStatsProps {
+  counts: ProfileCounts;
+  viewerDid: string | null;
+  isSelf: boolean;
+  targetDid: string;
+  isFollowing: boolean;
+}
+
+export function ProfileStats({ counts, viewerDid, isSelf, targetDid, isFollowing }: ProfileStatsProps) {
+  return (
+    <div className="mb-6 flex flex-col items-center gap-3">
+      <p className="text-sm text-gray-400">
+        <span className="text-white font-medium">{counts.followers}</span> followers
+        {' · '}
+        <span className="text-white font-medium">{counts.following}</span> following
+        {' · '}
+        <span className="text-white font-medium">{counts.connections}</span> connections
+      </p>
+      {viewerDid && !isSelf && (
+        <FollowButton targetDid={targetDid} initialFollowing={isFollowing} />
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/ScopeHeader.tsx
+++ b/apps/kernel/app/profile/components/ScopeHeader.tsx
@@ -1,0 +1,50 @@
+import { Avatar } from './Avatar';
+import { getScopeLabel } from '../lib/profile-utils';
+import type { ProfileData, IdentityInfo } from '../lib/types';
+
+interface ScopeHeaderProps {
+  profile: ProfileData;
+  identity: IdentityInfo;
+}
+
+export function ScopeHeader({ profile, identity }: ScopeHeaderProps) {
+  const typeLabel = getScopeLabel(identity.scope, identity.subtype);
+  const isSoftDID = identity.tier === 'soft';
+
+  return (
+    <>
+      {/* Avatar */}
+      <div className="mb-4 flex justify-center">
+        <Avatar avatar={profile.avatar} displayName={profile.displayName} size="lg" />
+      </div>
+
+      {/* Name & Handle */}
+      <h1 className="text-2xl font-bold mb-1 text-white">{profile.displayName}</h1>
+      {profile.handle && (
+        <p className="text-gray-400 mb-2">@{profile.handle}</p>
+      )}
+
+      {/* Type badge & Identity Tier */}
+      <div className="flex gap-2 justify-center mb-4 flex-wrap">
+        <span className="inline-block px-3 py-1 bg-gray-900 border border-gray-800 rounded-full text-sm text-gray-300">
+          {typeLabel}
+        </span>
+        {isSoftDID && (
+          <span className="inline-block px-3 py-1 bg-amber-900/30 border border-amber-700/50 rounded-full text-sm text-amber-400">
+            ⚡ Quick Profile
+          </span>
+        )}
+        {identity.chainVerified && (
+          <span className="inline-block px-3 py-1 bg-emerald-900/30 border border-emerald-700/50 rounded-full text-sm text-emerald-400">
+            ⛓ Chain Verified
+          </span>
+        )}
+        {identity.scope === 'business' && profile.claimStatus === 'unclaimed' && (
+          <span className="inline-block px-3 py-1 bg-sky-900/30 border border-sky-700/50 rounded-full text-sm text-sky-400">
+            🤝 Community-maintained
+          </span>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/kernel/app/profile/components/ServiceLinks.tsx
+++ b/apps/kernel/app/profile/components/ServiceLinks.tsx
@@ -1,0 +1,38 @@
+import { AskButton } from './AskButton';
+import { buildPublicUrl } from '@imajin/config';
+import type { ProfileData } from '../lib/types';
+
+interface ServiceLinksProps {
+  profile: ProfileData;
+  viewerDid: string | null;
+}
+
+export function ServiceLinks({ profile, viewerDid }: ServiceLinksProps) {
+  return (
+    <div className="flex justify-center gap-3 mb-6 flex-wrap">
+      <AskButton
+        targetDid={profile.did}
+        targetName={profile.displayName}
+        targetHandle={profile.handle}
+        inferenceEnabled={!!profile.featureToggles?.inference_enabled}
+        canAsk={!!viewerDid}
+      />
+      {profile.featureToggles?.links && (
+        <a
+          href={`${buildPublicUrl('links')}/${profile.featureToggles.links}`}
+          className="px-4 py-2 bg-gray-900 border border-gray-800 rounded-lg hover:bg-gray-800 transition text-white text-sm font-medium"
+        >
+          🔗 Links
+        </a>
+      )}
+      {profile.featureToggles?.coffee && (
+        <a
+          href={`${buildPublicUrl('coffee')}/${profile.featureToggles.coffee}`}
+          className="px-4 py-2 bg-[#F59E0B]/10 border-[#F59E0B]/30 text-[#F59E0B] rounded-lg hover:bg-[#F59E0B]/20 transition border text-sm font-medium"
+        >
+          ☕ Tip Me
+        </a>
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/StubActions.tsx
+++ b/apps/kernel/app/profile/components/StubActions.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+interface StubActionsProps {
+  identityDid: string;
+  profileHandle?: string;
+  claimStatus?: string | null;
+  isMaintainer: boolean;
+  viewerDid: string | null;
+}
+
+export function StubActions({
+  identityDid,
+  profileHandle,
+  claimStatus,
+  isMaintainer,
+  viewerDid,
+}: StubActionsProps) {
+  const isUnclaimed = !claimStatus || claimStatus === 'unclaimed';
+
+  if (!isUnclaimed && !isMaintainer) return null;
+
+  return (
+    <div className="mb-6 bg-sky-950/30 border border-sky-800/40 rounded-xl px-4 py-3 text-sm text-sky-300">
+      {isMaintainer ? (
+        <p className="text-xs text-sky-500 text-center">
+          ✓ You are a maintainer of this place.
+        </p>
+      ) : (
+        isUnclaimed && viewerDid && (
+          <div className="space-y-2">
+            <p className="text-center text-sky-300 text-xs">
+              This place is community-maintained.
+            </p>
+            <div className="flex flex-col items-center gap-2 mt-2">
+              <form
+                action={`/profile/api/stubs/${encodeURIComponent(identityDid)}/join`}
+                method="POST"
+              >
+                <button
+                  type="submit"
+                  className="px-4 py-1.5 bg-sky-700 hover:bg-sky-600 text-white rounded-lg text-xs font-medium transition-colors"
+                >
+                  Help maintain this place
+                </button>
+              </form>
+              {profileHandle && (
+                <a
+                  href={`/claim/${encodeURIComponent(profileHandle)}`}
+                  className="text-xs text-sky-400 hover:text-sky-300 hover:underline"
+                >
+                  Claim this business
+                </a>
+              )}
+            </div>
+          </div>
+        )
+      )}
+
+      <div className="mt-3 text-center">
+        <button
+          type="button"
+          disabled
+          className="text-xs text-gray-600 cursor-not-allowed"
+          title="Coming soon"
+        >
+          ✏️ Suggest an edit
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/UpcomingEvents.tsx
+++ b/apps/kernel/app/profile/components/UpcomingEvents.tsx
@@ -4,8 +4,7 @@ import { useState, useEffect } from 'react';
 
 interface UpcomingEventsProps {
   did: string;
-  servicePrefix: string;
-  domain: string;
+  eventsBaseUrl?: string;
   viewerDid?: string | null;
 }
 
@@ -37,10 +36,10 @@ function formatEventDate(startDate: string, endDate: string | null): string {
   return `${startStr} – ${end.toLocaleDateString('en-US', opts)}`;
 }
 
-export function UpcomingEvents({ did, servicePrefix, domain, viewerDid }: UpcomingEventsProps) {
+export function UpcomingEvents({ did, eventsBaseUrl, viewerDid }: UpcomingEventsProps) {
   const [events, setEvents] = useState<AttendingEvent[] | null>(null);
 
-  const eventsBase = process.env.NEXT_PUBLIC_EVENTS_URL || `${servicePrefix}events.${domain}`;
+  const eventsBase = eventsBaseUrl || process.env.NEXT_PUBLIC_EVENTS_URL || '/events';
 
   useEffect(() => {
     const url = new URL(`${eventsBase}/api/attending/${encodeURIComponent(did)}`);

--- a/apps/kernel/app/profile/components/profiles/ActorProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/ActorProfile.tsx
@@ -7,7 +7,7 @@ import { MarketItems } from '../MarketItems';
 import { formatMemberSince } from '../../lib/profile-utils';
 import type { ProfileViewProps } from '../../lib/types';
 
-export function ActorProfile({ profile, identity, viewer, counts, links, maintainerInfo }: ProfileViewProps) {
+export function ActorProfile({ profile, identity, viewer, counts, links }: ProfileViewProps) {
   const isSoftDID = identity.tier === 'soft';
   const servicePrefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
   const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
@@ -16,29 +16,6 @@ export function ActorProfile({ profile, identity, viewer, counts, links, maintai
     <div className="max-w-lg mx-auto">
       <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8 text-center">
         <ScopeHeader profile={profile} identity={identity} />
-
-        {/* Unclaimed stub — maintainer info + join CTA */}
-        {identity.scope === 'business' && profile.claimStatus === 'unclaimed' && maintainerInfo && (
-          <div className="mb-4 bg-sky-950/30 border border-sky-800/40 rounded-xl px-4 py-3 text-sm text-sky-300">
-            <p className="mb-1">
-              This place is community-maintained.{' '}
-              <span className="text-sky-400 font-medium">{maintainerInfo.count} maintainer{maintainerInfo.count !== 1 ? 's' : ''}</span> keeping it up to date.
-            </p>
-            {viewer.viewerDid && !maintainerInfo.isMaintainer && (
-              <form action={`/profile/api/stubs/${encodeURIComponent(profile.did)}/join`} method="POST">
-                <button
-                  type="submit"
-                  className="mt-2 px-4 py-1.5 bg-sky-700 hover:bg-sky-600 text-white rounded-lg text-xs font-medium transition-colors"
-                >
-                  Help maintain this place
-                </button>
-              </form>
-            )}
-            {viewer.viewerDid && maintainerInfo.isMaintainer && (
-              <p className="mt-1 text-xs text-sky-500">You are a maintainer of this place.</p>
-            )}
-          </div>
-        )}
 
         <ProfileStats
           counts={counts}

--- a/apps/kernel/app/profile/components/profiles/ActorProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/ActorProfile.tsx
@@ -1,0 +1,109 @@
+import { ScopeHeader } from '../ScopeHeader';
+import { ProfileStats } from '../ProfileStats';
+import { ContactCard } from '../ContactCard';
+import { ServiceLinks } from '../ServiceLinks';
+import { UpcomingEvents } from '../UpcomingEvents';
+import { MarketItems } from '../MarketItems';
+import { formatMemberSince } from '../../lib/profile-utils';
+import type { ProfileViewProps } from '../../lib/types';
+
+export function ActorProfile({ profile, identity, viewer, counts, links, maintainerInfo }: ProfileViewProps) {
+  const isSoftDID = identity.tier === 'soft';
+  const servicePrefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
+  const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8 text-center">
+        <ScopeHeader profile={profile} identity={identity} />
+
+        {/* Unclaimed stub — maintainer info + join CTA */}
+        {identity.scope === 'business' && profile.claimStatus === 'unclaimed' && maintainerInfo && (
+          <div className="mb-4 bg-sky-950/30 border border-sky-800/40 rounded-xl px-4 py-3 text-sm text-sky-300">
+            <p className="mb-1">
+              This place is community-maintained.{' '}
+              <span className="text-sky-400 font-medium">{maintainerInfo.count} maintainer{maintainerInfo.count !== 1 ? 's' : ''}</span> keeping it up to date.
+            </p>
+            {viewer.viewerDid && !maintainerInfo.isMaintainer && (
+              <form action={`/profile/api/stubs/${encodeURIComponent(profile.did)}/join`} method="POST">
+                <button
+                  type="submit"
+                  className="mt-2 px-4 py-1.5 bg-sky-700 hover:bg-sky-600 text-white rounded-lg text-xs font-medium transition-colors"
+                >
+                  Help maintain this place
+                </button>
+              </form>
+            )}
+            {viewer.viewerDid && maintainerInfo.isMaintainer && (
+              <p className="mt-1 text-xs text-sky-500">You are a maintainer of this place.</p>
+            )}
+          </div>
+        )}
+
+        <ProfileStats
+          counts={counts}
+          viewerDid={viewer.viewerDid}
+          isSelf={viewer.isSelf}
+          targetDid={profile.did}
+          isFollowing={viewer.isFollowing}
+        />
+
+        {/* Bio */}
+        {profile.bio && (
+          <p className="text-gray-300 mb-6">{profile.bio}</p>
+        )}
+
+        {/* Info note for invited members viewing their own profile */}
+        {isSoftDID && viewer.isSelf && (
+          <p className="mb-6 text-xs text-gray-500 border border-gray-800 rounded-lg px-4 py-3">
+            Invited members can claim a handle and download backup keys
+          </p>
+        )}
+
+        <ContactCard contactEmail={profile.contactEmail} phone={profile.phone} />
+
+        <ServiceLinks profile={profile} viewerDid={viewer.viewerDid} />
+
+        {/* Expanded links list */}
+        {links.length > 0 && (
+          <div className="mb-6 space-y-2">
+            {links.map((link, i) => (
+              <a
+                key={i}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg hover:bg-gray-800 transition text-left"
+              >
+                <p className="text-white text-sm font-medium">{link.title}</p>
+                {link.description && (
+                  <p className="text-gray-500 text-xs mt-0.5">{link.description}</p>
+                )}
+              </a>
+            ))}
+          </div>
+        )}
+
+        {/* Upcoming events */}
+        {profile.featureToggles?.show_events && (
+          <UpcomingEvents did={profile.did} servicePrefix={servicePrefix} domain={domain} viewerDid={viewer.viewerDid} />
+        )}
+
+        {/* Market items */}
+        {profile.featureToggles?.show_market_items && (
+          <MarketItems did={profile.did} handle={profile.handle} servicePrefix={servicePrefix} domain={domain} />
+        )}
+
+        {/* Member since */}
+        <p className="text-xs text-gray-500 mt-4">
+          Member since {formatMemberSince(profile.createdAt)}
+        </p>
+      </div>
+
+      {/* DID */}
+      <p className="text-center text-xs text-gray-500 mt-4 font-mono break-all">
+        {profile.did}
+      </p>
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/profiles/ActorProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/ActorProfile.tsx
@@ -1,3 +1,4 @@
+import { buildPublicUrl } from '@imajin/config';
 import { ScopeHeader } from '../ScopeHeader';
 import { ProfileStats } from '../ProfileStats';
 import { ContactCard } from '../ContactCard';
@@ -9,8 +10,6 @@ import type { ProfileViewProps } from '../../lib/types';
 
 export function ActorProfile({ profile, identity, viewer, counts, links }: ProfileViewProps) {
   const isSoftDID = identity.tier === 'soft';
-  const servicePrefix = process.env.NEXT_PUBLIC_SERVICE_PREFIX || 'https://';
-  const domain = process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai';
 
   return (
     <div className="max-w-lg mx-auto">
@@ -63,12 +62,12 @@ export function ActorProfile({ profile, identity, viewer, counts, links }: Profi
 
         {/* Upcoming events */}
         {profile.featureToggles?.show_events && (
-          <UpcomingEvents did={profile.did} servicePrefix={servicePrefix} domain={domain} viewerDid={viewer.viewerDid} />
+          <UpcomingEvents did={profile.did} eventsBaseUrl={buildPublicUrl('events')} viewerDid={viewer.viewerDid} />
         )}
 
         {/* Market items */}
         {profile.featureToggles?.show_market_items && (
-          <MarketItems did={profile.did} handle={profile.handle} servicePrefix={servicePrefix} domain={domain} />
+          <MarketItems did={profile.did} handle={profile.handle} marketBaseUrl={buildPublicUrl('market')} />
         )}
 
         {/* Member since */}

--- a/apps/kernel/app/profile/components/profiles/BusinessProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/BusinessProfile.tsx
@@ -1,0 +1,93 @@
+import { getMaintainerInfo } from '../../lib/profile-data';
+import { formatMemberSince } from '../../lib/profile-utils';
+import { ScopeHeader } from '../ScopeHeader';
+import { ServiceLinks } from '../ServiceLinks';
+import { BusinessDetails } from '../BusinessDetails';
+import { MemberList } from '../MemberList';
+import { StubActions } from '../StubActions';
+import type { ProfileViewProps } from '../../lib/types';
+
+export async function BusinessProfile({ profile, identity, viewer, counts, links }: ProfileViewProps) {
+  const maintainerInfo = await getMaintainerInfo(profile.did, viewer.viewerDid);
+  const isUnclaimed = !profile.claimStatus || profile.claimStatus === 'unclaimed';
+
+  // For unclaimed stubs: show maintainers. For claimed: show owners/admins.
+  const memberRoleFilter = isUnclaimed ? 'maintainer' : 'owner';
+  const memberTitle = isUnclaimed ? '🔧 Maintainers' : '👑 Owners & Admins';
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8 text-center">
+        <ScopeHeader profile={profile} identity={identity} />
+
+        {/* Bio / about */}
+        {profile.bio && (
+          <p className="text-gray-300 mb-6">{profile.bio}</p>
+        )}
+
+        {/* Business metadata */}
+        <BusinessDetails metadata={profile.metadata} />
+
+        {/* Members */}
+        {isUnclaimed ? (
+          <MemberList
+            identityDid={profile.did}
+            roleFilter="maintainer"
+            showCount
+            title={memberTitle}
+          />
+        ) : (
+          <MemberList
+            identityDid={profile.did}
+            grouped
+            showCount
+            title={memberTitle}
+          />
+        )}
+
+        {/* Stub / maintainer actions */}
+        {(isUnclaimed || maintainerInfo.isMaintainer) && (
+          <StubActions
+            identityDid={profile.did}
+            profileHandle={profile.handle}
+            claimStatus={profile.claimStatus}
+            isMaintainer={maintainerInfo.isMaintainer}
+            viewerDid={viewer.viewerDid}
+          />
+        )}
+
+        <ServiceLinks profile={profile} viewerDid={viewer.viewerDid} />
+
+        {/* Expanded links */}
+        {links.length > 0 && (
+          <div className="mb-6 space-y-2">
+            {links.map((link, i) => (
+              <a
+                key={i}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg hover:bg-gray-800 transition text-left"
+              >
+                <p className="text-white text-sm font-medium">{link.title}</p>
+                {link.description && (
+                  <p className="text-gray-500 text-xs mt-0.5">{link.description}</p>
+                )}
+              </a>
+            ))}
+          </div>
+        )}
+
+        {/* Member since */}
+        <p className="text-xs text-gray-500 mt-4">
+          Member since {formatMemberSince(profile.createdAt)}
+        </p>
+      </div>
+
+      {/* DID */}
+      <p className="text-center text-xs text-gray-500 mt-4 font-mono break-all">
+        {profile.did}
+      </p>
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/profiles/BusinessProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/BusinessProfile.tsx
@@ -1,4 +1,4 @@
-import { getMaintainerInfo } from '../../lib/profile-data';
+import { getMembersByRole, getViewerMembership } from '../../lib/profile-data';
 import { formatMemberSince } from '../../lib/profile-utils';
 import { ScopeHeader } from '../ScopeHeader';
 import { ServiceLinks } from '../ServiceLinks';
@@ -8,8 +8,11 @@ import { StubActions } from '../StubActions';
 import type { ProfileViewProps } from '../../lib/types';
 
 export async function BusinessProfile({ profile, identity, viewer, counts, links }: ProfileViewProps) {
-  const maintainerInfo = await getMaintainerInfo(profile.did, viewer.viewerDid);
   const isUnclaimed = !profile.claimStatus || profile.claimStatus === 'unclaimed';
+  const viewerRole = viewer.viewerDid && !viewer.isSelf
+    ? await getViewerMembership(profile.did, viewer.viewerDid)
+    : viewer.isSelf ? 'owner' : null;
+  const isMaintainer = viewerRole === 'maintainer' || viewerRole === 'owner' || viewerRole === 'admin';
 
   // For unclaimed stubs: show maintainers. For claimed: show owners/admins.
   const memberRoleFilter = isUnclaimed ? 'maintainer' : 'owner';
@@ -46,12 +49,12 @@ export async function BusinessProfile({ profile, identity, viewer, counts, links
         )}
 
         {/* Stub / maintainer actions */}
-        {(isUnclaimed || maintainerInfo.isMaintainer) && (
+        {(isUnclaimed || isMaintainer) && (
           <StubActions
             identityDid={profile.did}
             profileHandle={profile.handle}
             claimStatus={profile.claimStatus}
-            isMaintainer={maintainerInfo.isMaintainer}
+            isMaintainer={isMaintainer}
             viewerDid={viewer.viewerDid}
           />
         )}

--- a/apps/kernel/app/profile/components/profiles/CommunityProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/CommunityProfile.tsx
@@ -1,0 +1,57 @@
+import { getForestConfig, getViewerMembership } from '../../lib/profile-data';
+import { formatMemberSince } from '../../lib/profile-utils';
+import { ScopeHeader } from '../ScopeHeader';
+import { MemberList } from '../MemberList';
+import { ForestServices } from '../ForestServices';
+import { JoinButton } from '../JoinButton';
+import type { ProfileViewProps } from '../../lib/types';
+
+export async function CommunityProfile({ profile, identity, viewer }: ProfileViewProps) {
+  const [forestConfig, viewerMemberRole] = await Promise.all([
+    getForestConfig(profile.did),
+    viewer.viewerDid && !viewer.isSelf
+      ? getViewerMembership(profile.did, viewer.viewerDid)
+      : Promise.resolve(viewer.isSelf ? 'owner' : null),
+  ]);
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8 text-center">
+        <ScopeHeader profile={profile} identity={identity} />
+
+        {/* Purpose / about */}
+        {profile.bio && (
+          <p className="text-gray-300 mb-6">{profile.bio}</p>
+        )}
+
+        {/* Member list grouped by role */}
+        <MemberList identityDid={profile.did} grouped showCount title="Members" />
+
+        {/* Enabled services */}
+        {forestConfig && forestConfig.enabledServices.length > 0 && (
+          <ForestServices
+            enabledServices={forestConfig.enabledServices}
+            handle={profile.handle}
+          />
+        )}
+
+        {/* Join button */}
+        <JoinButton
+          identityDid={profile.did}
+          viewerDid={viewer.viewerDid}
+          initialMemberRole={viewerMemberRole}
+        />
+
+        {/* Member since */}
+        <p className="text-xs text-gray-500 mt-4">
+          Member since {formatMemberSince(profile.createdAt)}
+        </p>
+      </div>
+
+      {/* DID */}
+      <p className="text-center text-xs text-gray-500 mt-4 font-mono break-all">
+        {profile.did}
+      </p>
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/profiles/FamilyProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/FamilyProfile.tsx
@@ -1,0 +1,55 @@
+import { getMembersByRole } from '../../lib/profile-data';
+import { formatMemberSince } from '../../lib/profile-utils';
+import { ScopeHeader } from '../ScopeHeader';
+import { MemberList } from '../MemberList';
+import type { ProfileViewProps } from '../../lib/types';
+
+export async function FamilyProfile({ profile, identity, viewer }: ProfileViewProps) {
+  const members = await getMembersByRole(profile.did);
+  const isMember = viewer.viewerDid
+    ? members.some((m) => m.did === viewer.viewerDid)
+    : false;
+
+  return (
+    <div className="max-w-lg mx-auto">
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8 text-center">
+        <ScopeHeader profile={profile} identity={identity} />
+
+        {isMember || viewer.isSelf ? (
+          <>
+            {/* Bio */}
+            {profile.bio && (
+              <p className="text-gray-300 mb-6">{profile.bio}</p>
+            )}
+
+            {/* Member list (flat, no role grouping) */}
+            <MemberList
+              identityDid={profile.did}
+              showCount
+              title="Members"
+            />
+          </>
+        ) : (
+          /* Non-member locked view */
+          <div className="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg p-6">
+            <p className="text-2xl mb-2">🔒</p>
+            <p className="text-gray-300 font-medium mb-1">Private family group</p>
+            <p className="text-sm text-gray-500">
+              {members.length} {members.length === 1 ? 'member' : 'members'}
+            </p>
+          </div>
+        )}
+
+        {/* Member since */}
+        <p className="text-xs text-gray-500 mt-4">
+          Member since {formatMemberSince(profile.createdAt)}
+        </p>
+      </div>
+
+      {/* DID */}
+      <p className="text-center text-xs text-gray-500 mt-4 font-mono break-all">
+        {profile.did}
+      </p>
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/lib/profile-data.ts
+++ b/apps/kernel/app/profile/lib/profile-data.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { SESSION_COOKIE_NAME } from '@imajin/config';
-import { db, profiles, follows, connections, identityMembers } from '@/src/db';
+import { db, profiles, follows, connections, identityMembers, forestConfig } from '@/src/db';
 import { getClient } from '@imajin/db';
 import { eq, count, and, isNull } from 'drizzle-orm';
 import { getSessionFromCookies } from '@/src/lib/kernel/session';
@@ -124,6 +124,46 @@ export async function getMembersByRole(identityDid: string): Promise<MemberEntry
     }));
   } catch {
     return [];
+  }
+}
+
+export interface ForestConfigData {
+  enabledServices: string[];
+  landingService: string | null;
+}
+
+export async function getForestConfig(groupDid: string): Promise<ForestConfigData | null> {
+  try {
+    const [config] = await db
+      .select({
+        enabledServices: forestConfig.enabledServices,
+        landingService: forestConfig.landingService,
+      })
+      .from(forestConfig)
+      .where(eq(forestConfig.groupDid, groupDid))
+      .limit(1);
+    return config ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getViewerMembership(identityDid: string, viewerDid: string): Promise<string | null> {
+  try {
+    const [row] = await db
+      .select({ role: identityMembers.role })
+      .from(identityMembers)
+      .where(
+        and(
+          eq(identityMembers.identityDid, identityDid),
+          eq(identityMembers.memberDid, viewerDid),
+          isNull(identityMembers.removedAt)
+        )
+      )
+      .limit(1);
+    return row?.role ?? null;
+  } catch {
+    return null;
   }
 }
 

--- a/apps/kernel/app/profile/lib/profile-data.ts
+++ b/apps/kernel/app/profile/lib/profile-data.ts
@@ -167,36 +167,15 @@ export async function getViewerMembership(identityDid: string, viewerDid: string
   }
 }
 
+/**
+ * @deprecated Use getMembersByRole() + getViewerMembership() instead.
+ * Kept temporarily for any external callers. Will be removed.
+ */
 export async function getMaintainerInfo(identityDid: string, viewerDid: string | null): Promise<{ count: number; isMaintainer: boolean }> {
-  try {
-    const [{ value: mc }] = await db
-      .select({ value: count() })
-      .from(identityMembers)
-      .where(
-        and(
-          eq(identityMembers.identityDid, identityDid),
-          eq(identityMembers.role, 'maintainer'),
-          isNull(identityMembers.removedAt)
-        )
-      );
-    let isMaintainer = false;
-    if (viewerDid) {
-      const [maintainerRow] = await db
-        .select({ identityDid: identityMembers.identityDid })
-        .from(identityMembers)
-        .where(
-          and(
-            eq(identityMembers.identityDid, identityDid),
-            eq(identityMembers.memberDid, viewerDid),
-            eq(identityMembers.role, 'maintainer'),
-            isNull(identityMembers.removedAt)
-          )
-        )
-        .limit(1);
-      isMaintainer = !!maintainerRow;
-    }
-    return { count: mc, isMaintainer };
-  } catch {
-    return { count: 0, isMaintainer: false };
-  }
+  const members = await getMembersByRole(identityDid);
+  const maintainers = members.filter((m) => m.role === 'maintainer');
+  const isMaintainer = viewerDid
+    ? members.some((m) => m.did === viewerDid && ['maintainer', 'owner', 'admin'].includes(m.role))
+    : false;
+  return { count: maintainers.length, isMaintainer };
 }

--- a/apps/kernel/app/profile/lib/profile-data.ts
+++ b/apps/kernel/app/profile/lib/profile-data.ts
@@ -6,6 +6,14 @@ import { eq, count, and, isNull } from 'drizzle-orm';
 import { getSessionFromCookies } from '@/src/lib/kernel/session';
 import type { ProfileData, ProfileCounts, LinkItem, IdentityInfo } from './types';
 
+export interface MemberEntry {
+  role: string;
+  did: string;
+  displayName: string;
+  handle?: string;
+  avatar?: string;
+}
+
 export async function getViewerDid(): Promise<string | null> {
   try {
     const cookieStore = await cookies();
@@ -87,6 +95,36 @@ export async function getIdentityInfo(did: string): Promise<IdentityInfo> {
     tier: identityRow?.tier ?? '',
     chainVerified: !!chainRow,
   };
+}
+
+export async function getMembersByRole(identityDid: string): Promise<MemberEntry[]> {
+  try {
+    const rows = await db
+      .select({
+        role: identityMembers.role,
+        memberDid: identityMembers.memberDid,
+        displayName: profiles.displayName,
+        handle: profiles.handle,
+        avatar: profiles.avatar,
+      })
+      .from(identityMembers)
+      .leftJoin(profiles, eq(profiles.did, identityMembers.memberDid))
+      .where(
+        and(
+          eq(identityMembers.identityDid, identityDid),
+          isNull(identityMembers.removedAt)
+        )
+      );
+    return rows.map((r) => ({
+      role: r.role,
+      did: r.memberDid,
+      displayName: r.displayName ?? r.memberDid,
+      handle: r.handle ?? undefined,
+      avatar: r.avatar ?? undefined,
+    }));
+  } catch {
+    return [];
+  }
 }
 
 export async function getMaintainerInfo(identityDid: string, viewerDid: string | null): Promise<{ count: number; isMaintainer: boolean }> {

--- a/apps/kernel/app/profile/lib/profile-data.ts
+++ b/apps/kernel/app/profile/lib/profile-data.ts
@@ -1,0 +1,124 @@
+import { cookies } from 'next/headers';
+import { SESSION_COOKIE_NAME } from '@imajin/config';
+import { db, profiles, follows, connections, identityMembers } from '@/src/db';
+import { getClient } from '@imajin/db';
+import { eq, count, and, isNull } from 'drizzle-orm';
+import { getSessionFromCookies } from '@/src/lib/kernel/session';
+import type { ProfileData, ProfileCounts, LinkItem, IdentityInfo } from './types';
+
+export async function getViewerDid(): Promise<string | null> {
+  try {
+    const cookieStore = await cookies();
+    const session = cookieStore.get(SESSION_COOKIE_NAME);
+    if (!session?.value) return null;
+    const kernelSession = await getSessionFromCookies(`${SESSION_COOKIE_NAME}=${session.value}`);
+    return kernelSession?.did ?? null;
+  } catch { return null; }
+}
+
+export async function isConnected(viewerDid: string, targetDid: string): Promise<boolean> {
+  try {
+    const [connDidA, connDidB] = [viewerDid, targetDid].sort((a, b) => a.localeCompare(b));
+    const row = await db.query.connections.findFirst({
+      where: (c, { eq, and, isNull }) => and(
+        eq(c.didA, connDidA),
+        eq(c.didB, connDidB),
+        isNull(c.disconnectedAt)
+      ),
+    });
+    return !!row;
+  } catch { return false; }
+}
+
+export async function getProfile(handle: string): Promise<ProfileData | null> {
+  const row = await db.query.profiles.findFirst({
+    where: (profiles, { eq, or }) => or(eq(profiles.did, handle), eq(profiles.handle, handle)),
+  });
+  return row as unknown as ProfileData | null;
+}
+
+export async function getProfileCounts(profileDid: string): Promise<ProfileCounts> {
+  try {
+    const [followersResult] = await db.select({ count: count() }).from(follows).where(eq(follows.followedDid, profileDid));
+    const [followingResult] = await db.select({ count: count() }).from(follows).where(eq(follows.followerDid, profileDid));
+    const sql = getClient();
+    const [connectionsResult] = await sql`
+      SELECT count(*)::int as count
+      FROM connections.connections
+      WHERE (did_a = ${profileDid} OR did_b = ${profileDid})
+        AND disconnected_at IS NULL
+    `;
+    return {
+      followers: Number(followersResult.count),
+      following: Number(followingResult.count),
+      connections: connectionsResult?.count ?? 0,
+    };
+  } catch { return { followers: 0, following: 0, connections: 0 }; }
+}
+
+export async function getFollowStatus(viewerDid: string, targetDid: string): Promise<boolean> {
+  const existingFollow = await db.query.follows.findFirst({
+    where: (follows, { eq, and }) => and(eq(follows.followerDid, viewerDid), eq(follows.followedDid, targetDid)),
+  });
+  return !!existingFollow;
+}
+
+export async function getLinks(linksHandle: string): Promise<LinkItem[]> {
+  const linksServiceUrl = process.env.LINKS_SERVICE_URL;
+  if (!linksServiceUrl) return [];
+  try {
+    const res = await fetch(
+      `${linksServiceUrl}/api/pages/${encodeURIComponent(linksHandle)}/links`,
+      { cache: 'no-store' }
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? data : (data.links || []);
+  } catch { return []; }
+}
+
+export async function getIdentityInfo(did: string): Promise<IdentityInfo> {
+  const authSql = getClient();
+  const [identityRow] = await authSql`SELECT tier, scope, subtype FROM auth.identities WHERE id = ${did} LIMIT 1`.catch(() => []);
+  const [chainRow] = await authSql`SELECT did FROM auth.identity_chains WHERE did = ${did} LIMIT 1`.catch(() => []);
+  return {
+    scope: (identityRow?.scope ?? 'actor') as IdentityInfo['scope'],
+    subtype: identityRow?.subtype ?? null,
+    tier: identityRow?.tier ?? '',
+    chainVerified: !!chainRow,
+  };
+}
+
+export async function getMaintainerInfo(identityDid: string, viewerDid: string | null): Promise<{ count: number; isMaintainer: boolean }> {
+  try {
+    const [{ value: mc }] = await db
+      .select({ value: count() })
+      .from(identityMembers)
+      .where(
+        and(
+          eq(identityMembers.identityDid, identityDid),
+          eq(identityMembers.role, 'maintainer'),
+          isNull(identityMembers.removedAt)
+        )
+      );
+    let isMaintainer = false;
+    if (viewerDid) {
+      const [maintainerRow] = await db
+        .select({ identityDid: identityMembers.identityDid })
+        .from(identityMembers)
+        .where(
+          and(
+            eq(identityMembers.identityDid, identityDid),
+            eq(identityMembers.memberDid, viewerDid),
+            eq(identityMembers.role, 'maintainer'),
+            isNull(identityMembers.removedAt)
+          )
+        )
+        .limit(1);
+      isMaintainer = !!maintainerRow;
+    }
+    return { count: mc, isMaintainer };
+  } catch {
+    return { count: 0, isMaintainer: false };
+  }
+}

--- a/apps/kernel/app/profile/lib/profile-utils.ts
+++ b/apps/kernel/app/profile/lib/profile-utils.ts
@@ -1,0 +1,39 @@
+import { buildPublicUrl } from '@imajin/config';
+
+export function getScopeEmoji(scope: string, subtype: string | null): string {
+  if (scope === 'actor') {
+    const map: Record<string, string> = { human: '👤', agent: '🤖', device: '📱', presence: '🟠' };
+    return map[subtype ?? 'human'] ?? '👤';
+  }
+  const map: Record<string, string> = { business: '🏢', family: '👨‍👩‍👧‍👦', community: '🌐' };
+  return map[scope] ?? '👤';
+}
+
+export function getScopeLabel(scope: string, subtype: string | null): string {
+  if (scope === 'actor') {
+    const map: Record<string, string> = {
+      human: '👤 Human',
+      agent: '🤖 Agent',
+      device: '📱 Device',
+      presence: '🟠 Presence',
+    };
+    return map[subtype ?? 'human'] ?? '👤 Human';
+  }
+  const map: Record<string, string> = {
+    business: '🏢 Business',
+    family: '👨‍👩‍👧‍👦 Family',
+    community: '🌐 Community',
+  };
+  return map[scope] ?? scope;
+}
+
+export function buildServiceUrl(service: string): string {
+  return buildPublicUrl(service);
+}
+
+export function formatMemberSince(createdAt: string): string {
+  return new Date(createdAt).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+}

--- a/apps/kernel/app/profile/lib/types.ts
+++ b/apps/kernel/app/profile/lib/types.ts
@@ -55,5 +55,4 @@ export interface ProfileViewProps {
   viewer: ViewerContext;
   counts: ProfileCounts;
   links: LinkItem[];
-  maintainerInfo?: { count: number; isMaintainer: boolean };
 }

--- a/apps/kernel/app/profile/lib/types.ts
+++ b/apps/kernel/app/profile/lib/types.ts
@@ -1,0 +1,59 @@
+export interface FeatureToggles {
+  inference_enabled?: boolean;
+  show_market_items?: boolean;
+  show_events?: boolean;
+  links?: string | null;
+  coffee?: string | null;
+  dykil?: string | null;
+  learn?: string | null;
+}
+
+export interface ProfileData {
+  did: string;
+  handle?: string;
+  displayName: string;
+  bio?: string;
+  avatar?: string;
+  email?: string;
+  phone?: string;
+  contactEmail?: string;
+  featureToggles?: FeatureToggles;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+  claimStatus?: string | null;
+}
+
+export interface IdentityInfo {
+  scope: 'actor' | 'business' | 'community' | 'family';
+  subtype: string | null;
+  tier: string;
+  chainVerified: boolean;
+}
+
+export interface ViewerContext {
+  viewerDid: string | null;
+  isSelf: boolean;
+  isConnected: boolean;
+  isFollowing: boolean;
+}
+
+export interface ProfileCounts {
+  followers: number;
+  following: number;
+  connections: number;
+}
+
+export interface LinkItem {
+  title: string;
+  url: string;
+  description?: string;
+}
+
+export interface ProfileViewProps {
+  profile: ProfileData;
+  identity: IdentityInfo;
+  viewer: ViewerContext;
+  counts: ProfileCounts;
+  links: LinkItem[];
+  maintainerInfo?: { count: number; isMaintainer: boolean };
+}


### PR DESCRIPTION
## Summary

Splits the monolithic `[handle]/page.tsx` (481 lines) into a thin resolver + four scope-specific profile components with shared helpers.

Closes #689

## What Changed

### WO1: Shared Foundation + ActorProfile
- **`lib/types.ts`** — shared types (ProfileData, IdentityInfo, ViewerContext, etc.)
- **`lib/profile-data.ts`** — all data-fetching helpers extracted from page.tsx
- **`lib/profile-utils.ts`** — display helpers (getScopeEmoji, buildServiceUrl, formatMemberSince)
- **5 shared components:** ScopeHeader, ProfileStats, ContactCard, ServiceLinks, GatedProfile
- **ActorProfile** — current actor view extracted, composing shared components
- **page.tsx** → thin resolver (scope switch, ~40 lines)

### WO2: BusinessProfile
- **BusinessDetails** — renders metadata JSONB (category, location, phone, website)
- **MemberList** — reusable, supports roleFilter and grouped modes with role ordering
- **StubActions** — maintain/claim CTAs for unclaimed businesses
- **BusinessProfile** — async server component, claim-aware layout
- Business conditionals removed from ActorProfile

### WO3: CommunityProfile
- **ForestServices** — renders enabled services from forest_config
- **JoinButton** — client component with membership status
- **CommunityProfile** — members grouped by role, services, join flow
- `getForestConfig()` + `getViewerMembership()` helpers added

### WO4: FamilyProfile
- Member-gated: non-members see locked card with count only
- Members see bio + flat member list
- Simplest scope, private by default

## Testing
- Actor profiles render identically to before (pure extraction)
- Business profiles show maintainer list, claim status, business details
- Community profiles show grouped members, forest services, join button
- Family profiles are private by default with member-gated full view

## Dependencies
- PR #687 (identity scopes) — merged ✅