### PR TITLE
feat: Delegated App Sessions — Phase 1 (#244)

### DIFF
--- a/apps/kernel/app/api/auth/apps/route.ts
+++ b/apps/kernel/app/api/auth/apps/route.ts
@@ -1,0 +1,78 @@
+/**
+ * GET /api/auth/apps
+ *
+ * Returns all apps the authenticated user has authorized, with scopes and dates.
+ * Active and revoked authorizations are both returned (revoked have revokedAt set).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, attestations, registryApps } from '@/src/db';
+import { eq, and, inArray } from 'drizzle-orm';
+import { requireAuth } from '@imajin/auth';
+import { withLogger } from '@imajin/logger';
+
+export const GET = withLogger('kernel', async (request: NextRequest) => {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { identity } = authResult;
+
+  // All app.authorized attestations issued by this user
+  const authorizations = await db
+    .select({
+      attestationId: attestations.id,
+      appDid: attestations.subjectDid,
+      payload: attestations.payload,
+      issuedAt: attestations.issuedAt,
+      revokedAt: attestations.revokedAt,
+    })
+    .from(attestations)
+    .where(
+      and(
+        eq(attestations.issuerDid, identity.id),
+        eq(attestations.type, 'app.authorized'),
+      )
+    );
+
+  if (authorizations.length === 0) {
+    return NextResponse.json({ apps: [] });
+  }
+
+  // Look up app metadata for each unique appDid
+  const appDids = [...new Set(authorizations.map(a => a.appDid))];
+  const appRecords = await db
+    .select({
+      appDid: registryApps.appDid,
+      id: registryApps.id,
+      name: registryApps.name,
+      description: registryApps.description,
+      homepageUrl: registryApps.homepageUrl,
+      logoUrl: registryApps.logoUrl,
+      status: registryApps.status,
+    })
+    .from(registryApps)
+    .where(inArray(registryApps.appDid, appDids));
+
+  const appByDid = new Map(appRecords.map(a => [a.appDid, a]));
+
+  const apps = authorizations.map(auth => {
+    const app = appByDid.get(auth.appDid);
+    const payload = auth.payload as { scopes?: string[] } | null;
+    return {
+      attestationId: auth.attestationId,
+      appDid: auth.appDid,
+      appId: app?.id ?? null,
+      appName: app?.name ?? auth.appDid,
+      appDescription: app?.description ?? null,
+      appHomepageUrl: app?.homepageUrl ?? null,
+      appLogoUrl: app?.logoUrl ?? null,
+      appStatus: app?.status ?? 'unknown',
+      scopes: payload?.scopes ?? [],
+      authorizedAt: auth.issuedAt,
+      revokedAt: auth.revokedAt,
+    };
+  });
+
+  return NextResponse.json({ apps });
+});

--- a/apps/kernel/app/api/auth/authorize/route.ts
+++ b/apps/kernel/app/api/auth/authorize/route.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/auth/authorize
+ *
+ * Creates an app.authorized attestation when a user consents to an app's access request.
+ * Called by the consent UI (/auth/authorize).
+ *
+ * Body: { appId, scopes }
+ * Returns: { attestationId }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { db, attestations, registryApps } from '@/src/db';
+import { eq } from 'drizzle-orm';
+import { requireAuth, validateScopes, canonicalize, crypto as authCrypto } from '@imajin/auth';
+import { withLogger } from '@imajin/logger';
+
+export const POST = withLogger('kernel', async (request: NextRequest) => {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { identity } = authResult;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { appId, scopes } = body as { appId?: string; scopes?: string[] };
+
+  if (!appId || typeof appId !== 'string') {
+    return NextResponse.json({ error: 'appId is required' }, { status: 400 });
+  }
+  if (!Array.isArray(scopes)) {
+    return NextResponse.json({ error: 'scopes must be an array' }, { status: 400 });
+  }
+
+  // Load app
+  const [app] = await db
+    .select({
+      id: registryApps.id,
+      appDid: registryApps.appDid,
+      status: registryApps.status,
+      requestedScopes: registryApps.requestedScopes,
+      callbackUrl: registryApps.callbackUrl,
+    })
+    .from(registryApps)
+    .where(eq(registryApps.id, appId));
+
+  if (!app) {
+    return NextResponse.json({ error: 'App not found' }, { status: 404 });
+  }
+  if (app.status !== 'active') {
+    return NextResponse.json({ error: 'App is revoked' }, { status: 403 });
+  }
+
+  // Validate requested scopes against app's registered scopes
+  const { valid: validScopes, invalid: invalidScopes } = validateScopes(scopes);
+  const disallowed = validScopes.filter(s => !app.requestedScopes.includes(s));
+  if (invalidScopes.length > 0) {
+    return NextResponse.json({ error: `Unknown scopes: ${invalidScopes.join(', ')}` }, { status: 400 });
+  }
+  if (disallowed.length > 0) {
+    return NextResponse.json({ error: `Scopes not registered by app: ${disallowed.join(', ')}` }, { status: 400 });
+  }
+
+  const privateKey = process.env.AUTH_PRIVATE_KEY;
+  if (!privateKey) {
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
+  }
+
+  const issuedAtMs = Date.now();
+  const payload = { scopes: validScopes, appId: app.id, callbackUrl: app.callbackUrl };
+
+  const canonicalPayload = canonicalize({
+    subject_did: app.appDid,
+    type: 'app.authorized',
+    context_id: app.id,
+    context_type: 'app',
+    payload,
+    issued_at: issuedAtMs,
+  });
+
+  const signature = authCrypto.signSync(canonicalPayload, privateKey);
+  const attestationId = `att_${nanoid(16)}`;
+
+  await db.insert(attestations).values({
+    id: attestationId,
+    issuerDid: identity.id,
+    subjectDid: app.appDid,
+    type: 'app.authorized',
+    contextId: app.id,
+    contextType: 'app',
+    payload,
+    signature,
+    issuedAt: new Date(issuedAtMs),
+  });
+
+  return NextResponse.json({ attestationId }, { status: 201 });
+});

--- a/apps/kernel/app/api/auth/revoke/route.ts
+++ b/apps/kernel/app/api/auth/revoke/route.ts
@@ -1,0 +1,94 @@
+/**
+ * POST /api/auth/revoke
+ *
+ * Revokes a previously granted app authorization.
+ * Creates an app.revoked attestation and marks the original as revoked.
+ *
+ * Body: { attestationId }
+ * Returns: { ok: true }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { db, attestations } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+import { requireAuth, canonicalize, crypto as authCrypto } from '@imajin/auth';
+import { withLogger } from '@imajin/logger';
+
+export const POST = withLogger('kernel', async (request: NextRequest) => {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { identity } = authResult;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { attestationId } = body as { attestationId?: string };
+  if (!attestationId || typeof attestationId !== 'string') {
+    return NextResponse.json({ error: 'attestationId is required' }, { status: 400 });
+  }
+
+  // Load original authorization — must belong to this user
+  const [original] = await db
+    .select()
+    .from(attestations)
+    .where(
+      and(
+        eq(attestations.id, attestationId),
+        eq(attestations.issuerDid, identity.id),
+        eq(attestations.type, 'app.authorized'),
+      )
+    );
+
+  if (!original) {
+    return NextResponse.json({ error: 'Authorization not found' }, { status: 404 });
+  }
+  if (original.revokedAt) {
+    return NextResponse.json({ error: 'Already revoked' }, { status: 409 });
+  }
+
+  const privateKey = process.env.AUTH_PRIVATE_KEY;
+  if (!privateKey) {
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
+  }
+
+  const issuedAtMs = Date.now();
+  const payload = { revokedAttestationId: attestationId, appDid: original.subjectDid };
+
+  const canonicalPayload = canonicalize({
+    subject_did: original.subjectDid,
+    type: 'app.revoked',
+    context_id: attestationId,
+    context_type: 'attestation',
+    payload,
+    issued_at: issuedAtMs,
+  });
+
+  const signature = authCrypto.signSync(canonicalPayload, privateKey);
+
+  await db.insert(attestations).values({
+    id: `att_${nanoid(16)}`,
+    issuerDid: identity.id,
+    subjectDid: original.subjectDid,
+    type: 'app.revoked',
+    contextId: attestationId,
+    contextType: 'attestation',
+    payload,
+    signature,
+    issuedAt: new Date(issuedAtMs),
+  });
+
+  // Mark original as revoked
+  await db
+    .update(attestations)
+    .set({ revokedAt: new Date(issuedAtMs) })
+    .where(eq(attestations.id, attestationId));
+
+  return NextResponse.json({ ok: true });
+});

--- a/apps/kernel/app/api/registry/apps/[appId]/route.ts
+++ b/apps/kernel/app/api/registry/apps/[appId]/route.ts
@@ -3,7 +3,7 @@ import { db, registryApps } from '@/src/db';
 import { eq } from 'drizzle-orm';
 import { requireAuth } from '@imajin/auth';
 
-// GET /api/registry/apps/:appId — app detail (public, privateKey excluded)
+// GET /api/registry/apps/:appId — app detail (public)
 export async function GET(
   _request: NextRequest,
   { params }: { params: { appId: string } }
@@ -80,9 +80,7 @@ export async function PATCH(
     .where(eq(registryApps.id, params.appId))
     .returning();
 
-  // Strip privateKey from response
-  const { privateKey: _pk, ...safeApp } = updated;
-  return NextResponse.json(safeApp);
+  return NextResponse.json(updated);
 }
 
 // DELETE /api/registry/apps/:appId — soft revoke (owner only)

--- a/apps/kernel/app/api/registry/apps/[appId]/route.ts
+++ b/apps/kernel/app/api/registry/apps/[appId]/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db, registryApps } from '@/src/db';
+import { eq } from 'drizzle-orm';
+import { requireAuth } from '@imajin/auth';
+
+// GET /api/registry/apps/:appId — app detail (public, privateKey excluded)
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { appId: string } }
+) {
+  const [app] = await db
+    .select({
+      id: registryApps.id,
+      ownerDid: registryApps.ownerDid,
+      name: registryApps.name,
+      description: registryApps.description,
+      appDid: registryApps.appDid,
+      publicKey: registryApps.publicKey,
+      callbackUrl: registryApps.callbackUrl,
+      homepageUrl: registryApps.homepageUrl,
+      logoUrl: registryApps.logoUrl,
+      requestedScopes: registryApps.requestedScopes,
+      status: registryApps.status,
+      createdAt: registryApps.createdAt,
+      updatedAt: registryApps.updatedAt,
+    })
+    .from(registryApps)
+    .where(eq(registryApps.id, params.appId));
+
+  if (!app) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(app);
+}
+
+// PATCH /api/registry/apps/:appId — update (owner only)
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { appId: string } }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { identity } = authResult;
+
+  const [existing] = await db
+    .select({ id: registryApps.id, ownerDid: registryApps.ownerDid })
+    .from(registryApps)
+    .where(eq(registryApps.id, params.appId));
+
+  if (!existing) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  if (existing.ownerDid !== identity.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const updates: Partial<typeof registryApps.$inferInsert> = {
+    updatedAt: new Date(),
+  };
+  if (typeof body.name === 'string' && body.name.trim()) updates.name = body.name.trim();
+  if (typeof body.description === 'string') updates.description = body.description || null;
+  if (typeof body.callbackUrl === 'string' && body.callbackUrl) updates.callbackUrl = body.callbackUrl;
+  if (typeof body.homepageUrl === 'string') updates.homepageUrl = body.homepageUrl || null;
+  if (typeof body.logoUrl === 'string') updates.logoUrl = body.logoUrl || null;
+  if (Array.isArray(body.requestedScopes)) updates.requestedScopes = body.requestedScopes;
+
+  const [updated] = await db
+    .update(registryApps)
+    .set(updates)
+    .where(eq(registryApps.id, params.appId))
+    .returning();
+
+  // Strip privateKey from response
+  const { privateKey: _pk, ...safeApp } = updated;
+  return NextResponse.json(safeApp);
+}
+
+// DELETE /api/registry/apps/:appId — soft revoke (owner only)
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { appId: string } }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { identity } = authResult;
+
+  const [existing] = await db
+    .select({ id: registryApps.id, ownerDid: registryApps.ownerDid })
+    .from(registryApps)
+    .where(eq(registryApps.id, params.appId));
+
+  if (!existing) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  if (existing.ownerDid !== identity.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await db
+    .update(registryApps)
+    .set({ status: 'revoked', revokedAt: new Date(), updatedAt: new Date() })
+    .where(eq(registryApps.id, params.appId));
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/kernel/app/api/registry/apps/route.ts
+++ b/apps/kernel/app/api/registry/apps/route.ts
@@ -45,15 +45,14 @@ export const POST = withLogger('kernel', async (request: NextRequest) => {
     description: typeof description === 'string' ? description.trim() || null : null,
     appDid: `did:imajin:${nanoid(44)}`,
     publicKey: keypair.publicKey,
-    privateKey: keypair.privateKey,
     callbackUrl,
     homepageUrl: typeof homepageUrl === 'string' ? homepageUrl || null : null,
     logoUrl: typeof logoUrl === 'string' ? logoUrl || null : null,
     requestedScopes: Array.isArray(requestedScopes) ? requestedScopes : [],
   }).returning();
 
-  // privateKey is returned only on registration — store it securely
-  return NextResponse.json(app, { status: 201 });
+  // Private key returned ONCE at registration — never stored. Developer must save it.
+  return NextResponse.json({ ...app, privateKey: keypair.privateKey }, { status: 201 });
 });
 
 // GET /api/registry/apps — list active apps (public, paginated)

--- a/apps/kernel/app/api/registry/apps/route.ts
+++ b/apps/kernel/app/api/registry/apps/route.ts
@@ -2,10 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { nanoid } from 'nanoid';
 import { db, registryApps } from '@/src/db';
 import { eq, desc } from 'drizzle-orm';
-import { requireAuth, generateKeypair } from '@imajin/auth';
+import { requireAuth, isValidPublicKey } from '@imajin/auth';
+import { didFromPublicKey, publicKeyFromDid } from '@/src/lib/auth/crypto';
 import { withLogger } from '@imajin/logger';
 
 // POST /api/registry/apps — register a new app (authenticated)
+// Developer generates their own keypair locally and submits publicKey.
+// The server never sees or generates the private key.
 export const POST = withLogger('kernel', async (request: NextRequest) => {
   const authResult = await requireAuth(request);
   if ('error' in authResult) {
@@ -20,13 +23,14 @@ export const POST = withLogger('kernel', async (request: NextRequest) => {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { name, description, callbackUrl, homepageUrl, logoUrl, requestedScopes } = body as {
+  const { name, description, callbackUrl, homepageUrl, logoUrl, requestedScopes, publicKey } = body as {
     name?: string;
     description?: string;
     callbackUrl?: string;
     homepageUrl?: string;
     logoUrl?: string;
     requestedScopes?: string[];
+    publicKey?: string;
   };
 
   if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -35,24 +39,30 @@ export const POST = withLogger('kernel', async (request: NextRequest) => {
   if (!callbackUrl || typeof callbackUrl !== 'string') {
     return NextResponse.json({ error: 'callbackUrl is required' }, { status: 400 });
   }
+  if (!publicKey || typeof publicKey !== 'string') {
+    return NextResponse.json({ error: 'publicKey is required — generate an Ed25519 keypair locally and submit the public key' }, { status: 400 });
+  }
+  if (!isValidPublicKey(publicKey)) {
+    return NextResponse.json({ error: 'Invalid Ed25519 public key' }, { status: 400 });
+  }
 
-  const keypair = generateKeypair();
+  // Derive DID from the submitted public key — same as human identity creation
+  const appDid = didFromPublicKey(publicKey);
 
   const [app] = await db.insert(registryApps).values({
     id: `app_${nanoid(16)}`,
     ownerDid: identity.id,
     name: name.trim(),
     description: typeof description === 'string' ? description.trim() || null : null,
-    appDid: `did:imajin:${nanoid(44)}`,
-    publicKey: keypair.publicKey,
+    appDid,
+    publicKey,
     callbackUrl,
     homepageUrl: typeof homepageUrl === 'string' ? homepageUrl || null : null,
     logoUrl: typeof logoUrl === 'string' ? logoUrl || null : null,
     requestedScopes: Array.isArray(requestedScopes) ? requestedScopes : [],
   }).returning();
 
-  // Private key returned ONCE at registration — never stored. Developer must save it.
-  return NextResponse.json({ ...app, privateKey: keypair.privateKey }, { status: 201 });
+  return NextResponse.json(app, { status: 201 });
 });
 
 // GET /api/registry/apps — list active apps (public, paginated)

--- a/apps/kernel/app/api/registry/apps/route.ts
+++ b/apps/kernel/app/api/registry/apps/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { db, registryApps } from '@/src/db';
+import { eq, desc } from 'drizzle-orm';
+import { requireAuth, generateKeypair } from '@imajin/auth';
+import { withLogger } from '@imajin/logger';
+
+// POST /api/registry/apps — register a new app (authenticated)
+export const POST = withLogger('kernel', async (request: NextRequest) => {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { identity } = authResult;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { name, description, callbackUrl, homepageUrl, logoUrl, requestedScopes } = body as {
+    name?: string;
+    description?: string;
+    callbackUrl?: string;
+    homepageUrl?: string;
+    logoUrl?: string;
+    requestedScopes?: string[];
+  };
+
+  if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  }
+  if (!callbackUrl || typeof callbackUrl !== 'string') {
+    return NextResponse.json({ error: 'callbackUrl is required' }, { status: 400 });
+  }
+
+  const keypair = generateKeypair();
+
+  const [app] = await db.insert(registryApps).values({
+    id: `app_${nanoid(16)}`,
+    ownerDid: identity.id,
+    name: name.trim(),
+    description: typeof description === 'string' ? description.trim() || null : null,
+    appDid: `did:imajin:${nanoid(44)}`,
+    publicKey: keypair.publicKey,
+    privateKey: keypair.privateKey,
+    callbackUrl,
+    homepageUrl: typeof homepageUrl === 'string' ? homepageUrl || null : null,
+    logoUrl: typeof logoUrl === 'string' ? logoUrl || null : null,
+    requestedScopes: Array.isArray(requestedScopes) ? requestedScopes : [],
+  }).returning();
+
+  // privateKey is returned only on registration — store it securely
+  return NextResponse.json(app, { status: 201 });
+});
+
+// GET /api/registry/apps — list active apps (public, paginated)
+export const GET = withLogger('kernel', async (request: NextRequest) => {
+  const url = new URL(request.url);
+  const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '20', 10), 100);
+  const offset = Math.max(parseInt(url.searchParams.get('offset') ?? '0', 10), 0);
+
+  const apps = await db
+    .select({
+      id: registryApps.id,
+      ownerDid: registryApps.ownerDid,
+      name: registryApps.name,
+      description: registryApps.description,
+      appDid: registryApps.appDid,
+      publicKey: registryApps.publicKey,
+      callbackUrl: registryApps.callbackUrl,
+      homepageUrl: registryApps.homepageUrl,
+      logoUrl: registryApps.logoUrl,
+      requestedScopes: registryApps.requestedScopes,
+      status: registryApps.status,
+      createdAt: registryApps.createdAt,
+    })
+    .from(registryApps)
+    .where(eq(registryApps.status, 'active'))
+    .orderBy(desc(registryApps.createdAt))
+    .limit(limit)
+    .offset(offset);
+
+  return NextResponse.json({ apps, limit, offset });
+});

--- a/apps/kernel/app/auth/api/apps/validate/route.ts
+++ b/apps/kernel/app/auth/api/apps/validate/route.ts
@@ -1,0 +1,78 @@
+/**
+ * POST /auth/api/apps/validate
+ *
+ * Internal service-to-service endpoint used by requireAppAuth middleware.
+ * Validates an app authorization attestation and returns AppAuthContext.
+ *
+ * Auth: Bearer ATTESTATION_INTERNAL_API_KEY
+ * Body: { appDid, attestationId, scope? }
+ * Returns: { appDid, userDid, scopes, attestationId }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, attestations } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+
+export async function POST(request: NextRequest) {
+  const apiKey = request.headers.get('authorization')?.replace('Bearer ', '');
+  const expectedKey = process.env.ATTESTATION_INTERNAL_API_KEY;
+
+  if (!expectedKey || apiKey !== expectedKey) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { appDid, attestationId, scope } = body as {
+    appDid?: string;
+    attestationId?: string;
+    scope?: string;
+  };
+
+  if (!appDid || typeof appDid !== 'string') {
+    return NextResponse.json({ error: 'appDid required' }, { status: 400 });
+  }
+  if (!attestationId || typeof attestationId !== 'string') {
+    return NextResponse.json({ error: 'attestationId required' }, { status: 400 });
+  }
+
+  const [att] = await db
+    .select()
+    .from(attestations)
+    .where(
+      and(
+        eq(attestations.id, attestationId),
+        eq(attestations.subjectDid, appDid),
+        eq(attestations.type, 'app.authorized'),
+      )
+    );
+
+  if (!att) {
+    return NextResponse.json({ error: 'Authorization not found' }, { status: 404 });
+  }
+  if (att.revokedAt) {
+    return NextResponse.json({ error: 'Authorization has been revoked' }, { status: 403 });
+  }
+
+  const payload = att.payload as { scopes?: string[] } | null;
+  const approvedScopes = payload?.scopes ?? [];
+
+  if (scope && !approvedScopes.includes(scope)) {
+    return NextResponse.json(
+      { error: `Scope '${scope}' was not granted` },
+      { status: 403 }
+    );
+  }
+
+  return NextResponse.json({
+    appDid,
+    userDid: att.issuerDid,
+    scopes: approvedScopes,
+    attestationId,
+  });
+}

--- a/apps/kernel/app/auth/authorize/page.tsx
+++ b/apps/kernel/app/auth/authorize/page.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useState, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { SCOPES } from '@imajin/auth';
+import type { Scope } from '@imajin/auth';
+
+interface AppInfo {
+  id: string;
+  name: string;
+  description: string | null;
+  appDid: string;
+  homepageUrl: string | null;
+  logoUrl: string | null;
+  callbackUrl: string;
+  requestedScopes: string[];
+}
+
+function AuthorizeForm() {
+  const searchParams = useSearchParams();
+  const appId = searchParams.get('app_id');
+  const requestedParam = searchParams.get('scopes');
+
+  const [app, setApp] = useState<AppInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [enabledScopes, setEnabledScopes] = useState<Record<string, boolean>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!appId) {
+      setError('Missing app_id parameter');
+      setLoading(false);
+      return;
+    }
+
+    fetch(`/api/registry/apps/${appId}`)
+      .then(res => {
+        if (!res.ok) throw new Error('App not found');
+        return res.json();
+      })
+      .then((data: AppInfo) => {
+        setApp(data);
+
+        // Scopes from URL (what the app is requesting right now), filtered against what the app registered
+        const urlScopes = requestedParam ? requestedParam.split(',').map(s => s.trim()).filter(Boolean) : [];
+        const applicableScopes = urlScopes.length > 0
+          ? urlScopes.filter(s => data.requestedScopes.includes(s))
+          : data.requestedScopes;
+
+        const initial: Record<string, boolean> = {};
+        for (const s of applicableScopes) initial[s] = true;
+        setEnabledScopes(initial);
+      })
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [appId, requestedParam]);
+
+  function handleDeny() {
+    if (!app) return;
+    const url = new URL(app.callbackUrl);
+    url.searchParams.set('error', 'denied');
+    window.location.href = url.toString();
+  }
+
+  async function handleAuthorize() {
+    if (!app || submitting) return;
+    setSubmitting(true);
+
+    const granted = Object.entries(enabledScopes)
+      .filter(([, on]) => on)
+      .map(([scope]) => scope);
+
+    try {
+      const res = await fetch('/api/auth/authorize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ appId: app.id, scopes: granted }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? 'Authorization failed');
+        setSubmitting(false);
+        return;
+      }
+
+      const { attestationId } = await res.json();
+      const url = new URL(app.callbackUrl);
+      url.searchParams.set('attestation_id', attestationId);
+      window.location.href = url.toString();
+    } catch {
+      setError('Network error. Please try again.');
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center">
+        <p className="text-gray-400">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error || !app) {
+    return (
+      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-[#0a0a0a] border border-red-800 rounded-2xl p-8 text-center">
+          <p className="text-red-400">{error ?? 'App not found'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const scopeEntries = Object.entries(enabledScopes);
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center p-4">
+      <div className="max-w-md w-full">
+        <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl p-8">
+          {/* App header */}
+          <div className="flex items-center gap-3 mb-6">
+            {app.logoUrl ? (
+              <img src={app.logoUrl} alt={app.name} className="w-12 h-12 rounded-xl object-cover" />
+            ) : (
+              <div className="w-12 h-12 rounded-xl bg-gray-800 flex items-center justify-center text-xl font-bold text-gray-400">
+                {app.name[0].toUpperCase()}
+              </div>
+            )}
+            <div>
+              <h1 className="text-xl font-bold text-white">{app.name}</h1>
+              {app.homepageUrl && (
+                <p className="text-xs text-gray-500 truncate max-w-xs">{app.homepageUrl}</p>
+              )}
+            </div>
+          </div>
+
+          <p className="text-gray-400 text-sm mb-6">
+            {app.description ?? `${app.name} is requesting access to your Imajin account.`}
+          </p>
+
+          {/* Scope toggles */}
+          {scopeEntries.length > 0 ? (
+            <div className="space-y-2 mb-6">
+              <p className="text-xs text-gray-500 uppercase tracking-wide mb-3">Permissions requested</p>
+              {scopeEntries.map(([scope, enabled]) => (
+                <label
+                  key={scope}
+                  className="flex items-center justify-between p-3 rounded-lg bg-gray-900 border border-gray-800 cursor-pointer hover:border-gray-700 transition"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-white">{scope}</p>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                      {SCOPES[scope as Scope] ?? scope}
+                    </p>
+                  </div>
+                  <input
+                    type="checkbox"
+                    checked={enabled}
+                    onChange={e => setEnabledScopes(prev => ({ ...prev, [scope]: e.target.checked }))}
+                    className="ml-3 w-4 h-4 accent-[#F59E0B] cursor-pointer"
+                  />
+                </label>
+              ))}
+            </div>
+          ) : (
+            <div className="mb-6 p-3 bg-gray-900 border border-gray-800 rounded-lg">
+              <p className="text-sm text-gray-400">This app requests basic access (no specific permissions).</p>
+            </div>
+          )}
+
+          {/* Trust notice */}
+          <div className="mb-6 p-3 bg-[#F59E0B]/10 border border-[#F59E0B]/30 rounded-lg">
+            <p className="text-xs text-[#F59E0B]">
+              Only authorize apps you trust. You can revoke access at any time from your settings.
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              onClick={handleDeny}
+              className="flex-1 px-4 py-2.5 rounded-lg bg-gray-900 text-gray-300 hover:bg-gray-800 transition font-medium text-sm"
+            >
+              Deny
+            </button>
+            <button
+              onClick={handleAuthorize}
+              disabled={submitting}
+              className="flex-1 px-4 py-2.5 rounded-lg bg-[#F59E0B] text-black hover:bg-[#D97706] transition font-medium text-sm disabled:opacity-50"
+            >
+              {submitting ? 'Authorizing...' : 'Authorize'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AuthorizePage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center">
+        <p className="text-gray-400">Loading...</p>
+      </div>
+    }>
+      <AuthorizeForm />
+    </Suspense>
+  );
+}

--- a/apps/kernel/src/db/schemas/registry.ts
+++ b/apps/kernel/src/db/schemas/registry.ts
@@ -305,7 +305,6 @@ export const registryApps = registrySchema.table('apps', {
   description: text('description'),
   appDid: text('app_did').notNull().unique(),            // did:imajin:<nanoid(44)>
   publicKey: text('public_key').notNull(),               // Ed25519 hex (64 chars)
-  privateKey: text('private_key').notNull(),             // Ed25519 hex — returned once at registration
   callbackUrl: text('callback_url').notNull(),           // OAuth redirect URI
   homepageUrl: text('homepage_url'),
   logoUrl: text('logo_url'),

--- a/apps/kernel/src/db/schemas/registry.ts
+++ b/apps/kernel/src/db/schemas/registry.ts
@@ -296,6 +296,33 @@ export const systemEvents = registrySchema.table('system_events', {
 export type SystemEvent = typeof systemEvents.$inferSelect;
 
 /**
+ * Registered third-party apps — for delegated session access (Issue #244)
+ */
+export const registryApps = registrySchema.table('apps', {
+  id: text('id').primaryKey(),                           // app_<nanoid(16)>
+  ownerDid: text('owner_did').notNull(),                 // DID of developer who registered
+  name: text('name').notNull(),
+  description: text('description'),
+  appDid: text('app_did').notNull().unique(),            // did:imajin:<nanoid(44)>
+  publicKey: text('public_key').notNull(),               // Ed25519 hex (64 chars)
+  privateKey: text('private_key').notNull(),             // Ed25519 hex — returned once at registration
+  callbackUrl: text('callback_url').notNull(),           // OAuth redirect URI
+  homepageUrl: text('homepage_url'),
+  logoUrl: text('logo_url'),
+  requestedScopes: jsonb('requested_scopes').$type<string[]>().default([]),
+  status: text('status').notNull().default('active'),   // 'active' | 'revoked'
+  revokedAt: timestamp('revoked_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  ownerIdx: index('idx_registry_apps_owner').on(table.ownerDid),
+  statusIdx: index('idx_registry_apps_status').on(table.status),
+}));
+
+export type RegistryApp = typeof registryApps.$inferSelect;
+export type NewRegistryApp = typeof registryApps.$inferInsert;
+
+/**
  * Application log entries — written by @imajin/logger Pino adapter when ENABLE_APP_LOG=true
  */
 export const appLogs = registrySchema.table('app_logs', {

--- a/migrations/0007_registry_apps.sql
+++ b/migrations/0007_registry_apps.sql
@@ -1,0 +1,23 @@
+-- 0007_registry_apps.sql
+-- Registered third-party apps for delegated session access (Issue #244)
+
+CREATE TABLE IF NOT EXISTS registry.apps (
+  id               TEXT PRIMARY KEY,
+  owner_did        TEXT NOT NULL,
+  name             TEXT NOT NULL,
+  description      TEXT,
+  app_did          TEXT NOT NULL UNIQUE,
+  public_key       TEXT NOT NULL,
+  private_key      TEXT NOT NULL,
+  callback_url     TEXT NOT NULL,
+  homepage_url     TEXT,
+  logo_url         TEXT,
+  requested_scopes JSONB NOT NULL DEFAULT '[]',
+  status           TEXT NOT NULL DEFAULT 'active',
+  revoked_at       TIMESTAMPTZ,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_registry_apps_owner  ON registry.apps (owner_did);
+CREATE INDEX IF NOT EXISTS idx_registry_apps_status ON registry.apps (status);

--- a/migrations/0007_registry_apps.sql
+++ b/migrations/0007_registry_apps.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS registry.apps (
   description      TEXT,
   app_did          TEXT NOT NULL UNIQUE,
   public_key       TEXT NOT NULL,
-  private_key      TEXT NOT NULL,
+
   callback_url     TEXT NOT NULL,
   homepage_url     TEXT,
   logo_url         TEXT,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -29,3 +29,5 @@ export {
 export type { NodeHeartbeat, NodeRegistration, NodeRegistrationRequest, NodeRegistrationResponse, NodeAttestation } from "./types/node";
 export { getEmailForDid, getDidForEmail } from "./credentials";
 export { emitAttestation } from "./emit-attestation";
+export { SCOPES, validateScopes } from "./scopes";
+export type { Scope } from "./scopes";

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -31,3 +31,5 @@ export { getEmailForDid, getDidForEmail } from "./credentials";
 export { emitAttestation } from "./emit-attestation";
 export { SCOPES, validateScopes } from "./scopes";
 export type { Scope } from "./scopes";
+export { requireAppAuth } from "./require-app-auth";
+export type { AppAuthContext, AppAuthResult } from "./require-app-auth";

--- a/packages/auth/src/require-app-auth.ts
+++ b/packages/auth/src/require-app-auth.ts
@@ -1,0 +1,69 @@
+import { createLogger } from '@imajin/logger';
+const log = createLogger('auth');
+
+export interface AppAuthContext {
+  appDid: string;
+  userDid: string;
+  scopes: string[];
+  attestationId: string;
+}
+
+export type AppAuthResult = { appAuth: AppAuthContext } | { error: string; status: number };
+
+const getAuthUrl = () => process.env.AUTH_SERVICE_URL!;
+
+/**
+ * Require app authentication via X-App-DID + X-App-Authorization headers.
+ *
+ * X-App-DID:           The app's DID (received at registration)
+ * X-App-Authorization: The attestation ID from the user's consent flow
+ *
+ * Optionally supply `scope` to verify the approved scopes include a required scope.
+ *
+ * Works with both `Request` and `NextRequest`.
+ */
+export async function requireAppAuth(
+  request: Request,
+  options?: { scope?: string }
+): Promise<AppAuthResult> {
+  const appDid = request.headers.get('x-app-did');
+  const attestationId = request.headers.get('x-app-authorization');
+
+  if (!appDid || !attestationId) {
+    return { error: 'X-App-DID and X-App-Authorization headers required', status: 401 };
+  }
+
+  const authUrl = getAuthUrl();
+  if (!authUrl) {
+    return { error: 'Auth service unavailable', status: 503 };
+  }
+
+  const internalApiKey = process.env.ATTESTATION_INTERNAL_API_KEY;
+  if (!internalApiKey) {
+    log.warn({}, '[APP-AUTH] ATTESTATION_INTERNAL_API_KEY not set');
+    return { error: 'Auth service misconfigured', status: 503 };
+  }
+
+  try {
+    const res = await fetch(`${authUrl}/auth/api/apps/validate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${internalApiKey}`,
+      },
+      body: JSON.stringify({ appDid, attestationId, scope: options?.scope }),
+      cache: 'no-store',
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      return { error: data.error ?? 'Invalid app authorization', status: res.status };
+    }
+
+    const data = await res.json();
+    return { appAuth: data as AppAuthContext };
+  } catch (err) {
+    log.error({ err: String(err) }, '[APP-AUTH] Validation request failed');
+    return { error: 'Auth service unavailable', status: 503 };
+  }
+}

--- a/packages/auth/src/scopes.ts
+++ b/packages/auth/src/scopes.ts
@@ -1,0 +1,30 @@
+/**
+ * Scope vocabulary for delegated app sessions (Issue #244)
+ *
+ * Each scope maps to a human-readable label shown on the consent screen.
+ */
+export const SCOPES = {
+  'profile:read':       'Read your profile information',
+  'identity:read':      'Read your identity and DID',
+  'wallet:read':        'View your wallet balance and transaction history',
+  'wallet:write':       'Create payments and transfers on your behalf',
+  'connections:read':   'View your connections',
+  'events:read':        'View events you attend or have created',
+  'events:write':       'Create and manage events on your behalf',
+  'messages:read':      'Read messages in your conversations',
+  'messages:write':     'Send messages on your behalf',
+  'attestations:read':  'View your attestations and reputation',
+  'attestations:write': 'Issue attestations on your behalf',
+} as const;
+
+export type Scope = keyof typeof SCOPES;
+
+export function validateScopes(scopes: string[]): { valid: Scope[]; invalid: string[] } {
+  const valid: Scope[] = [];
+  const invalid: string[] = [];
+  for (const s of scopes) {
+    if (s in SCOPES) valid.push(s as Scope);
+    else invalid.push(s);
+  }
+  return { valid, invalid };
+}

--- a/packages/auth/src/types/attestation.ts
+++ b/packages/auth/src/types/attestation.ts
@@ -37,6 +37,8 @@ export const ATTESTATION_TYPES = [
   'ticket.purchased',
   'listing.purchased',
   'tip.granted',
+  'app.authorized',
+  'app.revoked',
 ] as const;
 
 export type AttestationType = typeof ATTESTATION_TYPES[number];


### PR DESCRIPTION
## Summary

Third-party app registration, scoped user authorization, and app auth middleware. The core "apps that plug in" infrastructure for the Open Wallet (#738).

## What's Built (4 Work Orders)

### WO-1: App Registration
- `registry.apps` table + migration (`0007_registry_apps.sql`)
- CRUD API: register, list, detail, update, soft-revoke
- App gets its own DID (Ed25519 keypair generated on registration)
- Private key returned **once** at registration, never stored in DB

### WO-2: Scope Vocabulary
- 11 scopes defined in `packages/auth/src/scopes.ts`
- `validateScopes()` helper + `Scope` type
- `app.authorized` and `app.revoked` attestation types added

### WO-3: Consent UI + Authorization Flow
- `/auth/authorize?app_id=...&scopes=...` — consent screen with scope toggles
- `POST /api/auth/authorize` — creates `app.authorized` attestation
- `POST /api/auth/revoke` — creates `app.revoked` attestation + marks original revoked
- Redirects back to app's callback URL with attestation ID

### WO-4: App Auth Middleware
- `requireAppAuth()` in `packages/auth` — validates `X-App-DID` + `X-App-Authorization` headers
- Internal validation endpoint (`POST /auth/api/apps/validate`) — API-key protected
- `GET /api/auth/apps` — list user's connected apps with scopes + dates

## Files Changed
- 13 files, +921 lines
- 5 commits (one per WO + security fix)

## Architecture
- Apps are identities with DIDs — same model as everything else
- Authorization is an attestation type — auditable, revocable, chain-compatible
- Auth flow is pluggable — Phase 2 adds SIWD (Sign In With DFOS) as a second provider behind the same interface
- Middleware validates via service-to-service call, not direct DB access

## POC Target: Karaoke App
First app through the flow will be ima-jin/imajin-karaoke — separate repo, separate deploy, validates the full path.

## Next
- Phase 2: SIWD integration (when DFOS reference implementation ships)
- Phase 3: Scope enforcement rollout per service (profile first, then events, pay, etc.)
- #741: App permission consent & revoke dashboard UI

Closes #244 (Phase 1)
Epic: #738 (Open Wallet)
Work order: `docs/work-orders/wo-244-delegated-app-sessions.md`