### PR TITLE
feat(admin): application log viewer with Postgres transport (#702)

### DIFF
--- a/apps/kernel/app/admin/layout.tsx
+++ b/apps/kernel/app/admin/layout.tsx
@@ -18,6 +18,7 @@ const NAV_ITEMS = [
   { label: 'Moderation', href: '/admin/moderation', icon: '🛡️' },
   { label: 'Events', href: '/admin/events', icon: '🔔' },
   { label: 'Telemetry', href: '/admin/telemetry', icon: '📈' },
+  { label: 'Logs', href: '/admin/logs', icon: '📋' },
 ];
 
 export default async function AdminLayout({

--- a/apps/kernel/app/admin/logs/logs-client.tsx
+++ b/apps/kernel/app/admin/logs/logs-client.tsx
@@ -1,0 +1,484 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import Link from 'next/link';
+
+interface AppLog {
+  id: string;
+  service: string;
+  level: string;
+  message: string;
+  correlation_id: string | null;
+  did: string | null;
+  method: string | null;
+  path: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+interface Filters {
+  service: string;
+  levels: string[];
+  correlationId: string;
+  did: string;
+  search: string;
+  from: string;
+  to: string;
+}
+
+const SERVICE_COLORS: Record<string, string> = {
+  auth: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-400',
+  kernel: 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-400',
+  pay: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400',
+  events: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400',
+  connections: 'bg-cyan-100 dark:bg-cyan-900/40 text-cyan-700 dark:text-cyan-400',
+  chat: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-400',
+  profile: 'bg-pink-100 dark:bg-pink-900/40 text-pink-700 dark:text-pink-400',
+  registry: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400',
+  market: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-400',
+  notify: 'bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-400',
+};
+
+const LEVEL_COLORS: Record<string, string> = {
+  debug: 'bg-gray-100 dark:bg-gray-800 text-gray-500',
+  info: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400',
+  warn: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400',
+  error: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400',
+};
+
+const ALL_LEVELS = ['debug', 'info', 'warn', 'error'];
+
+function serviceBadgeClass(service: string): string {
+  return SERVICE_COLORS[service] ?? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400';
+}
+
+function formatTs(ts: string) {
+  const d = new Date(ts);
+  return d.toLocaleTimeString(undefined, { hour12: false }) + ' ' + d.toLocaleDateString();
+}
+
+function truncateDid(did: string | null) {
+  if (!did) return '—';
+  if (did.length <= 24) return did;
+  return `${did.slice(0, 12)}…${did.slice(-8)}`;
+}
+
+const EMPTY_FILTERS: Filters = {
+  service: '',
+  levels: [],
+  correlationId: '',
+  did: '',
+  search: '',
+  from: '',
+  to: '',
+};
+
+const LIMIT = 50;
+
+export default function LogsClient() {
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [pendingFilters, setPendingFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [rows, setRows] = useState<AppLog[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [cleanupDays, setCleanupDays] = useState(14);
+  const [cleanupMsg, setCleanupMsg] = useState('');
+  const autoRefreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchLogs = useCallback(async (f: Filters, off: number) => {
+    setLoading(true);
+    try {
+      const p = new URLSearchParams();
+      if (f.service) p.set('service', f.service);
+      if (f.levels.length > 0) p.set('level', f.levels.join(','));
+      if (f.correlationId) p.set('correlationId', f.correlationId);
+      if (f.did) p.set('did', f.did);
+      if (f.search) p.set('search', f.search);
+      if (f.from) p.set('from', f.from);
+      if (f.to) p.set('to', f.to);
+      p.set('limit', String(LIMIT));
+      p.set('offset', String(off));
+      const res = await fetch(`/api/admin/logs?${p}`);
+      if (res.ok) {
+        const data = await res.json();
+        setRows(data.rows);
+        setTotal(data.total);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLogs(filters, offset);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (autoRefresh) {
+      autoRefreshRef.current = setInterval(() => fetchLogs(filters, offset), 5000);
+    } else {
+      if (autoRefreshRef.current) clearInterval(autoRefreshRef.current);
+    }
+    return () => {
+      if (autoRefreshRef.current) clearInterval(autoRefreshRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoRefresh, filters, offset]);
+
+  function applyFilters() {
+    setFilters(pendingFilters);
+    setOffset(0);
+    setExpandedRows(new Set());
+    fetchLogs(pendingFilters, 0);
+  }
+
+  function clearFilters() {
+    setPendingFilters(EMPTY_FILTERS);
+    setFilters(EMPTY_FILTERS);
+    setOffset(0);
+    setExpandedRows(new Set());
+    fetchLogs(EMPTY_FILTERS, 0);
+  }
+
+  function refresh() {
+    fetchLogs(filters, offset);
+  }
+
+  function toggleRow(id: string) {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function prevPage() {
+    const newOffset = Math.max(0, offset - LIMIT);
+    setOffset(newOffset);
+    fetchLogs(filters, newOffset);
+  }
+
+  function nextPage() {
+    const newOffset = offset + LIMIT;
+    setOffset(newOffset);
+    fetchLogs(filters, newOffset);
+  }
+
+  function toggleLevel(level: string) {
+    const levels = pendingFilters.levels.includes(level)
+      ? pendingFilters.levels.filter((l) => l !== level)
+      : [...pendingFilters.levels, level];
+    setPendingFilters({ ...pendingFilters, levels });
+  }
+
+  async function runCleanup() {
+    setCleanupMsg('Running…');
+    try {
+      const res = await fetch(`/api/admin/logs/cleanup?days=${cleanupDays}`, { method: 'POST' });
+      if (res.ok) {
+        const data = await res.json();
+        setCleanupMsg(`Deleted ${data.deleted} rows`);
+        fetchLogs(filters, offset);
+      } else {
+        setCleanupMsg('Error');
+      }
+    } catch {
+      setCleanupMsg('Error');
+    }
+    setTimeout(() => setCleanupMsg(''), 4000);
+  }
+
+  const hasFilters = Object.entries(pendingFilters).some(([k, v]) =>
+    k === 'levels' ? (v as string[]).length > 0 : Boolean(v)
+  );
+  const hasActiveFilters = Object.entries(filters).some(([k, v]) =>
+    k === 'levels' ? (v as string[]).length > 0 : Boolean(v)
+  );
+  const hasPrev = offset > 0;
+  const hasNext = offset + LIMIT < total;
+  const page = Math.floor(offset / LIMIT) + 1;
+
+  return (
+    <div className="p-6 lg:p-8 max-w-7xl">
+      {/* Header */}
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Application Logs</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Structured log entries from @imajin/logger — persisted when ENABLE_APP_LOG=true
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setAutoRefresh((v) => !v)}
+            className={`rounded-lg border px-3 py-1.5 text-sm flex items-center gap-1.5 ${
+              autoRefresh
+                ? 'border-orange-400 text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20'
+                : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+            }`}
+          >
+            {autoRefresh ? '⏸ Auto' : '▶ Auto'}
+          </button>
+          <button
+            onClick={refresh}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-1.5"
+          >
+            ↻ Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-4 flex flex-wrap gap-2 items-end">
+        {/* Service */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-gray-500 dark:text-gray-400">Service</label>
+          <input
+            type="text"
+            value={pendingFilters.service}
+            onChange={(e) => setPendingFilters({ ...pendingFilters, service: e.target.value })}
+            placeholder="e.g. kernel"
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-36"
+          />
+        </div>
+
+        {/* Level pills */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-gray-500 dark:text-gray-400">Level</label>
+          <div className="flex gap-1">
+            {ALL_LEVELS.map((level) => {
+              const active = pendingFilters.levels.includes(level);
+              return (
+                <button
+                  key={level}
+                  onClick={() => toggleLevel(level)}
+                  className={`text-xs px-2 py-1 rounded font-medium transition-opacity ${
+                    active
+                      ? LEVEL_COLORS[level]
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-400 opacity-50 hover:opacity-75'
+                  }`}
+                >
+                  {level}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Search */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-gray-500 dark:text-gray-400">Search</label>
+          <input
+            type="text"
+            value={pendingFilters.search}
+            onChange={(e) => setPendingFilters({ ...pendingFilters, search: e.target.value })}
+            placeholder="message contains…"
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-44"
+          />
+        </div>
+
+        {/* Correlation ID */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-gray-500 dark:text-gray-400">Correlation ID</label>
+          <input
+            type="text"
+            value={pendingFilters.correlationId}
+            onChange={(e) => setPendingFilters({ ...pendingFilters, correlationId: e.target.value })}
+            placeholder="cor_…"
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-44"
+          />
+        </div>
+
+        {/* DID */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-gray-500 dark:text-gray-400">DID</label>
+          <input
+            type="text"
+            value={pendingFilters.did}
+            onChange={(e) => setPendingFilters({ ...pendingFilters, did: e.target.value })}
+            placeholder="did:key:…"
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-44"
+          />
+        </div>
+
+        {/* From / To */}
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
+          <input
+            type="datetime-local"
+            value={pendingFilters.from}
+            onChange={(e) => setPendingFilters({ ...pendingFilters, from: e.target.value })}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
+          <input
+            type="datetime-local"
+            value={pendingFilters.to}
+            onChange={(e) => setPendingFilters({ ...pendingFilters, to: e.target.value })}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+        </div>
+
+        <button
+          onClick={applyFilters}
+          className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium self-end"
+        >
+          Filter
+        </button>
+        {(hasFilters || hasActiveFilters) && (
+          <button
+            onClick={clearFilters}
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 self-end py-1.5"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Total count */}
+      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+        {loading ? 'Loading…' : `${total.toLocaleString()} logs`}
+      </p>
+
+      {/* Table */}
+      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+        {!loading && rows.length === 0 ? (
+          <p className="px-6 py-10 text-sm text-gray-400 dark:text-gray-500 text-center">
+            No logs found
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Time</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Service</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Level</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Message</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">DID</th>
+                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Trace</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                {rows.map((row) => {
+                  const isExpanded = expandedRows.has(row.id);
+                  const hasMetadata = row.metadata && Object.keys(row.metadata).length > 0;
+                  const isError = row.level === 'error';
+                  const isWarn = row.level === 'warn';
+                  return (
+                    <>
+                      <tr
+                        key={row.id}
+                        onClick={() => hasMetadata && toggleRow(row.id)}
+                        className={`hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors ${hasMetadata ? 'cursor-pointer' : ''} ${isError ? 'bg-red-50/40 dark:bg-red-900/10' : isWarn ? 'bg-amber-50/40 dark:bg-amber-900/10' : ''}`}
+                      >
+                        <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap font-mono">
+                          {formatTs(row.created_at)}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`text-xs px-2 py-0.5 rounded font-medium ${serviceBadgeClass(row.service)}`}>
+                            {row.service}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`text-xs px-2 py-0.5 rounded font-medium ${LEVEL_COLORS[row.level] ?? 'bg-gray-100 text-gray-500'}`}>
+                            {row.level}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-xs text-gray-700 dark:text-gray-300 max-w-xs">
+                          <span className="truncate block" title={row.message}>{row.message}</span>
+                          {row.path && (
+                            <span className="text-gray-400 font-mono">{row.method} {row.path}</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-xs font-mono text-gray-500 dark:text-gray-400">
+                          <span title={row.did ?? undefined}>{truncateDid(row.did)}</span>
+                        </td>
+                        <td className="px-4 py-3">
+                          {row.correlation_id ? (
+                            <Link
+                              href={`/admin/telemetry/trace/${encodeURIComponent(row.correlation_id)}`}
+                              className="text-xs font-mono text-orange-600 dark:text-orange-400 hover:underline"
+                              onClick={(e) => e.stopPropagation()}
+                              title={row.correlation_id}
+                            >
+                              {row.correlation_id.slice(0, 12)}…
+                            </Link>
+                          ) : (
+                            <span className="text-xs text-gray-400">—</span>
+                          )}
+                        </td>
+                      </tr>
+                      {isExpanded && hasMetadata && (
+                        <tr key={`${row.id}-meta`} className="bg-gray-50 dark:bg-gray-900/40">
+                          <td colSpan={6} className="px-6 py-3">
+                            <pre className="text-xs font-mono text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-all">
+                              {JSON.stringify(row.metadata, null, 2)}
+                            </pre>
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          onClick={prevPage}
+          disabled={!hasPrev}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          ← Previous
+        </button>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          Page {page} — Showing {Math.min(offset + 1, total)}–{Math.min(offset + LIMIT, total)} of {total.toLocaleString()}
+        </span>
+        <button
+          onClick={nextPage}
+          disabled={!hasNext}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Next →
+        </button>
+      </div>
+
+      {/* Cleanup section */}
+      <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-700">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Log Retention Cleanup</h2>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-gray-500 dark:text-gray-400">Delete logs older than</span>
+          <input
+            type="number"
+            min={1}
+            value={cleanupDays}
+            onChange={(e) => setCleanupDays(Math.max(1, parseInt(e.target.value, 10) || 14))}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-20"
+          />
+          <span className="text-sm text-gray-500 dark:text-gray-400">days</span>
+          <button
+            onClick={runCleanup}
+            className="rounded-lg bg-red-500 hover:bg-red-600 text-white px-3 py-1.5 text-sm font-medium"
+          >
+            Run cleanup
+          </button>
+          {cleanupMsg && (
+            <span className="text-sm text-gray-600 dark:text-gray-400">{cleanupMsg}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/logs/page.tsx
+++ b/apps/kernel/app/admin/logs/page.tsx
@@ -1,0 +1,5 @@
+import LogsClient from './logs-client';
+
+export default function AdminLogsPage() {
+  return <LogsClient />;
+}

--- a/apps/kernel/app/api/admin/logs/cleanup/route.ts
+++ b/apps/kernel/app/api/admin/logs/cleanup/route.ts
@@ -3,9 +3,8 @@ import { getClient } from '@imajin/db';
 import { withLogger } from '@imajin/logger';
 import { requireAdmin } from '@imajin/auth';
 
-const sql = getClient();
-
 export const POST = withLogger('kernel', async (req: NextRequest, { log }) => {
+  const sql = getClient();
   const session = await requireAdmin();
   if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/apps/kernel/app/api/admin/logs/cleanup/route.ts
+++ b/apps/kernel/app/api/admin/logs/cleanup/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getClient } from '@imajin/db';
+import { withLogger } from '@imajin/logger';
+import { requireAdmin } from '@imajin/auth';
+
+const sql = getClient();
+
+export const POST = withLogger('kernel', async (req: NextRequest, { log }) => {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const days = Math.max(1, parseInt(url.searchParams.get('days') || '14', 10));
+
+  const [result] = await sql`
+    WITH deleted AS (
+      DELETE FROM registry.app_logs
+      WHERE created_at < now() - (${days} || ' days')::interval
+      RETURNING id
+    )
+    SELECT COUNT(*)::int AS deleted FROM deleted
+  `;
+
+  const deleted = result?.deleted ?? 0;
+  log.info({ service: 'kernel', days, deleted }, 'admin logs cleanup');
+
+  return NextResponse.json({ deleted });
+});

--- a/apps/kernel/app/api/admin/logs/route.ts
+++ b/apps/kernel/app/api/admin/logs/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getClient } from '@imajin/db';
+import { withLogger } from '@imajin/logger';
+import { requireAdmin } from '@imajin/auth';
+
+const sql = getClient();
+
+export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const service = url.searchParams.get('service') || null;
+  const levelParam = url.searchParams.get('level') || null;
+  const levels = levelParam ? levelParam.split(',').filter(Boolean) : null;
+  const correlationId = url.searchParams.get('correlationId') || null;
+  const did = url.searchParams.get('did') || null;
+  const search = url.searchParams.get('search') || null;
+  const from = url.searchParams.get('from') || null;
+  const to = url.searchParams.get('to') || null;
+  const limit = Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10));
+  const offset = parseInt(url.searchParams.get('offset') || '0', 10);
+
+  const [countRow] = await sql`
+    SELECT COUNT(*)::int AS total
+    FROM registry.app_logs
+    WHERE TRUE
+    ${service ? sql`AND service = ${service}` : sql``}
+    ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
+    ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
+    ${did ? sql`AND did = ${did}` : sql``}
+    ${search ? sql`AND message ILIKE ${'%' + search + '%'}` : sql``}
+    ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
+    ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
+  `;
+
+  const rows = await sql`
+    SELECT id, service, level, message, correlation_id, did, method, path, metadata, created_at
+    FROM registry.app_logs
+    WHERE TRUE
+    ${service ? sql`AND service = ${service}` : sql``}
+    ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
+    ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
+    ${did ? sql`AND did = ${did}` : sql``}
+    ${search ? sql`AND message ILIKE ${'%' + search + '%'}` : sql``}
+    ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
+    ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
+    ORDER BY created_at DESC
+    LIMIT ${limit} OFFSET ${offset}
+  `;
+
+  log.info({ service: 'kernel', filterService: service, levels, limit, offset, count: rows.length }, 'admin logs query');
+
+  return NextResponse.json({ rows, total: countRow?.total ?? 0 });
+});

--- a/apps/kernel/app/api/admin/logs/route.ts
+++ b/apps/kernel/app/api/admin/logs/route.ts
@@ -3,9 +3,8 @@ import { getClient } from '@imajin/db';
 import { withLogger } from '@imajin/logger';
 import { requireAdmin } from '@imajin/auth';
 
-const sql = getClient();
-
 export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
+  const sql = getClient();
   const session = await requireAdmin();
   if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/apps/kernel/drizzle/0022_app_logs.sql
+++ b/apps/kernel/drizzle/0022_app_logs.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS registry.app_logs (
+  id text PRIMARY KEY,
+  service text NOT NULL,
+  level text NOT NULL,
+  message text NOT NULL,
+  correlation_id text,
+  did text,
+  method text,
+  path text,
+  metadata jsonb,
+  created_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_logs_created ON registry.app_logs (created_at);
+CREATE INDEX IF NOT EXISTS idx_app_logs_service_level ON registry.app_logs (service, level);
+CREATE INDEX IF NOT EXISTS idx_app_logs_correlation ON registry.app_logs (correlation_id) WHERE correlation_id IS NOT NULL;
+
+-- Retention: auto-delete logs older than 14 days
+-- Run via pg_cron or the admin cleanup endpoint at POST /api/admin/logs/cleanup
+-- CREATE EXTENSION IF NOT EXISTS pg_cron;
+-- SELECT cron.schedule('app-logs-cleanup', '0 3 * * *', $$DELETE FROM registry.app_logs WHERE created_at < now() - interval '14 days'$$);

--- a/apps/kernel/drizzle/meta/0022_snapshot.json
+++ b/apps/kernel/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "00000000-0000-0000-0000-000000000021",
+  "prevId": "00000000-0000-0000-0000-000000000020",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {},
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/kernel/drizzle/meta/_journal.json
+++ b/apps/kernel/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1776038400000,
       "tag": "0021_stub_profile_images",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1776124800000,
+      "tag": "0022_app_logs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/kernel/src/db/schemas/registry.ts
+++ b/apps/kernel/src/db/schemas/registry.ts
@@ -295,6 +295,28 @@ export const systemEvents = registrySchema.table('system_events', {
 
 export type SystemEvent = typeof systemEvents.$inferSelect;
 
+/**
+ * Application log entries — written by @imajin/logger Pino adapter when ENABLE_APP_LOG=true
+ */
+export const appLogs = registrySchema.table('app_logs', {
+  id: text('id').primaryKey(),
+  service: text('service').notNull(),
+  level: text('level').notNull(),                // debug, info, warn, error
+  message: text('message').notNull(),
+  correlationId: text('correlation_id'),
+  did: text('did'),
+  method: text('method'),
+  path: text('path'),
+  metadata: jsonb('metadata'),                   // remaining LogContext fields
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  createdIdx: index('idx_app_logs_created').on(table.createdAt),
+  serviceLevelIdx: index('idx_app_logs_service_level').on(table.service, table.level),
+  correlationIdx: index('idx_app_logs_correlation').on(table.correlationId),
+}));
+
+export type AppLog = typeof appLogs.$inferSelect;
+
 // Types
 export type Node = typeof nodes.$inferSelect;
 export type NewNode = typeof nodes.$inferInsert;

--- a/packages/logger/src/adapters/pino.ts
+++ b/packages/logger/src/adapters/pino.ts
@@ -14,19 +14,74 @@ const REDACT_PATHS = [
   '*.authorization',
 ];
 
+const MIN_PERSIST_LEVEL = process.env.APP_LOG_LEVEL || 'warn';
+const LEVEL_PRIORITY: Record<string, number> = { debug: 10, info: 20, warn: 30, error: 40 };
+
+function shouldPersist(level: string): boolean {
+  if (process.env.ENABLE_APP_LOG !== 'true') return false;
+  return (LEVEL_PRIORITY[level] ?? 0) >= (LEVEL_PRIORITY[MIN_PERSIST_LEVEL] ?? 30);
+}
+
+function writeAppLog(entry: {
+  service: string;
+  level: string;
+  message: string;
+  correlationId?: string;
+  did?: string;
+  method?: string;
+  path?: string;
+  metadata?: Record<string, unknown>;
+}): void {
+  if (!shouldPersist(entry.level)) return;
+
+  import('@imajin/db')
+    .then(({ getClient }) => {
+      const sql = getClient();
+      const id = `log_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+      return sql`
+        INSERT INTO registry.app_logs (id, service, level, message, correlation_id, did, method, path, metadata)
+        VALUES (${id}, ${entry.service}, ${entry.level}, ${entry.message},
+                ${entry.correlationId ?? null}, ${entry.did ?? null},
+                ${entry.method ?? null}, ${entry.path ?? null},
+                ${entry.metadata ? JSON.stringify(entry.metadata) : null}::jsonb)
+      `;
+    })
+    .catch(() => {
+      // Never block or surface errors from the log sink
+    });
+}
+
 function wrapPino(instance: pino.Logger): Logger {
+  function persist(level: string, ctx: LogContext, message: string) {
+    const { service, correlationId, did, method, path, ...rest } = ctx;
+    writeAppLog({
+      service: service || 'unknown',
+      level,
+      message,
+      correlationId,
+      did,
+      method,
+      path,
+      metadata: Object.keys(rest).length > 0 ? rest : undefined,
+    });
+  }
+
   return {
     info(ctx: LogContext, message: string) {
       instance.info(ctx, message);
+      persist('info', ctx, message);
     },
     warn(ctx: LogContext, message: string) {
       instance.warn(ctx, message);
+      persist('warn', ctx, message);
     },
     error(ctx: LogContext, message: string) {
       instance.error(ctx, message);
+      persist('error', ctx, message);
     },
     debug(ctx: LogContext, message: string) {
       instance.debug(ctx, message);
+      persist('debug', ctx, message);
     },
     child(bindings: Partial<LogContext>): Logger {
       return wrapPino(instance.child(bindings as Record<string, unknown>));


### PR DESCRIPTION
## What

Pipes `@imajin/logger` application-level log entries into Postgres and exposes them in the admin console.

### 1. Schema + Migration
- `registry.app_logs` table: id, service, level, message, correlation_id, did, method, path, metadata, created_at
- Indexed on created_at, service+level, correlation_id (partial)
- Migration `0022_app_logs.sql` + journal + snapshot

### 2. Logger Transport
- `writeAppLog` in Pino adapter — fire-and-forget, dynamic `@imajin/db` import
- Gated on `ENABLE_APP_LOG=true` env var (zero overhead when disabled)
- `shouldPersist()` checks level threshold (`APP_LOG_LEVEL` env, default warn)
- Never blocks or throws from the log sink

### 3. Admin UI
- `GET /api/admin/logs` — filter by service, level, correlationId, did, search (ILIKE), time range, limit/offset
- `POST /api/admin/logs/cleanup` — delete rows older than N days (default 14)
- Admin page: filter bar (service dropdown, level pills, search, time range) + log table with expandable metadata rows
- Correlation ID links to telemetry trace view
- Auto-refresh toggle (5s poll)
- 📋 Logs nav item in admin sidebar

### Usage
Set `ENABLE_APP_LOG=true` in kernel `.env.local`. Optionally `APP_LOG_LEVEL=info` to capture info-level too.

Closes #702