### PR TITLE
feat(stubs): server-side Nominatim geocoding fallback

### DIFF
--- a/apps/kernel/app/profile/api/stubs/route.ts
+++ b/apps/kernel/app/profile/api/stubs/route.ts
@@ -39,12 +39,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { name, subtype, handle, location, category } = body as {
+  const { name, subtype, handle, location, category, lat, lon } = body as {
     name?: string;
     subtype?: string;
     handle?: string;
     location?: string;
     category?: string;
+    lat?: number;
+    lon?: number;
   };
 
   if (!name || typeof name !== 'string' || !name.trim()) {
@@ -122,6 +124,29 @@ export async function POST(request: NextRequest) {
     const metadata: Record<string, string> = {};
     if (location) metadata.location = String(location).slice(0, 200);
     if (category) metadata.category = String(category).slice(0, 100);
+
+    // Server-side geocoding fallback: if no coords from client but location text is present, query Nominatim
+    let resolvedLat = lat;
+    let resolvedLon = lon;
+    if (!resolvedLat && !resolvedLon && location) {
+      try {
+        const geoUrl = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(location)}&format=json&limit=1`;
+        const geoRes = await fetch(geoUrl, {
+          headers: { 'User-Agent': 'Imajin/1.0 (https://imajin.ai)' },
+        });
+        if (geoRes.ok) {
+          const geoData = await geoRes.json() as Array<{ lat: string; lon: string }>;
+          if (geoData.length > 0) {
+            resolvedLat = parseFloat(geoData[0].lat);
+            resolvedLon = parseFloat(geoData[0].lon);
+          }
+        }
+      } catch (err) {
+        log.error({ err: String(err) }, '[stubs] Nominatim geocode failed (non-fatal)');
+      }
+    }
+    if (resolvedLat != null) metadata.lat = String(resolvedLat);
+    if (resolvedLon != null) metadata.lon = String(resolvedLon);
 
     await db.insert(profiles).values({
       did: stubDid,


### PR DESCRIPTION
When the client doesn't send lat/lon but does send a location string, the stubs API now forward-geocodes via Nominatim as a fallback. Best-effort — errors are logged but don't block stub creation.

Closes #698