### PR TITLE
feat(events): multi-ticket quantity picker with max-per-order

### DIFF
--- a/apps/events/app/[eventId]/ticket-purchase.tsx
+++ b/apps/events/app/[eventId]/ticket-purchase.tsx
@@ -11,6 +11,7 @@ interface Props {
   inviteToken?: string;
   etransferEnabled?: boolean;
   stripeDisabled?: boolean;
+  maxPerOrder?: number;
 }
 
 interface ETransferInstructions {
@@ -25,20 +26,30 @@ interface ETransferInstructions {
 
 type Step = 'button' | 'selector' | 'loading-card' | 'etransfer-confirm' | 'loading-etransfer' | 'etransfer-done' | 'rsvp-form' | 'loading-rsvp' | 'rsvp-done';
 
-export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etransferEnabled = false, stripeDisabled = false }: Props) {
+export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etransferEnabled = false, stripeDisabled = false, maxPerOrder }: Props) {
   const [step, setStep] = useState<Step>('button');
   const [error, setError] = useState<string | null>(null);
   const [etransfer, setEtransfer] = useState<ETransferInstructions | null>(null);
   const [email, setEmail] = useState('');
   const [name, setName] = useState('');
+  const [quantity, setQuantity] = useState(1);
 
   const isFree = ticket.price === 0;
 
-  const available = ticket.quantity === null
+  const availableCount = ticket.quantity === null
+    ? null
+    : ticket.quantity - (ticket.sold ?? 0);
+
+  const available = availableCount === null
     ? 'Unlimited'
-    : `${ticket.quantity - (ticket.sold ?? 0)} left`;
+    : `${availableCount} left`;
 
   const soldOut = ticket.quantity !== null && (ticket.sold ?? 0) >= ticket.quantity;
+
+  // Effective max: per-type override > prop > default 10, capped at 20
+  const resolvedMax = maxPerOrder ?? (ticket as any).maxPerOrder ?? 10;
+  const effectiveMax = Math.min(resolvedMax, availableCount ?? 20, 20);
+  const showQuantity = !isFree && effectiveMax > 1;
 
   const handleCardPayment = async () => {
     setStep('loading-card');
@@ -51,7 +62,7 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
         body: JSON.stringify({
           eventId,
           ticketTypeId: ticket.id,
-          quantity: 1,
+          quantity,
           ...(inviteToken && { invite: inviteToken }),
         }),
       });
@@ -336,6 +347,7 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
     return (
       <div className="space-y-2">
         {error && <p className="text-red-500 text-xs">{error}</p>}
+        {showQuantity && <QuantityStepper quantity={quantity} setQuantity={setQuantity} max={effectiveMax} price={ticket.price} currency={ticket.currency} />}
         <div className="flex flex-col gap-2 w-full">
           {!stripeDisabled && (
             <button
@@ -396,6 +408,7 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
       {error && (
         <p className="text-red-500 text-xs mb-2">{error}</p>
       )}
+      {showQuantity && <QuantityStepper quantity={quantity} setQuantity={setQuantity} max={effectiveMax} price={ticket.price} currency={ticket.currency} />}
       <button
         onClick={handleButtonClick}
         disabled={(step as string) === 'loading-rsvp'}
@@ -405,8 +418,58 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
             : 'bg-orange-500 text-white hover:bg-orange-600'
         }`}
       >
-        {(step as string) === 'loading-rsvp' ? 'Confirming...' : isFree ? 'RSVP' : (stripeDisabled && etransferEnabled) ? '🏦 Pay by e-Transfer' : 'Get Ticket'}
+        {(step as string) === 'loading-rsvp'
+          ? 'Confirming...'
+          : isFree
+          ? 'RSVP'
+          : (stripeDisabled && etransferEnabled)
+          ? '🏦 Pay by e-Transfer'
+          : quantity > 1
+          ? `Get ${quantity} Tickets`
+          : 'Get Ticket'}
       </button>
     </>
+  );
+}
+
+function QuantityStepper({ quantity, setQuantity, max, price, currency }: {
+  quantity: number;
+  setQuantity: (q: number) => void;
+  max: number;
+  price: number;
+  currency: string;
+}) {
+  const total = new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency,
+  }).format((price * quantity) / 100);
+
+  return (
+    <div className="flex items-center gap-3 mb-2">
+      <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden">
+        <button
+          onClick={() => setQuantity(Math.max(1, quantity - 1))}
+          disabled={quantity <= 1}
+          className="px-3 py-1.5 text-lg font-bold hover:bg-gray-100 dark:hover:bg-gray-800 transition disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          −
+        </button>
+        <span className="px-3 py-1.5 min-w-[2.5rem] text-center font-semibold text-sm border-x border-gray-300 dark:border-gray-600">
+          {quantity}
+        </span>
+        <button
+          onClick={() => setQuantity(Math.min(max, quantity + 1))}
+          disabled={quantity >= max}
+          className="px-3 py-1.5 text-lg font-bold hover:bg-gray-100 dark:hover:bg-gray-800 transition disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          +
+        </button>
+      </div>
+      {quantity > 1 && (
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {total} total
+        </span>
+      )}
+    </div>
   );
 }

--- a/apps/events/app/api/checkout/route.ts
+++ b/apps/events/app/api/checkout/route.ts
@@ -112,6 +112,19 @@ export const POST = withLogger('events', async (request, { log, correlationId })
     const session = await optionalAuth(request);
     const buyerDid = (session && session.tier !== 'soft') ? session.id : undefined;
 
+    // Enforce max per order: per-type override > event metadata > default 10, hard cap 20
+    const eventMeta = (event.metadata || {}) as Record<string, any>;
+    const maxPerOrder = Math.min(
+      ticketType.maxPerOrder ?? eventMeta.maxTicketsPerOrder ?? 10,
+      20
+    );
+    if (quantity > maxPerOrder) {
+      return NextResponse.json(
+        { error: `Maximum ${maxPerOrder} tickets per order` },
+        { status: 400 }
+      );
+    }
+
     // Check availability
     if (ticketType.quantity !== null) {
       const available = ticketType.quantity - (ticketType.sold ?? 0);

--- a/apps/events/drizzle/0003_add-max-per-order.sql
+++ b/apps/events/drizzle/0003_add-max-per-order.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events"."ticket_types" ADD COLUMN IF NOT EXISTS "max_per_order" integer;

--- a/apps/events/drizzle/meta/0003_snapshot.json
+++ b/apps/events/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1182 @@
+{
+  "id": "027d3a9a-5304-460a-9069-e8edbbc663af",
+  "prevId": "2678a704-95a4-4e0b-b25c-cc95d2e70c74",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "events.event_invites": {
+      "name": "event_invites",
+      "schema": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_invites_event_id_events_id_fk": {
+          "name": "event_invites_event_id_events_id_fk",
+          "tableFrom": "event_invites",
+          "tableTo": "events",
+          "schemaTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_invites_token_unique": {
+          "name": "event_invites_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "events.events": {
+      "name": "events",
+      "schema": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_did": {
+          "name": "creator_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'physical'"
+        },
+        "is_virtual": {
+          "name": "is_virtual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "virtual_url": {
+          "name": "virtual_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_asset_id": {
+          "name": "image_asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "registration_config": {
+          "name": "registration_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "name_display_policy": {
+          "name": "name_display_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'attendee_choice'"
+        },
+        "course_slug": {
+          "name": "course_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emt_email": {
+          "name": "emt_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pod_id": {
+          "name": "pod_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lobby_conversation_id": {
+          "name": "lobby_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator": {
+          "name": "idx_events_creator",
+          "columns": [
+            {
+              "expression": "creator_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_status": {
+          "name": "idx_events_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_starts": {
+          "name": "idx_events_starts",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_pod_id": {
+          "name": "idx_events_pod_id",
+          "columns": [
+            {
+              "expression": "pod_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_course_slug": {
+          "name": "idx_events_course_slug",
+          "columns": [
+            {
+              "expression": "course_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_did_unique": {
+          "name": "events_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "did"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "events.ticket_queue": {
+      "name": "ticket_queue",
+      "schema": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_type_id": {
+          "name": "ticket_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "did": {
+          "name": "did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        }
+      },
+      "indexes": {
+        "idx_ticket_queue_type": {
+          "name": "idx_ticket_queue_type",
+          "columns": [
+            {
+              "expression": "ticket_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ticket_queue_did": {
+          "name": "idx_ticket_queue_did",
+          "columns": [
+            {
+              "expression": "did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ticket_queue_position": {
+          "name": "idx_ticket_queue_position",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ticket_queue_status": {
+          "name": "idx_ticket_queue_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ticket_queue_ticket_type_id_ticket_types_id_fk": {
+          "name": "ticket_queue_ticket_type_id_ticket_types_id_fk",
+          "tableFrom": "ticket_queue",
+          "tableTo": "ticket_types",
+          "schemaTo": "events",
+          "columnsFrom": [
+            "ticket_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "events.ticket_registrations": {
+      "name": "ticket_registrations",
+      "schema": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_did": {
+          "name": "registered_by_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ticket_registrations_ticket": {
+          "name": "idx_ticket_registrations_ticket",
+          "columns": [
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ticket_registrations_event": {
+          "name": "idx_ticket_registrations_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ticket_registrations_email": {
+          "name": "idx_ticket_registrations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ticket_registrations_ticket_id_tickets_id_fk": {
+          "name": "ticket_registrations_ticket_id_tickets_id_fk",
+          "tableFrom": "ticket_registrations",
+          "tableTo": "tickets",
+          "schemaTo": "events",
+          "columnsFrom": [
+            "ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ticket_registrations_event_id_events_id_fk": {
+          "name": "ticket_registrations_event_id_events_id_fk",
+          "tableFrom": "ticket_registrations",
+          "tableTo": "events",
+          "schemaTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "events.ticket_transfers": {
+      "name": "ticket_transfers",
+      "schema": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_did": {
+          "name": "from_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_did": {
+          "name": "to_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transferred_at": {
+          "name": "transferred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_ticket_transfers_ticket": {
+          "name": "idx_ticket_transfers_ticket",
+          "columns": [
+            {
+              "expression": "ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ticket_transfers_from": {
+          "name": "idx_ticket_transfers_from",
+          "columns": [
+            {
+              "expression": "from_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ticket_transfers_to": {
+          "name": "idx_ticket_transfers_to",
+          "columns": [
+            {
+              "expression": "to_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ticket_transfers_ticket_id_tickets_id_fk": {
+          "name": "ticket_transfers_ticket_id_tickets_id_fk",
+          "tableFrom": "ticket_transfers",
+          "tableTo": "tickets",
+          "schemaTo": "events",
+          "columnsFrom": [
+            "ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "events.ticket_types": {
+      "name": "ticket_types",
+      "schema": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sold": {
+          "name": "sold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "perks": {
+          "name": "perks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "requires_registration": {
+          "name": "requires_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "registration_form_id": {
+          "name": "registration_form_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "max_per_order": {
+          "name": "max_per_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ticket_types_event": {
+          "name": "idx_ticket_types_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ticket_types_event_id_events_id_fk": {
+          "name": "ticket_types_event_id_events_id_fk",
+          "tableFrom": "ticket_types",
+          "tableTo": "events",
+          "schemaTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "events.tickets": {
+      "name": "tickets",
+      "schema": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_type_id": {
+          "name": "ticket_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_did": {
+          "name": "owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_owner_did": {
+          "name": "original_owner_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_paid": {
+          "name": "price_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "held_by": {
+          "name": "held_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "held_until": {
+          "name": "held_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_expires_at": {
+          "name": "hold_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_confirmed_at": {
+          "name": "payment_confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "last_email_sent_at": {
+          "name": "last_email_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tickets_event": {
+          "name": "idx_tickets_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tickets_owner": {
+          "name": "idx_tickets_owner",
+          "columns": [
+            {
+              "expression": "owner_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tickets_status": {
+          "name": "idx_tickets_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tickets_held_by": {
+          "name": "idx_tickets_held_by",
+          "columns": [
+            {
+              "expression": "held_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tickets_registration_status": {
+          "name": "idx_tickets_registration_status",
+          "columns": [
+            {
+              "expression": "registration_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tickets_event_id_events_id_fk": {
+          "name": "tickets_event_id_events_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "events",
+          "schemaTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tickets_ticket_type_id_ticket_types_id_fk": {
+          "name": "tickets_ticket_type_id_ticket_types_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "ticket_types",
+          "schemaTo": "events",
+          "columnsFrom": [
+            "ticket_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "events": "events"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/events/drizzle/meta/_journal.json
+++ b/apps/events/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775078437543,
       "tag": "0002_add-location-type",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1744570000000,
+      "tag": "0003_add-max-per-order",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/events/drizzle/schema.ts
+++ b/apps/events/drizzle/schema.ts
@@ -1,0 +1,165 @@
+import { pgTable, pgSchema, index, foreignKey, text, integer, timestamp, unique, jsonb, boolean, primaryKey } from "drizzle-orm/pg-core"
+import { sql } from "drizzle-orm"
+
+export const events = pgSchema("events");
+
+
+export const ticketQueueInEvents = events.table("ticket_queue", {
+	id: text().primaryKey().notNull(),
+	ticketTypeId: text("ticket_type_id").notNull(),
+	did: text().notNull(),
+	position: integer().notNull(),
+	joinedAt: timestamp("joined_at", { withTimezone: true, mode: 'string' }).defaultNow(),
+	notifiedAt: timestamp("notified_at", { withTimezone: true, mode: 'string' }),
+	expiresAt: timestamp("expires_at", { withTimezone: true, mode: 'string' }),
+	status: text().default('waiting').notNull(),
+}, (table) => [
+	index("idx_ticket_queue_did").using("btree", table.did.asc().nullsLast().op("text_ops")),
+	index("idx_ticket_queue_position").using("btree", table.position.asc().nullsLast().op("int4_ops")),
+	index("idx_ticket_queue_status").using("btree", table.status.asc().nullsLast().op("text_ops")),
+	index("idx_ticket_queue_type").using("btree", table.ticketTypeId.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.ticketTypeId],
+			foreignColumns: [ticketTypesInEvents.id],
+			name: "ticket_queue_ticket_type_id_ticket_types_id_fk"
+		}),
+]);
+
+export const ticketsInEvents = events.table("tickets", {
+	id: text().primaryKey().notNull(),
+	eventId: text("event_id").notNull(),
+	ticketTypeId: text("ticket_type_id").notNull(),
+	ownerDid: text("owner_did"),
+	originalOwnerDid: text("original_owner_did"),
+	purchasedAt: timestamp("purchased_at", { withTimezone: true, mode: 'string' }),
+	pricePaid: integer("price_paid"),
+	currency: text(),
+	paymentId: text("payment_id"),
+	status: text().default('available').notNull(),
+	heldBy: text("held_by"),
+	heldUntil: timestamp("held_until", { withTimezone: true, mode: 'string' }),
+	usedAt: timestamp("used_at", { withTimezone: true, mode: 'string' }),
+	signature: text(),
+	metadata: jsonb().default({}),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
+	magicToken: text("magic_token"),
+	paymentMethod: text("payment_method").default('stripe'),
+	holdExpiresAt: timestamp("hold_expires_at", { withTimezone: true, mode: 'string' }),
+	paymentConfirmedAt: timestamp("payment_confirmed_at", { withTimezone: true, mode: 'string' }),
+}, (table) => [
+	index("idx_tickets_event").using("btree", table.eventId.asc().nullsLast().op("text_ops")),
+	index("idx_tickets_held_by").using("btree", table.heldBy.asc().nullsLast().op("text_ops")),
+	index("idx_tickets_magic_token").using("btree", table.magicToken.asc().nullsLast().op("text_ops")),
+	index("idx_tickets_owner").using("btree", table.ownerDid.asc().nullsLast().op("text_ops")),
+	index("idx_tickets_status").using("btree", table.status.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.eventId],
+			foreignColumns: [eventsInEvents.id],
+			name: "tickets_event_id_events_id_fk"
+		}),
+	foreignKey({
+			columns: [table.ticketTypeId],
+			foreignColumns: [ticketTypesInEvents.id],
+			name: "tickets_ticket_type_id_ticket_types_id_fk"
+		}),
+	unique("tickets_magic_token_unique").on(table.magicToken),
+]);
+
+export const ticketTransfersInEvents = events.table("ticket_transfers", {
+	id: text().primaryKey().notNull(),
+	ticketId: text("ticket_id").notNull(),
+	fromDid: text("from_did").notNull(),
+	toDid: text("to_did").notNull(),
+	transferredAt: timestamp("transferred_at", { withTimezone: true, mode: 'string' }).defaultNow(),
+	signature: text().notNull(),
+}, (table) => [
+	index("idx_ticket_transfers_from").using("btree", table.fromDid.asc().nullsLast().op("text_ops")),
+	index("idx_ticket_transfers_ticket").using("btree", table.ticketId.asc().nullsLast().op("text_ops")),
+	index("idx_ticket_transfers_to").using("btree", table.toDid.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.ticketId],
+			foreignColumns: [ticketsInEvents.id],
+			name: "ticket_transfers_ticket_id_tickets_id_fk"
+		}),
+]);
+
+export const ticketTypesInEvents = events.table("ticket_types", {
+	id: text().primaryKey().notNull(),
+	eventId: text("event_id").notNull(),
+	name: text().notNull(),
+	description: text(),
+	price: integer().notNull(),
+	currency: text().default('USD').notNull(),
+	quantity: integer(),
+	sold: integer().default(0),
+	perks: jsonb().default([]),
+	metadata: jsonb().default({}),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
+	sortOrder: integer("sort_order").default(0).notNull(),
+	requiresRegistration: boolean("requires_registration").default(false),
+	registrationFormId: text("registration_form_id"),
+	maxPerOrder: integer("max_per_order"),
+}, (table) => [
+	index("idx_ticket_types_event").using("btree", table.eventId.asc().nullsLast().op("text_ops")),
+	foreignKey({
+			columns: [table.eventId],
+			foreignColumns: [eventsInEvents.id],
+			name: "ticket_types_event_id_events_id_fk"
+		}),
+]);
+
+export const eventsInEvents = events.table("events", {
+	id: text().primaryKey().notNull(),
+	did: text().notNull(),
+	publicKey: text("public_key").notNull(),
+	creatorDid: text("creator_did").notNull(),
+	title: text().notNull(),
+	description: text(),
+	startsAt: timestamp("starts_at", { withTimezone: true, mode: 'string' }).notNull(),
+	endsAt: timestamp("ends_at", { withTimezone: true, mode: 'string' }),
+	isVirtual: boolean("is_virtual").default(false),
+	virtualUrl: text("virtual_url"),
+	venue: text(),
+	address: text(),
+	city: text(),
+	country: text(),
+	status: text().default('draft').notNull(),
+	imageUrl: text("image_url"),
+	tags: jsonb().default([]),
+	metadata: jsonb().default({}),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).defaultNow(),
+	podId: text("pod_id"),
+	privateKey: text("private_key"),
+	lobbyConversationId: text("lobby_conversation_id"),
+	accessMode: text("access_mode").default('public').notNull(),
+	nameDisplayPolicy: text("name_display_policy").default('attendee_choice').notNull(),
+	timezone: text(),
+	courseSlug: text("course_slug"),
+}, (table) => [
+	index("idx_events_course_slug").using("btree", table.courseSlug.asc().nullsLast().op("text_ops")),
+	index("idx_events_creator").using("btree", table.creatorDid.asc().nullsLast().op("text_ops")),
+	index("idx_events_pod_id").using("btree", table.podId.asc().nullsLast().op("text_ops")),
+	index("idx_events_starts").using("btree", table.startsAt.asc().nullsLast().op("timestamptz_ops")),
+	index("idx_events_status").using("btree", table.status.asc().nullsLast().op("text_ops")),
+	unique("events_did_unique").on(table.did),
+]);
+
+export const eventInvitesInEvents = events.table("event_invites", {
+	id: text().primaryKey().notNull(),
+	eventId: text("event_id").notNull(),
+	token: text().notNull(),
+	label: text(),
+	maxUses: integer("max_uses"),
+	usedCount: integer("used_count").default(0).notNull(),
+	expiresAt: timestamp("expires_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow(),
+}, (table) => [
+	foreignKey({
+			columns: [table.eventId],
+			foreignColumns: [eventsInEvents.id],
+			name: "event_invites_event_id_fkey"
+		}),
+	unique("event_invites_token_key").on(table.token),
+]);
+

--- a/apps/events/src/db/schema.ts
+++ b/apps/events/src/db/schema.ts
@@ -93,6 +93,7 @@ export const ticketTypes = eventsSchema.table('ticket_types', {
 
   requiresRegistration: boolean('requires_registration').notNull().default(false),
   registrationFormId: text('registration_form_id'),         // Dykil form ID
+  maxPerOrder: integer('max_per_order'),                    // null = use event default (10)
 
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({


### PR DESCRIPTION
## Summary

Adds quantity selection to ticket purchase flow. Backend already supported `quantity` param — this adds the UI picker and server-side max enforcement.

Closes #691

## Changes

**Schema:** `ticket_types.max_per_order` (integer, nullable) — per-type override

**API:** Checkout route enforces `min(type.maxPerOrder, event.maxTicketsPerOrder, 10)`, hard cap 20

**UI:** `QuantityStepper` component — +/- buttons with live total price display. Only shows for paid tickets with max > 1. Button text updates dynamically ('Get 3 Tickets'). Free RSVP and e-Transfer stay at quantity 1.

## Migration needed
```sql
ALTER TABLE events.ticket_types ADD COLUMN IF NOT EXISTS max_per_order INTEGER;
```

## Defaults
- Event-level: `metadata.maxTicketsPerOrder` (default 10 if not set)
- Type-level: `max_per_order` column (overrides event default)  
- Hard ceiling: 20 (server-side)