### PR TITLE
feat(market): .fair settlement, display, and manifest recalculation (#685)

### DIFF
--- a/apps/market/.env.example
+++ b/apps/market/.env.example
@@ -28,3 +28,7 @@ IMAJIN_ENV=dev
 # Internal API key for attestation emission (must match kernel)
 ATTESTATION_INTERNAL_API_KEY=""
 AUTH_INTERNAL_API_KEY=""
+
+# .fair settlement — pay service credentials + node identity
+PAY_SERVICE_API_KEY=
+NODE_DID=

--- a/apps/market/app/api/listings/[id]/route.ts
+++ b/apps/market/app/api/listings/[id]/route.ts
@@ -7,6 +7,8 @@ import { db, listings } from '@/db';
 import { requireAuth, getSession } from '@imajin/auth';
 import { jsonResponse, errorResponse } from '@/lib/utils';
 import { resolveMediaRef } from '@imajin/media';
+import { buildFairManifest } from '@imajin/fair';
+import { getClient } from '@imajin/db';
 import { eq } from 'drizzle-orm';
 
 /**
@@ -138,6 +140,47 @@ export async function PATCH(
     if (type !== undefined) updates.type = type;
     if (showContactInfo !== undefined) updates.showContactInfo = showContactInfo;
     if (expiresAt !== undefined) updates.expiresAt = expiresAt ? new Date(expiresAt) : null;
+
+    // Recalculate .fair manifest if price, sellerTier, or seller DID changes
+    const priceChanged = price !== undefined && price !== listing.price;
+    const tierChanged = sellerTier !== undefined && sellerTier !== listing.sellerTier;
+    const currentDid = identity.actingAs || identity.id;
+    const sellerDidChanged = currentDid !== listing.sellerDid;
+
+    if (priceChanged || tierChanged || sellerDidChanged) {
+      try {
+        const rawSql = getClient();
+        const [relayRow] = await rawSql`
+          SELECT node_fee_bps, buyer_credit_bps, node_operator_did
+          FROM relay.relay_config
+          WHERE id = 'singleton'
+          LIMIT 1
+        `;
+        const scopeDid = listing.sellerDid !== currentDid ? null : (identity.actingAs || null);
+        let scopeFeeBps: number | null = null;
+        if (scopeDid) {
+          const [forestRow] = await rawSql`
+            SELECT scope_fee_bps
+            FROM profile.forest_config
+            WHERE group_did = ${scopeDid}
+            LIMIT 1
+          `;
+          scopeFeeBps = forestRow?.scope_fee_bps ?? null;
+        }
+        updates.fairManifest = buildFairManifest({
+          creatorDid: currentDid,
+          contentDid: params.id,
+          contentType: 'listing',
+          scopeDid,
+          scopeFeeBps,
+          nodeFeeBps: relayRow?.node_fee_bps ?? undefined,
+          buyerCreditBps: relayRow?.buyer_credit_bps ?? undefined,
+          nodeOperatorDid: relayRow?.node_operator_did ?? undefined,
+        });
+      } catch (manifestErr) {
+        log.warn({ err: String(manifestErr) }, 'Failed to recalculate .fair manifest (non-fatal)');
+      }
+    }
 
     const [updated] = await db.update(listings).set(updates).where(eq(listings.id, params.id)).returning();
 

--- a/apps/market/app/api/webhook/route.ts
+++ b/apps/market/app/api/webhook/route.ts
@@ -12,6 +12,7 @@ import { db, listings } from '@/db';
 import { emitAttestation } from '@imajin/auth';
 import { notify } from '@imajin/notify';
 import { jsonResponse, errorResponse } from '@/lib/utils';
+import { settleListingPurchase } from '@/lib/settle';
 import { eq } from 'drizzle-orm';
 
 const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET!;
@@ -63,6 +64,16 @@ export async function POST(request: NextRequest) {
               })
               .where(eq(listings.id, listingId));
           }
+
+          // Settle .fair chain — fire and forget, never block the response
+          settleListingPurchase({
+            listingId,
+            sellerDid: listing.sellerDid,
+            buyerDid: body.metadata?.buyerDid || '',
+            amount: body.metadata?.amount || 0,
+            currency: body.metadata?.currency || 'CAD',
+            fairManifest: (listing.fairManifest as any) || null,
+          }).catch((err: unknown) => log.error({ err: String(err) }, 'Settlement error'));
         }
 
         // Fire and forget — never block the response

--- a/apps/market/app/listings/[id]/ListingDetail.tsx
+++ b/apps/market/app/listings/[id]/ListingDetail.tsx
@@ -7,6 +7,7 @@ import { resolveMediaRef } from '@imajin/media';
 import { apiFetch } from '@imajin/config';
 import PriceDisplay from '../../components/PriceDisplay';
 import { OnboardGate } from '@imajin/onboard';
+import { FairAccordion } from '@imajin/fair';
 
 interface ContactInfo {
   phone?: string;
@@ -30,6 +31,7 @@ interface Listing {
   type: string;
   createdAt: string;
   updatedAt: string;
+  fairManifest?: Record<string, unknown> | null;
 }
 
 interface RelatedListing {
@@ -615,6 +617,15 @@ export default function ListingDetail() {
                   </p>
                 </div>
               )
+            )}
+
+            {/* .fair attribution */}
+            {listing.fairManifest && (
+              <FairAccordion
+                manifest={listing.fairManifest as any}
+                nodeDid={process.env.NEXT_PUBLIC_NODE_DID}
+                viewerDid={sessionDid || undefined}
+              />
             )}
 
             {/* Metadata */}

--- a/apps/market/src/lib/settle.ts
+++ b/apps/market/src/lib/settle.ts
@@ -1,0 +1,179 @@
+/**
+ * settleListingPurchase
+ *
+ * Calls POST /api/settle on the pay service after a listing purchase completes.
+ * Settlement failure is non-fatal — the listing has already been updated.
+ *
+ * Uses the listing's .fair manifest chain for the fee split:
+ *   protocol + node + buyer_credit + seller (remainder)
+ *
+ * Processing fees are deducted from the seller's share — they receive
+ * (total - applicationFee) from Stripe, so the chain must reflect that.
+ *
+ * If the listing has no .fair manifest or no chain, settlement is skipped.
+ */
+
+import { createLogger } from '@imajin/logger';
+import { db, listings } from '@/db';
+import { eq } from 'drizzle-orm';
+
+const log = createLogger('market');
+
+const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
+const PAY_SERVICE_API_KEY = process.env.PAY_SERVICE_API_KEY!;
+
+const SELLER_ROLES = new Set(['seller', 'creator', 'event']);
+
+interface FairEntry {
+  did: string;
+  role: string;
+  share: number; // 0–1 fraction
+}
+
+interface FairFee {
+  role: string;
+  name: string;
+  rateBps: number;
+  fixedCents: number;
+}
+
+interface FairManifest {
+  version?: string;
+  fees?: FairFee[];
+  chain?: FairEntry[];
+  distributions?: FairEntry[];
+  [key: string]: unknown;
+}
+
+interface SettleListingPurchaseParams {
+  listingId: string;
+  sellerDid: string;
+  buyerDid: string;
+  amount: number;   // cents (from Stripe)
+  currency: string;
+  fairManifest: FairManifest | null;
+}
+
+export async function settleListingPurchase(params: SettleListingPurchaseParams): Promise<void> {
+  const { listingId, buyerDid, amount, fairManifest } = params;
+
+  // v0.3.0+ manifests have a chain with the full fee cascade
+  const chain = fairManifest?.chain;
+  if (!fairManifest || !chain?.length) {
+    log.warn({ listingId }, '[settle] No .fair manifest chain for listing — skipping settlement');
+    return;
+  }
+
+  const totalDollars = amount / 100;
+
+  // Resolve node DID from environment
+  const NODE_DID = process.env.NODE_DID || process.env.RELAY_IMAJIN_DID || null;
+  if (!NODE_DID) {
+    log.warn({ listingId }, '[settle] NODE_DID not set — node fee recipient unresolved');
+  }
+
+  // Calculate estimated processing fee to deduct from seller's share
+  const fees = fairManifest?.fees || [];
+  const processorFee = fees.find(f => f.role === 'processor');
+  const estimatedFeeDollars = processorFee
+    ? parseFloat(((amount * processorFee.rateBps / 10000 + processorFee.fixedCents) / 100).toFixed(2))
+    : parseFloat(((amount * 370 / 10000 + 30) / 100).toFixed(2));  // fallback: 3.7% + 30¢
+
+  // Replace placeholder DIDs and deduct processing fee from seller
+  const resolvedChain = chain.map((entry) => {
+    let did = entry.did;
+    if (did === 'BUYER_PLACEHOLDER') did = buyerDid;
+    if (did === 'NODE_PLACEHOLDER') did = NODE_DID || 'did:imajin:node-unresolved';
+
+    let entryAmount = parseFloat((totalDollars * entry.share).toFixed(2));
+
+    // Seller's actual payout = (total × sellerShare) - processingFee
+    // Because Stripe deducts applicationFee (which includes processing) from connected account transfer
+    if (SELLER_ROLES.has(entry.role)) {
+      entryAmount = parseFloat((entryAmount - estimatedFeeDollars).toFixed(2));
+    }
+
+    return { did, amount: entryAmount, role: entry.role };
+  });
+
+  // Chain now sums to totalDollars - estimatedFeeDollars
+  const expectedTotal = parseFloat((totalDollars - estimatedFeeDollars).toFixed(2));
+
+  // Fix rounding drift: adjust seller so chain sums to expectedTotal exactly
+  const chainSum = resolvedChain.reduce((sum, e) => sum + e.amount, 0);
+  const drift = parseFloat((expectedTotal - chainSum).toFixed(2));
+  if (drift !== 0 && resolvedChain.length > 0) {
+    const seller = resolvedChain.find(e => SELLER_ROLES.has(e.role));
+    const target = seller || resolvedChain.reduce((max, e) => e.amount > max.amount ? e : max, resolvedChain[0]);
+    target.amount = parseFloat((target.amount + drift).toFixed(2));
+  }
+
+  const body = {
+    from_did: buyerDid,
+    total_amount: expectedTotal,
+    service: 'market',
+    type: 'listing_purchase',
+    funded: true,
+    funded_provider: 'stripe',
+    fair_manifest: { chain: resolvedChain },
+    metadata: {
+      listingId,
+    },
+  };
+
+  try {
+    const response = await fetch(`${PAY_SERVICE_URL}/api/settle`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${PAY_SERVICE_API_KEY}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      log.error({ status: response.status, text }, '[settle] pay /api/settle returned error');
+      return;
+    }
+
+    const result = await response.json();
+    log.info({ listingId, result }, '[settle] Settlement complete for listing');
+
+    // Snapshot the resolved .fair receipt onto the listing metadata
+    try {
+      const resolvedFees = (fairManifest.fees || []).map((fee) => ({
+        role: fee.role,
+        name: fee.name,
+        rateBps: fee.rateBps,
+        fixedCents: fee.fixedCents,
+        amount: parseFloat(((amount * fee.rateBps / 10000 + fee.fixedCents) / 100).toFixed(2)),
+        estimated: true,
+      }));
+
+      const fairSettlement = {
+        version: fairManifest.version || (fairManifest as any).fair || '1.0',
+        settledAt: new Date().toISOString(),
+        totalAmount: totalDollars,
+        netAmount: expectedTotal,
+        currency: params.currency,
+        fees: resolvedFees,
+        chain: resolvedChain,
+      };
+
+      // Store on metadata.fairSettlement since listings don't have an orders table
+      const [current] = await db.select().from(listings).where(eq(listings.id, listingId)).limit(1);
+      const existingMetadata = (current?.metadata as Record<string, unknown>) || {};
+
+      await db.update(listings)
+        .set({ metadata: { ...existingMetadata, fairSettlement } })
+        .where(eq(listings.id, listingId));
+
+      log.info({ listingId }, '[settle] .fair settlement snapshot saved to listing metadata');
+    } catch (snapshotError) {
+      log.warn({ err: String(snapshotError) }, '[settle] Failed to snapshot .fair to listing (non-fatal)');
+    }
+  } catch (error) {
+    log.error({ err: String(error) }, '[settle] Settlement request failed (non-fatal)');
+  }
+}


### PR DESCRIPTION
Closes #685

## Changes

Wires up the full .fair lifecycle for marketplace listings — settlement on purchase, attribution display for buyers, and manifest recalculation on updates.

### 1. Settlement (`src/lib/settle.ts` — new, 179 lines)
- `settleListingPurchase()` — same pattern as events' `settleTicketPurchase()`
- Resolves placeholder DIDs (BUYER_PLACEHOLDER, NODE_PLACEHOLDER)
- Deducts estimated Stripe processing fee from seller's share
- POSTs resolved chain to pay service `/api/settle`
- Snapshots `fairSettlement` to `metadata.fairSettlement` on the listing
- Non-fatal: errors are logged, never thrown

### 2. Webhook integration (`webhook/route.ts`)
- Calls `settleListingPurchase()` fire-and-forget after payment success
- Reads listing `fairManifest`, buyer DID, amount from webhook payload

### 3. Manifest recalculation (`listings/[id]/route.ts` PATCH)
- Rebuilds .fair manifest via `buildFairManifest` when price, sellerTier, or seller DID changes
- Loads node config from `relay.relay_config` and scope fee from `profile.forest_config` (same as POST handler)

### 4. FairAccordion on listing detail (`ListingDetail.tsx`)
- Imports `FairAccordion` from `@imajin/fair`
- Shows attribution split below seller section
- Handles null manifest gracefully

### 5. `.env.example`
- Documents `PAY_SERVICE_URL`, `PAY_SERVICE_API_KEY`, `NODE_DID`

## Files changed (5)
```
apps/market/.env.example                        +4  (new)
apps/market/app/api/listings/[id]/route.ts      +43
apps/market/app/api/webhook/route.ts            +11
apps/market/app/listings/[id]/ListingDetail.tsx  +11
apps/market/src/lib/settle.ts                   +179 (new)
```

+248 lines, 0 deletions. No migrations needed.