### PR TITLE
feat(auth): developer apps management UI — register, view, edit, revoke (#244)

### DIFF
--- a/apps/kernel/app/api/registry/apps/route.ts
+++ b/apps/kernel/app/api/registry/apps/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { nanoid } from 'nanoid';
 import { db, registryApps } from '@/src/db';
-import { eq, desc } from 'drizzle-orm';
+import { eq, desc, and } from 'drizzle-orm';
 import { requireAuth, isValidPublicKey } from '@imajin/auth';
 import { didFromPublicKey, publicKeyFromDid } from '@/src/lib/auth/crypto';
 import { withLogger } from '@imajin/logger';
@@ -66,10 +66,25 @@ export const POST = withLogger('kernel', async (request: NextRequest) => {
 });
 
 // GET /api/registry/apps — list active apps (public, paginated)
+// ?owner=me — filter to apps owned by the authenticated user
 export const GET = withLogger('kernel', async (request: NextRequest) => {
   const url = new URL(request.url);
   const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '20', 10), 100);
   const offset = Math.max(parseInt(url.searchParams.get('offset') ?? '0', 10), 0);
+  const owner = url.searchParams.get('owner');
+
+  let ownerDid: string | null = null;
+  if (owner === 'me') {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    ownerDid = authResult.identity.id;
+  }
+
+  const whereClause = ownerDid
+    ? and(eq(registryApps.ownerDid, ownerDid))
+    : eq(registryApps.status, 'active');
 
   const apps = await db
     .select({
@@ -87,7 +102,7 @@ export const GET = withLogger('kernel', async (request: NextRequest) => {
       createdAt: registryApps.createdAt,
     })
     .from(registryApps)
-    .where(eq(registryApps.status, 'active'))
+    .where(whereClause)
     .orderBy(desc(registryApps.createdAt))
     .limit(limit)
     .offset(offset);

--- a/apps/kernel/app/auth/components/IdentityTabBar.tsx
+++ b/apps/kernel/app/auth/components/IdentityTabBar.tsx
@@ -17,6 +17,7 @@ interface Tab {
 const ALL_TABS: Tab[] = [
   { label: 'Profile', href: '/auth', exact: true },
   { label: 'Attestations', href: '/auth/attestations', exact: false },
+  { label: 'Developer', href: '/auth/developer/apps', exact: false },
   { label: 'Settings', href: '/auth/settings', exact: false },
   { label: 'Members', href: '/auth/members', exact: false },
 ];

--- a/apps/kernel/app/auth/developer/apps/[appId]/components/AppDetailClient.tsx
+++ b/apps/kernel/app/auth/developer/apps/[appId]/components/AppDetailClient.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { SCOPES } from '@imajin/auth';
+
+interface App {
+  id: string;
+  name: string;
+  description: string | null;
+  appDid: string;
+  publicKey: string;
+  callbackUrl: string;
+  homepageUrl: string | null;
+  logoUrl: string | null;
+  requestedScopes: string[] | null;
+  status: string;
+  createdAt: Date | string | null;
+  updatedAt: Date | string | null;
+}
+
+interface Props {
+  app: App;
+}
+
+function CopyButton({ text, label }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+  return (
+    <button
+      onClick={copy}
+      className="text-xs px-2 py-0.5 rounded border border-zinc-700 text-zinc-500 hover:text-amber-400 hover:border-amber-500/50 transition-colors"
+    >
+      {copied ? 'Copied!' : (label ?? 'Copy')}
+    </button>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-1">{label}</p>
+      {children}
+    </div>
+  );
+}
+
+export default function AppDetailClient({ app: initialApp }: Props) {
+  const router = useRouter();
+  const [app, setApp] = useState(initialApp);
+  const [editing, setEditing] = useState(false);
+  const [showRevoke, setShowRevoke] = useState(false);
+
+  // Edit state
+  const [editName, setEditName] = useState(app.name);
+  const [editDescription, setEditDescription] = useState(app.description ?? '');
+  const [editCallbackUrl, setEditCallbackUrl] = useState(app.callbackUrl);
+  const [editHomepageUrl, setEditHomepageUrl] = useState(app.homepageUrl ?? '');
+  const [editLogoUrl, setEditLogoUrl] = useState(app.logoUrl ?? '');
+  const [editScopes, setEditScopes] = useState<string[]>(app.requestedScopes ?? []);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+
+  const [revoking, setRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState('');
+
+  function toggleEditScope(scope: string) {
+    setEditScopes(prev =>
+      prev.includes(scope) ? prev.filter(s => s !== scope) : [...prev, scope]
+    );
+  }
+
+  function startEdit() {
+    setEditName(app.name);
+    setEditDescription(app.description ?? '');
+    setEditCallbackUrl(app.callbackUrl);
+    setEditHomepageUrl(app.homepageUrl ?? '');
+    setEditLogoUrl(app.logoUrl ?? '');
+    setEditScopes(app.requestedScopes ?? []);
+    setSaveError('');
+    setEditing(true);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaveError('');
+    try {
+      const res = await fetch(`/api/registry/apps/${app.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          name: editName.trim(),
+          description: editDescription.trim() || null,
+          callbackUrl: editCallbackUrl.trim(),
+          homepageUrl: editHomepageUrl.trim() || null,
+          logoUrl: editLogoUrl.trim() || null,
+          requestedScopes: editScopes,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setSaveError(data.error || 'Save failed');
+        return;
+      }
+      setApp(data);
+      setEditing(false);
+    } catch {
+      setSaveError('Network error — please try again');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRevoke() {
+    setRevoking(true);
+    setRevokeError('');
+    try {
+      const res = await fetch(`/api/registry/apps/${app.id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setRevokeError(data.error || 'Revoke failed');
+        return;
+      }
+      router.push('/auth/developer/apps');
+    } catch {
+      setRevokeError('Network error — please try again');
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  const scopes = app.requestedScopes ?? [];
+  const createdAt = app.createdAt ? new Date(app.createdAt).toLocaleString() : '—';
+  const updatedAt = app.updatedAt ? new Date(app.updatedAt).toLocaleString() : '—';
+
+  if (editing) {
+    return (
+      <div className="space-y-4">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 space-y-4">
+          <div className="flex items-center justify-between mb-1">
+            <h2 className="text-sm font-semibold text-white">Edit App</h2>
+            <button
+              onClick={() => setEditing(false)}
+              className="text-zinc-500 hover:text-zinc-300 text-sm transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+
+          {/* Name */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Name <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={editName}
+              onChange={e => setEditName(e.target.value)}
+              required
+              maxLength={100}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors text-sm"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Description
+            </label>
+            <textarea
+              value={editDescription}
+              onChange={e => setEditDescription(e.target.value)}
+              rows={2}
+              maxLength={500}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors resize-none text-sm"
+            />
+          </div>
+
+          {/* Callback URL */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Callback URL <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="url"
+              value={editCallbackUrl}
+              onChange={e => setEditCallbackUrl(e.target.value)}
+              required
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors text-sm"
+            />
+          </div>
+
+          {/* Homepage URL */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Homepage URL
+            </label>
+            <input
+              type="url"
+              value={editHomepageUrl}
+              onChange={e => setEditHomepageUrl(e.target.value)}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors text-sm"
+            />
+          </div>
+
+          {/* Logo URL */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              Logo URL
+            </label>
+            <input
+              type="url"
+              value={editLogoUrl}
+              onChange={e => setEditLogoUrl(e.target.value)}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors text-sm"
+            />
+          </div>
+
+          {/* Scopes */}
+          <div>
+            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
+              Requested Scopes
+            </label>
+            <div className="space-y-1.5">
+              {Object.entries(SCOPES).map(([scope, label]) => (
+                <label key={scope} className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={editScopes.includes(scope)}
+                    onChange={() => toggleEditScope(scope)}
+                    className="w-4 h-4 rounded border-zinc-600 bg-zinc-800 text-amber-500 focus:ring-amber-500 focus:ring-offset-zinc-900"
+                  />
+                  <span className="text-sm">
+                    <span className="font-mono text-xs text-amber-400/80 mr-2">{scope}</span>
+                    <span className="text-zinc-400">{label}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {saveError && (
+            <p className="text-sm text-red-400 bg-red-900/20 border border-red-800/40 rounded-lg px-3 py-2.5">
+              {saveError}
+            </p>
+          )}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={() => setEditing(false)}
+              className="flex-1 px-4 py-2.5 bg-zinc-800 border border-zinc-700 rounded-lg text-zinc-400 hover:text-white transition-colors text-sm font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || !editName.trim() || !editCallbackUrl.trim()}
+              className="flex-1 px-4 py-2.5 bg-amber-500 hover:bg-amber-400 disabled:bg-amber-900/40 disabled:text-amber-700 text-black font-semibold rounded-lg transition-colors text-sm"
+            >
+              {saving ? 'Saving…' : 'Save Changes'}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <h1 className="text-base font-semibold text-white">{app.name}</h1>
+              <span className={`text-[10px] px-1.5 py-0.5 rounded-full border ${
+                app.status === 'active'
+                  ? 'bg-green-900/30 border-green-800/50 text-green-400'
+                  : 'bg-red-900/30 border-red-800/50 text-red-400'
+              }`}>
+                {app.status}
+              </span>
+            </div>
+            {app.description && (
+              <p className="text-sm text-zinc-400">{app.description}</p>
+            )}
+          </div>
+          {app.status === 'active' && (
+            <button
+              onClick={startEdit}
+              className="px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors shrink-0"
+            >
+              Edit
+            </button>
+          )}
+        </div>
+
+        <div className="grid gap-3 pt-2 border-t border-zinc-800">
+          <Field label="App ID">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-mono text-zinc-300">{app.id}</span>
+              <CopyButton text={app.id} />
+            </div>
+          </Field>
+
+          <Field label="App DID">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-mono text-zinc-300 break-all">{app.appDid}</span>
+              <CopyButton text={app.appDid} />
+            </div>
+          </Field>
+
+          <Field label="Public Key">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-mono text-zinc-400 break-all">{app.publicKey}</span>
+              <CopyButton text={app.publicKey} />
+            </div>
+          </Field>
+
+          <Field label="Callback URL">
+            <span className="text-sm text-zinc-300">{app.callbackUrl}</span>
+          </Field>
+
+          {app.homepageUrl && (
+            <Field label="Homepage URL">
+              <span className="text-sm text-zinc-300">{app.homepageUrl}</span>
+            </Field>
+          )}
+
+          {app.logoUrl && (
+            <Field label="Logo URL">
+              <span className="text-sm text-zinc-300">{app.logoUrl}</span>
+            </Field>
+          )}
+
+          {scopes.length > 0 && (
+            <Field label="Requested Scopes">
+              <div className="flex flex-wrap gap-1.5 mt-1">
+                {scopes.map(scope => (
+                  <span key={scope} className="text-xs px-2 py-0.5 rounded-full bg-zinc-800 border border-zinc-700 text-zinc-300 font-mono">
+                    {scope}
+                  </span>
+                ))}
+              </div>
+            </Field>
+          )}
+
+          <div className="grid grid-cols-2 gap-3 pt-1 border-t border-zinc-800">
+            <Field label="Created">
+              <span className="text-xs text-zinc-400">{createdAt}</span>
+            </Field>
+            <Field label="Updated">
+              <span className="text-xs text-zinc-400">{updatedAt}</span>
+            </Field>
+          </div>
+        </div>
+      </div>
+
+      {/* Danger zone */}
+      {app.status === 'active' && (
+        <div className="bg-zinc-900 border border-red-900/40 rounded-xl p-5">
+          <h3 className="text-sm font-semibold text-red-400 mb-1">Danger Zone</h3>
+          <p className="text-xs text-zinc-500 mb-3">
+            Revoking this app will immediately invalidate all active sessions and prevent any new authorizations.
+          </p>
+
+          {!showRevoke ? (
+            <button
+              onClick={() => setShowRevoke(true)}
+              className="px-4 py-2 border border-red-900/60 text-red-400 hover:bg-red-900/20 rounded-lg text-sm transition-colors"
+            >
+              Revoke App
+            </button>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-sm text-red-300">
+                Are you sure you want to revoke <strong>{app.name}</strong>? This cannot be undone.
+              </p>
+              {revokeError && (
+                <p className="text-sm text-red-400 bg-red-900/20 border border-red-800/40 rounded-lg px-3 py-2">
+                  {revokeError}
+                </p>
+              )}
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setShowRevoke(false)}
+                  className="px-4 py-2 bg-zinc-800 border border-zinc-700 text-zinc-400 hover:text-white rounded-lg text-sm transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleRevoke}
+                  disabled={revoking}
+                  className="px-4 py-2 bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white font-semibold rounded-lg text-sm transition-colors"
+                >
+                  {revoking ? 'Revoking…' : 'Yes, Revoke App'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/developer/apps/[appId]/page.tsx
+++ b/apps/kernel/app/auth/developer/apps/[appId]/page.tsx
@@ -1,0 +1,54 @@
+import { cookies } from 'next/headers';
+import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
+import { db, registryApps } from '@/src/db';
+import { eq } from 'drizzle-orm';
+import { redirect, notFound } from 'next/navigation';
+import Link from 'next/link';
+import AppDetailClient from './components/AppDetailClient';
+
+export default async function AppDetailPage({
+  params,
+}: {
+  params: { appId: string };
+}) {
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  if (!sessionDid) {
+    redirect('/auth/login');
+  }
+
+  const [app] = await db
+    .select()
+    .from(registryApps)
+    .where(eq(registryApps.id, params.appId));
+
+  if (!app) {
+    notFound();
+  }
+
+  if (app.ownerDid !== sessionDid) {
+    redirect('/auth/developer/apps');
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Link
+          href="/auth/developer/apps"
+          className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+        >
+          ← Developer Apps
+        </Link>
+      </div>
+      <AppDetailClient app={app} />
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/developer/apps/components/DevAppsShell.tsx
+++ b/apps/kernel/app/auth/developer/apps/components/DevAppsShell.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import RegisterAppForm from './RegisterAppForm';
+
+interface App {
+  id: string;
+  name: string;
+  description: string | null;
+  appDid: string;
+  status: string;
+  requestedScopes: string[] | null;
+  createdAt: Date | string | null;
+}
+
+interface RegisteredApp {
+  id: string;
+  appDid: string;
+  name: string;
+}
+
+interface Props {
+  apps: App[];
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <button
+      onClick={copy}
+      className="text-[10px] text-zinc-600 hover:text-amber-400 transition-colors ml-1"
+      title="Copy"
+    >
+      {copied ? '✓' : '⧉'}
+    </button>
+  );
+}
+
+function SuccessBanner({ app, onDismiss }: { app: RegisteredApp; onDismiss: () => void }) {
+  return (
+    <div className="bg-green-900/20 border border-green-800/40 rounded-xl p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-semibold text-green-400">App registered successfully</p>
+        <button onClick={onDismiss} className="text-zinc-500 hover:text-zinc-300 text-xs transition-colors">
+          Dismiss
+        </button>
+      </div>
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-zinc-500 w-16 shrink-0">App ID</span>
+          <span className="text-xs font-mono text-zinc-300">{app.id}</span>
+          <CopyButton text={app.id} />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-zinc-500 w-16 shrink-0">App DID</span>
+          <span className="text-xs font-mono text-zinc-300 break-all">{app.appDid}</span>
+          <CopyButton text={app.appDid} />
+        </div>
+      </div>
+      <Link
+        href={`/auth/developer/apps/${app.id}`}
+        className="inline-block text-xs text-amber-400 hover:text-amber-300 transition-colors"
+      >
+        View app details →
+      </Link>
+    </div>
+  );
+}
+
+function AppCard({ app }: { app: App }) {
+  const createdAt = app.createdAt ? new Date(app.createdAt).toLocaleDateString() : '—';
+  const scopes = (app.requestedScopes ?? []) as string[];
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 hover:border-zinc-700 transition-colors">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="text-sm font-semibold text-white truncate">{app.name}</h3>
+            <span className={`text-[10px] px-1.5 py-0.5 rounded-full border shrink-0 ${
+              app.status === 'active'
+                ? 'bg-green-900/30 border-green-800/50 text-green-400'
+                : 'bg-red-900/30 border-red-800/50 text-red-400'
+            }`}>
+              {app.status}
+            </span>
+          </div>
+          {app.description && (
+            <p className="text-xs text-zinc-400 mb-2 line-clamp-2">{app.description}</p>
+          )}
+          <div className="flex items-center gap-1 mb-2">
+            <span className="text-[10px] font-mono text-zinc-500 truncate">{app.appDid}</span>
+            <CopyButton text={app.appDid} />
+          </div>
+          {scopes.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {scopes.slice(0, 4).map(scope => (
+                <span key={scope} className="text-[10px] px-1.5 py-0.5 rounded-full bg-zinc-800 border border-zinc-700 text-zinc-400 font-mono">
+                  {scope}
+                </span>
+              ))}
+              {scopes.length > 4 && (
+                <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-zinc-800 border border-zinc-700 text-zinc-500">
+                  +{scopes.length - 4} more
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="text-right shrink-0">
+          <p className="text-[10px] text-zinc-600 mb-2">{createdAt}</p>
+          <Link
+            href={`/auth/developer/apps/${app.id}`}
+            className="text-xs text-amber-400 hover:text-amber-300 transition-colors"
+          >
+            Manage →
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DevAppsShell({ apps: initialApps }: Props) {
+  const [apps, setApps] = useState<App[]>(initialApps);
+  const [showForm, setShowForm] = useState(false);
+  const [newApp, setNewApp] = useState<RegisteredApp | null>(null);
+
+  function handleSuccess(app: RegisteredApp) {
+    setNewApp(app);
+    setShowForm(false);
+    // Reload to pick up new app from server
+    window.location.reload();
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-base font-semibold text-white">Developer Apps</h1>
+          <p className="text-xs text-zinc-500 mt-0.5">Apps registered under your identity</p>
+        </div>
+        {!showForm && (
+          <button
+            onClick={() => setShowForm(true)}
+            className="px-3 py-2 bg-amber-500 hover:bg-amber-400 text-black text-sm font-semibold rounded-lg transition-colors"
+          >
+            Register new app
+          </button>
+        )}
+      </div>
+
+      {newApp && <SuccessBanner app={newApp} onDismiss={() => setNewApp(null)} />}
+
+      {showForm && (
+        <RegisterAppForm
+          onSuccess={handleSuccess}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
+
+      {apps.length === 0 && !showForm ? (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-8 text-center">
+          <p className="text-2xl mb-3">🔑</p>
+          <p className="text-sm text-zinc-400 mb-4">No apps registered yet.</p>
+          <button
+            onClick={() => setShowForm(true)}
+            className="px-4 py-2 bg-amber-500 hover:bg-amber-400 text-black text-sm font-semibold rounded-lg transition-colors"
+          >
+            Register your first app
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {apps.map(app => (
+            <AppCard key={app.id} app={app} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/developer/apps/components/RegisterAppForm.tsx
+++ b/apps/kernel/app/auth/developer/apps/components/RegisterAppForm.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { SCOPES } from '@imajin/auth';
+
+interface RegisteredApp {
+  id: string;
+  appDid: string;
+  name: string;
+}
+
+interface Props {
+  onSuccess: (app: RegisteredApp) => void;
+  onCancel: () => void;
+}
+
+const NODE_ONELINER = `node -e "const{generateKeyPairSync}=require('crypto');const{publicKey,privateKey}=generateKeyPairSync('ed25519');console.log('Public:',publicKey.export({type:'spki',format:'der'}).toString('hex').slice(-64));console.log('Private:',privateKey.export({type:'pkcs8',format:'der'}).toString('hex').slice(-64))"`;
+
+const NOBLE_ONELINER = `npx -y tsx -e "import{etc,getPublicKey}from'@noble/ed25519';const priv=etc.randomPrivateKey();console.log('Private:',Buffer.from(priv).toString('hex'));import{sha512}from'@noble/hashes/sha2.js';etc.sha512Sync=(...m)=>sha512(etc.concatBytes(...m));console.log('Public:',Buffer.from(getPublicKey(priv)).toString('hex'))"`;
+
+export default function RegisterAppForm({ onSuccess, onCancel }: Props) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [callbackUrl, setCallbackUrl] = useState('');
+  const [homepageUrl, setHomepageUrl] = useState('');
+  const [logoUrl, setLogoUrl] = useState('');
+  const [publicKey, setPublicKey] = useState('');
+  const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
+  const [showKeypairHelp, setShowKeypairHelp] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const [error, setError] = useState('');
+
+  function toggleScope(scope: string) {
+    setSelectedScopes(prev =>
+      prev.includes(scope) ? prev.filter(s => s !== scope) : [...prev, scope]
+    );
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus('loading');
+    setError('');
+
+    try {
+      const res = await fetch('/api/registry/apps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim() || undefined,
+          callbackUrl: callbackUrl.trim(),
+          homepageUrl: homepageUrl.trim() || undefined,
+          logoUrl: logoUrl.trim() || undefined,
+          publicKey: publicKey.trim(),
+          requestedScopes: selectedScopes,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setStatus('error');
+        setError(data.error || 'Registration failed');
+        return;
+      }
+
+      onSuccess(data);
+    } catch {
+      setStatus('error');
+      setError('Network error — please try again');
+    }
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
+      <div className="flex items-center justify-between mb-5">
+        <h2 className="text-base font-semibold text-white">Register New App</h2>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-zinc-500 hover:text-zinc-300 text-sm transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Name */}
+        <div>
+          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            App Name <span className="text-red-400">*</span>
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="My Awesome App"
+            required
+            maxLength={100}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors text-sm"
+          />
+        </div>
+
+        {/* Description */}
+        <div>
+          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            Description <span className="text-zinc-600">(optional)</span>
+          </label>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="What does your app do?"
+            rows={2}
+            maxLength={500}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors resize-none text-sm"
+          />
+        </div>
+
+        {/* Callback URL */}
+        <div>
+          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            Callback URL <span className="text-red-400">*</span>
+          </label>
+          <input
+            type="url"
+            value={callbackUrl}
+            onChange={e => setCallbackUrl(e.target.value)}
+            placeholder="https://yourapp.com/auth/callback"
+            required
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors text-sm"
+          />
+          <p className="mt-1 text-xs text-zinc-600">Where users are redirected after granting consent</p>
+        </div>
+
+        {/* Homepage URL */}
+        <div>
+          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            Homepage URL <span className="text-zinc-600">(optional)</span>
+          </label>
+          <input
+            type="url"
+            value={homepageUrl}
+            onChange={e => setHomepageUrl(e.target.value)}
+            placeholder="https://yourapp.com"
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors text-sm"
+          />
+        </div>
+
+        {/* Logo URL */}
+        <div>
+          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            Logo URL <span className="text-zinc-600">(optional)</span>
+          </label>
+          <input
+            type="url"
+            value={logoUrl}
+            onChange={e => setLogoUrl(e.target.value)}
+            placeholder="https://yourapp.com/logo.png"
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors text-sm"
+          />
+        </div>
+
+        {/* Requested Scopes */}
+        <div>
+          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
+            Requested Scopes
+          </label>
+          <div className="space-y-1.5">
+            {Object.entries(SCOPES).map(([scope, label]) => (
+              <label key={scope} className="flex items-center gap-3 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  checked={selectedScopes.includes(scope)}
+                  onChange={() => toggleScope(scope)}
+                  className="w-4 h-4 rounded border-zinc-600 bg-zinc-800 text-amber-500 focus:ring-amber-500 focus:ring-offset-zinc-900"
+                />
+                <span className="text-sm">
+                  <span className="font-mono text-xs text-amber-400/80 mr-2">{scope}</span>
+                  <span className="text-zinc-400">{label}</span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Public Key */}
+        <div>
+          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            Public Key <span className="text-red-400">*</span>
+          </label>
+          <textarea
+            value={publicKey}
+            onChange={e => setPublicKey(e.target.value)}
+            placeholder="64-character hex Ed25519 public key"
+            rows={2}
+            required
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2.5 text-white placeholder-zinc-600 focus:outline-none focus:border-amber-500 transition-colors resize-none text-sm font-mono"
+          />
+          <p className="mt-1 text-xs text-zinc-500">
+            Generate an Ed25519 keypair and paste your public key (hex, 64 chars). Your private key stays with you.
+          </p>
+
+          {/* Keypair help */}
+          <div className="mt-2">
+            <button
+              type="button"
+              onClick={() => setShowKeypairHelp(!showKeypairHelp)}
+              className="text-xs text-amber-400/70 hover:text-amber-400 transition-colors flex items-center gap-1"
+            >
+              <span>{showKeypairHelp ? '▼' : '▶'}</span>
+              How to generate a keypair
+            </button>
+
+            {showKeypairHelp && (
+              <div className="mt-2 space-y-3 p-3 bg-zinc-800/50 rounded-lg border border-zinc-700/50">
+                <div>
+                  <p className="text-xs text-zinc-400 mb-1.5 font-medium">Option 1 — Node.js built-in:</p>
+                  <div className="relative">
+                    <pre className="text-[10px] text-zinc-300 font-mono bg-zinc-900 rounded p-2 overflow-x-auto whitespace-pre-wrap break-all">{NODE_ONELINER}</pre>
+                  </div>
+                </div>
+                <div>
+                  <p className="text-xs text-zinc-400 mb-1.5 font-medium">Option 2 — @noble/ed25519:</p>
+                  <div className="relative">
+                    <pre className="text-[10px] text-zinc-300 font-mono bg-zinc-900 rounded p-2 overflow-x-auto whitespace-pre-wrap break-all">{NOBLE_ONELINER}</pre>
+                  </div>
+                </div>
+                <p className="text-[10px] text-zinc-500">
+                  Save the private key securely — you will need it to sign requests. Never share it.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-400 bg-red-900/20 border border-red-800/40 rounded-lg px-3 py-2.5">
+            {error}
+          </p>
+        )}
+
+        <div className="flex gap-3 pt-1">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 px-4 py-2.5 bg-zinc-800 border border-zinc-700 rounded-lg text-zinc-400 hover:text-white hover:border-zinc-600 transition-colors text-sm font-medium"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={status === 'loading' || !name.trim() || !callbackUrl.trim() || !publicKey.trim()}
+            className="flex-1 px-4 py-2.5 bg-amber-500 hover:bg-amber-400 disabled:bg-amber-900/40 disabled:text-amber-700 text-black font-semibold rounded-lg transition-colors text-sm"
+          >
+            {status === 'loading' ? 'Registering…' : 'Register App'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/developer/apps/page.tsx
+++ b/apps/kernel/app/auth/developer/apps/page.tsx
@@ -1,0 +1,38 @@
+import { cookies } from 'next/headers';
+import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
+import { db, registryApps } from '@/src/db';
+import { eq, desc } from 'drizzle-orm';
+import { redirect } from 'next/navigation';
+import DevAppsShell from './components/DevAppsShell';
+
+export default async function DeveloperAppsPage() {
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  if (!sessionDid) {
+    redirect('/auth/login');
+  }
+
+  const apps = await db
+    .select({
+      id: registryApps.id,
+      name: registryApps.name,
+      description: registryApps.description,
+      appDid: registryApps.appDid,
+      status: registryApps.status,
+      requestedScopes: registryApps.requestedScopes,
+      createdAt: registryApps.createdAt,
+    })
+    .from(registryApps)
+    .where(eq(registryApps.ownerDid, sessionDid))
+    .orderBy(desc(registryApps.createdAt));
+
+  return <DevAppsShell apps={apps} />;
+}


### PR DESCRIPTION
Developer-facing app management for Delegated App Sessions.

## Pages
- `/auth/developer/apps` — list your registered apps, register new ones
- `/auth/developer/apps/[appId]` — detail, inline edit, revoke

## Registration form
- Name, description, callback URL, homepage, logo, scope checkboxes
- Public key textarea with collapsible keypair generation instructions
- Submit → POST /api/registry/apps → shows app ID + DID (copyable)

## App detail
- All fields displayed with copy buttons (ID, DID, public key)
- Inline edit mode for name, description, URLs, scopes
- Revoke with confirmation step

## API update
- `GET /api/registry/apps?owner=me` filters to authenticated user's apps

## Navigation
- 'Developer' tab added to identity hub tab bar

7 files, +976 lines. Epic: #738