### PR TITLE
feat(kernel): scope-aware write operations (#602)

### DIFF
--- a/apps/coffee/app/api/tip/route.ts
+++ b/apps/coffee/app/api/tip/route.ts
@@ -77,9 +77,11 @@ export async function POST(request: NextRequest) {
 
     // Get sender identity if authenticated
     let fromDid: string | null = null;
+    let fromHumanDid: string | null = null;
     const authResult = await requireAuth(request as any);
     if ('identity' in authResult) {
-      fromDid = authResult.identity.id;
+      fromDid = authResult.identity.actingAs || authResult.identity.id;
+      fromHumanDid = authResult.identity.id;
     }
 
     // Create tip record (pending)
@@ -142,7 +144,7 @@ export async function POST(request: NextRequest) {
       // Fire and forget — never block the response
       if (fromDid) {
         emitAttestation({
-          issuer_did: fromDid,
+          issuer_did: fromHumanDid!,
           subject_did: page.did,
           type: 'tip.granted',
           context_id: tipId,
@@ -179,7 +181,7 @@ export async function POST(request: NextRequest) {
       // Fire and forget — never block the response
       if (fromDid) {
         emitAttestation({
-          issuer_did: fromDid,
+          issuer_did: fromHumanDid!,
           subject_did: page.did,
           type: 'tip.granted',
           context_id: tipId,

--- a/apps/dykil/app/api/surveys/[id]/responses/route.ts
+++ b/apps/dykil/app/api/surveys/[id]/responses/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     // Get survey and check ownership
@@ -41,7 +42,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return errorResponse('Survey not found', 404, cors);
     }
 
-    if (survey.did !== identity.id) {
+    if (survey.did !== did) {
       return errorResponse('Not authorized to view responses', 403, cors);
     }
 

--- a/apps/dykil/app/api/surveys/[id]/route.ts
+++ b/apps/dykil/app/api/surveys/[id]/route.ts
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Only return published surveys to non-owners
     const authResult = await requireAuth(request);
-    const isOwner = !('error' in authResult) && authResult.identity.id === survey.did;
+    const isOwner = !('error' in authResult) && (authResult.identity.actingAs || authResult.identity.id) === survey.did;
 
     if (!isOwner && survey.status !== 'published') {
       return errorResponse('Survey not found', 404, cors);
@@ -61,6 +61,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     const existing = await db.query.surveys.findFirst({
@@ -71,7 +72,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
       return errorResponse('Survey not found', 404, cors);
     }
 
-    if (existing.did !== identity.id) {
+    if (existing.did !== did) {
       return errorResponse('Not authorized to update this survey', 403, cors);
     }
 
@@ -114,6 +115,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     const existing = await db.query.surveys.findFirst({
@@ -124,7 +126,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
       return errorResponse('Survey not found', 404, cors);
     }
 
-    if (existing.did !== identity.id) {
+    if (existing.did !== did) {
       return errorResponse('Not authorized to delete this survey', 403, cors);
     }
 

--- a/apps/dykil/app/api/surveys/mine/route.ts
+++ b/apps/dykil/app/api/surveys/mine/route.ts
@@ -26,6 +26,7 @@ export async function GET(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { searchParams } = new URL(request.url);
   const didsParam = searchParams.get('dids');
 
@@ -35,12 +36,12 @@ export async function GET(request: NextRequest) {
     if (didsParam) {
       // Return surveys for specified DIDs (caller must be one of them)
       ownerDids = didsParam.split(',').map(d => d.trim()).filter(Boolean);
-      // Always include the current user
-      if (!ownerDids.includes(identity.id)) {
-        ownerDids.push(identity.id);
+      // Always include the current user (or their active scope)
+      if (!ownerDids.includes(did)) {
+        ownerDids.push(did);
       }
     } else {
-      ownerDids = [identity.id];
+      ownerDids = [did];
     }
 
     const userSurveys = await db.query.surveys.findMany({

--- a/apps/dykil/app/api/surveys/route.ts
+++ b/apps/dykil/app/api/surveys/route.ts
@@ -16,6 +16,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   try {
     const body = await request.json();
@@ -51,7 +52,7 @@ export async function POST(request: NextRequest) {
 
     const [survey] = await db.insert(surveys).values({
       id: generateId('survey'),
-      did: identity.id,
+      did,
       handle: identity.handle || null,
       title,
       description: description || null,
@@ -79,10 +80,11 @@ export async function GET(request: NextRequest) {
   }
 
   const { identity } = authResult;
+  const ownerDid = identity.actingAs || identity.id;
 
   try {
     const userSurveys = await db.query.surveys.findMany({
-      where: (surveys, { eq }) => eq(surveys.did, identity.id),
+      where: (surveys, { eq }) => eq(surveys.did, ownerDid),
       orderBy: (surveys, { desc }) => [desc(surveys.createdAt)],
     });
 

--- a/apps/events/app/api/events/[id]/cohosts/route.ts
+++ b/apps/events/app/api/events/[id]/cohosts/route.ts
@@ -159,7 +159,7 @@ export async function POST(
     // Add to pod as cohost
     await sql`
       INSERT INTO connections.pod_members (pod_id, did, role, added_by, joined_at)
-      VALUES (${event.podId}, ${coHostDid}, 'cohost', ${identity.id}, NOW())
+      VALUES (${event.podId}, ${coHostDid}, 'cohost', ${did}, NOW())
       ON CONFLICT (pod_id, did) DO NOTHING
     `;
 

--- a/apps/events/app/api/events/[id]/my-ticket/route.ts
+++ b/apps/events/app/api/events/[id]/my-ticket/route.ts
@@ -23,6 +23,7 @@ export async function GET(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id: eventId } = await params;
 
   try {
@@ -37,7 +38,7 @@ export async function GET(
       .where(
         and(
           eq(tickets.eventId, eventId),
-          eq(tickets.ownerDid, identity.id)
+          eq(tickets.ownerDid, did)
         )
       );
 
@@ -53,7 +54,7 @@ export async function GET(
 
     if (event.length > 0) {
       // Direct creator check
-      if (event[0].creatorDid === identity.id) {
+      if (event[0].creatorDid === did) {
         isOrganizer = true;
       }
 
@@ -62,7 +63,7 @@ export async function GET(
         const podRole = await sql`
           SELECT role FROM connections.pod_members
           WHERE pod_id = ${event[0].podId}
-            AND did = ${identity.id}
+            AND did = ${did}
             AND role IN ('owner', 'host', 'cohost')
           LIMIT 1
         `;

--- a/apps/events/app/api/events/[id]/queue/route.ts
+++ b/apps/events/app/api/events/[id]/queue/route.ts
@@ -20,6 +20,7 @@ export async function GET(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { searchParams } = new URL(request.url);
   const ticketTypeId = searchParams.get('ticketTypeId');
 
@@ -34,7 +35,7 @@ export async function GET(
       .from(ticketQueue)
       .where(and(
         eq(ticketQueue.ticketTypeId, ticketTypeId),
-        eq(ticketQueue.did, identity.id),
+        eq(ticketQueue.did, did),
         eq(ticketQueue.status, 'waiting')
       ))
       .limit(1);
@@ -84,6 +85,7 @@ export async function POST(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
@@ -114,7 +116,7 @@ export async function POST(
       .from(ticketQueue)
       .where(and(
         eq(ticketQueue.ticketTypeId, ticketTypeId),
-        eq(ticketQueue.did, identity.id),
+        eq(ticketQueue.did, did),
         eq(ticketQueue.status, 'waiting')
       ))
       .limit(1);
@@ -140,7 +142,7 @@ export async function POST(
     const [entry] = await db.insert(ticketQueue).values({
       id: queueId,
       ticketTypeId,
-      did: identity.id,
+      did,
       position: nextPosition,
       status: 'waiting',
     }).returning();
@@ -170,6 +172,7 @@ export async function DELETE(
   }
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
   const { searchParams } = new URL(request.url);
   const ticketTypeId = searchParams.get('ticketTypeId');
 
@@ -182,7 +185,7 @@ export async function DELETE(
       .delete(ticketQueue)
       .where(and(
         eq(ticketQueue.ticketTypeId, ticketTypeId),
-        eq(ticketQueue.did, identity.id),
+        eq(ticketQueue.did, did),
         eq(ticketQueue.status, 'waiting')
       ))
       .returning();

--- a/apps/kernel/app/connections/api/pods/[id]/links/route.ts
+++ b/apps/kernel/app/connections/api/pods/[id]/links/route.ts
@@ -8,11 +8,12 @@ export async function POST(request: Request, { params }: { params: { id: string 
   if ('error' in auth) return NextResponse.json({ error: auth.error }, { status: auth.status });
 
   const body = await request.json();
+  const linkedBy = auth.identity.actingAs || auth.identity.id;
 
   const [link] = await db.insert(podLinks).values({
     parentPodId: params.id,
     childPodId: body.childPodId,
-    linkedBy: auth.identity.id,
+    linkedBy,
     linkedAt: new Date().toISOString(),
   }).returning();
 

--- a/apps/learn/app/api/courses/[slug]/enroll/route.ts
+++ b/apps/learn/app/api/courses/[slug]/enroll/route.ts
@@ -22,6 +22,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
   if (!courseResult[0]) return errorResponse('Course not found', 404);
@@ -34,7 +35,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   const existing = await db.select().from(enrollments)
     .where(and(
       eq(enrollments.courseId, course.id),
-      eq(enrollments.studentDid, identity.id),
+      eq(enrollments.studentDid, did),
     )).limit(1);
 
   if (existing.length > 0) {
@@ -46,7 +47,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const enrollment = {
       id: generateId('enr'),
       courseId: course.id,
-      studentDid: identity.id,
+      studentDid: did,
       paymentId: null,
     };
 
@@ -102,7 +103,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           metadata: {
             type: 'course_enrollment',
             courseId: course.id,
-            studentDid: identity.id,
+            studentDid: did,
           },
         }],
         successUrl,

--- a/apps/learn/app/api/courses/[slug]/lessons/[lessonId]/complete/route.ts
+++ b/apps/learn/app/api/courses/[slug]/lessons/[lessonId]/complete/route.ts
@@ -18,6 +18,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
   if (!courseResult[0]) return errorResponse('Course not found', 404);
@@ -28,7 +29,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   const enrollResult = await db.select().from(enrollments)
     .where(and(
       eq(enrollments.courseId, course.id),
-      eq(enrollments.studentDid, identity.id),
+      eq(enrollments.studentDid, did),
     )).limit(1);
 
   if (enrollResult.length === 0) {

--- a/apps/learn/app/api/courses/[slug]/progress/route.ts
+++ b/apps/learn/app/api/courses/[slug]/progress/route.ts
@@ -17,6 +17,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if ('error' in authResult) return errorResponse(authResult.error, authResult.status);
 
   const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
 
   const courseResult = await db.select().from(courses).where(eq(courses.slug, slug)).limit(1);
   if (!courseResult[0]) return errorResponse('Course not found', 404);
@@ -26,7 +27,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const enrollResult = await db.select().from(enrollments)
     .where(and(
       eq(enrollments.courseId, course.id),
-      eq(enrollments.studentDid, identity.id),
+      eq(enrollments.studentDid, did),
     )).limit(1);
 
   if (enrollResult.length === 0) {

--- a/apps/market/app/api/listings/[id]/purchase/route.ts
+++ b/apps/market/app/api/listings/[id]/purchase/route.ts
@@ -49,10 +49,10 @@ export async function POST(
       if ('error' in authResult) {
         return errorResponse('This listing requires a verified identity to purchase', 403);
       }
-      buyerDid = authResult.identity.id;
+      buyerDid = authResult.identity.actingAs || authResult.identity.id;
     } else {
       const session = await getSession(request);
-      buyerDid = session?.identity?.id;
+      buyerDid = session?.actingAs || session?.id;
     }
 
     // 3. Parse body for quantity


### PR DESCRIPTION
## Summary

Implements scope-aware write operations across all services so that when acting as a scope (e.g. Mooi), write operations use `identity.actingAs || identity.id` instead of `identity.id`.

**Routes updated (13 files):**

- `apps/events/[id]/my-ticket/route.ts` — ticket ownership lookup uses scope DID
- `apps/events/[id]/queue/route.ts` — queue join/check/leave uses scope DID
- `apps/events/[id]/cohosts/route.ts` — `addedBy` uses scope DID
- `apps/market/listings/[id]/purchase/route.ts` — `buyerDid` uses scope DID (trust_gated + standard)
- `apps/coffee/api/tip/route.ts` — `fromDid` uses scope DID; attestation `issuer_did` stays as human DID
- `apps/learn/courses/[slug]/enroll/route.ts` — enrollment `studentDid` uses scope DID
- `apps/learn/courses/[slug]/progress/route.ts` — progress lookup uses scope DID
- `apps/learn/courses/[slug]/lessons/[lessonId]/complete/route.ts` — completion uses scope DID
- `apps/dykil/surveys/route.ts` — survey creation `did` and mine-list query use scope DID
- `apps/dykil/surveys/[id]/route.ts` — GET/PUT/DELETE ownership checks use scope DID
- `apps/dykil/surveys/[id]/responses/route.ts` — ownership check uses scope DID
- `apps/dykil/surveys/mine/route.ts` — owned surveys list uses scope DID
- `apps/kernel/connections/pods/[id]/links/route.ts` — `linkedBy` uses scope DID

**Already correct (no changes needed):** events POST, market listings POST, all chat routes, all pod routes, media assets route

**Intentionally unchanged per spec:** all attestation `issuer_did` fields (always human), auth routes, check-in `checkedInBy`, DFOS chain presentation

Closes #602 / Epic #581

## Test plan
- [ ] Acting as Mooi: create event → `creatorDid` is Mooi's DID
- [ ] Acting as Mooi: join ticket queue → queue entry `did` is Mooi's DID
- [ ] Acting as Mooi: purchase listing → `buyerDid` is Mooi's DID
- [ ] Acting as Mooi: send tip → `fromDid` is Mooi's DID, attestation issuer remains human
- [ ] Acting as Mooi: enroll in course → `studentDid` is Mooi's DID
- [ ] Acting as Mooi: create survey → survey `did` is Mooi's DID
- [ ] Acting as Mooi: `/surveys/mine` → returns Mooi's surveys
- [ ] Acting as self (no scope): all routes behave identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)