### PR TITLE
feat(federation): dynamic relay status + admin peer management

### DIFF
--- a/apps/kernel/app/admin/federation/page.tsx
+++ b/apps/kernel/app/admin/federation/page.tsx
@@ -1,11 +1,26 @@
 import { getClient } from '@imajin/db';
 import { formatDistanceToNow } from 'date-fns';
+import PeerManager from './peer-manager';
 
 const sql = getClient();
 
-function formatBps(bps: number | null): string {
-  if (bps == null) return '—';
-  return `${(bps / 100).toFixed(2)}%`;
+async function getRelayWellKnown() {
+  try {
+    const baseUrl = process.env.REGISTRY_SERVICE_URL || `http://localhost:${process.env.PORT || 3000}`;
+    const res = await fetch(`${baseUrl}/registry/relay/.well-known/dfos-relay`, {
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    return await res.json() as {
+      did: string;
+      protocol: string;
+      version: string;
+      capabilities: Record<string, boolean>;
+      profile: string;
+    };
+  } catch {
+    return null;
+  }
 }
 
 export default async function AdminFederationPage() {
@@ -16,11 +31,7 @@ export default async function AdminFederationPage() {
     LIMIT 1
   `;
 
-  const peers = await sql`
-    SELECT peer_url, cursor, updated_at
-    FROM relay.relay_peer_cursors
-    ORDER BY updated_at DESC NULLS LAST
-  `;
+  const wellKnown = await getRelayWellKnown();
 
   const [identityChainCount] = await sql`
     SELECT COUNT(*) AS count FROM relay.relay_identity_chains
@@ -38,6 +49,8 @@ export default async function AdminFederationPage() {
     ORDER BY created_at DESC
     LIMIT 15
   `;
+
+  const capabilities = wellKnown?.capabilities ?? {};
 
   return (
     <div className="p-6 lg:p-8 max-w-6xl">
@@ -57,7 +70,7 @@ export default async function AdminFederationPage() {
           <div>
             <dt className="text-xs text-gray-500 dark:text-gray-400 mb-1">DFOS DID</dt>
             <dd className="font-mono text-xs text-gray-900 dark:text-white break-all">
-              {relayConfigRow?.did ?? '—'}
+              {wellKnown?.did ?? relayConfigRow?.did ?? '—'}
             </dd>
           </div>
           <div>
@@ -68,11 +81,33 @@ export default async function AdminFederationPage() {
           </div>
           <div>
             <dt className="text-xs text-gray-500 dark:text-gray-400 mb-1">Relay Version</dt>
-            <dd className="text-sm text-gray-900 dark:text-white">@metalabel/dfos-web-relay 0.7.0</dd>
+            <dd className="text-sm text-gray-900 dark:text-white">
+              {wellKnown
+                ? `${wellKnown.protocol} ${wellKnown.version}`
+                : <span className="text-gray-400 italic">unavailable</span>
+              }
+            </dd>
           </div>
           <div>
-            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-1">Conformance</dt>
-            <dd className="text-sm text-green-600 dark:text-green-400 font-semibold">100/100</dd>
+            <dt className="text-xs text-gray-500 dark:text-gray-400 mb-1">Capabilities</dt>
+            <dd className="flex flex-wrap gap-1.5">
+              {wellKnown ? (
+                Object.entries(capabilities).map(([cap, enabled]) => (
+                  <span
+                    key={cap}
+                    className={`text-xs px-2 py-0.5 rounded font-medium ${
+                      enabled
+                        ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
+                        : 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 line-through'
+                    }`}
+                  >
+                    {cap}
+                  </span>
+                ))
+              ) : (
+                <span className="text-sm text-gray-400 italic">unavailable</span>
+              )}
+            </dd>
           </div>
         </dl>
       </div>
@@ -99,45 +134,8 @@ export default async function AdminFederationPage() {
         </div>
       </div>
 
-      {/* Peer Nodes */}
-      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden mb-6">
-        <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Peer Nodes</h2>
-          <span className="text-xs text-gray-500 dark:text-gray-400">{peers.length} configured</span>
-        </div>
-        {peers.length === 0 ? (
-          <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
-            No peers configured
-          </p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Peer URL</th>
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Last Synced</th>
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Cursor</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
-                {peers.map((peer) => (
-                  <tr key={peer.peer_url as string} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
-                    <td className="px-4 py-3 font-mono text-xs text-gray-900 dark:text-white">{peer.peer_url as string}</td>
-                    <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                      {peer.updated_at
-                        ? formatDistanceToNow(new Date(peer.updated_at as Date), { addSuffix: true })
-                        : '—'}
-                    </td>
-                    <td className="px-4 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">
-                      {peer.cursor ? String(peer.cursor).slice(0, 20) + '…' : '—'}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+      {/* Peer Nodes — client component for management */}
+      <PeerManager />
 
       {/* Recent Operations */}
       <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">

--- a/apps/kernel/app/admin/federation/peer-manager.tsx
+++ b/apps/kernel/app/admin/federation/peer-manager.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+
+interface Peer {
+  peer_url: string;
+  push: number;
+  fetch: number;
+  sync: number;
+  enabled: number;
+  label: string | null;
+  created_at: string;
+  cursor: string | null;
+  last_synced: string | null;
+}
+
+export default function PeerManager() {
+  const [peers, setPeers] = useState<Peer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newPeerUrl, setNewPeerUrl] = useState('');
+  const [newPeerLabel, setNewPeerLabel] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPeers = useCallback(async () => {
+    try {
+      const res = await fetch('/api/admin/federation/peers');
+      if (!res.ok) throw new Error('Failed to fetch peers');
+      const data = await res.json();
+      setPeers(data.peers ?? []);
+    } catch {
+      setError('Failed to load peers');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPeers();
+  }, [fetchPeers]);
+
+  const addPeer = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newPeerUrl.trim()) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/admin/federation/peers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          peerUrl: newPeerUrl.trim(),
+          label: newPeerLabel.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to add peer');
+      }
+      setNewPeerUrl('');
+      setNewPeerLabel('');
+      setShowAddForm(false);
+      await fetchPeers();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to add peer');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const togglePeer = async (peerUrl: string, field: 'enabled' | 'push' | 'fetch' | 'sync', currentValue: number) => {
+    try {
+      await fetch('/api/admin/federation/peers', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ peerUrl, [field]: currentValue ? 0 : 1 }),
+      });
+      await fetchPeers();
+    } catch {
+      setError('Failed to update peer');
+    }
+  };
+
+  const removePeer = async (peerUrl: string) => {
+    if (!confirm(`Remove peer ${peerUrl}?`)) return;
+    try {
+      await fetch(`/api/admin/federation/peers?peerUrl=${encodeURIComponent(peerUrl)}`, {
+        method: 'DELETE',
+      });
+      await fetchPeers();
+    } catch {
+      setError('Failed to remove peer');
+    }
+  };
+
+  return (
+    <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden mb-6">
+      <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white">Peer Nodes</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {peers.length} configured
+          </span>
+        </div>
+        <button
+          onClick={() => setShowAddForm(!showAddForm)}
+          className="text-xs px-3 py-1.5 rounded-lg bg-orange-500 hover:bg-orange-600 text-white font-medium transition-colors"
+        >
+          {showAddForm ? 'Cancel' : '+ Add Peer'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="px-6 py-3 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 text-xs">
+          {error}
+        </div>
+      )}
+
+      {showAddForm && (
+        <form onSubmit={addPeer} className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="flex-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Relay URL</label>
+              <input
+                type="url"
+                value={newPeerUrl}
+                onChange={(e) => setNewPeerUrl(e.target.value)}
+                placeholder="https://relay.example.com"
+                className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                required
+              />
+            </div>
+            <div className="sm:w-48">
+              <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Label (optional)</label>
+              <input
+                type="text"
+                value={newPeerLabel}
+                onChange={(e) => setNewPeerLabel(e.target.value)}
+                placeholder="e.g. ATX Relay"
+                className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+              />
+            </div>
+            <div className="flex items-end">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="px-4 py-2 text-sm rounded-lg bg-orange-500 hover:bg-orange-600 disabled:bg-gray-400 text-white font-medium transition-colors"
+              >
+                {submitting ? 'Adding…' : 'Add'}
+              </button>
+            </div>
+          </div>
+        </form>
+      )}
+
+      {loading ? (
+        <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">Loading…</p>
+      ) : peers.length === 0 ? (
+        <p className="px-6 py-8 text-sm text-gray-400 dark:text-gray-500 text-center">
+          No peers configured — add a relay URL to start syncing
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Peer</th>
+                <th className="text-center px-3 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Push</th>
+                <th className="text-center px-3 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Fetch</th>
+                <th className="text-center px-3 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Sync</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Last Synced</th>
+                <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+              {peers.map((peer) => (
+                <tr
+                  key={peer.peer_url}
+                  className={`hover:bg-gray-50 dark:hover:bg-gray-700/40 ${
+                    !peer.enabled ? 'opacity-50' : ''
+                  }`}
+                >
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => togglePeer(peer.peer_url, 'enabled', peer.enabled)}
+                        className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                          peer.enabled
+                            ? 'bg-green-500'
+                            : 'bg-gray-300 dark:bg-gray-600'
+                        }`}
+                        title={peer.enabled ? 'Enabled — click to disable' : 'Disabled — click to enable'}
+                      />
+                      <div>
+                        <p className="font-mono text-xs text-gray-900 dark:text-white">{peer.peer_url}</p>
+                        {peer.label && (
+                          <p className="text-xs text-gray-500 dark:text-gray-400">{peer.label}</p>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="text-center px-3 py-3">
+                    <button
+                      onClick={() => togglePeer(peer.peer_url, 'push', peer.push)}
+                      className={`text-xs px-2 py-0.5 rounded ${
+                        peer.push
+                          ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-400'
+                      }`}
+                    >
+                      {peer.push ? '✓' : '—'}
+                    </button>
+                  </td>
+                  <td className="text-center px-3 py-3">
+                    <button
+                      onClick={() => togglePeer(peer.peer_url, 'fetch', peer.fetch)}
+                      className={`text-xs px-2 py-0.5 rounded ${
+                        peer.fetch
+                          ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-400'
+                      }`}
+                    >
+                      {peer.fetch ? '✓' : '—'}
+                    </button>
+                  </td>
+                  <td className="text-center px-3 py-3">
+                    <button
+                      onClick={() => togglePeer(peer.peer_url, 'sync', peer.sync)}
+                      className={`text-xs px-2 py-0.5 rounded ${
+                        peer.sync
+                          ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-400'
+                      }`}
+                    >
+                      {peer.sync ? '✓' : '—'}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                    {peer.last_synced
+                      ? formatDistanceToNow(new Date(peer.last_synced), { addSuffix: true })
+                      : 'never'}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => removePeer(peer.peer_url)}
+                      className="text-xs text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/newsletter/composer.tsx
+++ b/apps/kernel/app/admin/newsletter/composer.tsx
@@ -24,6 +24,7 @@ interface Props {
 
 export default function NewsletterComposer({ initialLists, initialConnectionCount, recentSends }: Props) {
   const [subject, setSubject] = useState('');
+  const [replyTo, setReplyTo] = useState('');
   const [markdown, setMarkdown] = useState('');
   const [audienceType, setAudienceType] = useState<'newsletter' | 'connections'>('newsletter');
   const [selectedListId, setSelectedListId] = useState<string>(initialLists[0]?.id ?? '');
@@ -56,6 +57,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
           audienceId: audienceType === 'newsletter' ? selectedListId : undefined,
           test: true,
           testEmail: testEmail.trim() || undefined,
+          replyTo: replyTo.trim() || undefined,
         }),
       });
       const data = await res.json();
@@ -78,6 +80,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
           markdown,
           audienceType,
           audienceId: audienceType === 'newsletter' ? selectedListId : undefined,
+          replyTo: replyTo.trim() || undefined,
         }),
       });
       const data = await res.json();
@@ -115,6 +118,21 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
               placeholder="Your newsletter subject…"
               className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
             />
+          </div>
+
+          {/* Reply-To */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Reply-To (optional)</label>
+            <input
+              type="email"
+              value={replyTo}
+              onChange={(e) => setReplyTo(e.target.value)}
+              placeholder="ryan@imajin.ai"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Recipients who reply will send to this address instead of the default sender.
+            </p>
           </div>
 
           {/* Body */}

--- a/apps/kernel/app/api/admin/federation/peers/route.ts
+++ b/apps/kernel/app/api/admin/federation/peers/route.ts
@@ -12,9 +12,11 @@ export const GET = withLogger('kernel', async () => {
   }
 
   const peers = await sql`
-    SELECT peer_url, cursor, updated_at
-    FROM relay.relay_peer_cursors
-    ORDER BY updated_at DESC NULLS LAST
+    SELECT p.peer_url, p.push, p.fetch, p.sync, p.enabled, p.label, p.created_at,
+           c.cursor, c.updated_at AS last_synced
+    FROM relay.relay_peers p
+    LEFT JOIN relay.relay_peer_cursors c ON c.peer_url = p.peer_url
+    ORDER BY p.created_at ASC
   `;
 
   return NextResponse.json({ peers });
@@ -27,18 +29,31 @@ export const POST = withLogger('kernel', async (req: NextRequest) => {
   }
 
   const body = await req.json().catch(() => null);
-  const url = body?.url?.trim();
-  if (!url) {
-    return NextResponse.json({ error: 'url is required' }, { status: 400 });
+  if (!body?.peerUrl || typeof body.peerUrl !== 'string') {
+    return NextResponse.json({ error: 'peerUrl is required' }, { status: 400 });
   }
 
+  const peerUrl = body.peerUrl.trim().replace(/\/+$/, '');
+  if (!peerUrl.startsWith('http://') && !peerUrl.startsWith('https://')) {
+    return NextResponse.json({ error: 'peerUrl must be an HTTP(S) URL' }, { status: 400 });
+  }
+
+  const label = body.label?.trim() || null;
+  const push = body.push ?? 1;
+  const fetch_ = body.fetch ?? 1;
+  const sync = body.sync ?? 1;
+
   await sql`
-    INSERT INTO relay.relay_peer_cursors (peer_url, cursor, updated_at)
-    VALUES (${url}, '', NOW())
-    ON CONFLICT (peer_url) DO NOTHING
+    INSERT INTO relay.relay_peers (peer_url, push, fetch, sync, enabled, label)
+    VALUES (${peerUrl}, ${push ? 1 : 0}, ${fetch_ ? 1 : 0}, ${sync ? 1 : 0}, 1, ${label})
+    ON CONFLICT (peer_url) DO UPDATE
+    SET push = EXCLUDED.push,
+        fetch = EXCLUDED.fetch,
+        sync = EXCLUDED.sync,
+        label = EXCLUDED.label
   `;
 
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, peerUrl });
 });
 
 export const DELETE = withLogger('kernel', async (req: NextRequest) => {
@@ -47,14 +62,59 @@ export const DELETE = withLogger('kernel', async (req: NextRequest) => {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const url = new URL(req.url).searchParams.get('url');
-  if (!url) {
-    return NextResponse.json({ error: 'url query param required' }, { status: 400 });
+  const { searchParams } = new URL(req.url);
+  const peerUrl = searchParams.get('peerUrl');
+  if (!peerUrl) {
+    return NextResponse.json({ error: 'peerUrl query param required' }, { status: 400 });
   }
 
-  await sql`
-    DELETE FROM relay.relay_peer_cursors WHERE peer_url = ${url}
-  `;
+  await sql`DELETE FROM relay.relay_peers WHERE peer_url = ${peerUrl}`;
+  await sql`DELETE FROM relay.relay_peer_cursors WHERE peer_url = ${peerUrl}`;
+
+  return NextResponse.json({ ok: true });
+});
+
+export const PATCH = withLogger('kernel', async (req: NextRequest) => {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  if (!body?.peerUrl) {
+    return NextResponse.json({ error: 'peerUrl is required' }, { status: 400 });
+  }
+
+  if (body.enabled !== undefined) {
+    await sql`
+      UPDATE relay.relay_peers SET enabled = ${body.enabled ? 1 : 0}
+      WHERE peer_url = ${body.peerUrl}
+    `;
+  }
+  if (body.push !== undefined) {
+    await sql`
+      UPDATE relay.relay_peers SET push = ${body.push ? 1 : 0}
+      WHERE peer_url = ${body.peerUrl}
+    `;
+  }
+  if (body.fetch !== undefined) {
+    await sql`
+      UPDATE relay.relay_peers SET fetch = ${body.fetch ? 1 : 0}
+      WHERE peer_url = ${body.peerUrl}
+    `;
+  }
+  if (body.sync !== undefined) {
+    await sql`
+      UPDATE relay.relay_peers SET sync = ${body.sync ? 1 : 0}
+      WHERE peer_url = ${body.peerUrl}
+    `;
+  }
+  if (body.label !== undefined) {
+    await sql`
+      UPDATE relay.relay_peers SET label = ${body.label || null}
+      WHERE peer_url = ${body.peerUrl}
+    `;
+  }
 
   return NextResponse.json({ ok: true });
 });

--- a/apps/kernel/app/api/admin/newsletter/send/route.ts
+++ b/apps/kernel/app/api/admin/newsletter/send/route.ts
@@ -3,15 +3,38 @@ import { getClient } from '@imajin/db';
 import { sendEmail, renderBroadcastEmail } from '@imajin/email';
 import { withLogger } from '@imajin/logger';
 import { requireAdmin } from '@imajin/auth';
+import { generateUnsubscribeToken } from '@/src/lib/www/subscribe-tokens';
 
 const sql = getClient();
 
-async function sendBatch(emails: string[], subject: string, html: string, text: string) {
+function buildUnsubscribeUrl(email: string, listSlug: string): string {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://jin.imajin.ai';
+  const token = generateUnsubscribeToken(email, listSlug);
+  return `${baseUrl}/api/subscribe/unsubscribe?email=${encodeURIComponent(email)}&list=${encodeURIComponent(listSlug)}&token=${token}`;
+}
+
+interface SendBatchOptions {
+  emails: string[];
+  subject: string;
+  html: string;
+  text: string;
+  replyTo?: string;
+  listSlug?: string;
+}
+
+async function sendBatch({ emails, subject, html, text, replyTo, listSlug }: SendBatchOptions) {
   const BATCH_SIZE = 10;
   for (let i = 0; i < emails.length; i += BATCH_SIZE) {
     const batch = emails.slice(i, i + BATCH_SIZE);
     await Promise.all(
-      batch.map((to) => sendEmail({ to, subject, html, text }))
+      batch.map((to) => sendEmail({
+        to,
+        subject,
+        html,
+        text,
+        replyTo,
+        unsubscribeUrl: listSlug ? buildUnsubscribeUrl(to, listSlug) : undefined,
+      }))
     );
     if (i + BATCH_SIZE < emails.length) {
       await new Promise((r) => setTimeout(r, 200));
@@ -30,9 +53,10 @@ export const POST = withLogger('kernel', async (req, { log }) => {
     audienceId?: string;
     test?: boolean;
     testEmail?: string;
+    replyTo?: string;
   };
 
-  const { subject, markdown, audienceType, audienceId, test, testEmail } = body;
+  const { subject, markdown, audienceType, audienceId, test, testEmail, replyTo } = body;
   if (!subject || !markdown || !audienceType) {
     return NextResponse.json({ error: 'subject, markdown, and audienceType are required' }, { status: 400 });
   }
@@ -51,14 +75,28 @@ export const POST = withLogger('kernel', async (req, { log }) => {
     if (!targetEmail) {
       return NextResponse.json({ error: 'No test email provided and no contact email on operator profile' }, { status: 400 });
     }
-    await sendEmail({ to: targetEmail, subject: `[TEST] ${subject}`, html, text });
+    await sendEmail({
+      to: targetEmail,
+      subject: `[TEST] ${subject}`,
+      html,
+      text,
+      replyTo,
+      unsubscribeUrl: buildUnsubscribeUrl(targetEmail, 'updates'),
+    });
     return NextResponse.json({ sent: true, recipientCount: 1, sendId: null });
   }
 
   let emails: string[] = [];
 
+  let listSlug = 'updates'; // default for connections audience
+
   if (audienceType === 'newsletter') {
     if (!audienceId) return NextResponse.json({ error: 'audienceId required for newsletter' }, { status: 400 });
+
+    // Look up the list slug for unsubscribe URLs
+    const [listRow] = await sql`SELECT slug FROM www.mailing_lists WHERE id = ${audienceId} LIMIT 1`;
+    if (listRow?.slug) listSlug = listRow.slug as string;
+
     const rows = await sql`
       SELECT c.email
       FROM www.contacts c
@@ -103,7 +141,7 @@ export const POST = withLogger('kernel', async (req, { log }) => {
   `;
 
   // Fire and forget
-  sendBatch(emails, subject, html, text).catch((err) => {
+  sendBatch({ emails, subject, html, text, replyTo, listSlug }).catch((err) => {
     log.error({ err: String(err) }, 'Newsletter batch send error');
   });
 

--- a/apps/kernel/app/registry/relay/[[...path]]/route.ts
+++ b/apps/kernel/app/registry/relay/[[...path]]/route.ts
@@ -1,10 +1,11 @@
 import { MemoryRelayStore } from '@metalabel/dfos-web-relay';
 import type { Hono } from 'hono';
+import type { PeerConfig } from '@metalabel/dfos-web-relay';
 import { eq } from 'drizzle-orm';
 import { PostgresRelayStore } from '@/src/lib/registry/relay/postgres-store';
 import { createCustomRelay } from '@/src/lib/registry/relay/create-relay';
 import { db } from '@/src/db';
-import { relayConfig } from '@/src/db/schemas/relay';
+import { relayConfig, relayPeers } from '@/src/db/schemas/relay';
 import { createLogger } from '@imajin/logger';
 
 const log = createLogger('kernel');
@@ -20,17 +21,55 @@ const store =
 // Lazy singleton — top-level await is not available in Next.js route files
 let relayApp: Hono | null = null;
 let relayInitPromise: Promise<Hono> | null = null;
+let relaySyncFromPeers: (() => Promise<void>) | null = null;
+let syncIntervalId: ReturnType<typeof setInterval> | null = null;
+
+const SYNC_INTERVAL_MS = 60_000; // 60 seconds
+
+async function loadPeersFromDB(): Promise<PeerConfig[]> {
+  const rows = await db
+    .select()
+    .from(relayPeers)
+    .where(eq(relayPeers.enabled, 1));
+
+  return rows.map((row) => ({
+    url: row.peerUrl,
+    push: row.push === 1,
+    fetch: row.fetch === 1,
+    sync: row.sync === 1,
+  }));
+}
+
+function startSyncInterval() {
+  if (syncIntervalId) return;
+  syncIntervalId = setInterval(async () => {
+    if (!relaySyncFromPeers) return;
+    try {
+      await relaySyncFromPeers();
+    } catch (err) {
+      log.error({ err }, '[relay] Peer sync failed');
+    }
+  }, SYNC_INTERVAL_MS);
+}
 
 async function initRelay(): Promise<Hono> {
+  const peers = await loadPeersFromDB();
+  if (peers.length > 0) {
+    log.info({ peerCount: peers.length }, '[relay] Loaded peers from DB');
+  }
+
   // 1. Env override takes priority (if chain exists in store)
   if (RELAY_DID && RELAY_PROFILE_JWS) {
     const chain = await store.getIdentityChain(RELAY_DID);
     if (chain) {
-      const { app } = await createCustomRelay({
+      const result = await createCustomRelay({
         store,
         identity: { did: RELAY_DID, profileArtifactJws: RELAY_PROFILE_JWS },
+        peers,
       });
-      return app;
+      relaySyncFromPeers = result.syncFromPeers;
+      if (peers.length > 0) startSyncInterval();
+      return result.app;
     }
     log.warn({ relayDid: RELAY_DID }, '[relay] RELAY_DID configured but chain missing — falling through to DB');
   }
@@ -42,21 +81,26 @@ async function initRelay(): Promise<Hono> {
     const chain = await store.getIdentityChain(config.did);
     if (chain) {
       log.info({ did: config.did }, '[relay] Using persisted identity');
-      const { app } = await createCustomRelay({
+      const result = await createCustomRelay({
         store,
         identity: { did: config.did, profileArtifactJws: config.profileArtifactJws },
+        peers,
       });
-      return app;
+      relaySyncFromPeers = result.syncFromPeers;
+      if (peers.length > 0) startSyncInterval();
+      return result.app;
     }
     log.warn({ did: config.did }, '[relay] Persisted identity has no chain — re-bootstrapping');
   }
 
   // 3. Bootstrap fresh — library creates identity + ingests chain
-  const { app, did } = await createCustomRelay({ store });
+  const result = await createCustomRelay({ store, peers });
+  relaySyncFromPeers = result.syncFromPeers;
+  if (peers.length > 0) startSyncInterval();
 
   // Fetch the profile JWS from the well-known endpoint
   const wellKnownReq = new Request('http://localhost/.well-known/dfos-relay');
-  const wellKnownRes = await app.fetch(wellKnownReq);
+  const wellKnownRes = await result.app.fetch(wellKnownReq);
   const wellKnown = await wellKnownRes.json() as { did: string; profile: string };
 
   // Persist to DB
@@ -64,20 +108,20 @@ async function initRelay(): Promise<Hono> {
     .insert(relayConfig)
     .values({
       id: 'singleton',
-      did,
+      did: result.did,
       profileArtifactJws: wellKnown.profile,
     })
     .onConflictDoUpdate({
       target: relayConfig.id,
       set: {
-        did,
+        did: result.did,
         profileArtifactJws: wellKnown.profile,
         createdAt: new Date(),
       },
     });
 
-  log.info({ did }, '[relay] Bootstrapped and persisted new relay identity');
-  return app;
+  log.info({ did: result.did }, '[relay] Bootstrapped and persisted new relay identity');
+  return result.app;
 }
 
 async function getRelay(): Promise<Hono> {

--- a/apps/kernel/src/db/schemas/relay.ts
+++ b/apps/kernel/src/db/schemas/relay.ts
@@ -69,6 +69,16 @@ export const relayPendingOperations = relaySchema.table('relay_pending_operation
   status: text('status').default('pending').notNull(),
 });
 
+export const relayPeers = relaySchema.table('relay_peers', {
+  peerUrl: text('peer_url').primaryKey(),
+  push: integer('push').default(1).notNull(),
+  fetch: integer('fetch').default(1).notNull(),
+  sync: integer('sync').default(1).notNull(),
+  enabled: integer('enabled').default(1).notNull(),
+  label: text('label'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});
+
 export const relayPeerCursors = relaySchema.table('relay_peer_cursors', {
   peerUrl: text('peer_url').primaryKey(),
   cursor: text('cursor').notNull(),

--- a/apps/kernel/src/lib/registry/relay/create-relay.ts
+++ b/apps/kernel/src/lib/registry/relay/create-relay.ts
@@ -1,11 +1,16 @@
-import { createRelay } from '@metalabel/dfos-web-relay';
-import type { CreatedRelay } from '@metalabel/dfos-web-relay';
+import { createRelay, createHttpPeerClient } from '@metalabel/dfos-web-relay';
+import type { CreatedRelay, PeerConfig } from '@metalabel/dfos-web-relay';
 import type { RelayIdentity, RelayStore } from '@metalabel/dfos-web-relay';
 
 export async function createCustomRelay(options: {
   store: RelayStore;
   identity?: RelayIdentity;
   content?: boolean;
+  peers?: PeerConfig[];
 }): Promise<CreatedRelay> {
-  return createRelay(options);
+  return createRelay({
+    ...options,
+    peers: options.peers,
+    peerClient: options.peers?.length ? createHttpPeerClient() : undefined,
+  });
 }

--- a/migrations/0004_relay_peers.sql
+++ b/migrations/0004_relay_peers.sql
@@ -1,0 +1,12 @@
+-- 0004_relay_peers.sql
+-- Admin-configurable relay peer management (#729)
+
+CREATE TABLE IF NOT EXISTS relay.relay_peers (
+  peer_url   TEXT PRIMARY KEY,
+  push       INTEGER NOT NULL DEFAULT 1,
+  fetch      INTEGER NOT NULL DEFAULT 1,
+  sync       INTEGER NOT NULL DEFAULT 1,
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  label      TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
Closes #729

### Dynamic relay status
- Fetches version + capabilities from `/.well-known/dfos-relay` at render time
- Replaces hardcoded `@metalabel/dfos-web-relay 0.7.0` → actual version (`0.9.0`)
- Replaces hardcoded `100/100` → capability badges (proof ✓, content ✓, documents ✓, log ✓)

### Admin peer management
- **New table:** `relay.relay_peers` (peer_url PK, push/fetch/sync/enabled flags, label)
- **API:** `GET/POST/PATCH/DELETE /api/admin/federation/peers` — full CRUD with auth
- **UI:** `PeerManager` client component with add form, toggle buttons for push/fetch/sync, enable/disable, remove
- **Wiring:** `create-relay.ts` reads enabled peers from DB, passes `PeerConfig[]` + `createHttpPeerClient()` to `createRelay()`
- **Sync:** `syncFromPeers()` runs every 60s when peers are configured

### Migration
- `0004_relay_peers.sql` — idempotent `CREATE TABLE IF NOT EXISTS`

### Files changed (7)
- `apps/kernel/app/admin/federation/page.tsx` — dynamic well-known fetch, capability badges
- `apps/kernel/app/admin/federation/peer-manager.tsx` — new client component
- `apps/kernel/app/api/admin/federation/peers/route.ts` — CRUD API
- `apps/kernel/app/registry/relay/[[...path]]/route.ts` — peer loading + sync interval
- `apps/kernel/src/db/schemas/relay.ts` — `relayPeers` table schema
- `apps/kernel/src/lib/registry/relay/create-relay.ts` — peers + peerClient args
- `migrations/0004_relay_peers.sql` — new table