### PR TITLE
feat: @imajin/bus event pipeline with 4 route migrations - Claude Code (#759)

### DIFF
--- a/apps/coffee/app/api/tip/route.ts
+++ b/apps/coffee/app/api/tip/route.ts
@@ -2,7 +2,8 @@ import { NextRequest } from 'next/server';
 import { createLogger } from '@imajin/logger';
 const log = createLogger('coffee');
 import { db, coffeePages, tips } from '@/db';
-import { requireAuth, emitAttestation } from '@imajin/auth';
+import { requireAuth } from '@imajin/auth';
+import { bus } from '@imajin/bus';
 import { jsonResponse, errorResponse, generateId } from '@/lib/utils';
 import { rateLimit, getClientIP } from '@/lib/rate-limit';
 
@@ -143,14 +144,14 @@ export async function POST(request: NextRequest) {
 
       // Fire and forget — never block the response
       if (fromDid) {
-        emitAttestation({
-          issuer_did: fromHumanDid!,
-          subject_did: page.did,
-          type: 'tip.granted',
-          context_id: tipId,
-          context_type: 'coffee',
-          payload: { amount, currency },
-        }).catch((err) => log.error({ err: String(err) }, 'Attestation emit error'));
+        bus.publish('tip.initiated', {
+          fromDid,
+          fromHumanDid: fromHumanDid!,
+          toDid: page.did,
+          tipId,
+          amount,
+          currency,
+        }).catch((err) => log.error({ err: String(err) }, '[tip] bus tip.initiated error'));
       }
 
       // Return checkout URL for redirect
@@ -180,14 +181,14 @@ export async function POST(request: NextRequest) {
 
       // Fire and forget — never block the response
       if (fromDid) {
-        emitAttestation({
-          issuer_did: fromHumanDid!,
-          subject_did: page.did,
-          type: 'tip.granted',
-          context_id: tipId,
-          context_type: 'coffee',
-          payload: { amount, currency: 'SOL' },
-        }).catch((err) => log.error({ err: String(err) }, 'Attestation emit error'));
+        bus.publish('tip.initiated', {
+          fromDid,
+          fromHumanDid: fromHumanDid!,
+          toDid: page.did,
+          tipId,
+          amount,
+          currency: 'SOL',
+        }).catch((err) => log.error({ err: String(err) }, '[tip] bus tip.initiated error'));
       }
 
       return jsonResponse({

--- a/apps/coffee/package.json
+++ b/apps/coffee/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@imajin/auth": "workspace:*",
+    "@imajin/bus": "workspace:*",
     "@imajin/logger": "workspace:*",
     "@imajin/fair": "workspace:*",
     "@imajin/media": "workspace:*",

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -12,14 +12,12 @@ import { db, events, ticketTypes, tickets, orders } from '@/src/db';
 const log = createLogger('events');
 import { eq, and, sql } from 'drizzle-orm';
 import { sendEmail, ticketConfirmationEmail, purchaseReceiptEmail, generateQRCode } from '@/src/lib/email';
-import { settleTicketPurchase } from '@/src/lib/settle';
+import { bus } from '@imajin/bus';
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha2.js';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
 import { randomBytes } from 'crypto';
 import { getClient } from '@imajin/db';
-import { emitAttestation } from '@imajin/auth';
-import { notify } from '@imajin/notify';
 
 // Configure ed25519 with sha512
 ed.hashes.sha512 = sha512;
@@ -346,15 +344,15 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
 
     createdTickets.push(ticket);
 
-    // Fire and forget — never block the response
-    emitAttestation({
-      issuer_did: ownerDid,
-      subject_did: event.creatorDid,
-      type: 'ticket.purchased',
-      context_id: event.id,
-      context_type: 'event',
-      payload: { ticketId: ticket.id, amount: amountTotal / quantity, currency },
-    }).catch((err) => log.error({ err: String(err) }, 'Attestation emit error'));
+    // Fire and forget — attestation via bus
+    bus.publish('ticket.purchased', {
+      ownerDid,
+      creatorDid: event.creatorDid,
+      eventId: event.id,
+      ticketId: ticket.id,
+      amount: amountTotal / quantity,
+      currency,
+    }).catch((err) => log.error({ err: String(err) }, '[webhook] bus ticket.purchased error'));
   }
 
   // Update sold count
@@ -365,22 +363,25 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
 
   log.info({ count: createdTickets.length, orderId, customerEmail }, 'Order + tickets created');
 
-  // Notify buyer — fire and forget
-  notify.send({
-    to: ownerDid,
-    scope: "event:ticket",
-    data: {
-      email: customerEmail,
-      eventTitle: event.title,
-      ticketType: ticketType.name,
-      amount: amountTotal,
-      currency: currency.toUpperCase(),
-    },
-  }).catch((err) => log.error({ err: String(err) }, 'Notify error'));
+  const eventMetadata = (event.metadata || {}) as Record<string, any>;
 
-  // Record interest signal — ticket.purchased → events scope
-  notify.interest({ did: ownerDid, attestationType: 'ticket.purchased' })
-    .catch((err) => log.error({ err: String(err) }, 'Interest signal error'));
+  // Notify buyer + settle fair chain via bus — fire and forget
+  bus.publish('order.completed', {
+    ownerDid,
+    eventId: event.id,
+    eventTitle: event.title,
+    ticketTypeName: ticketType.name,
+    orderId,
+    amount: amountTotal,
+    currency,
+    customerEmail,
+    fairManifest: (eventMetadata.fair as any) || null,
+    metadata: {
+      ticketIds: createdTickets.map((t) => t.id),
+      ticketTypeId: ticketType.id,
+      stripeSessionId: sessionId,
+    },
+  }).catch((err) => log.error({ err: String(err) }, '[webhook] bus order.completed error'));
 
   // Add buyer to event chat conversation_members (non-fatal)
   // The event DID is the conversation DID
@@ -400,27 +401,6 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     } catch (chatError) {
       log.warn({ err: String(chatError) }, 'Event chat member sync failed (non-fatal)');
     }
-  }
-
-  // After ticket creation, trigger .fair settlement (non-fatal)
-  const eventMetadata = (event.metadata || {}) as Record<string, any>;
-  try {
-    await settleTicketPurchase({
-      orderId,
-      eventId: event.id,
-      eventDid: event.did,
-      buyerDid: ownerDid,
-      amount: amountTotal, // cents from Stripe
-      currency,
-      fairManifest: eventMetadata.fair || null,
-      metadata: {
-        ticketIds: createdTickets.map(t => t.id),
-        ticketTypeId: ticketType.id,
-        stripeSessionId: sessionId,
-      },
-    });
-  } catch (settleError) {
-    log.error({ err: String(settleError) }, '[settle] Unexpected settlement error (non-fatal)');
   }
 
   // Send confirmation email with onboard verification link

--- a/apps/events/package.json
+++ b/apps/events/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@imajin/auth": "workspace:*",
+    "@imajin/bus": "workspace:*",
     "@imajin/emit": "workspace:*",
     "@imajin/logger": "workspace:*",
     "@imajin/chat": "workspace:*",

--- a/apps/kernel/app/auth/api/register/route.ts
+++ b/apps/kernel/app/auth/api/register/route.ts
@@ -6,16 +6,13 @@ import { createSessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt'
 import { rateLimit, getClientIP } from '@/src/lib/kernel/rate-limit';
 import { generateId } from '@/src/lib/kernel/utils';
 import { getNodeDid } from '@/src/lib/kernel/node-identity';
-import { emitAttestation } from '@imajin/auth';
-import { notify } from '@imajin/notify';
 import { sendEmail } from '@imajin/email';
+import { bus } from '@imajin/bus';
 import { generateVerifyToken, verifyTokenExpiry } from '@/src/lib/www/subscribe-tokens';
 import { verificationEmail, verificationEmailText } from '@/src/lib/www/verify-email-template';
 import { createLogger } from '@imajin/logger';
-import { createEmitter } from '@imajin/emit';
 
 const log = createLogger('kernel');
-const events = createEmitter('kernel');
 
 /**
  * POST /api/register
@@ -260,30 +257,16 @@ export async function POST(request: NextRequest) {
 
     response.cookies.set(cookieConfig.name, token, cookieConfig.options);
 
-    events.emit({ action: 'identity.register', did: identity.id, payload: { scope: identity.scope, subtype: identity.subtype, tier: 'preliminary' } });
-
-    // Emit identity.created attestation → triggers 10 MJN emission
-    emitAttestation({
-      issuer_did: identity.id,
-      subject_did: identity.id,
-      type: 'identity.created',
-      context_id: identity.id,
-      context_type: 'identity',
-      payload: { tier: 'preliminary', scope: identity.scope, subtype: identity.subtype },
-    }).catch((err) => log.error({ err: String(err) }, '[register] Attestation (identity.created) error (non-fatal)'));
-
-    // Emit identity.verified.preliminary → triggers 100 MJN emission
+    // Emit identity.created + identity.verified.preliminary attestations, and system event
     // Key-based registrations are preliminary by definition (proved key ownership).
-    // checkPreliminaryEligibility only fires for 'soft' tier, so we emit directly here.
     const platformDid = await getNodeDid();
-    emitAttestation({
-      issuer_did: platformDid,
-      subject_did: identity.id,
-      type: 'identity.verified.preliminary',
-      context_id: identity.id,
-      context_type: 'identity',
-      payload: { tier: 'preliminary', scope: identity.scope, subtype: identity.subtype },
-    }).catch((err) => log.error({ err: String(err) }, '[register] Attestation (identity.verified.preliminary) error (non-fatal)'));
+    bus.publish('identity.registered', {
+      did: identity.id,
+      scope: identity.scope,
+      subtype: identity.subtype,
+      tier: 'preliminary',
+      platformDid,
+    }).catch((err) => log.error({ err: String(err) }, '[register] bus identity.registered error (non-fatal)'));
 
     // Create profile row so the user is visible/discoverable
     try {
@@ -407,8 +390,6 @@ export async function POST(request: NextRequest) {
             set: { disconnectedAt: null, connectedAt: new Date() },
           });
 
-        events.emit({ action: 'connection.create', did: identity.id, payload: { otherDid: inviteData.fromDid, source: 'invite' } });
-
         const now = new Date().toISOString();
         await db
           .update(invites)
@@ -421,41 +402,15 @@ export async function POST(request: NextRequest) {
           })
           .where(eq(invites.code, inviteCode));
 
-        emitAttestation({
-          issuer_did: identity.id,
-          subject_did: inviteData.fromDid,
-          type: 'connection.accepted',
-          context_id: podId,
-          context_type: 'connection',
-          payload: { invite_code: inviteCode },
-        }).catch((err) => log.error({ err: String(err) }, '[register] Attestation (connection.accepted) error (non-fatal)'));
-
-        emitAttestation({
-          issuer_did: inviteData.fromDid,
-          subject_did: identity.id,
-          type: 'vouch',
-          context_id: podId,
-          context_type: 'connection',
-          payload: { invite_code: inviteCode },
-        }).catch((err) => log.error({ err: String(err) }, '[register] Attestation (vouch) error (non-fatal)'));
-
-        // Notify inviter — fire and forget
-        (async () => {
-          const [inviterProfile] = await db
-            .select()
-            .from(profiles)
-            .where(eq(profiles.did, inviteData.fromDid))
-            .limit(1);
-
-          notify.send({
-            to: inviteData.fromDid,
-            scope: 'connection:invite-accepted',
-            data: {
-              ...(inviterProfile?.contactEmail && { email: inviterProfile.contactEmail }),
-              name: identity.handle || identity.id.slice(0, 16),
-            },
-          }).catch((err: unknown) => log.error({ err: String(err) }, '[register] Notify error (non-fatal)'));
-        })().catch((err: unknown) => log.error({ err: String(err) }, '[register] Notify setup error (non-fatal)'));
+        // Publish connection.accepted — fires attestations (connection.accepted, vouch),
+        // system emit (connection.create), and notify to inviter
+        bus.publish('connection.accepted', {
+          did: identity.id,
+          fromDid: inviteData.fromDid,
+          newUserLabel: identity.handle || identity.id.slice(0, 16),
+          podId,
+          inviteCode,
+        }).catch((err) => log.error({ err: String(err) }, '[register] bus connection.accepted error (non-fatal)'));
 
         const acceptedResponse = NextResponse.json({
           did: identity.id,

--- a/apps/kernel/package.json
+++ b/apps/kernel/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@ai-sdk/react": "^1.2",
     "@imajin/auth": "workspace:*",
+    "@imajin/bus": "workspace:*",
     "@imajin/chat": "workspace:*",
     "@imajin/cid": "workspace:*",
     "@imajin/config": "workspace:*",

--- a/apps/market/app/api/webhook/route.ts
+++ b/apps/market/app/api/webhook/route.ts
@@ -9,10 +9,8 @@ import { NextRequest } from 'next/server';
 import { createLogger } from '@imajin/logger';
 const log = createLogger('market');
 import { db, listings } from '@/db';
-import { emitAttestation } from '@imajin/auth';
-import { notify } from '@imajin/notify';
 import { jsonResponse, errorResponse } from '@/lib/utils';
-import { settleListingPurchase } from '@/lib/settle';
+import { bus } from '@imajin/bus';
 import { eq } from 'drizzle-orm';
 
 const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET!;
@@ -64,37 +62,17 @@ export async function POST(request: NextRequest) {
               })
               .where(eq(listings.id, listingId));
           }
-
-          // Settle .fair chain — fire and forget, never block the response
-          settleListingPurchase({
-            listingId,
-            sellerDid: listing.sellerDid,
-            buyerDid: body.metadata?.buyerDid || '',
-            amount: body.metadata?.amount || 0,
-            currency: body.metadata?.currency || 'CAD',
-            fairManifest: (listing.fairManifest as any) || null,
-          }).catch((err: unknown) => log.error({ err: String(err) }, 'Settlement error'));
         }
 
-        // Fire and forget — never block the response
-        emitAttestation({
-          issuer_did: body.metadata?.buyerDid,
-          subject_did: listing.sellerDid,
-          type: 'listing.purchased',
-          context_id: listingId,
-          context_type: 'market',
-          payload: { amount: body.metadata?.amount },
-        }).catch((err: unknown) => log.error({ err: String(err) }, 'Attestation emit error'));
-
-        // Record interest signals — listing.purchased → market scope (buyer + seller)
-        if (body.metadata?.buyerDid) {
-          notify.interest({ did: body.metadata.buyerDid, attestationType: 'listing.purchased' })
-            .catch((err: unknown) => log.error({ err: String(err) }, 'Interest signal error'));
-        }
-        if (listing.sellerDid) {
-          notify.interest({ did: listing.sellerDid, attestationType: 'listing.purchased' })
-            .catch((err: unknown) => log.error({ err: String(err) }, 'Interest signal error'));
-        }
+        // Fire and forget — attestation, interest signals, and settle via bus
+        bus.publish('listing.purchased', {
+          buyerDid: body.metadata?.buyerDid || '',
+          sellerDid: listing?.sellerDid || '',
+          listingId,
+          amount: body.metadata?.amount || 0,
+          currency: body.metadata?.currency || 'CAD',
+          fairManifest: (listing?.fairManifest as any) || null,
+        }).catch((err: unknown) => log.error({ err: String(err) }, '[webhook] bus listing.purchased error'));
       }
     }
 

--- a/apps/market/package.json
+++ b/apps/market/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@imajin/auth": "workspace:*",
+    "@imajin/bus": "workspace:*",
     "@imajin/emit": "workspace:*",
     "@imajin/logger": "workspace:*",
     "@imajin/media": "workspace:*",

--- a/packages/bus/package.json
+++ b/packages/bus/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@imajin/bus",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Imajin event bus — fire-and-forget side-effect pipeline (attestation, emit, notify, settle)",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@imajin/auth": "workspace:*",
+    "@imajin/emit": "workspace:*",
+    "@imajin/logger": "workspace:*",
+    "@imajin/notify": "workspace:*"
+  }
+}

--- a/packages/bus/src/index.ts
+++ b/packages/bus/src/index.ts
@@ -1,0 +1,15 @@
+export { bus, publish } from './publish';
+export type {
+  BusEvent,
+  BusEventType,
+  BusPayload,
+  IdentityRegisteredPayload,
+  ConnectionAcceptedPayload,
+  TipInitiatedPayload,
+  TicketPurchasedPayload,
+  OrderCompletedPayload,
+  ListingPurchasedPayload,
+  FairManifest,
+  FairEntry,
+  FairFee,
+} from './types';

--- a/packages/bus/src/publish.ts
+++ b/packages/bus/src/publish.ts
@@ -1,0 +1,33 @@
+/**
+ * bus.publish() — dispatch a BusEvent to all registered reactors.
+ *
+ * Runs all reactors concurrently via Promise.allSettled so a single reactor
+ * failure never silences others. Errors are caught by each reactor individually.
+ */
+
+import { createLogger } from '@imajin/logger';
+import { registry } from './registry';
+import type { BusEvent, BusEventType, BusPayload } from './types';
+
+const log = createLogger('bus');
+
+export async function publish<T extends BusEventType>(
+  type: T,
+  payload: BusPayload<T>,
+): Promise<void> {
+  const reactors = registry[type];
+  if (!reactors?.length) return;
+
+  const results = await Promise.allSettled(
+    reactors.map((reactor) => Promise.resolve(reactor(payload))),
+  );
+
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      log.error({ type, err: String(result.reason) }, '[bus] reactor threw unexpectedly');
+    }
+  }
+}
+
+/** Convenience: fire-and-forget publish — attach .catch() at the call site if needed. */
+export const bus = { publish };

--- a/packages/bus/src/reactors/attestation.ts
+++ b/packages/bus/src/reactors/attestation.ts
@@ -1,0 +1,102 @@
+/**
+ * Attestation reactor — wraps emitAttestation from @imajin/auth.
+ *
+ * All calls are fire-and-forget; errors are logged but never thrown.
+ */
+
+import { emitAttestation } from '@imajin/auth';
+import { createLogger } from '@imajin/logger';
+import type {
+  IdentityRegisteredPayload,
+  ConnectionAcceptedPayload,
+  TipInitiatedPayload,
+  TicketPurchasedPayload,
+  ListingPurchasedPayload,
+} from '../types';
+
+const log = createLogger('bus');
+
+export async function onIdentityRegistered(payload: IdentityRegisteredPayload): Promise<void> {
+  const { did, scope, subtype, tier, platformDid } = payload;
+
+  await emitAttestation({
+    issuer_did: did,
+    subject_did: did,
+    type: 'identity.created',
+    context_id: did,
+    context_type: 'identity',
+    payload: { tier, scope, subtype },
+  }).catch((err) => log.error({ err: String(err) }, '[bus/attestation] identity.created error'));
+
+  if (platformDid) {
+    await emitAttestation({
+      issuer_did: platformDid,
+      subject_did: did,
+      type: 'identity.verified.preliminary',
+      context_id: did,
+      context_type: 'identity',
+      payload: { tier, scope, subtype },
+    }).catch((err) => log.error({ err: String(err) }, '[bus/attestation] identity.verified.preliminary error'));
+  }
+}
+
+export async function onConnectionAccepted(payload: ConnectionAcceptedPayload): Promise<void> {
+  const { did, fromDid, podId, inviteCode } = payload;
+
+  await emitAttestation({
+    issuer_did: did,
+    subject_did: fromDid,
+    type: 'connection.accepted',
+    context_id: podId,
+    context_type: 'connection',
+    payload: { invite_code: inviteCode },
+  }).catch((err) => log.error({ err: String(err) }, '[bus/attestation] connection.accepted error'));
+
+  await emitAttestation({
+    issuer_did: fromDid,
+    subject_did: did,
+    type: 'vouch',
+    context_id: podId,
+    context_type: 'connection',
+    payload: { invite_code: inviteCode },
+  }).catch((err) => log.error({ err: String(err) }, '[bus/attestation] vouch error'));
+}
+
+export async function onTipInitiated(payload: TipInitiatedPayload): Promise<void> {
+  const { fromHumanDid, toDid, tipId, amount, currency } = payload;
+
+  await emitAttestation({
+    issuer_did: fromHumanDid,
+    subject_did: toDid,
+    type: 'tip.granted',
+    context_id: tipId,
+    context_type: 'coffee',
+    payload: { amount, currency },
+  }).catch((err) => log.error({ err: String(err) }, '[bus/attestation] tip.granted error'));
+}
+
+export async function onTicketPurchased(payload: TicketPurchasedPayload): Promise<void> {
+  const { ownerDid, creatorDid, eventId, ticketId, amount, currency } = payload;
+
+  await emitAttestation({
+    issuer_did: ownerDid,
+    subject_did: creatorDid,
+    type: 'ticket.purchased',
+    context_id: eventId,
+    context_type: 'event',
+    payload: { ticketId, amount, currency },
+  }).catch((err) => log.error({ err: String(err) }, '[bus/attestation] ticket.purchased error'));
+}
+
+export async function onListingPurchased(payload: ListingPurchasedPayload): Promise<void> {
+  const { buyerDid, sellerDid, listingId, amount } = payload;
+
+  await emitAttestation({
+    issuer_did: buyerDid,
+    subject_did: sellerDid,
+    type: 'listing.purchased',
+    context_id: listingId,
+    context_type: 'market',
+    payload: { amount },
+  }).catch((err) => log.error({ err: String(err) }, '[bus/attestation] listing.purchased error'));
+}

--- a/packages/bus/src/reactors/emit.ts
+++ b/packages/bus/src/reactors/emit.ts
@@ -1,0 +1,26 @@
+/**
+ * Emit reactor — wraps createEmitter from @imajin/emit.
+ *
+ * Records system events to the events log (postgres adapter).
+ */
+
+import { createEmitter } from '@imajin/emit';
+import type { IdentityRegisteredPayload, ConnectionAcceptedPayload } from '../types';
+
+const emitter = createEmitter('bus');
+
+export function onIdentityRegistered(payload: IdentityRegisteredPayload): void {
+  emitter.emit({
+    action: 'identity.register',
+    did: payload.did,
+    payload: { scope: payload.scope, subtype: payload.subtype, tier: payload.tier },
+  });
+}
+
+export function onConnectionAccepted(payload: ConnectionAcceptedPayload): void {
+  emitter.emit({
+    action: 'connection.create',
+    did: payload.did,
+    payload: { otherDid: payload.fromDid, source: 'invite' },
+  });
+}

--- a/packages/bus/src/reactors/notify.ts
+++ b/packages/bus/src/reactors/notify.ts
@@ -1,0 +1,65 @@
+/**
+ * Notify reactor — wraps notify.send and notify.interest from @imajin/notify.
+ *
+ * All calls are fire-and-forget; errors are logged but never thrown.
+ */
+
+import { notify } from '@imajin/notify';
+import { createLogger } from '@imajin/logger';
+import type {
+  ConnectionAcceptedPayload,
+  OrderCompletedPayload,
+  ListingPurchasedPayload,
+} from '../types';
+
+const log = createLogger('bus');
+
+export async function onConnectionAccepted(payload: ConnectionAcceptedPayload): Promise<void> {
+  const { fromDid, newUserLabel } = payload;
+
+  await notify
+    .send({
+      to: fromDid,
+      scope: 'connection:invite-accepted',
+      data: { name: newUserLabel },
+    })
+    .catch((err) => log.error({ err: String(err) }, '[bus/notify] connection:invite-accepted error'));
+}
+
+export async function onOrderCompleted(payload: OrderCompletedPayload): Promise<void> {
+  const { ownerDid, customerEmail, eventTitle, ticketTypeName, amount, currency } = payload;
+
+  await notify
+    .send({
+      to: ownerDid,
+      scope: 'event:ticket',
+      data: {
+        email: customerEmail,
+        eventTitle,
+        ticketType: ticketTypeName,
+        amount,
+        currency: currency.toUpperCase(),
+      },
+    })
+    .catch((err) => log.error({ err: String(err) }, '[bus/notify] event:ticket error'));
+
+  await notify
+    .interest({ did: ownerDid, attestationType: 'ticket.purchased' })
+    .catch((err) => log.error({ err: String(err) }, '[bus/notify] interest(ticket.purchased) error'));
+}
+
+export async function onListingPurchased(payload: ListingPurchasedPayload): Promise<void> {
+  const { buyerDid, sellerDid } = payload;
+
+  if (buyerDid) {
+    await notify
+      .interest({ did: buyerDid, attestationType: 'listing.purchased' })
+      .catch((err) => log.error({ err: String(err) }, '[bus/notify] interest(listing.purchased buyer) error'));
+  }
+
+  if (sellerDid) {
+    await notify
+      .interest({ did: sellerDid, attestationType: 'listing.purchased' })
+      .catch((err) => log.error({ err: String(err) }, '[bus/notify] interest(listing.purchased seller) error'));
+  }
+}

--- a/packages/bus/src/reactors/settle.ts
+++ b/packages/bus/src/reactors/settle.ts
@@ -1,0 +1,169 @@
+/**
+ * Settle reactor — makes HTTP POST to PAY_SERVICE_URL/api/settle.
+ *
+ * Implements fair chain resolution shared by both ticket and listing purchases.
+ * Settlement failure is non-fatal — domain records have already been written.
+ */
+
+import { createLogger } from '@imajin/logger';
+import type { FairManifest, FairEntry, OrderCompletedPayload, ListingPurchasedPayload } from '../types';
+
+const log = createLogger('bus');
+
+const SELLER_ROLES = new Set(['seller', 'creator', 'event']);
+
+interface ResolvedEntry {
+  did: string;
+  amount: number;
+  role: string;
+}
+
+interface ResolvedChain {
+  chain: ResolvedEntry[];
+  expectedTotal: number;
+}
+
+function resolveChain(
+  entries: FairEntry[],
+  fees: FairManifest['fees'],
+  buyerDid: string,
+  amountCents: number,
+): ResolvedChain {
+  const totalDollars = amountCents / 100;
+
+  const nodeDid =
+    process.env.NODE_DID || process.env.RELAY_IMAJIN_DID || 'did:imajin:node-unresolved';
+
+  const feeList = fees || [];
+  const processorFee = feeList.find((f) => f.role === 'processor');
+  const estimatedFeeDollars = processorFee
+    ? parseFloat(
+        ((amountCents * processorFee.rateBps) / 10000 / 100 + processorFee.fixedCents / 100).toFixed(2),
+      )
+    : parseFloat(((amountCents * 370) / 10000 / 100 + 0.3).toFixed(2)); // fallback: 3.7% + 30¢
+
+  const resolvedChain: ResolvedEntry[] = entries.map((entry) => {
+    let did = entry.did;
+    if (did === 'BUYER_PLACEHOLDER') did = buyerDid;
+    if (did === 'NODE_PLACEHOLDER') did = nodeDid;
+
+    let entryAmount = parseFloat((totalDollars * entry.share).toFixed(2));
+    if (SELLER_ROLES.has(entry.role)) {
+      entryAmount = parseFloat((entryAmount - estimatedFeeDollars).toFixed(2));
+    }
+
+    return { did, amount: entryAmount, role: entry.role };
+  });
+
+  const expectedTotal = parseFloat((totalDollars - estimatedFeeDollars).toFixed(2));
+
+  // Fix rounding drift on the seller entry
+  const chainSum = resolvedChain.reduce((sum, e) => sum + e.amount, 0);
+  const drift = parseFloat((expectedTotal - chainSum).toFixed(2));
+  if (drift !== 0 && resolvedChain.length > 0) {
+    const seller = resolvedChain.find((e) => SELLER_ROLES.has(e.role));
+    const target =
+      seller ||
+      resolvedChain.reduce((max, e) => (e.amount > max.amount ? e : max), resolvedChain[0]);
+    target.amount = parseFloat((target.amount + drift).toFixed(2));
+  }
+
+  return { chain: resolvedChain, expectedTotal };
+}
+
+async function postSettle(body: Record<string, unknown>, contextId: string): Promise<void> {
+  const payUrl = process.env.PAY_SERVICE_URL;
+  const payKey = process.env.PAY_SERVICE_API_KEY;
+
+  if (!payUrl || !payKey) {
+    log.warn({ contextId }, '[bus/settle] PAY_SERVICE_URL or PAY_SERVICE_API_KEY not set — skipping');
+    return;
+  }
+
+  const response = await fetch(`${payUrl}/api/settle`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${payKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    log.error({ status: response.status, text, contextId }, '[bus/settle] /api/settle returned error');
+    return;
+  }
+
+  const result = await response.json();
+  log.info({ contextId, result }, '[bus/settle] Settlement complete');
+}
+
+export async function onOrderCompleted(payload: OrderCompletedPayload): Promise<void> {
+  const { ownerDid, orderId, eventId, fairManifest, amount, currency, metadata } = payload;
+
+  const chain = fairManifest?.chain;
+  if (!fairManifest || !chain?.length) {
+    log.warn({ eventId }, '[bus/settle] No .fair manifest chain for event — skipping settlement');
+    return;
+  }
+
+  const { chain: resolvedChain, expectedTotal } = resolveChain(
+    chain,
+    fairManifest.fees,
+    ownerDid,
+    amount,
+  );
+
+  const body = {
+    from_did: ownerDid,
+    total_amount: expectedTotal,
+    service: 'events',
+    type: 'ticket_purchase',
+    funded: true,
+    funded_provider: 'stripe',
+    fair_manifest: { chain: resolvedChain },
+    metadata: {
+      orderId,
+      ticketIds: metadata.ticketIds,
+      stripeSessionId: metadata.stripeSessionId,
+      eventId,
+    },
+  };
+
+  await postSettle(body, orderId).catch((err) =>
+    log.error({ err: String(err) }, '[bus/settle] order.completed settlement error (non-fatal)'),
+  );
+}
+
+export async function onListingPurchased(payload: ListingPurchasedPayload): Promise<void> {
+  const { buyerDid, listingId, fairManifest, amount, currency } = payload;
+
+  const chain = fairManifest?.chain;
+  if (!fairManifest || !chain?.length) {
+    log.warn({ listingId }, '[bus/settle] No .fair manifest chain for listing — skipping settlement');
+    return;
+  }
+
+  const { chain: resolvedChain, expectedTotal } = resolveChain(
+    chain,
+    fairManifest.fees,
+    buyerDid,
+    amount,
+  );
+
+  const body = {
+    from_did: buyerDid,
+    total_amount: expectedTotal,
+    service: 'market',
+    type: 'listing_purchase',
+    funded: true,
+    funded_provider: 'stripe',
+    fair_manifest: { chain: resolvedChain },
+    metadata: { listingId },
+  };
+
+  await postSettle(body, listingId).catch((err) =>
+    log.error({ err: String(err) }, '[bus/settle] listing.purchased settlement error (non-fatal)'),
+  );
+}

--- a/packages/bus/src/registry.ts
+++ b/packages/bus/src/registry.ts
@@ -1,0 +1,42 @@
+/**
+ * Bus reactor registry — maps each event type to its ordered list of reactors.
+ *
+ * All reactors are fire-and-forget; publish() runs them with Promise.allSettled
+ * so one failure never blocks the others.
+ */
+
+import * as attestation from './reactors/attestation';
+import * as emitReactor from './reactors/emit';
+import * as notifyReactor from './reactors/notify';
+import * as settleReactor from './reactors/settle';
+import type { BusEvent } from './types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyReactor = (payload: any) => Promise<void> | void;
+
+export const registry: Record<BusEvent['type'], AnyReactor[]> = {
+  'identity.registered': [
+    attestation.onIdentityRegistered,
+    emitReactor.onIdentityRegistered,
+  ],
+  'connection.accepted': [
+    attestation.onConnectionAccepted,
+    emitReactor.onConnectionAccepted,
+    notifyReactor.onConnectionAccepted,
+  ],
+  'tip.initiated': [
+    attestation.onTipInitiated,
+  ],
+  'ticket.purchased': [
+    attestation.onTicketPurchased,
+  ],
+  'order.completed': [
+    notifyReactor.onOrderCompleted,
+    settleReactor.onOrderCompleted,
+  ],
+  'listing.purchased': [
+    attestation.onListingPurchased,
+    notifyReactor.onListingPurchased,
+    settleReactor.onListingPurchased,
+  ],
+};

--- a/packages/bus/src/types.ts
+++ b/packages/bus/src/types.ts
@@ -1,0 +1,106 @@
+/**
+ * BusEvent discriminated union — all events that flow through the @imajin/bus pipeline.
+ *
+ * Each event type carries exactly the payload its reactors need.
+ * Routes construct the payload and call bus.publish(); reactors handle side-effects.
+ */
+
+export interface IdentityRegisteredPayload {
+  did: string;
+  scope: string;
+  subtype: string | null;
+  tier: string;
+  /** Platform/node DID used as issuer for identity.verified.preliminary attestation */
+  platformDid: string;
+}
+
+export interface ConnectionAcceptedPayload {
+  /** Newly registered user's DID */
+  did: string;
+  /** Inviter's DID */
+  fromDid: string;
+  /** Handle or truncated DID of the newly registered user (for notifications) */
+  newUserLabel: string;
+  podId: string;
+  inviteCode: string;
+}
+
+export interface TipInitiatedPayload {
+  fromDid: string;
+  fromHumanDid: string;
+  /** Page owner DID */
+  toDid: string;
+  tipId: string;
+  amount: number;
+  currency: string;
+}
+
+export interface TicketPurchasedPayload {
+  ownerDid: string;
+  /** Event creator DID */
+  creatorDid: string;
+  eventId: string;
+  ticketId: string;
+  /** Per-ticket amount in cents */
+  amount: number;
+  currency: string;
+}
+
+export interface FairFee {
+  role: string;
+  name: string;
+  rateBps: number;
+  fixedCents: number;
+}
+
+export interface FairEntry {
+  did: string;
+  role: string;
+  share: number;
+}
+
+export interface FairManifest {
+  version?: string;
+  fees?: FairFee[];
+  chain?: FairEntry[];
+  [key: string]: unknown;
+}
+
+export interface OrderCompletedPayload {
+  ownerDid: string;
+  eventId: string;
+  eventTitle: string;
+  ticketTypeName: string;
+  orderId: string;
+  /** Total amount in cents */
+  amount: number;
+  currency: string;
+  customerEmail: string;
+  fairManifest: FairManifest | null;
+  metadata: {
+    ticketIds: string[];
+    ticketTypeId: string;
+    stripeSessionId: string;
+  };
+}
+
+export interface ListingPurchasedPayload {
+  buyerDid: string;
+  sellerDid: string;
+  listingId: string;
+  /** Amount in cents */
+  amount: number;
+  currency: string;
+  fairManifest: FairManifest | null;
+}
+
+export type BusEvent =
+  | { type: 'identity.registered'; payload: IdentityRegisteredPayload }
+  | { type: 'connection.accepted'; payload: ConnectionAcceptedPayload }
+  | { type: 'tip.initiated'; payload: TipInitiatedPayload }
+  | { type: 'ticket.purchased'; payload: TicketPurchasedPayload }
+  | { type: 'order.completed'; payload: OrderCompletedPayload }
+  | { type: 'listing.purchased'; payload: ListingPurchasedPayload };
+
+export type BusEventType = BusEvent['type'];
+export type BusPayload<T extends BusEventType> = Extract<BusEvent, { type: T }>['payload'];

--- a/packages/bus/tsconfig.json
+++ b/packages/bus/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 14.2.35(eslint@8.57.1)(typescript@5.9.3)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -49,11 +49,127 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.19.17)
 
+  ../imajin-fixready:
+    dependencies:
+      '@imajin/db':
+        specifier: workspace:*
+        version: link:../imajin-ai/packages/db
+      clsx:
+        specifier: ^2.1.0
+        version: 2.1.1
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.7
+      next:
+        specifier: ^14.2.0
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      qrcode:
+        specifier: ^1.5.3
+        version: 1.5.4
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
+      autoprefixer:
+        specifier: ^10
+        version: 10.4.27(postcss@8.5.9)
+      drizzle-kit:
+        specifier: ^0.31.9
+        version: 0.31.10
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.4(jiti@1.21.7)
+      eslint-config-next:
+        specifier: ^16.1.6
+        version: 16.2.4(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      postcss:
+        specifier: ^8
+        version: 8.5.9
+      tailwindcss:
+        specifier: ^3.4.0
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  ../imajin-karaoke:
+    dependencies:
+      '@imajin/db':
+        specifier: workspace:*
+        version: link:../imajin-ai/packages/db
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
+      next:
+        specifier: ^14.2.0
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
+      autoprefixer:
+        specifier: ^10
+        version: 10.4.27(postcss@8.5.9)
+      drizzle-kit:
+        specifier: ^0.31.9
+        version: 0.31.10
+      postcss:
+        specifier: ^8
+        version: 8.5.9
+      tailwindcss:
+        specifier: ^3.4.0
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   apps/coffee:
     dependencies:
       '@imajin/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@imajin/bus':
+        specifier: workspace:*
+        version: link:../../packages/bus
       '@imajin/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -83,7 +199,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -138,7 +254,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -182,6 +298,9 @@ importers:
       '@imajin/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@imajin/bus':
+        specifier: workspace:*
+        version: link:../../packages/bus
       '@imajin/chat':
         specifier: workspace:*
         version: link:../../packages/chat
@@ -232,7 +351,7 @@ importers:
         version: 12.0.2
       next:
         specifier: 14.2.35
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -282,6 +401,9 @@ importers:
       '@imajin/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@imajin/bus':
+        specifier: workspace:*
+        version: link:../../packages/bus
       '@imajin/chat':
         specifier: workspace:*
         version: link:../../packages/chat
@@ -383,7 +505,7 @@ importers:
         version: 5.1.7
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       otplib:
         specifier: ^13.4.0
         version: 13.4.0
@@ -519,7 +641,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -580,7 +702,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -618,6 +740,9 @@ importers:
       '@imajin/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@imajin/bus':
+        specifier: workspace:*
+        version: link:../../packages/bus
       '@imajin/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -650,7 +775,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -702,11 +827,26 @@ importers:
         version: 1.8.0
       next:
         specifier: '>=14'
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
+
+  packages/bus:
+    dependencies:
+      '@imajin/auth':
+        specifier: workspace:*
+        version: link:../auth
+      '@imajin/emit':
+        specifier: workspace:*
+        version: link:../emit
+      '@imajin/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@imajin/notify':
+        specifier: workspace:*
+        version: link:../notify
 
   packages/chat:
     dependencies:
@@ -743,7 +883,7 @@ importers:
     dependencies:
       next:
         specifier: '>=14'
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/db:
     dependencies:
@@ -861,7 +1001,7 @@ importers:
         version: 5.1.7
       next:
         specifier: '>=14'
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       pino:
         specifier: ^9
         version: 9.14.0
@@ -1012,12 +1152,54 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.2':
@@ -1027,6 +1209,14 @@ packages:
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -1763,13 +1953,41 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1792,6 +2010,18 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -1804,6 +2034,10 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1960,6 +2194,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -2129,6 +2366,9 @@ packages:
 
   '@next/eslint-plugin-next@14.2.35':
     resolution: {integrity: sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==}
+
+  '@next/eslint-plugin-next@16.2.4':
+    resolution: {integrity: sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==}
 
   '@next/swc-darwin-arm64@14.2.33':
     resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
@@ -2915,6 +3155,12 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
@@ -2976,6 +3222,14 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/eslint-plugin@8.59.0':
+    resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@7.18.0':
     resolution: {integrity: sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -2986,9 +3240,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@7.18.0':
     resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@7.18.0':
     resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
@@ -3000,9 +3277,20 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/type-utils@8.59.0':
+    resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@7.18.0':
     resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.18.0':
     resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
@@ -3013,15 +3301,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@7.18.0':
     resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@8.59.0':
+    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@7.18.0':
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -3529,6 +3834,10 @@ packages:
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   cm6-theme-basic-light@0.2.0:
     resolution: {integrity: sha512-1prg2gv44sYfpHscP26uLT/ePrh0mlmVwMSoSd3zYKQ92Ab3jPRLzyCnpyOCQLJbK+YdNs4HvMRqMNYdy4pMhA==}
     peerDependencies:
@@ -3573,6 +3882,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -3945,6 +4257,15 @@ packages:
       typescript:
         optional: true
 
+  eslint-config-next@16.2.4:
+    resolution: {integrity: sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==}
+    peerDependencies:
+      eslint: '>=9.0.0'
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   eslint-import-resolver-node@0.3.10:
     resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
 
@@ -4004,6 +4325,12 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
 
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
     engines: {node: '>=4'}
@@ -4014,9 +4341,21 @@ packages:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
@@ -4024,9 +4363,23 @@ packages:
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -4096,6 +4449,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -4131,6 +4488,10 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -4149,6 +4510,10 @@ packages:
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -4189,6 +4554,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -4246,6 +4615,14 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -4312,6 +4689,12 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
@@ -4347,6 +4730,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -4564,6 +4951,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
@@ -4584,6 +4974,11 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4601,6 +4996,11 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jsondiffpatch@0.6.0:
@@ -4679,6 +5079,9 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -5799,6 +6202,12 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -5843,6 +6252,13 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.59.0:
+    resolution: {integrity: sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -6198,6 +6614,9 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
@@ -6227,6 +6646,12 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -6286,15 +6711,102 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -6928,7 +7440,28 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -6944,7 +7477,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.57.1': {}
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -6971,6 +7527,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -6982,6 +7550,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.1.0': {}
 
@@ -7102,6 +7672,11 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -7461,6 +8036,10 @@ snapshots:
   '@next/eslint-plugin-next@14.2.35':
     dependencies:
       glob: 10.3.10
+
+  '@next/eslint-plugin-next@16.2.4':
+    dependencies:
+      fast-glob: 3.3.1
 
   '@next/swc-darwin-arm64@14.2.33':
     optional: true
@@ -8209,6 +8788,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/js-yaml@4.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
   '@types/json5@0.0.29': {}
 
   '@types/mdast@4.0.4':
@@ -8276,6 +8859,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/type-utils': 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      eslint: 9.39.4(jiti@1.21.7)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
@@ -8289,10 +8888,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
+
+  '@typescript-eslint/scope-manager@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -8306,7 +8935,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@1.21.7)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@7.18.0': {}
+
+  '@typescript-eslint/types@8.59.0': {}
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
     dependencies:
@@ -8323,6 +8966,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
@@ -8334,10 +8992,26 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -8879,6 +9553,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
+  clsx@2.1.1: {}
+
   cm6-theme-basic-light@0.2.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)(@lezer/highlight@1.2.3):
     dependencies:
       '@codemirror/language': 6.12.3
@@ -8917,6 +9593,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  convert-source-map@2.0.0: {}
 
   crelt@1.0.6: {}
 
@@ -9352,11 +10030,46 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
+  eslint-config-next@16.2.4(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.4
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
+      globals: 16.4.0
+      typescript-eslint: 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 2.0.0-next.6
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@1.21.7)
+      get-tsconfig: 4.13.7
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -9383,6 +10096,17 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -9415,6 +10139,35 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
     dependencies:
       aria-query: 5.3.2
@@ -9434,9 +10187,39 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.2
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.4(jiti@1.21.7)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
   eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
+
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      eslint: 9.39.4(jiti@1.21.7)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
@@ -9460,12 +10243,43 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.3.2
+      eslint: 9.39.4(jiti@1.21.7)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.6
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
   eslint-scope@7.2.2:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@8.57.1:
     dependencies:
@@ -9510,12 +10324,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint@9.39.4(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
       event-emitter: 0.3.5
       type: 2.7.3
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -9585,6 +10446,14 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -9617,6 +10486,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
@@ -9638,6 +10511,11 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
       rimraf: 3.0.2
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
 
   flatted@3.4.2: {}
 
@@ -9673,6 +10551,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   generator-function@2.0.1: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -9747,6 +10627,10 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globals@14.0.0: {}
+
+  globals@16.4.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -9843,6 +10727,12 @@ snapshots:
 
   he@1.2.0: {}
 
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
+
   hono@4.12.12: {}
 
   html-escaper@2.0.2: {}
@@ -9873,6 +10763,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -10107,6 +10999,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@5.10.0: {}
+
   jose@6.2.2: {}
 
   js-tokens@10.0.0: {}
@@ -10124,6 +11018,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -10137,6 +11033,8 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  json5@2.2.3: {}
 
   jsondiffpatch@0.6.0:
     dependencies:
@@ -10208,6 +11106,10 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lz-string@1.5.0: {}
 
@@ -10771,7 +11673,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -10781,7 +11683,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -11628,10 +12530,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.1(react@18.3.1):
+  styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   sucrase@3.35.1:
     dependencies:
@@ -11756,6 +12660,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
@@ -11816,6 +12724,17 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript-eslint@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 
@@ -12250,6 +13169,8 @@ snapshots:
 
   y18n@4.0.3: {}
 
+  yallist@3.1.1: {}
+
   yaml@2.8.3: {}
 
   yargs-parser@18.1.3:
@@ -12280,6 +13201,10 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Summary

- Introduces `packages/bus/` — a lightweight event pipeline package that decouples side-effects (attestation, system emit, notify, settle) from route handlers via `bus.publish()`
- Migrates 4 routes off direct `emitAttestation`/`notify.send`/`settleTicketPurchase` calls
- Settlement is a **reactor**, not a bus caller — the settle reactor POSTs to `PAY_SERVICE_URL/api/settle`

## What's in `@imajin/bus`

**6 event types:** `identity.registered`, `connection.accepted`, `tip.initiated`, `ticket.purchased`, `order.completed`, `listing.purchased`

**4 reactors:**
- `attestation.ts` — wraps `emitAttestation` from `@imajin/auth`
- `emit.ts` — wraps `createEmitter` from `@imajin/emit`
- `notify.ts` — wraps `notify.send` / `notify.interest` from `@imajin/notify`
- `settle.ts` — fair chain resolution + HTTP POST to `PAY_SERVICE_URL/api/settle`

All reactors are fire-and-forget; `publish()` uses `Promise.allSettled` so one failure never blocks others.

## Routes migrated

| Route | Old calls removed | Bus event |
|-------|-------------------|-----------|
| `kernel/register` | 4× `emitAttestation`, 2× `events.emit`, 1× `notify.send` | `identity.registered` + `connection.accepted` |
| `coffee/tip` | 2× `emitAttestation` (stripe + solana paths) | `tip.initiated` |
| `events/webhook/payment` | `emitAttestation` per ticket, `notify.send`, `notify.interest`, `settleTicketPurchase` | `ticket.purchased` (per ticket) + `order.completed` (once) |
| `market/webhook` | `emitAttestation`, `notify.interest` ×2, `settleListingPurchase` | `listing.purchased` |

## Test plan

- [ ] Register a new identity → verify `identity.created` + `identity.verified.preliminary` attestations emit
- [ ] Register with an invite code → verify `connection.accepted` + `vouch` attestations + invite notification
- [ ] Submit a tip (authenticated) → verify `tip.granted` attestation emits for both stripe and solana paths
- [ ] Complete a ticket purchase webhook → verify per-ticket `ticket.purchased` attestation, `event:ticket` notification, interest signal, and fair settle call
- [ ] Complete a listing purchase webhook → verify `listing.purchased` attestation, interest signals for buyer + seller, and fair settle call
- [ ] Confirm domain logic (DB writes, emails, session tokens, chat sync) is unchanged in all routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)