### PR TITLE
feat(profile): scope enforcement for app auth (#244 P3)

### DIFF
--- a/apps/kernel/app/profile/api/profile/[id]/counts/route.ts
+++ b/apps/kernel/app/profile/api/profile/[id]/counts/route.ts
@@ -4,6 +4,7 @@ import { getClient } from '@imajin/db';
 import { jsonResponse, errorResponse } from '@/src/lib/kernel/utils';
 import { eq, count } from 'drizzle-orm';
 import { createLogger } from '@imajin/logger';
+import { requireAppAuth } from '@imajin/auth';
 
 const log = createLogger('kernel');
 
@@ -16,6 +17,14 @@ interface RouteParams {
  */
 export async function GET(request: NextRequest, { params }: RouteParams) {
   const { id } = await params;
+
+  // App auth path — validate credentials before returning counts
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'profile:read' });
+    if ('error' in appResult) {
+      return errorResponse(appResult.error, appResult.status);
+    }
+  }
 
   try {
     const profile = await db.query.profiles.findFirst({

--- a/apps/kernel/app/profile/api/profile/[id]/route.ts
+++ b/apps/kernel/app/profile/api/profile/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha2.js';
 import { db, profiles, connections, identityMembers } from '@/src/db';
-import { requireAuth } from '@imajin/auth';
+import { requireAuth, requireAppAuth } from '@imajin/auth';
 import { corsOptions, corsHeaders } from "@/src/lib/kernel/cors";
 import { eq, or, and, isNull, count } from 'drizzle-orm';
 import { getSessionFromCookies } from '@/src/lib/kernel/session';
@@ -71,6 +71,12 @@ async function verifySignedRequest(request: NextRequest, body: string): Promise<
   }
 }
 
+/** Fields safe to return for profile:read app scope */
+function filterProfileForApp(profile: Record<string, any>): Record<string, any> {
+  const { did, displayName, handle, avatar, bio, visibility, scope, subtype } = profile;
+  return { did, displayName, handle, avatar, bio, visibility, scope, subtype };
+}
+
 /** Try to get viewer DID from session cookie (non-blocking) */
 async function getViewerDid(request: NextRequest): Promise<string | null> {
   try {
@@ -113,6 +119,27 @@ export async function OPTIONS(request: NextRequest) {
 export async function GET(request: NextRequest, { params }: RouteParams) {
   const { id } = await params;
   const cors = corsHeaders(request);
+
+  // App auth path — takes precedence over cookie auth if app headers are present
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'profile:read' });
+    if ('error' in appResult) {
+      return NextResponse.json({ error: appResult.error }, { status: appResult.status, headers: cors });
+    }
+    try {
+      const profile = await db.query.profiles.findFirst({
+        where: (profiles, { eq, or }) =>
+          or(eq(profiles.did, id), eq(profiles.handle, id)),
+      });
+      if (!profile) {
+        return NextResponse.json({ error: 'Profile not found' }, { status: 404, headers: cors });
+      }
+      return NextResponse.json(filterProfileForApp(profile as Record<string, any>), { headers: cors });
+    } catch (error) {
+      log.error({ err: String(error) }, 'Failed to fetch profile (app auth)');
+      return NextResponse.json({ error: 'Failed to fetch profile' }, { status: 500, headers: cors });
+    }
+  }
 
   try {
     // Look up by DID or handle

--- a/apps/kernel/app/profile/api/profile/search/route.ts
+++ b/apps/kernel/app/profile/api/profile/search/route.ts
@@ -1,8 +1,16 @@
 import { NextRequest } from 'next/server';
 import { db, profiles } from '@/src/db';
 import { jsonResponse, errorResponse } from '@/src/lib/kernel/utils';
+import { corsHeaders } from '@/src/lib/kernel/cors';
 import { ilike, or, sql, type SQL } from 'drizzle-orm';
 import { withLogger } from '@imajin/logger';
+import { requireAppAuth } from '@imajin/auth';
+
+/** Fields safe to return for profile:read app scope */
+function filterProfileForApp(profile: Record<string, any>): Record<string, any> {
+  const { did, displayName, handle, avatar, bio, visibility, scope, subtype } = profile;
+  return { did, displayName, handle, avatar, bio, visibility, scope, subtype };
+}
 
 /**
  * GET /api/profile/search - Search profiles
@@ -13,6 +21,17 @@ import { withLogger } from '@imajin/logger';
  * - offset: pagination offset
  */
 export const GET = withLogger('kernel', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  // App auth path — validate and return filtered results
+  const isAppRequest = !!request.headers.get('x-app-did');
+  if (isAppRequest) {
+    const appResult = await requireAppAuth(request, { scope: 'profile:read' });
+    if ('error' in appResult) {
+      return errorResponse(appResult.error, appResult.status, cors);
+    }
+  }
+
   const searchParams = request.nextUrl.searchParams;
 
   const q = searchParams.get('q');
@@ -49,15 +68,19 @@ export const GET = withLogger('kernel', async (request: NextRequest, { log }) =>
     
     const total = Number(countResult[0]?.count || 0);
 
+    const profileData = isAppRequest
+      ? results.map(p => filterProfileForApp(p as Record<string, any>))
+      : results;
+
     return jsonResponse({
-      profiles: results,
+      profiles: profileData,
       pagination: {
         total,
         limit,
         offset,
         hasMore: offset + results.length < total,
       },
-    });
+    }, 200, isAppRequest ? cors : undefined);
   } catch (error) {
     log.error({ err: String(error) }, 'Failed to search profiles');
     return errorResponse('Failed to search profiles', 500);


### PR DESCRIPTION
Wires `requireAppAuth('profile:read')` into profile GET, search, and counts endpoints. Apps with valid credentials get filtered profile data (did, displayName, handle, avatar, bio, visibility, scope, subtype). Existing cookie-based auth is untouched.

3 files, +62 lines. Epic: #738