### PR TITLE
feat(auth): identity hub Phase 1 — persistent layout + route-based tabs (#731)

### DIFF
--- a/apps/kernel/app/auth/attestations/page.tsx
+++ b/apps/kernel/app/auth/attestations/page.tsx
@@ -1,0 +1,32 @@
+import { cookies } from 'next/headers';
+import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
+import { redirect } from 'next/navigation';
+import AttestationList from '../components/AttestationList';
+
+interface SearchParams {
+  type?: string;
+  role?: string;
+  page?: string;
+}
+
+export default async function AttestationsPage({ searchParams }: { searchParams: SearchParams }) {
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  if (!sessionDid) {
+    redirect('/auth');
+  }
+
+  // Effective DID: actingAs cookie OR personal DID
+  const actingAs = cookieStore.get('x-acting-as')?.value || null;
+  const effectiveDid = actingAs || sessionDid;
+
+  return <AttestationList sessionDid={effectiveDid} searchParams={searchParams} />;
+}

--- a/apps/kernel/app/auth/components/AttestationList.tsx
+++ b/apps/kernel/app/auth/components/AttestationList.tsx
@@ -155,7 +155,7 @@ export default async function AttestationList({ sessionDid, searchParams }: Prop
           </button>
           {hasFilters && (
             <Link
-              href="/auth"
+              href="/auth/attestations"
               className="px-4 py-2 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
             >
               Clear
@@ -170,7 +170,7 @@ export default async function AttestationList({ sessionDid, searchParams }: Prop
           No attestations found
           {hasFilters && (
             <div className="mt-2">
-              <Link href="/auth" className="text-amber-500 hover:text-amber-400 text-sm">
+              <Link href="/auth/attestations" className="text-amber-500 hover:text-amber-400 text-sm">
                 Clear filters
               </Link>
             </div>
@@ -305,7 +305,7 @@ export default async function AttestationList({ sessionDid, searchParams }: Prop
         <div className="flex justify-between items-center">
           {page > 1 ? (
             <Link
-              href={`/auth?${new URLSearchParams({ ...filterParams, page: String(page - 1) })}`}
+              href={`/auth/attestations?${new URLSearchParams({ ...filterParams, page: String(page - 1) })}`}
               className="px-4 py-2 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
             >
               ← Previous
@@ -315,7 +315,7 @@ export default async function AttestationList({ sessionDid, searchParams }: Prop
           )}
           {hasMore && (
             <Link
-              href={`/auth?${new URLSearchParams({ ...filterParams, page: String(page + 1) })}`}
+              href={`/auth/attestations?${new URLSearchParams({ ...filterParams, page: String(page + 1) })}`}
               className="px-4 py-2 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
             >
               Next →

--- a/apps/kernel/app/auth/components/AuthLayoutShell.tsx
+++ b/apps/kernel/app/auth/components/AuthLayoutShell.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+const BYPASS_PREFIXES = ['/auth/login', '/auth/register', '/auth/onboard'];
+
+interface Props {
+  leftRail: React.ReactNode;
+  identityDetail: React.ReactNode;
+  tabBar: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export default function AuthLayoutShell({ leftRail, identityDetail, tabBar, children }: Props) {
+  const pathname = usePathname();
+
+  if (BYPASS_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="flex flex-col lg:flex-row gap-6 min-h-[calc(100vh-4rem)]">
+      {/* Left rail (desktop) / Top section (mobile) */}
+      <div className="lg:w-72 lg:shrink-0">
+        <div className="sticky top-6 bg-[#0a0a0a] border border-gray-800 rounded-2xl p-4">
+          <h2 className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3 px-1">
+            Identities
+          </h2>
+          {leftRail}
+        </div>
+      </div>
+
+      {/* Main area */}
+      <div className="flex-1 min-w-0">
+        <div className="space-y-4">
+          {identityDetail}
+          <div>
+            {tabBar}
+            <div className="pt-4">{children}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/components/IdentityMembersPanel.tsx
+++ b/apps/kernel/app/auth/components/IdentityMembersPanel.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface Controller {
+  controllerDid: string;
+  role: string;
+  addedBy: string;
+  addedAt: string;
+}
+
+const ROLE_STYLES: Record<string, string> = {
+  owner: 'border-amber-600 text-amber-400 bg-amber-900/20',
+  admin: 'border-blue-700 text-blue-400 bg-blue-900/20',
+  maintainer: 'border-sky-700 text-sky-400 bg-sky-900/20',
+  member: 'border-gray-700 text-gray-400 bg-gray-900/20',
+};
+
+const ADD_ROLES = ['admin', 'maintainer', 'member'];
+
+export default function IdentityMembersPanel({ groupDid }: { groupDid: string }) {
+  const [loading, setLoading] = useState(true);
+  const [controllers, setControllers] = useState<Controller[]>([]);
+  const [addDid, setAddDid] = useState('');
+  const [addRole, setAddRole] = useState('member');
+  const [addingMember, setAddingMember] = useState(false);
+  const [removingDid, setRemovingDid] = useState<string | null>(null);
+  const [status, setStatus] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const authUrl =
+    typeof window !== 'undefined' ? window.location.origin : (process.env.NEXT_PUBLIC_AUTH_URL ?? '');
+
+  useEffect(() => {
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupDid]);
+
+  async function loadData() {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `${authUrl}/api/groups/${encodeURIComponent(groupDid)}`,
+        { credentials: 'include' }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setControllers(data.controllers ?? []);
+      }
+    } catch (err) {
+      console.error('Failed to load members:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function showStatus(type: 'success' | 'error', text: string) {
+    setStatus({ type, text });
+    setTimeout(() => setStatus(null), 5000);
+  }
+
+  async function handleAddMember(e: React.FormEvent) {
+    e.preventDefault();
+    if (!addDid.trim()) return;
+    setAddingMember(true);
+    try {
+      const res = await fetch(
+        `${authUrl}/api/groups/${encodeURIComponent(groupDid)}/controllers`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ did: addDid.trim(), role: addRole }),
+        }
+      );
+      if (res.ok) {
+        setAddDid('');
+        setAddRole('member');
+        showStatus('success', 'Member added.');
+        await loadData();
+      } else {
+        const body = await res.json().catch(() => ({}));
+        showStatus('error', body.error || 'Failed to add member.');
+      }
+    } catch {
+      showStatus('error', 'Network error. Please try again.');
+    } finally {
+      setAddingMember(false);
+    }
+  }
+
+  async function handleRemoveMember(controllerDid: string) {
+    setRemovingDid(controllerDid);
+    try {
+      const res = await fetch(
+        `${authUrl}/api/groups/${encodeURIComponent(groupDid)}/controllers/${encodeURIComponent(controllerDid)}`,
+        { method: 'DELETE', credentials: 'include' }
+      );
+      if (res.ok) {
+        showStatus('success', 'Member removed.');
+        await loadData();
+      } else {
+        const body = await res.json().catch(() => ({}));
+        showStatus('error', body.error || 'Failed to remove member.');
+      }
+    } catch {
+      showStatus('error', 'Network error. Please try again.');
+    } finally {
+      setRemovingDid(null);
+    }
+  }
+
+  if (loading) {
+    return <div className="text-gray-400 py-8">Loading members…</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      {status && (
+        <div
+          className={`p-4 rounded-lg border ${
+            status.type === 'success'
+              ? 'bg-green-900/20 border-green-800 text-green-400'
+              : 'bg-red-900/20 border-red-800 text-red-400'
+          }`}
+        >
+          {status.text}
+        </div>
+      )}
+
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-1">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500">Members</h2>
+          {controllers.length > 0 && (
+            <span className="px-1.5 py-0.5 text-xs rounded bg-gray-800 text-gray-400 font-mono">
+              {controllers.length}
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-gray-400 mb-6">People who can manage this identity.</p>
+
+        {controllers.length === 0 ? (
+          <p className="text-sm text-gray-500 mb-6">No members found.</p>
+        ) : (
+          <div className="space-y-2 mb-6">
+            {controllers.map((ctrl) => {
+              const isOwner = ctrl.role === 'owner';
+              const roleStyle = ROLE_STYLES[ctrl.role] ?? ROLE_STYLES.member;
+              const isRemoving = removingDid === ctrl.controllerDid;
+              return (
+                <div
+                  key={ctrl.controllerDid}
+                  className="flex items-center justify-between p-3 bg-gray-900 rounded-lg border border-gray-800"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="text-xl flex-shrink-0">👤</span>
+                    <div className="min-w-0">
+                      <p className="text-sm text-white font-medium font-mono truncate">
+                        {ctrl.controllerDid.length > 32
+                          ? ctrl.controllerDid.slice(0, 28) + '…'
+                          : ctrl.controllerDid}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        Added {new Date(ctrl.addedAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0 ml-3">
+                    <span className={`px-2 py-0.5 text-xs rounded border capitalize ${roleStyle}`}>
+                      {ctrl.role}
+                    </span>
+                    {!isOwner && (
+                      <button
+                        onClick={() => handleRemoveMember(ctrl.controllerDid)}
+                        disabled={isRemoving}
+                        className="w-6 h-6 flex items-center justify-center rounded text-gray-600 hover:text-red-400 hover:bg-red-900/20 transition disabled:opacity-40"
+                        title="Remove member"
+                      >
+                        {isRemoving ? '…' : '×'}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Add member form */}
+        <form onSubmit={handleAddMember} className="flex gap-2">
+          <input
+            type="text"
+            value={addDid}
+            onChange={(e) => setAddDid(e.target.value)}
+            placeholder="DID or handle"
+            className="flex-1 px-3 py-2 bg-gray-900 border border-gray-800 rounded-lg text-sm text-white placeholder-gray-600 focus:outline-none focus:ring-1 focus:ring-amber-500 focus:border-transparent"
+          />
+          <select
+            value={addRole}
+            onChange={(e) => setAddRole(e.target.value)}
+            className="px-3 py-2 bg-gray-900 border border-gray-800 rounded-lg text-sm text-white focus:outline-none focus:ring-1 focus:ring-amber-500 focus:border-transparent"
+          >
+            {ADD_ROLES.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            disabled={addingMember || !addDid.trim()}
+            className="px-4 py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg text-sm text-gray-300 transition disabled:opacity-40 whitespace-nowrap"
+          >
+            {addingMember ? 'Adding…' : 'Add'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/components/IdentitySettingsPanel.tsx
+++ b/apps/kernel/app/auth/components/IdentitySettingsPanel.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { SERVICES, buildPublicUrl } from '@imajin/config';
+
+interface IdentityConfig {
+  enabledServices: string[];
+  landingService: string | null;
+  theme: Record<string, unknown>;
+}
+
+const KERNEL_SERVICES = SERVICES.filter((s) => s.category === 'kernel' && s.visibility !== 'internal');
+
+const SELECTABLE_SERVICES = SERVICES.filter(
+  (s) =>
+    s.visibility !== 'internal' &&
+    s.category !== 'meta' &&
+    s.category !== 'infrastructure' &&
+    s.category !== 'kernel'
+);
+
+export default function IdentitySettingsPanel({ groupDid }: { groupDid: string }) {
+  const [loading, setLoading] = useState(true);
+  const [enabledServices, setEnabledServices] = useState<string[]>([]);
+  const [landingService, setLandingService] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [copyLabel, setCopyLabel] = useState('Copy');
+
+  const authUrl =
+    typeof window !== 'undefined' ? window.location.origin : (process.env.NEXT_PUBLIC_AUTH_URL ?? '');
+  const profileUrl = buildPublicUrl('profile');
+  const onboardUrl = `${authUrl}/onboard?scope=${encodeURIComponent(groupDid)}`;
+
+  useEffect(() => {
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupDid]);
+
+  async function loadData() {
+    setLoading(true);
+    try {
+      const configRes = await fetch(
+        `${profileUrl}/api/forest/${encodeURIComponent(groupDid)}/config`,
+        { credentials: 'include' }
+      );
+      if (configRes.ok) {
+        const cfg: IdentityConfig = await configRes.json();
+        setEnabledServices(cfg.enabledServices ?? []);
+        setLandingService(cfg.landingService ?? null);
+      }
+    } catch (err) {
+      console.error('Failed to load identity settings:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function toggleService(name: string) {
+    setEnabledServices((prev) => {
+      const next = prev.includes(name) ? prev.filter((s) => s !== name) : [...prev, name];
+      if (landingService && !next.includes(landingService)) {
+        setLandingService(null);
+      }
+      return next;
+    });
+  }
+
+  function showStatus(type: 'success' | 'error', text: string) {
+    setStatus({ type, text });
+    setTimeout(() => setStatus(null), 5000);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const res = await fetch(
+        `${profileUrl}/api/forest/${encodeURIComponent(groupDid)}/config`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ enabledServices, landingService }),
+        }
+      );
+      if (res.ok) {
+        showStatus('success', 'Settings saved.');
+      } else {
+        const body = await res.json().catch(() => ({}));
+        showStatus('error', body.error || 'Failed to save settings.');
+      }
+    } catch {
+      showStatus('error', 'Network error. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return <div className="text-gray-400 py-8">Loading settings…</div>;
+  }
+
+  const enabledServiceOptions = SELECTABLE_SERVICES.filter((s) => enabledServices.includes(s.name));
+
+  return (
+    <div className="space-y-6">
+      {status && (
+        <div
+          className={`p-4 rounded-lg border ${
+            status.type === 'success'
+              ? 'bg-green-900/20 border-green-800 text-green-400'
+              : 'bg-red-900/20 border-red-800 text-red-400'
+          }`}
+        >
+          {status.text}
+        </div>
+      )}
+
+      {/* Included (kernel) services */}
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-6">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-1">
+          Included with every identity
+        </h2>
+        <p className="text-sm text-gray-400 mb-4">
+          These core services are always available and cannot be disabled.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {KERNEL_SERVICES.map((svc) => (
+            <span
+              key={svc.name}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-800 bg-gray-900/50 text-gray-500 text-sm"
+            >
+              <span>{svc.icon}</span>
+              <span>{svc.label}</span>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Selectable services */}
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-6">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-1">
+          Available Apps
+        </h2>
+        <p className="text-sm text-gray-400 mb-4">
+          Toggle which apps are available for this identity.
+        </p>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+          {SELECTABLE_SERVICES.map((svc) => {
+            const isEnabled = enabledServices.includes(svc.name);
+            return (
+              <button
+                key={svc.name}
+                onClick={() => toggleService(svc.name)}
+                className={`flex flex-col items-start gap-1 p-3 rounded-xl border transition text-left ${
+                  isEnabled
+                    ? 'border-amber-500/60 bg-amber-500/10 text-white'
+                    : 'border-gray-800 bg-gray-900/30 text-gray-500 hover:border-gray-700 hover:text-gray-400'
+                }`}
+              >
+                <span className="text-xl">{svc.icon}</span>
+                <span className="text-sm font-medium leading-tight">{svc.label}</span>
+                <span
+                  className={`text-xs leading-tight ${isEnabled ? 'text-amber-400/70' : 'text-gray-600'}`}
+                >
+                  {isEnabled ? 'Enabled' : 'Disabled'}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Landing page */}
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-6">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-1">
+          Landing Page
+        </h2>
+        <p className="text-sm text-gray-400 mb-4">
+          Choose which app loads first for this identity.
+        </p>
+        <select
+          value={landingService ?? ''}
+          onChange={(e) => setLandingService(e.target.value || null)}
+          className="w-full px-4 py-2 border border-gray-700 rounded-lg bg-black text-white focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+        >
+          <option value="">— Default (no preference) —</option>
+          {enabledServiceOptions.map((svc) => (
+            <option key={svc.name} value={svc.name}>
+              {svc.icon} {svc.label}
+            </option>
+          ))}
+        </select>
+        {enabledServiceOptions.length === 0 && (
+          <p className="text-xs text-gray-600 mt-2">
+            Enable at least one app to set a landing page.
+          </p>
+        )}
+      </div>
+
+      {/* Onboarding */}
+      <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-6">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-500 mb-1">
+          Onboarding
+        </h2>
+        <p className="text-sm text-gray-400 mb-4">
+          Share this link to invite people to this identity.
+        </p>
+        <div className="flex items-center gap-2">
+          <code className="flex-1 px-3 py-2 bg-gray-900 border border-gray-800 rounded-lg text-sm text-gray-300 font-mono overflow-x-auto whitespace-nowrap">
+            {onboardUrl}
+          </code>
+          <button
+            onClick={() => {
+              navigator.clipboard.writeText(onboardUrl).then(() => {
+                setCopyLabel('Copied!');
+                setTimeout(() => setCopyLabel('Copy'), 2000);
+              });
+            }}
+            className="px-3 py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg text-sm text-gray-300 transition whitespace-nowrap"
+          >
+            {copyLabel}
+          </button>
+        </div>
+      </div>
+
+      {/* Save button */}
+      <div className="flex justify-end">
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="px-6 py-2.5 bg-amber-500 hover:bg-amber-400 text-gray-950 font-semibold rounded-lg transition disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save Changes'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/components/IdentityTabBar.tsx
+++ b/apps/kernel/app/auth/components/IdentityTabBar.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+interface Props {
+  showSettings: boolean;
+  showMembers: boolean;
+}
+
+interface Tab {
+  label: string;
+  href: string;
+  exact: boolean;
+}
+
+const ALL_TABS: Tab[] = [
+  { label: 'Profile', href: '/auth', exact: true },
+  { label: 'Attestations', href: '/auth/attestations', exact: false },
+  { label: 'Settings', href: '/auth/settings', exact: false },
+  { label: 'Members', href: '/auth/members', exact: false },
+];
+
+export default function IdentityTabBar({ showSettings, showMembers }: Props) {
+  const pathname = usePathname();
+
+  const tabs = ALL_TABS.filter((tab) => {
+    if (tab.href === '/auth/settings') return showSettings;
+    if (tab.href === '/auth/members') return showMembers;
+    return true;
+  });
+
+  return (
+    <div className="border-b border-zinc-800 flex gap-1">
+      {tabs.map((tab) => {
+        const isActive = tab.exact ? pathname === tab.href : pathname.startsWith(tab.href);
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              isActive
+                ? 'border-amber-500 text-amber-400'
+                : 'border-transparent text-zinc-400 hover:text-white hover:border-zinc-600'
+            }`}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/layout.tsx
+++ b/apps/kernel/app/auth/layout.tsx
@@ -1,0 +1,92 @@
+import { cookies } from 'next/headers';
+import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
+import { db, identities, identityMembers } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import IdentitySwitcher from './components/IdentitySwitcher';
+import IdentityDetail from './components/IdentityDetail';
+import PlacesMaintained from './components/PlacesMaintained';
+import IdentityTabBar from './components/IdentityTabBar';
+import AuthLayoutShell from './components/AuthLayoutShell';
+
+export default async function AuthLayout({ children }: { children: React.ReactNode }) {
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  // Unauthenticated: just render children (login/register/onboard work normally)
+  if (!sessionDid) {
+    return <>{children}</>;
+  }
+
+  // Fetch personal identity info for the switcher
+  const [personalIdentity] = await db
+    .select({ name: identities.name, handle: identities.handle })
+    .from(identities)
+    .where(eq(identities.id, sessionDid))
+    .limit(1);
+
+  const personalName = personalIdentity?.name ?? null;
+  const personalHandle = personalIdentity?.handle ?? null;
+
+  // Effective DID: actingAs cookie OR personal DID
+  const actingAs = cookieStore.get('x-acting-as')?.value || null;
+  const effectiveDid = actingAs || sessionDid;
+
+  // Check if Settings/Members tabs should show (non-actor scope + owner/admin role)
+  const [effectiveIdentity] = await db
+    .select({ scope: identities.scope })
+    .from(identities)
+    .where(eq(identities.id, effectiveDid))
+    .limit(1);
+
+  let showSettings = false;
+  let showMembers = false;
+  if (effectiveIdentity?.scope && effectiveIdentity.scope !== 'actor') {
+    const [membership] = await db
+      .select({ role: identityMembers.role })
+      .from(identityMembers)
+      .where(
+        and(
+          eq(identityMembers.identityDid, effectiveDid),
+          eq(identityMembers.memberDid, sessionDid),
+          isNull(identityMembers.removedAt)
+        )
+      )
+      .limit(1);
+    if (membership?.role === 'owner' || membership?.role === 'admin') {
+      showSettings = true;
+      showMembers = true;
+    }
+  }
+
+  const authUrl = '/auth';
+  const profileUrl = process.env.NEXT_PUBLIC_PROFILE_URL ?? '';
+
+  const leftRail = (
+    <>
+      <IdentitySwitcher
+        authUrl={authUrl}
+        profileUrl={profileUrl}
+        personalDid={sessionDid}
+        personalName={personalName}
+        personalHandle={personalHandle}
+      />
+      <PlacesMaintained sessionDid={sessionDid} />
+    </>
+  );
+
+  const identityDetail = <IdentityDetail did={effectiveDid} sessionDid={sessionDid} />;
+  const tabBar = <IdentityTabBar showSettings={showSettings} showMembers={showMembers} />;
+
+  return (
+    <AuthLayoutShell leftRail={leftRail} identityDetail={identityDetail} tabBar={tabBar}>
+      {children}
+    </AuthLayoutShell>
+  );
+}

--- a/apps/kernel/app/auth/members/page.tsx
+++ b/apps/kernel/app/auth/members/page.tsx
@@ -1,0 +1,61 @@
+import { cookies } from 'next/headers';
+import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
+import { db, identities, identityMembers } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import { redirect } from 'next/navigation';
+import IdentityMembersPanel from '../components/IdentityMembersPanel';
+
+export default async function MembersPage() {
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  if (!sessionDid) {
+    redirect('/auth');
+  }
+
+  const actingAs = cookieStore.get('x-acting-as')?.value || null;
+  const effectiveDid = actingAs || sessionDid;
+
+  const [identity] = await db
+    .select({ scope: identities.scope })
+    .from(identities)
+    .where(eq(identities.id, effectiveDid))
+    .limit(1);
+
+  if (!identity || identity.scope === 'actor') {
+    return (
+      <div className="text-zinc-500 text-sm py-8">
+        Members are only available for group identities.
+      </div>
+    );
+  }
+
+  const [membership] = await db
+    .select({ role: identityMembers.role })
+    .from(identityMembers)
+    .where(
+      and(
+        eq(identityMembers.identityDid, effectiveDid),
+        eq(identityMembers.memberDid, sessionDid),
+        isNull(identityMembers.removedAt)
+      )
+    )
+    .limit(1);
+
+  if (membership?.role !== 'owner' && membership?.role !== 'admin') {
+    return (
+      <div className="text-zinc-500 text-sm py-8">
+        You need owner or admin access to manage members for this identity.
+      </div>
+    );
+  }
+
+  return <IdentityMembersPanel groupDid={effectiveDid} />;
+}

--- a/apps/kernel/app/auth/page.tsx
+++ b/apps/kernel/app/auth/page.tsx
@@ -1,6 +1,9 @@
 import { cookies } from 'next/headers';
 import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
+import { db, profiles } from '@/src/db';
+import { eq } from 'drizzle-orm';
 import Link from 'next/link';
+import Image from 'next/image';
 
 export default async function AuthPage() {
   const cookieConfig = getSessionCookieOptions();
@@ -31,6 +34,122 @@ export default async function AuthPage() {
     );
   }
 
-  // Profile tab — IdentityDetail is rendered by the layout above the tabs
-  return null;
+  // Effective DID: actingAs cookie OR personal DID
+  const actingAs = cookieStore.get('x-acting-as')?.value || null;
+  const effectiveDid = actingAs || sessionDid;
+
+  // Fetch profile data
+  const [profile] = await db
+    .select()
+    .from(profiles)
+    .where(eq(profiles.did, effectiveDid))
+    .limit(1);
+
+  if (!profile) {
+    return (
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+        <p className="text-zinc-400 text-sm">No profile found for this identity.</p>
+        <Link
+          href="/profile/edit"
+          className="inline-block mt-3 text-sm text-amber-400 hover:text-amber-300 transition-colors"
+        >
+          Create profile →
+        </Link>
+      </div>
+    );
+  }
+
+  const metadata = (profile.metadata ?? {}) as Record<string, unknown>;
+  const location = metadata.location as string | undefined;
+  const website = metadata.website as string | undefined;
+
+  const mediaUrl = process.env.NEXT_PUBLIC_MEDIA_URL ?? '';
+
+  // Resolve avatar URL
+  let avatarSrc: string | null = null;
+  if (profile.avatarAssetId && mediaUrl) {
+    avatarSrc = `${mediaUrl}/api/media/${profile.avatarAssetId}`;
+  } else if (profile.avatar && (profile.avatar.startsWith('http') || profile.avatar.startsWith('/'))) {
+    avatarSrc = profile.avatar;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Banner */}
+      {profile.banner && (
+        <div className="relative h-32 rounded-xl overflow-hidden bg-zinc-800">
+          <Image
+            src={profile.bannerAssetId && mediaUrl ? `${mediaUrl}/api/media/${profile.bannerAssetId}` : profile.banner}
+            alt=""
+            fill
+            className="object-cover"
+          />
+        </div>
+      )}
+
+      {/* Profile info */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 space-y-4">
+        <div className="flex items-start gap-4">
+          {/* Avatar */}
+          {avatarSrc ? (
+            <div className="relative w-16 h-16 rounded-full overflow-hidden bg-zinc-800 shrink-0">
+              <Image src={avatarSrc} alt="" fill className="object-cover" />
+            </div>
+          ) : profile.avatar ? (
+            <div className="w-16 h-16 rounded-full bg-zinc-800 flex items-center justify-center text-2xl shrink-0">
+              {profile.avatar}
+            </div>
+          ) : null}
+
+          <div className="min-w-0">
+            <h2 className="text-lg font-semibold text-white">{profile.displayName}</h2>
+            {profile.handle && (
+              <p className="text-sm text-zinc-400">@{profile.handle}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Bio */}
+        {profile.bio && (
+          <p className="text-sm text-zinc-300 leading-relaxed">{profile.bio}</p>
+        )}
+
+        {/* Details */}
+        <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-zinc-400">
+          {location && (
+            <span className="flex items-center gap-1.5">
+              <span className="text-zinc-600">📍</span> {location}
+            </span>
+          )}
+          {website && (
+            <a
+              href={website.startsWith('http') ? website : `https://${website}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 hover:text-amber-400 transition-colors"
+            >
+              <span className="text-zinc-600">🔗</span> {website.replace(/^https?:\/\//, '')}
+            </a>
+          )}
+          {profile.contactEmail && (
+            <span className="flex items-center gap-1.5">
+              <span className="text-zinc-600">✉️</span> {profile.contactEmail}
+            </span>
+          )}
+          {profile.phone && (
+            <span className="flex items-center gap-1.5">
+              <span className="text-zinc-600">📞</span> {profile.phone}
+            </span>
+          )}
+        </div>
+
+        {/* Visibility badge */}
+        {profile.visibility === 'incognito' && (
+          <span className="inline-block text-xs px-2 py-1 rounded-full bg-zinc-800 text-zinc-500 border border-zinc-700">
+            Incognito
+          </span>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/apps/kernel/app/auth/page.tsx
+++ b/apps/kernel/app/auth/page.tsx
@@ -1,20 +1,8 @@
 import { cookies } from 'next/headers';
 import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
-import { db, identities } from '@/src/db';
-import { eq } from 'drizzle-orm';
 import Link from 'next/link';
-import IdentitySwitcher from './components/IdentitySwitcher';
-import IdentityDetail from './components/IdentityDetail';
-import AttestationList from './components/AttestationList';
-import PlacesMaintained from './components/PlacesMaintained';
 
-interface SearchParams {
-  type?: string;
-  role?: string;
-  page?: string;
-}
-
-export default async function AuthPage({ searchParams }: { searchParams: SearchParams }) {
+export default async function AuthPage() {
   const cookieConfig = getSessionCookieOptions();
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(cookieConfig.name)?.value;
@@ -25,7 +13,6 @@ export default async function AuthPage({ searchParams }: { searchParams: SearchP
     sessionDid = session?.sub ?? null;
   }
 
-  // Unauthenticated view
   if (!sessionDid) {
     return (
       <div className="max-w-2xl mx-auto text-center py-20">
@@ -44,48 +31,6 @@ export default async function AuthPage({ searchParams }: { searchParams: SearchP
     );
   }
 
-  // Fetch personal identity info for the switcher
-  const [personalIdentity] = await db
-    .select({ name: identities.name, handle: identities.handle })
-    .from(identities)
-    .where(eq(identities.id, sessionDid))
-    .limit(1);
-
-  const personalName = personalIdentity?.name ?? null;
-  const personalHandle = personalIdentity?.handle ?? null;
-
-  // Effective DID: actingAs cookie OR personal DID
-  const actingAs = cookieStore.get('x-acting-as')?.value || null;
-  const effectiveDid = actingAs || sessionDid;
-
-  // Auth URL for the useIdentities hook (same-origin relative path)
-  const authUrl = '/auth';
-  const profileUrl = process.env.NEXT_PUBLIC_PROFILE_URL ?? '';
-
-  return (
-    <div className="flex flex-col lg:flex-row gap-6 min-h-[calc(100vh-4rem)]">
-      {/* Left rail (desktop) / Top section (mobile) */}
-      <div className="lg:w-72 lg:shrink-0">
-        <div className="sticky top-6 bg-[#0a0a0a] border border-gray-800 rounded-2xl p-4">
-          <h2 className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3 px-1">
-            Identities
-          </h2>
-          <IdentitySwitcher
-            authUrl={authUrl}
-            profileUrl={profileUrl}
-            personalDid={sessionDid}
-            personalName={personalName}
-            personalHandle={personalHandle}
-          />
-          <PlacesMaintained sessionDid={sessionDid} />
-        </div>
-      </div>
-
-      {/* Main area */}
-      <div className="flex-1 min-w-0 space-y-6">
-        <IdentityDetail did={effectiveDid} sessionDid={sessionDid} />
-        <AttestationList sessionDid={effectiveDid} searchParams={searchParams} />
-      </div>
-    </div>
-  );
+  // Profile tab — IdentityDetail is rendered by the layout above the tabs
+  return null;
 }

--- a/apps/kernel/app/auth/settings/page.tsx
+++ b/apps/kernel/app/auth/settings/page.tsx
@@ -1,0 +1,73 @@
+import { cookies } from 'next/headers';
+import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
+import { db, identities, identityMembers } from '@/src/db';
+import { eq, and, isNull } from 'drizzle-orm';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import IdentitySettingsPanel from '../components/IdentitySettingsPanel';
+
+export default async function SettingsPage() {
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  if (!sessionDid) {
+    redirect('/auth');
+  }
+
+  const actingAs = cookieStore.get('x-acting-as')?.value || null;
+  const effectiveDid = actingAs || sessionDid;
+
+  const [identity] = await db
+    .select({ scope: identities.scope })
+    .from(identities)
+    .where(eq(identities.id, effectiveDid))
+    .limit(1);
+
+  // Actor scope: show link to security settings
+  if (!identity || identity.scope === 'actor') {
+    return (
+      <div className="space-y-4">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+          <h2 className="text-sm font-semibold text-white mb-1">Security</h2>
+          <p className="text-sm text-zinc-400 mb-4">Manage your account security settings.</p>
+          <Link
+            href="/auth/settings/security"
+            className="inline-block px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+          >
+            Security settings →
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Non-actor: check admin/owner access
+  const [membership] = await db
+    .select({ role: identityMembers.role })
+    .from(identityMembers)
+    .where(
+      and(
+        eq(identityMembers.identityDid, effectiveDid),
+        eq(identityMembers.memberDid, sessionDid),
+        isNull(identityMembers.removedAt)
+      )
+    )
+    .limit(1);
+
+  if (membership?.role !== 'owner' && membership?.role !== 'admin') {
+    return (
+      <div className="text-zinc-500 text-sm py-8">
+        You need owner or admin access to manage settings for this identity.
+      </div>
+    );
+  }
+
+  return <IdentitySettingsPanel groupDid={effectiveDid} />;
+}


### PR DESCRIPTION
## Summary

Refactors `/auth` into a proper identity management hub with persistent left rail navigation and route-based tabs.

Includes #732 (scope-aware Edit Profile routing).

## Architecture

**Server-component-as-slot pattern:** Layout renders server components (left rail, identity detail, tab bar) and passes them as `ReactNode` props to a client shell. DB queries stay server-side, pathname routing stays client-side.

### New routes
| Tab | Route | Shows for |
|-----|-------|-----------|
| Profile | `/auth` (default) | Everyone |
| Attestations | `/auth/attestations` | Everyone |
| Settings | `/auth/settings` | Actors: security link. Groups: forest config (owner/admin only) |
| Members | `/auth/members` | Groups with owner/admin role only |

### New files
- `layout.tsx` — server layout, reads cookies, fetches identity + membership, renders slots
- `AuthLayoutShell.tsx` — client shell, bypasses hub for login/register/onboard
- `IdentityTabBar.tsx` — client tab bar with amber active state, conditional tabs
- `IdentitySettingsPanel.tsx` — extracted from group settings page (239 lines)
- `IdentityMembersPanel.tsx` — extracted member management (219 lines)
- Route pages for attestations, settings, members

### Updated files
- `page.tsx` — stripped to unauth CTA only (left rail moved to layout)
- `AttestationList.tsx` — pagination links updated to `/auth/attestations`

## Details
- 11 files changed, +869/-67 lines
- Login/register/onboard routes unaffected (AuthLayoutShell bypasses hub layout)
- Existing standalone group settings page (`/auth/groups/[did]/settings`) still works
- Phase 2 (service dashboard tabs) depends on #244

Closes #732
Progress on #731 (Phase 1 complete)
Epic: #738 (Open Wallet)