### PR TITLE
feat(auth): add steward + operator tiers, tie invite limits to identity tiers

### DIFF
--- a/apps/kernel/app/connections/api/invites/route.ts
+++ b/apps/kernel/app/connections/api/invites/route.ts
@@ -16,20 +16,20 @@ const INVITE_COOLDOWN_DAYS = 7;
 const INVITE_EXPIRY_DAYS = 7;
 
 /**
- * Role-based invite limits (link invites only).
- * Role comes from the auth session (defaults to 'member').
- * Limit counts total pending link invites.
+ * Tier-based invite limits.
+ * Tier comes from the auth session identity tier.
+ * Limit counts total pending invites (link or email).
  */
 const INVITE_LIMITS: Record<string, number> = {
-  admin: Infinity,
-  legendary: 10,
-  trusted: 5,
-  member: 3,
-  newbie: 1,
+  soft: 0,
+  preliminary: 5,
+  established: 20,
+  steward: 50,
+  operator: Infinity,
 };
 
-function getInviteLimit(role: string): number {
-  return INVITE_LIMITS[role] ?? INVITE_LIMITS.member;
+function getInviteLimit(tier: string): number {
+  return INVITE_LIMITS[tier] ?? INVITE_LIMITS.preliminary;
 }
 
 async function isInTrustGraph(did: string): Promise<boolean> {
@@ -85,8 +85,8 @@ export async function POST(request: NextRequest) {
       }, { status: 429 });
     }
 
-    // Check pending email invite count (max 10)
-    const MAX_PENDING_EMAIL_INVITES = 10;
+    // Check pending email invite count (tier-based limit)
+    const emailLimit = getInviteLimit(session.tier);
     const pendingEmailCount = await db
       .select({ value: count() })
       .from(invites)
@@ -96,9 +96,11 @@ export async function POST(request: NextRequest) {
         eq(invites.status, 'pending'),
       ));
 
-    if (pendingEmailCount[0]?.value >= MAX_PENDING_EMAIL_INVITES) {
+    if (pendingEmailCount[0]?.value >= emailLimit) {
       return NextResponse.json({
-        error: `You have ${MAX_PENDING_EMAIL_INVITES} pending email invites. Please wait for some to be accepted or revoke them first.`,
+        error: emailLimit === Infinity
+          ? `You have too many pending email invites. Please wait for some to be accepted or revoke them first.`
+          : `You have reached your email invite limit (${emailLimit}) for your tier. Please wait for some to be accepted or revoke them first.`,
       }, { status: 429 });
     }
 
@@ -157,8 +159,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Link invite flow
-  const role: string = session.role || 'member';
-  const limit = getInviteLimit(role);
+  const limit = getInviteLimit(session.tier);
 
   const [{ count }] = await db
     .select({ count: sql<number>`count(*)::int` })
@@ -171,8 +172,8 @@ export async function POST(request: NextRequest) {
 
   if (count >= limit) {
     return NextResponse.json({
-      error: `Invite limit reached (${limit}). ${limit < Infinity ? `Your role "${role}" allows ${limit} pending invite${limit === 1 ? '' : 's'}.` : ''}`,
-      limit,
+      error: `Invite limit reached (${limit === Infinity ? 'unlimited' : limit}). ${limit < Infinity ? `Your tier allows ${limit} pending invite${limit === 1 ? '' : 's'}.` : ''}`,
+      limit: limit === Infinity ? null : limit,
       pending: count,
     }, { status: 429 });
   }
@@ -218,8 +219,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
 
-  const role: string = session.role || 'member';
-  const limit = getInviteLimit(role);
+  const limit = getInviteLimit(session.tier);
 
   const results = await db
     .select({
@@ -246,7 +246,7 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({
     invites: withDaysAgo,
-    role,
+    tier: session.tier,
     limit: limit === Infinity ? null : limit,
     pending,
     remaining: limit === Infinity ? null : Math.max(0, limit - pending),

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -7,7 +7,7 @@ export { getSession } from "./session";
 export type { SessionOptions } from "./session";
 export { requireHardDID } from "./require-hard-did";
 export { requireEstablishedDID } from "./require-established-did";
-export { isVerifiedTier, isEstablishedTier, normalizeTier } from "./tiers";
+export { isVerifiedTier, isEstablishedTier, isStewardTier, isOperatorTier, normalizeTier } from "./tiers";
 export type { IdentityTier } from "./tiers";
 export { canonicalize, sign, signSync } from "./sign";
 export { verify, isValidMessageStructure } from "./verify";

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -17,7 +17,7 @@ export type Action =
   | 'edit_profile' | 'create_event'
   | 'dm' | 'pod_chat' | 'send_invite' | 'create_pod' | 'connections';
 
-export type Tier = 'none' | 'soft' | 'preliminary' | 'established' | 'established+graph';
+export type Tier = 'none' | 'soft' | 'preliminary' | 'established' | 'established+graph' | 'steward' | 'operator';
 
 /**
  * Returns the minimum tier required for an action
@@ -63,7 +63,7 @@ export function requiredTier(action: Action): Tier {
 export async function canDo(
   did: string,
   action: Action,
-  currentTier: 'soft' | 'preliminary' | 'established',
+  currentTier: 'soft' | 'preliminary' | 'established' | 'steward' | 'operator',
   connectionsServiceUrl?: string
 ): Promise<boolean> {
   const required = requiredTier(action);
@@ -77,15 +77,15 @@ export async function canDo(
   }
 
   if (required === 'preliminary') {
-    return currentTier === 'preliminary' || currentTier === 'established';
+    return currentTier === 'preliminary' || currentTier === 'established' || currentTier === 'steward' || currentTier === 'operator';
   }
 
   if (required === 'established') {
-    return currentTier === 'established';
+    return currentTier === 'established' || currentTier === 'steward' || currentTier === 'operator';
   }
 
   if (required === 'established+graph') {
-    if (currentTier !== 'established') {
+    if (currentTier !== 'established' && currentTier !== 'steward' && currentTier !== 'operator') {
       return false;
     }
 
@@ -114,13 +114,15 @@ export async function canDo(
  * Checks if a user has the minimum tier required for an action
  * Does not check graph membership
  */
-export function hasTier(currentTier: 'none' | 'soft' | 'preliminary' | 'established', required: Tier): boolean {
+export function hasTier(currentTier: 'none' | 'soft' | 'preliminary' | 'established' | 'steward' | 'operator', required: Tier): boolean {
   const tierLevels: Record<string, number> = {
     'none': 0,
     'soft': 1,
     'preliminary': 2,
     'established': 3,
     'established+graph': 3, // tier check only, graph check is separate
+    'steward': 4,
+    'operator': 5,
   };
 
   return (tierLevels[currentTier] ?? 0) >= (tierLevels[required] ?? 0);

--- a/packages/auth/src/tiers.ts
+++ b/packages/auth/src/tiers.ts
@@ -1,22 +1,34 @@
 /**
  * Identity tier helpers.
  *
- * Tier progression: soft → preliminary → established
+ * Tier progression: soft → preliminary → established → steward → operator
  * - soft: email-only, unverified
  * - preliminary: keypair-based, basic verification
  * - established: fully verified (MFA, attestations, etc.)
+ * - steward: trusted community steward
+ * - operator: platform operator (full access)
  */
 
-export type IdentityTier = 'soft' | 'preliminary' | 'established';
+export type IdentityTier = 'soft' | 'preliminary' | 'established' | 'steward' | 'operator';
 
 /** True if the identity has completed at least basic verification (preliminary or established). */
 export function isVerifiedTier(tier: string | undefined | null): boolean {
-  return tier === 'preliminary' || tier === 'established';
+  return tier === 'preliminary' || tier === 'established' || tier === 'steward' || tier === 'operator';
 }
 
 /** True if the identity has completed full verification (established only). */
 export function isEstablishedTier(tier: string | undefined | null): boolean {
-  return tier === 'established';
+  return tier === 'established' || tier === 'steward' || tier === 'operator';
+}
+
+/** True if the identity is a steward or operator. */
+export function isStewardTier(tier: string | undefined | null): boolean {
+  return tier === 'steward' || tier === 'operator';
+}
+
+/** True if the identity is an operator. */
+export function isOperatorTier(tier: string | undefined | null): boolean {
+  return tier === 'operator';
 }
 
 /** Normalize legacy tier values. Maps 'hard' → 'preliminary'. */
@@ -24,5 +36,7 @@ export function normalizeTier(tier: string | undefined | null): IdentityTier {
   if (tier === 'hard') return 'preliminary';
   if (tier === 'established') return 'established';
   if (tier === 'preliminary') return 'preliminary';
+  if (tier === 'steward') return 'steward';
+  if (tier === 'operator') return 'operator';
   return 'soft';
 }

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -4,7 +4,7 @@ export interface Identity {
   subtype?: string;             // scope-dependent: 'human' | 'agent' | 'device' | etc.
   name?: string;
   handle?: string;
-  tier?: "soft" | "preliminary" | "established";
+  tier?: "soft" | "preliminary" | "established" | "steward" | "operator";
   chainVerified?: boolean;
   actingAs?: string;            // DID of group the caller is acting on behalf of
   actingAsServices?: string[];  // Services this controller can access (undefined = full access)


### PR DESCRIPTION
Closes #718

## Changes

Extends the identity tier ladder with two new tiers and replaces the dead role-based invite limit system with tier-based limits.

### Tier progression
`soft → preliminary → established → steward → operator`

### Invite limits (pending, both link + email)
| Tier | Limit |
|------|-------|
| soft | 0 |
| preliminary | 5 |
| established | 20 |
| steward | 50 |
| operator | ∞ |

### Files
- `packages/auth/src/tiers.ts` — new tiers, `isStewardTier()`, `isOperatorTier()` helpers
- `packages/auth/src/permissions.ts` — tier levels + type updates
- `packages/auth/src/types.ts` — tier union
- `packages/auth/src/index.ts` — new exports
- `apps/kernel/app/connections/api/invites/route.ts` — role→tier swap, both POST handlers

### Notes
- DB `tier` column is `text` — no migration needed
- `session.role` untouched (still used for chat `cohost`)
- Existing tier gates unchanged (soft/preliminary/established behavior preserved)