### PR TITLE
feat(events): admin CSV export — guest list + all-events (#816)

### DIFF
--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -391,12 +391,20 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
       <div className="px-6 pt-6 pb-4">
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-xl font-semibold">Guest List</h2>
-          <button
-            onClick={() => setScannerOpen(v => !v)}
-            className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
-          >
-            {scannerOpen ? '✕ Close Scanner' : '📷 Scan Tickets'}
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => { window.location.href = `/api/events/${eventId}/guests/export.csv`; }}
+              className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
+            >
+              ⬇ Download CSV
+            </button>
+            <button
+              onClick={() => setScannerOpen(v => !v)}
+              className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
+            >
+              {scannerOpen ? '✕ Close Scanner' : '📷 Scan Tickets'}
+            </button>
+          </div>
         </div>
 
         {scannerOpen && (

--- a/apps/events/app/admin/page.tsx
+++ b/apps/events/app/admin/page.tsx
@@ -1,0 +1,117 @@
+import { redirect, notFound } from 'next/navigation';
+import { requireAdmin } from '@imajin/auth';
+import { db, events } from '@/src/db';
+import { desc } from 'drizzle-orm';
+import Link from 'next/link';
+
+export default async function AdminEventsPage() {
+  const session = await requireAdmin();
+  if (!session) {
+    notFound();
+  }
+
+  const allEvents = await db
+    .select()
+    .from(events)
+    .orderBy(desc(events.createdAt));
+
+  return (
+    <div className="max-w-6xl mx-auto p-4 md:p-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-3xl font-bold">Admin — Events</h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            {allEvents.length} event{allEvents.length !== 1 ? 's' : ''} on the network
+          </p>
+        </div>
+        <a
+          href="/api/admin/events/export.csv"
+          className="inline-flex items-center px-4 py-2 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-lg transition"
+        >
+          ⬇ Export Events
+        </a>
+      </div>
+
+      {allEvents.length === 0 ? (
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-8 text-center">
+          <p className="text-gray-500">No events yet.</p>
+        </div>
+      ) : (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+          <table className="w-full">
+            <thead className="bg-gray-50 dark:bg-gray-900">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Event
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Date
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Creator
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  City
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+              {allEvents.map((event) => (
+                <tr key={event.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/admin/${event.id}`}
+                      className="text-sm font-medium text-orange-500 hover:text-orange-600"
+                    >
+                      {event.title}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusBadge status={event.status} />
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+                    {event.startsAt
+                      ? new Date(event.startsAt).toLocaleDateString('en-CA', {
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 font-mono">
+                    {event.creatorDid}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+                    {event.city || '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string | null }) {
+  const color =
+    status === 'published'
+      ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400'
+      : status === 'draft'
+      ? 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400'
+      : status === 'cancelled'
+      ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400'
+      : status === 'completed'
+      ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400'
+      : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300';
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${color}`}>
+      {status || 'unknown'}
+    </span>
+  );
+}

--- a/apps/events/app/api/admin/events/export.csv/route.ts
+++ b/apps/events/app/api/admin/events/export.csv/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createLogger } from '@imajin/logger';
+import { requireAdmin } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const log = createLogger('events');
+const sql = getClient();
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
+
+function csvEscape(v: unknown): string {
+  if (v == null) return '';
+  const s = String(v);
+  if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function csvRow(values: unknown[]): string {
+  return values.map(csvEscape).join(',') + '\r\n';
+}
+
+async function resolveHandle(did: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${AUTH_SERVICE_URL}/api/lookup/${encodeURIComponent(did)}`, { cache: 'no-store' });
+    if (res.ok) {
+      const data = await res.json();
+      const identity = data.identity || data;
+      return identity.handle || null;
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+/**
+ * GET /api/admin/events/export.csv — export all events overview as CSV
+ */
+export async function GET(request: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const rows = await sql`
+      WITH ticket_stats AS (
+        SELECT
+          event_id,
+          COUNT(*) FILTER (WHERE status IN ('valid', 'used', 'held')) AS sold,
+          COUNT(*) FILTER (WHERE used_at IS NOT NULL) AS used,
+          SUM(price_paid) FILTER (WHERE status NOT IN ('refunded', 'cancelled')) AS revenue,
+          COUNT(*) FILTER (WHERE registration_status = 'complete') AS surveys_completed
+        FROM events.tickets
+        GROUP BY event_id
+      ),
+      currency_info AS (
+        SELECT
+          event_id,
+          COUNT(DISTINCT currency) AS currency_count,
+          MAX(currency) AS sample_currency
+        FROM events.tickets
+        WHERE currency IS NOT NULL
+        GROUP BY event_id
+      ),
+      type_info AS (
+        SELECT
+          event_id,
+          COUNT(*) AS type_count,
+          BOOL_OR(registration_form_id IS NOT NULL) AS has_form
+        FROM events.ticket_types
+        GROUP BY event_id
+      )
+      SELECT
+        e.id,
+        e.title,
+        e.status,
+        e.starts_at,
+        e.ends_at,
+        e.city,
+        e.creator_did,
+        COALESCE(ti.type_count, 0) AS ticket_type_count,
+        COALESCE(ts.sold, 0) AS tickets_sold,
+        COALESCE(ts.used, 0) AS tickets_used,
+        COALESCE(ts.revenue, 0) AS total_revenue,
+        CASE WHEN ci.currency_count > 1 THEN '' ELSE ci.sample_currency END AS currency,
+        COALESCE(ti.has_form, false) AS has_registration_form,
+        COALESCE(ts.surveys_completed, 0) AS surveys_completed
+      FROM events.events e
+      LEFT JOIN ticket_stats ts ON ts.event_id = e.id
+      LEFT JOIN currency_info ci ON ci.event_id = e.id
+      LEFT JOIN type_info ti ON ti.event_id = e.id
+      ORDER BY e.created_at DESC
+    `;
+
+    // Batch-resolve creator handles
+    const creatorDids = [...new Set(rows.map((r: any) => r.creator_did).filter(Boolean))] as string[];
+    const handleMap = new Map<string, string | null>();
+    await Promise.all(
+      creatorDids.map(async (did) => {
+        const handle = await resolveHandle(did);
+        handleMap.set(did, handle);
+      })
+    );
+
+    const dateStr = new Date().toISOString().split('T')[0];
+    const filename = `imajin-events-${dateStr}.csv`;
+
+    const headers = [
+      'Event ID', 'Title', 'Status', 'Starts At', 'Ends At', 'City',
+      'Creator DID', 'Creator Handle', 'Total Ticket Types', 'Tickets Sold',
+      'Tickets Used', 'Total Revenue', 'Currency', 'Has Registration Form',
+      'Surveys Completed Count',
+    ];
+
+    let csvBody = csvRow(headers);
+
+    for (const r of rows) {
+      const handle = r.creator_did ? (handleMap.get(r.creator_did) ?? '') : '';
+      csvBody += csvRow([
+        r.id,
+        r.title,
+        r.status,
+        r.starts_at ? new Date(r.starts_at).toISOString() : '',
+        r.ends_at ? new Date(r.ends_at).toISOString() : '',
+        r.city || '',
+        r.creator_did || '',
+        handle,
+        r.ticket_type_count,
+        r.tickets_sold,
+        r.tickets_used,
+        r.total_revenue,
+        r.currency || '',
+        r.has_registration_form ? 'true' : 'false',
+        r.surveys_completed,
+      ]);
+    }
+
+    const bom = '\uFEFF';
+    return new NextResponse(bom + csvBody, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Failed to export events');
+    return NextResponse.json({ error: 'Failed to export events' }, { status: 500 });
+  }
+}

--- a/apps/events/app/api/events/[id]/guests/export.csv/route.ts
+++ b/apps/events/app/api/events/[id]/guests/export.csv/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createLogger } from '@imajin/logger';
+import { requireAuth } from '@imajin/auth';
+import { isEventOrganizer } from '@/src/lib/organizer';
+import { getClient } from '@imajin/db';
+
+const log = createLogger('events');
+const sql = getClient();
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
+
+function csvEscape(v: unknown): string {
+  if (v == null) return '';
+  const s = String(v);
+  if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function csvRow(values: unknown[]): string {
+  return values.map(csvEscape).join(',') + '\r\n';
+}
+
+async function resolveProfile(did: string): Promise<{ name: string | null; handle: string | null; email: string | null }> {
+  try {
+    const res = await fetch(`${AUTH_SERVICE_URL}/api/lookup/${encodeURIComponent(did)}`, { cache: 'no-store' });
+    if (res.ok) {
+      const data = await res.json();
+      const identity = data.identity || data;
+      return {
+        name: identity.name || null,
+        handle: identity.handle || null,
+        email: identity.email || null,
+      };
+    }
+  } catch { /* ignore */ }
+  return { name: null, handle: null, email: null };
+}
+
+/**
+ * GET /api/events/[id]/guests/export.csv — export guest list as CSV
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+
+  const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
+  const { id } = await params;
+
+  try {
+    const orgCheck = await isEventOrganizer(id, did);
+    if (!orgCheck.authorized) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Fetch event for filename
+    const [event] = await sql`
+      SELECT id, title FROM events.events WHERE id = ${id} LIMIT 1
+    `;
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+
+    // Fetch tickets with all needed info
+    const ticketRows = await sql`
+      SELECT
+        t.id, t.status, t.owner_did, t.price_paid, t.currency, t.purchased_at, t.used_at,
+        t.payment_method, t.order_id, t.registration_status,
+        tt.name AS ticket_type, tt.registration_form_id,
+        tr.name AS attendee_name, tr.email AS attendee_email, tr.form_id, tr.response_id
+      FROM events.tickets t
+      JOIN events.ticket_types tt ON t.ticket_type_id = tt.id
+      LEFT JOIN events.ticket_registrations tr ON tr.ticket_id = t.id
+      WHERE t.event_id = ${id}
+      ORDER BY t.created_at DESC
+    `;
+
+    // Batch-resolve unique DIDs for profile info
+    const uniqueDids = [...new Set(ticketRows.map((t: any) => t.owner_did).filter(Boolean))] as string[];
+    const profileMap = new Map<string, { name: string | null; handle: string | null; email: string | null }>();
+    await Promise.all(
+      uniqueDids.map(async (ownerDid) => {
+        const profile = await resolveProfile(ownerDid);
+        profileMap.set(ownerDid, profile);
+      })
+    );
+
+    // Find distinct form IDs used by this event's ticket types
+    const formIds = [...new Set(ticketRows.map((t: any) => t.registration_form_id).filter(Boolean))] as string[];
+
+    // Fetch form definitions from Dykil and build survey column list
+    const surveyColumns: string[] = [];
+    const formFieldMap = new Map<string, Array<{ name: string; title: string }>>();
+
+    if (formIds.length > 0) {
+      const formRows = await sql`
+        SELECT id, fields FROM dykil.surveys WHERE id = ANY(${formIds})
+      `;
+      for (const row of formRows) {
+        const rawFields = row.fields || {};
+        const fields: Array<{ name: string; title?: string }> =
+          Array.isArray(rawFields) ? rawFields :
+          Array.isArray(rawFields.elements) ? rawFields.elements : [];
+        const mappedFields = fields.map((f) => ({ name: f.name, title: f.title || f.name }));
+        formFieldMap.set(row.id, mappedFields);
+        for (const f of mappedFields) {
+          const colName = `Survey: ${f.title}`;
+          if (!surveyColumns.includes(colName)) {
+            surveyColumns.push(colName);
+          }
+        }
+      }
+    }
+
+    // Fetch all survey responses for tickets that have them
+    const responseIds = [...new Set(ticketRows.map((t: any) => t.response_id).filter(Boolean))] as string[];
+    const responseMap = new Map<string, Record<string, unknown>>();
+
+    if (responseIds.length > 0) {
+      const responseRows = await sql`
+        SELECT id, answers FROM dykil.survey_responses WHERE id = ANY(${responseIds})
+      `;
+      for (const row of responseRows) {
+        responseMap.set(row.id, row.answers || {});
+      }
+    }
+
+    // Build CSV
+    const dateStr = new Date().toISOString().split('T')[0];
+    const safeTitle = event.title
+      ? event.title.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '').toLowerCase()
+      : event.id;
+    const filename = `${safeTitle || event.id}-guests-${dateStr}.csv`;
+
+    const baseHeaders = [
+      'Ticket ID', 'Order ID', 'Attendee Name', 'Attendee Email', 'Ticket Type',
+      'Status', 'Registration Status', 'Purchased At', 'Checked In At',
+      'Payment Method', 'Price Paid (cents)', 'Currency', 'Owner DID',
+    ];
+    const headers = [...baseHeaders, ...surveyColumns];
+
+    let csvBody = csvRow(headers);
+
+    for (const t of ticketRows) {
+      const profile = t.owner_did ? (profileMap.get(t.owner_did) ?? null) : null;
+      const attendeeName = t.attendee_name || profile?.name || '';
+      const attendeeEmail = t.attendee_email || profile?.email || '';
+
+      const baseValues = [
+        t.id,
+        t.order_id || '',
+        attendeeName,
+        attendeeEmail,
+        t.ticket_type,
+        t.status,
+        t.registration_status || '',
+        t.purchased_at ? new Date(t.purchased_at).toISOString() : '',
+        t.used_at ? new Date(t.used_at).toISOString() : '',
+        t.payment_method || '',
+        t.price_paid ?? '',
+        t.currency || '',
+        t.owner_did || '',
+      ];
+
+      // Survey answers
+      const surveyValues: string[] = [];
+      if (t.response_id && t.form_id && formFieldMap.has(t.form_id)) {
+        const fields = formFieldMap.get(t.form_id)!;
+        const answers = responseMap.get(t.response_id) || {};
+        for (const colName of surveyColumns) {
+          const question = colName.replace('Survey: ', '');
+          const field = fields.find((f) => f.title === question);
+          if (field && field.name in answers) {
+            const ans = answers[field.name];
+            surveyValues.push(ans === null || ans === undefined ? '' : String(ans));
+          } else {
+            surveyValues.push('');
+          }
+        }
+      } else {
+        surveyValues.push(...new Array(surveyColumns.length).fill(''));
+      }
+
+      csvBody += csvRow([...baseValues, ...surveyValues]);
+    }
+
+    const bom = '\uFEFF';
+    return new NextResponse(bom + csvBody, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Failed to export guest list');
+    return NextResponse.json({ error: 'Failed to export guest list' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Closes [#816](https://github.com/ima-jin/imajin-ai/issues/816). Debbie's export request.

## What this adds

### Per-event guest list CSV
- New: `GET /api/events/[id]/guests/export.csv`
- Auth: event organizer or admin (same as existing guests endpoint)
- Filename: `<event-title>-guests-<YYYY-MM-DD>.csv`
- UTF-8 BOM, proper CSV escaping, `\r\n` line endings
- Columns: ticket id, order id, attendee name + email, ticket type, status, registration status, purchased at, checked in at, payment method, price paid, currency, owner DID, **plus one column per registration form question** (`Survey: <question>`)
- Survey answers fetched from Dykil — form definitions pre-fetched, then responses batched in one query
- UI: "⬇ Download CSV" button next to "📷 Scan Tickets" in guest list header, native browser download via `window.location.href`

### All-events overview CSV
- New: `GET /api/admin/events/export.csv`
- Auth: `requireAdmin`
- Filename: `imajin-events-<YYYY-MM-DD>.csv`
- One row per event with stats: ticket types, sold, used, revenue, currency, has registration form, surveys completed
- Uses SQL CTEs for efficient aggregation
- New admin events list page at `/admin` with "⬇ Export Events" button top-right

## How to test

1. Visit any event admin guest list, click "⬇ Download CSV", open in Excel/Sheets — accents render cleanly, columns include survey answers
2. Visit `/admin` (events app), click "⬇ Export Events" — get a clean overview of all events with stats

## What's NOT in scope

- Bulk per-event guest exports as a zip — deferred to v2
- Streaming response for very large events — buffered for v1, can optimize later
- Cached `tickets.metadata.surveyAnswers` denormalization — depends on #815 landing first to be reliable