### PR TITLE
feat(auth): add change/reset password to security settings

### DIFF
--- a/apps/kernel/app/auth/settings/security/page.tsx
+++ b/apps/kernel/app/auth/settings/security/page.tsx
@@ -63,6 +63,24 @@ async function encryptPrivateKey(privateKeyJson: string, password: string): Prom
   return { encryptedKey, salt };
 }
 
+async function decryptStoredKey(encryptedKeyB64: string, saltB64: string, password: string): Promise<string> {
+  const enc = new TextEncoder();
+  const salt = Uint8Array.from(atob(saltB64), c => c.charCodeAt(0));
+  const keyMaterial = await crypto.subtle.importKey('raw', enc.encode(password), 'PBKDF2', false, ['deriveKey']);
+  const derivedKey = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt']
+  );
+  const combined = Uint8Array.from(atob(encryptedKeyB64), c => c.charCodeAt(0));
+  const iv = combined.slice(0, 12);
+  const ciphertext = combined.slice(12);
+  const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, derivedKey, ciphertext);
+  return new TextDecoder().decode(decrypted);
+}
+
 export default function SecuritySettingsPage() {
   const [loading, setLoading] = useState(true);
   const [methods, setMethods] = useState<AccountMethods | null>(null);
@@ -75,6 +93,9 @@ export default function SecuritySettingsPage() {
   const [showEmailSetup, setShowEmailSetup] = useState(false);
   const [emailCode, setEmailCode] = useState('');
   const [showPasswordSetup, setShowPasswordSetup] = useState(false);
+  const [showPasswordChange, setShowPasswordChange] = useState(false);
+  const [showPasswordReset, setShowPasswordReset] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [statusMessage, setStatusMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
@@ -310,6 +331,114 @@ export default function SecuritySettingsPage() {
     }
   }
 
+  // Change password: verify current password, then re-encrypt with new one
+  async function handlePasswordChange(e: React.FormEvent) {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      showStatus('error', 'Passwords do not match.');
+      return;
+    }
+    if (password.length < 8) {
+      showStatus('error', 'Password must be at least 8 characters.');
+      return;
+    }
+    setActionLoading('password-change');
+    try {
+      // Fetch the current stored key to verify the old password
+      const methodsRes = await fetch(`/auth/api/account/methods?did=${encodeURIComponent(methods?.did || '')}&includeKey=true`, {
+        credentials: 'include',
+      });
+      if (!methodsRes.ok) {
+        showStatus('error', 'Failed to fetch stored key.');
+        return;
+      }
+      const methodsData = await methodsRes.json();
+      if (!methodsData.encryptedKey || !methodsData.salt) {
+        showStatus('error', 'No stored key found.');
+        return;
+      }
+
+      // Verify current password by attempting decryption
+      try {
+        await decryptStoredKey(methodsData.encryptedKey, methodsData.salt, currentPassword);
+      } catch {
+        showStatus('error', 'Current password is incorrect.');
+        return;
+      }
+
+      // Re-encrypt with new password using the key from localStorage
+      const keypairJson = localStorage.getItem('imajin_keypair');
+      if (!keypairJson) {
+        showStatus('error', 'No key found in this browser.');
+        return;
+      }
+      const { encryptedKey, salt } = await encryptPrivateKey(keypairJson, password);
+      const res = await fetch('/auth/api/stored-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ encryptedKey, salt, keyDerivation: 'pbkdf2' }),
+        credentials: 'include',
+      });
+      if (res.ok) {
+        setShowPasswordChange(false);
+        setCurrentPassword('');
+        setPassword('');
+        setConfirmPassword('');
+        showStatus('success', 'Password changed successfully.');
+        await loadData();
+      } else {
+        const body = await res.json().catch(() => ({}));
+        showStatus('error', body.error || 'Failed to update password.');
+      }
+    } catch {
+      showStatus('error', 'Failed to change password. Please try again.');
+    } finally {
+      setActionLoading('');
+    }
+  }
+
+  // Reset password: re-encrypt from localStorage key without requiring current password
+  async function handlePasswordReset(e: React.FormEvent) {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      showStatus('error', 'Passwords do not match.');
+      return;
+    }
+    if (password.length < 8) {
+      showStatus('error', 'Password must be at least 8 characters.');
+      return;
+    }
+    setActionLoading('password-reset');
+    try {
+      const keypairJson = localStorage.getItem('imajin_keypair');
+      if (!keypairJson) {
+        showStatus('error', 'No key found in this browser. This device cannot reset the password.');
+        return;
+      }
+      const { encryptedKey, salt } = await encryptPrivateKey(keypairJson, password);
+      const res = await fetch('/auth/api/stored-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ encryptedKey, salt, keyDerivation: 'pbkdf2' }),
+        credentials: 'include',
+      });
+      if (res.ok) {
+        setShowPasswordReset(false);
+        setPassword('');
+        setConfirmPassword('');
+        showStatus('success', 'Password has been reset. Use your new password to log in on other devices.');
+        await loadData();
+      } else {
+        const body = await res.json().catch(() => ({}));
+        showStatus('error', body.error || 'Failed to reset password.');
+      }
+    } catch {
+      showStatus('error', 'Failed to reset password. Please try again.');
+    } finally {
+      setActionLoading('');
+    }
+  }
+
   async function handleRemoveDevice(deviceId: string) {
     setActionLoading(`device-${deviceId}`);
     try {
@@ -409,7 +538,15 @@ export default function SecuritySettingsPage() {
               </div>
               <div className="ml-4 flex flex-col items-end gap-2">
                 {methods?.hasStoredKey ? (
-                  <span className="px-2 py-1 text-xs bg-green-900/30 border border-green-800 rounded text-green-400 whitespace-nowrap">Active</span>
+                  <>
+                    <span className="px-2 py-1 text-xs bg-green-900/30 border border-green-800 rounded text-green-400 whitespace-nowrap">Active</span>
+                    <button
+                      onClick={() => { setShowPasswordChange(true); setShowPasswordReset(false); setCurrentPassword(''); setPassword(''); setConfirmPassword(''); }}
+                      className="text-sm px-3 py-1 bg-[#F59E0B] text-black rounded hover:bg-[#D97706] transition"
+                    >
+                      Change password
+                    </button>
+                  </>
                 ) : (
                   <>
                     <span className="px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-400 whitespace-nowrap">Not set up</span>
@@ -424,7 +561,109 @@ export default function SecuritySettingsPage() {
               </div>
             </div>
 
-            {/* Password setup flow */}
+            {/* Change password flow (requires current password) */}
+            {showPasswordChange && methods?.hasStoredKey && (
+              <div className="mt-4 p-4 bg-gray-900 border border-gray-700 rounded-lg">
+                <h3 className="text-white font-medium mb-2">Change password</h3>
+                <p className="text-sm text-gray-400 mb-4">
+                  Enter your current password to verify, then choose a new one.
+                </p>
+                <form onSubmit={handlePasswordChange} className="space-y-3">
+                  <input
+                    type="password"
+                    value={currentPassword}
+                    onChange={e => setCurrentPassword(e.target.value)}
+                    placeholder="Current password"
+                    autoFocus
+                    className="w-full px-4 py-2 border border-gray-700 rounded-lg bg-black text-white focus:ring-2 focus:ring-[#F59E0B] focus:border-transparent"
+                  />
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    placeholder="New password"
+                    className="w-full px-4 py-2 border border-gray-700 rounded-lg bg-black text-white focus:ring-2 focus:ring-[#F59E0B] focus:border-transparent"
+                  />
+                  <input
+                    type="password"
+                    value={confirmPassword}
+                    onChange={e => setConfirmPassword(e.target.value)}
+                    placeholder="Confirm new password"
+                    className="w-full px-4 py-2 border border-gray-700 rounded-lg bg-black text-white focus:ring-2 focus:ring-[#F59E0B] focus:border-transparent"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      type="submit"
+                      disabled={!currentPassword || !password || !confirmPassword || actionLoading === 'password-change'}
+                      className="flex-1 py-2 bg-[#F59E0B] text-black rounded-lg hover:bg-[#D97706] transition font-medium disabled:opacity-50"
+                    >
+                      {actionLoading === 'password-change' ? 'Changing…' : 'Change password'}
+                    </button>
+                  </div>
+                </form>
+                <div className="mt-3 flex items-center justify-between">
+                  <button
+                    onClick={() => { setShowPasswordChange(false); setCurrentPassword(''); setPassword(''); setConfirmPassword(''); }}
+                    className="text-sm text-gray-500 hover:text-gray-300 transition"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={() => { setShowPasswordChange(false); setShowPasswordReset(true); setCurrentPassword(''); setPassword(''); setConfirmPassword(''); }}
+                    className="text-sm text-amber-500 hover:text-amber-400 transition"
+                  >
+                    Forgot password?
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Reset password flow (no current password — uses device-local key) */}
+            {showPasswordReset && methods?.hasStoredKey && (
+              <div className="mt-4 p-4 bg-amber-900/10 border border-amber-700/50 rounded-lg">
+                <h3 className="text-white font-medium mb-2">Reset password from this device</h3>
+                <p className="text-sm text-gray-400 mb-2">
+                  Your key is present in this browser, so you can set a new password without the old one.
+                </p>
+                <p className="text-xs text-amber-400 mb-4">
+                  ⚠️ This works because your device already has your private key. It&apos;s no different from re-running initial setup.
+                </p>
+                <form onSubmit={handlePasswordReset} className="space-y-3">
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    placeholder="New password"
+                    autoFocus
+                    className="w-full px-4 py-2 border border-gray-700 rounded-lg bg-black text-white focus:ring-2 focus:ring-[#F59E0B] focus:border-transparent"
+                  />
+                  <input
+                    type="password"
+                    value={confirmPassword}
+                    onChange={e => setConfirmPassword(e.target.value)}
+                    placeholder="Confirm new password"
+                    className="w-full px-4 py-2 border border-gray-700 rounded-lg bg-black text-white focus:ring-2 focus:ring-[#F59E0B] focus:border-transparent"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      type="submit"
+                      disabled={!password || !confirmPassword || actionLoading === 'password-reset'}
+                      className="flex-1 py-2 bg-amber-600 text-black rounded-lg hover:bg-amber-500 transition font-medium disabled:opacity-50"
+                    >
+                      {actionLoading === 'password-reset' ? 'Resetting…' : 'Reset password'}
+                    </button>
+                  </div>
+                </form>
+                <button
+                  onClick={() => { setShowPasswordReset(false); setPassword(''); setConfirmPassword(''); }}
+                  className="mt-3 text-sm text-gray-500 hover:text-gray-300 transition"
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+
+            {/* Password setup flow (first time) */}
             {showPasswordSetup && !methods?.hasStoredKey && (
               <div className="mt-4 p-4 bg-gray-900 border border-gray-700 rounded-lg">
                 <h3 className="text-white font-medium mb-2">Set up password login</h3>

--- a/apps/kernel/app/auth/stubs/new/page.tsx
+++ b/apps/kernel/app/auth/stubs/new/page.tsx
@@ -1,9 +1,48 @@
 'use client';
 
-import { useState, FormEvent } from 'react';
+import { useState, useEffect, useRef, useCallback, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 
 const CATEGORY_PRESETS = ['café', 'restaurant', 'shop', 'venue', 'studio', 'bar', 'gallery', 'gym'];
+
+// Nominatim (OpenStreetMap) — no API key, 1 req/sec rate limit
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org';
+
+interface GeoResult {
+  lat: number;
+  lon: number;
+  displayName: string;
+}
+
+interface DeviceLocation {
+  lat: number;
+  lon: number;
+  accuracy: number;
+}
+
+async function forwardGeocode(query: string): Promise<GeoResult[]> {
+  const res = await fetch(
+    `${NOMINATIM_URL}/search?q=${encodeURIComponent(query)}&format=json&limit=5&addressdetails=1`,
+    { headers: { 'User-Agent': 'Imajin/1.0 (https://imajin.ai)' } }
+  );
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.map((r: { lat: string; lon: string; display_name: string }) => ({
+    lat: parseFloat(r.lat),
+    lon: parseFloat(r.lon),
+    displayName: r.display_name,
+  }));
+}
+
+async function reverseGeocode(lat: number, lon: number): Promise<string | null> {
+  const res = await fetch(
+    `${NOMINATIM_URL}/reverse?lat=${lat}&lon=${lon}&format=json&addressdetails=1`,
+    { headers: { 'User-Agent': 'Imajin/1.0 (https://imajin.ai)' } }
+  );
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data.display_name || null;
+}
 
 export default function NewStubPage() {
   const router = useRouter();
@@ -13,6 +52,110 @@ export default function NewStubPage() {
   const [handle, setHandle] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  // Geocoding state
+  const [resolvedLat, setResolvedLat] = useState<number | null>(null);
+  const [resolvedLon, setResolvedLon] = useState<number | null>(null);
+  const [geocodeSource, setGeocodeSource] = useState<'address' | 'device' | null>(null);
+  const [geocoding, setGeocoding] = useState(false);
+  const [suggestions, setSuggestions] = useState<GeoResult[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  // Device location
+  const [deviceLoc, setDeviceLoc] = useState<DeviceLocation | null>(null);
+  const [deviceLocError, setDeviceLocError] = useState<string | null>(null);
+  const [reversingDevice, setReversingDevice] = useState(false);
+  const watchIdRef = useRef<number | null>(null);
+  const geocodeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Watch device GPS
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setDeviceLocError('Geolocation not available');
+      return;
+    }
+    watchIdRef.current = navigator.geolocation.watchPosition(
+      (pos) => {
+        setDeviceLoc({
+          lat: pos.coords.latitude,
+          lon: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+        });
+        setDeviceLocError(null);
+      },
+      (err) => {
+        if (err.code === err.PERMISSION_DENIED) {
+          setDeviceLocError('Location permission denied');
+        } else {
+          setDeviceLocError('Location unavailable');
+        }
+      },
+      { enableHighAccuracy: true, maximumAge: 30000 }
+    );
+    return () => {
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+      }
+    };
+  }, []);
+
+  // Debounced forward geocode on address input
+  const handleLocationChange = useCallback((value: string) => {
+    setLocation(value);
+    // Clear resolved coords when user edits the address
+    if (geocodeSource === 'address') {
+      setResolvedLat(null);
+      setResolvedLon(null);
+      setGeocodeSource(null);
+    }
+    if (geocodeTimerRef.current) clearTimeout(geocodeTimerRef.current);
+    if (value.trim().length < 3) {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      return;
+    }
+    geocodeTimerRef.current = setTimeout(async () => {
+      try {
+        const results = await forwardGeocode(value);
+        setSuggestions(results);
+        setShowSuggestions(results.length > 0);
+      } catch {
+        setSuggestions([]);
+      }
+    }, 600);
+  }, [geocodeSource]);
+
+  function selectSuggestion(result: GeoResult) {
+    setLocation(result.displayName);
+    setResolvedLat(result.lat);
+    setResolvedLon(result.lon);
+    setGeocodeSource('address');
+    setSuggestions([]);
+    setShowSuggestions(false);
+  }
+
+  async function useDeviceLocation() {
+    if (!deviceLoc) return;
+    setReversingDevice(true);
+    try {
+      const address = await reverseGeocode(deviceLoc.lat, deviceLoc.lon);
+      if (address) {
+        setLocation(address);
+      }
+      setResolvedLat(deviceLoc.lat);
+      setResolvedLon(deviceLoc.lon);
+      setGeocodeSource('device');
+      setSuggestions([]);
+      setShowSuggestions(false);
+    } catch {
+      // Still set coords even if reverse geocode fails
+      setResolvedLat(deviceLoc.lat);
+      setResolvedLon(deviceLoc.lon);
+      setGeocodeSource('device');
+    } finally {
+      setReversingDevice(false);
+    }
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -29,6 +172,8 @@ export default function NewStubPage() {
           category: category.trim() || undefined,
           location: location.trim() || undefined,
           handle: handle.trim() || undefined,
+          lat: resolvedLat ?? undefined,
+          lon: resolvedLon ?? undefined,
         }),
       });
 
@@ -38,7 +183,6 @@ export default function NewStubPage() {
         return;
       }
 
-      // Redirect to the new stub's profile
       const dest = data.handle ? `/profile/${data.handle}` : `/profile/${data.did}`;
       router.push(dest);
     } catch {
@@ -106,17 +250,89 @@ export default function NewStubPage() {
 
           {/* Location */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
-              Location
-            </label>
-            <input
-              type="text"
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
-              placeholder="e.g. 123 Main St, Portland OR"
-              maxLength={200}
-              className="w-full bg-zinc-900 border border-gray-700 rounded-lg px-4 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors"
-            />
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+                Location
+              </label>
+              {deviceLoc ? (
+                <span className="text-[10px] text-zinc-500 font-mono tabular-nums">
+                  📍 {deviceLoc.lat.toFixed(4)}, {deviceLoc.lon.toFixed(4)}
+                  <span className="text-zinc-600 ml-1">(±{Math.round(deviceLoc.accuracy)}m)</span>
+                </span>
+              ) : deviceLocError ? (
+                <span className="text-[10px] text-zinc-600">{deviceLocError}</span>
+              ) : (
+                <span className="text-[10px] text-zinc-600">Locating…</span>
+              )}
+            </div>
+
+            <div className="relative flex gap-2">
+              <div className="relative flex-1">
+                <input
+                  type="text"
+                  value={location}
+                  onChange={(e) => handleLocationChange(e.target.value)}
+                  onFocus={() => { if (suggestions.length > 0) setShowSuggestions(true); }}
+                  onBlur={() => { setTimeout(() => setShowSuggestions(false), 200); }}
+                  placeholder="e.g. 123 Main St, Portland OR"
+                  maxLength={200}
+                  className="w-full bg-zinc-900 border border-gray-700 rounded-lg px-4 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors"
+                />
+
+                {/* Autocomplete suggestions */}
+                {showSuggestions && suggestions.length > 0 && (
+                  <div className="absolute z-10 top-full left-0 right-0 mt-1 bg-zinc-900 border border-gray-700 rounded-lg overflow-hidden shadow-xl max-h-48 overflow-y-auto">
+                    {suggestions.map((s, i) => (
+                      <button
+                        key={i}
+                        type="button"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => selectSuggestion(s)}
+                        className="w-full text-left px-4 py-2.5 text-sm text-zinc-300 hover:bg-zinc-800 transition-colors border-b border-gray-800 last:border-0"
+                      >
+                        <span className="line-clamp-2">{s.displayName}</span>
+                        <span className="text-[10px] text-zinc-600 font-mono block mt-0.5">
+                          {s.lat.toFixed(5)}, {s.lon.toFixed(5)}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <button
+                type="button"
+                onClick={useDeviceLocation}
+                disabled={!deviceLoc || reversingDevice}
+                title="Use device location"
+                className="px-3 py-2.5 bg-zinc-900 border border-gray-700 rounded-lg text-zinc-400 hover:text-amber-400 hover:border-amber-500/50 disabled:opacity-30 disabled:hover:text-zinc-400 disabled:hover:border-gray-700 transition-colors shrink-0"
+              >
+                {reversingDevice ? (
+                  <span className="text-xs">…</span>
+                ) : (
+                  <span className="text-sm">📍</span>
+                )}
+              </button>
+            </div>
+
+            {/* Resolved coordinates */}
+            {resolvedLat !== null && resolvedLon !== null && (
+              <div className="mt-2 flex items-center gap-2">
+                <span className="text-[10px] font-mono text-amber-400/80 tabular-nums">
+                  {resolvedLat.toFixed(5)}, {resolvedLon.toFixed(5)}
+                </span>
+                <span className="text-[10px] text-zinc-600">
+                  via {geocodeSource === 'device' ? 'GPS' : 'address lookup'}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => { setResolvedLat(null); setResolvedLon(null); setGeocodeSource(null); }}
+                  className="text-[10px] text-zinc-600 hover:text-zinc-400 transition-colors"
+                >
+                  ✕
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Handle */}

--- a/apps/kernel/app/profile/api/stubs/route.ts
+++ b/apps/kernel/app/profile/api/stubs/route.ts
@@ -39,12 +39,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { name, subtype, handle, location, category } = body as {
+  const { name, subtype, handle, location, category, lat, lon } = body as {
     name?: string;
     subtype?: string;
     handle?: string;
     location?: string;
     category?: string;
+    lat?: number;
+    lon?: number;
   };
 
   if (!name || typeof name !== 'string' || !name.trim()) {
@@ -119,9 +121,13 @@ export async function POST(request: NextRequest) {
     });
 
     // Create profile
-    const metadata: Record<string, string> = {};
+    const metadata: Record<string, string | number> = {};
     if (location) metadata.location = String(location).slice(0, 200);
     if (category) metadata.category = String(category).slice(0, 100);
+    if (typeof lat === 'number' && typeof lon === 'number' && isFinite(lat) && isFinite(lon)) {
+      metadata.lat = Math.round(lat * 1e6) / 1e6;  // ~11cm precision
+      metadata.lon = Math.round(lon * 1e6) / 1e6;
+    }
 
     await db.insert(profiles).values({
       did: stubDid,


### PR DESCRIPTION
## What

Two new flows on `/auth/settings/security` when a stored key exists:

### 1. Change Password
- Click 'Change password' button (replaces the bare 'Active' badge)
- Enter current password → new password → confirm
- Client decrypts stored key with current password to verify
- Re-encrypts localStorage key with new password → upserts via `POST /auth/api/stored-keys`

### 2. Reset from This Device
- Available via 'Forgot password?' link inside the change password form
- Amber-tinted UI with clear warning explaining this is a device-trust operation
- Skips current password — re-encrypts directly from localStorage key
- Same upsert endpoint, same security properties as initial setup

### Why both?
- **Change** protects against casual desk walkups (defense in depth)
- **Reset** is the escape hatch when you're logged in but forgot the password (Ryan's actual situation right now)

No backend changes — both use the existing `POST /auth/api/stored-keys` upsert and `GET /auth/api/account/methods?includeKey=true`.

Closes #695