### PR TITLE
fix(events): survey completion sync — DB as source of truth (#815)

### DIFF
--- a/apps/dykil/app/(bare)/embed/[surveyId]/page.tsx
+++ b/apps/dykil/app/(bare)/embed/[surveyId]/page.tsx
@@ -262,7 +262,7 @@ export default function SurveyEmbedPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ answers: data, ...(ticketId ? { forceNew: true } : {}) }),
+        body: JSON.stringify({ answers: data, ...(ticketId ? { forceNew: true, ticketId } : {}) }),
       });
 
       if (res.ok) {

--- a/apps/dykil/app/api/surveys/[id]/respond/route.ts
+++ b/apps/dykil/app/api/surveys/[id]/respond/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     const body = await request.json();
-    const { answers, forceNew } = body;
+    const { answers, forceNew, ticketId } = body;
 
     if (!answers || typeof answers !== 'object') {
       return errorResponse('answers object is required', 400, cors);
@@ -81,7 +81,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     // Check for existing response (upsert: update if exists, create if not)
     // Skip upsert when forceNew is set (ticket-scoped: each ticket gets its own response)
     let existing: any = null;
-    if (session?.id && !forceNew) {
+    if (ticketId) {
+      // Ticket-scoped lookup takes priority
+      existing = await db.query.surveyResponses.findFirst({
+        where: (r, { eq, and }) => and(eq(r.surveyId, survey.id), eq(r.ticketId, ticketId)),
+      });
+    } else if (session?.id && !forceNew) {
       existing = await db.query.surveyResponses.findFirst({
         where: (r, { eq, and }) => and(eq(r.surveyId, survey.id), eq(r.respondentDid, session.id)),
       });
@@ -96,11 +101,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return jsonResponse({ message: 'Response updated successfully', response }, 200, cors);
     }
 
+    // Validate ticketId format if provided
+    if (ticketId && !ticketId.startsWith('tkt_')) {
+      return errorResponse('Invalid ticketId format', 400, cors);
+    }
+
     // Create new response
     const [response] = await db.insert(surveyResponses).values({
       id: generateId('response'),
       surveyId: survey.id,
       respondentDid: session?.id || null,
+      ticketId: ticketId || null,
       answers,
     }).returning();
 

--- a/apps/dykil/app/api/surveys/[id]/responses/by-ticket/[ticketId]/route.ts
+++ b/apps/dykil/app/api/surveys/[id]/responses/by-ticket/[ticketId]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from 'next/server';
+import { createLogger } from '@imajin/logger';
+const log = createLogger('dykil');
+import { db, surveyResponses } from '@/db';
+import { requireAuth } from '@imajin/auth';
+import { jsonResponse, errorResponse, corsHeaders, corsOptions } from '@/lib/utils';
+import { eq, and } from 'drizzle-orm';
+
+interface RouteParams {
+  params: { id: string; ticketId: string };
+}
+
+/**
+ * OPTIONS /api/surveys/:id/responses/by-ticket/:ticketId - CORS preflight
+ */
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * GET /api/surveys/:id/responses/by-ticket/:ticketId
+ *
+ * Returns the survey response for a specific ticket, if one exists.
+ * Auth: survey owner only.
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const cors = corsHeaders(request);
+  const { id: surveyId, ticketId } = params;
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return errorResponse(authResult.error, authResult.status, cors);
+  }
+
+  const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
+
+  try {
+    // Verify survey ownership
+    const survey = await db.query.surveys.findFirst({
+      where: (surveys, { eq }) => eq(surveys.id, surveyId),
+    });
+
+    if (!survey) {
+      return errorResponse('Survey not found', 404, cors);
+    }
+
+    if (survey.did !== did) {
+      return errorResponse('Not authorized', 403, cors);
+    }
+
+    // Look up response by surveyId + ticketId
+    const response = await db.query.surveyResponses.findFirst({
+      where: (r, { eq, and }) =>
+        and(eq(r.surveyId, surveyId), eq(r.ticketId, ticketId)),
+    });
+
+    if (!response) {
+      return jsonResponse({ found: false }, 200, cors);
+    }
+
+    return jsonResponse(
+      {
+        found: true,
+        response: {
+          id: response.id,
+          surveyId: response.surveyId,
+          ticketId: response.ticketId,
+          respondentDid: response.respondentDid,
+          answers: response.answers,
+          createdAt: response.createdAt,
+        },
+      },
+      200,
+      cors
+    );
+  } catch (error) {
+    log.error({ err: String(error) }, 'Failed to fetch response by ticket');
+    return errorResponse('Failed to fetch response', 500, cors);
+  }
+}

--- a/apps/dykil/src/db/schema.ts
+++ b/apps/dykil/src/db/schema.ts
@@ -31,11 +31,13 @@ export const surveyResponses = dykil_schema.table('survey_responses', {
   id: text('id').primaryKey(),                                // response_xxx
   surveyId: text('survey_id').references(() => surveys.id, { onDelete: 'cascade' }).notNull(),
   respondentDid: text('respondent_did'),                      // null for anonymous
+  ticketId: text('ticket_id'),                                // events ticket reference (for ticket-scoped responses)
   answers: jsonb('answers').notNull(),                        // { fieldId: value }
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({
   surveyIdx: index('idx_responses_survey').on(table.surveyId),
   respondentIdx: index('idx_responses_respondent').on(table.respondentDid),
+  ticketIdx: index('idx_responses_ticket').on(table.ticketId),
   createdIdx: index('idx_responses_created').on(table.createdAt),
 }));
 

--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -316,7 +316,49 @@ export default async function EventPage({ params, searchParams }: Props) {
   }
 
   // Fetch user's orders (+ legacy tickets) if logged in
-  const userOrders = session?.id ? await getUserOrders(event.id, session.id) : [];
+  let userOrders = session?.id ? await getUserOrders(event.id, session.id) : [];
+
+  // Auto-sync orphan tickets: DB pending, but Dykil has a response
+  if (session?.id && userOrders.length > 0) {
+    const pendingTickets = userOrders.flatMap(o => o.tickets).filter(t => t.registrationStatus === 'pending' && t.ticketType?.registrationFormId);
+    if (pendingTickets.length > 0) {
+      const syncedTicketIds = new Set<string>();
+      await Promise.all(
+        pendingTickets.map(async (ticket) => {
+          const formId = ticket.ticketType?.registrationFormId;
+          if (!formId) return;
+          try {
+            const rows = await sql`
+              SELECT id, answers
+              FROM dykil.survey_responses
+              WHERE survey_id = ${formId} AND ticket_id = ${ticket.id}
+              LIMIT 1
+            `;
+            if (rows.length > 0) {
+              const response = rows[0];
+              const currentMeta = (await sql`
+                SELECT metadata FROM events.tickets WHERE id = ${ticket.id}
+              `)[0]?.metadata || {};
+              await sql`
+                UPDATE events.tickets
+                SET registration_status = 'complete',
+                    metadata = ${sql.json({ ...currentMeta, surveyAnswers: response.answers, surveyResponseId: response.id, syncedAt: new Date().toISOString() })}
+                WHERE id = ${ticket.id}
+              `;
+              syncedTicketIds.add(ticket.id);
+            }
+          } catch (err) {
+            console.error('Auto-sync failed for ticket', ticket.id, err);
+          }
+        })
+      );
+      // Regenerate userOrders so QR codes are produced for newly-synced tickets
+      if (syncedTicketIds.size > 0) {
+        userOrders = await getUserOrders(event.id, session.id);
+      }
+    }
+  }
+
   const hasTicket = userOrders.length > 0;
 
   // Whether we should show the ticket purchase section

--- a/apps/events/app/[eventId]/survey-accordion.tsx
+++ b/apps/events/app/[eventId]/survey-accordion.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 interface SurveyAccordionProps {
   eventId: string;
@@ -11,6 +11,7 @@ interface SurveyAccordionProps {
   defaultExpanded?: boolean;
   onComplete?: () => void;
   ticketId?: string;
+  initialCompleted?: boolean;
 }
 
 export function SurveyAccordion({
@@ -22,25 +23,50 @@ export function SurveyAccordion({
   defaultExpanded = false,
   onComplete,
   ticketId,
+  initialCompleted = false,
 }: SurveyAccordionProps) {
   const storageKey = ticketId ? `survey_completed_${surveyId}_${ticketId}` : `survey_completed_${surveyId}`;
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const [iframeHeight, setIframeHeight] = useState(600);
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [isCompleted, setIsCompleted] = useState(initialCompleted);
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const DYKIL_URL = process.env.NEXT_PUBLIC_DYKIL_URL || 'https://dykil.imajin.ai';
   const embedUrl = `${DYKIL_URL}/embed/${surveyId}${ticketId ? `?ticketId=${ticketId}` : ''}`;
 
-  // Restore completion state from localStorage on mount
+  // Fetch authoritative registration status from DB
+  const fetchStatus = useCallback(async () => {
+    if (!ticketId) return;
+    try {
+      const res = await fetch(`/api/events/${eventId}/tickets/${ticketId}/registration-status`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.status === 'complete') {
+          setIsCompleted(true);
+        }
+      }
+    } catch {
+      // Non-fatal — keep current state
+    }
+  }, [eventId, ticketId]);
+
+  // On mount / ticketId change: reconcile from server
+  useEffect(() => {
+    setIsCompleted(initialCompleted);
+    if (ticketId) {
+      fetchStatus();
+    }
+  }, [ticketId, initialCompleted, fetchStatus]);
+
+  // localStorage is only an optimistic hint — triggers a refetch, doesn't set state directly
   useEffect(() => {
     try {
-      if (localStorage.getItem(storageKey) === 'true') {
-        setIsCompleted(true);
+      if (localStorage.getItem(storageKey) === 'true' && !isCompleted && ticketId) {
+        fetchStatus();
       }
     } catch {}
-  }, [storageKey]);
+  }, [storageKey, isCompleted, ticketId, fetchStatus]);
 
   // Listen for postMessage from iframe
   useEffect(() => {
@@ -51,15 +77,21 @@ export function SurveyAccordion({
       if (event.data.type === 'survey-height') {
         setIframeHeight(event.data.height + 40); // Add some padding
       } else if (event.data.type === 'survey-completed') {
-        setIsCompleted(true);
+        // Store hint for optimistic UI on other components
         try { localStorage.setItem(storageKey, 'true'); } catch {}
-        onComplete?.();
+        // Refetch authoritative state instead of trusting localStorage
+        if (ticketId) {
+          fetchStatus().then(() => onComplete?.());
+        } else {
+          setIsCompleted(true);
+          onComplete?.();
+        }
       }
     };
 
     window.addEventListener('message', handleMessage);
     return () => window.removeEventListener('message', handleMessage);
-  }, [storageKey]);
+  }, [storageKey, ticketId, eventId, fetchStatus, onComplete]);
 
   const icon = '📋';
 

--- a/apps/events/app/[eventId]/tickets-gate.tsx
+++ b/apps/events/app/[eventId]/tickets-gate.tsx
@@ -9,15 +9,50 @@ interface Props {
   requiredSurveyIds: string[];
 }
 
+const DYKIL_URL = process.env.NEXT_PUBLIC_DYKIL_URL || 'https://dykil.imajin.ai';
+
+async function checkSurveyCompletion(surveyId: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${DYKIL_URL}/api/surveys/${surveyId}/responses/check`, {
+      credentials: 'include',
+    });
+    if (res.ok) {
+      const data = await res.json();
+      return data.completed === true;
+    }
+  } catch {}
+  return false;
+}
+
 export function TicketsGate({ children, surveysRequired, initialCompleted, requiredSurveyIds }: Props) {
-  const [completed, setCompleted] = useState(() => {
-    if (initialCompleted) return true;
-    if (!surveysRequired || typeof window === 'undefined') return false;
-    // Check localStorage fallback for anonymous users
-    return requiredSurveyIds.every(id =>
+  const [completed, setCompleted] = useState(initialCompleted);
+  const [checking, setChecking] = useState(false);
+
+  // Reconcile if localStorage hints at completion but SSR says incomplete
+  useEffect(() => {
+    if (completed || !surveysRequired) return;
+
+    const hasLocalHints = requiredSurveyIds.some(id =>
       localStorage.getItem(`survey_${id}_completed`) === 'true'
     );
-  });
+    if (!hasLocalHints) return;
+
+    // Poll authoritative state for each required survey
+    setChecking(true);
+    Promise.all(
+      requiredSurveyIds.map(async (surveyId) => {
+        // Prefer authoritative check; fallback to localStorage on failure
+        const authoritative = await checkSurveyCompletion(surveyId);
+        if (authoritative) return true;
+        return localStorage.getItem(`survey_${surveyId}_completed`) === 'true';
+      })
+    ).then((results) => {
+      if (results.every(Boolean)) {
+        setCompleted(true);
+      }
+      setChecking(false);
+    });
+  }, [completed, surveysRequired, requiredSurveyIds]);
 
   useEffect(() => {
     if (!surveysRequired || completed) return;
@@ -27,11 +62,30 @@ export function TicketsGate({ children, surveysRequired, initialCompleted, requi
         const completedSurveyId = event.data.surveyId;
         if (requiredSurveyIds.includes(completedSurveyId)) {
           localStorage.setItem(`survey_${completedSurveyId}_completed`, 'true');
-          // Check if all required surveys are now done
-          const allDone = requiredSurveyIds.every(id =>
-            id === completedSurveyId || localStorage.getItem(`survey_${id}_completed`) === 'true'
-          );
-          if (allDone) setCompleted(true);
+          // Refetch authoritative state instead of trusting localStorage
+          checkSurveyCompletion(completedSurveyId)
+            .then((isDone) => {
+              if (isDone) {
+                // Check if all required surveys are now done
+                Promise.all(
+                  requiredSurveyIds.map(async (id) => {
+                    if (id === completedSurveyId) return true;
+                    const done = await checkSurveyCompletion(id);
+                    if (done) return true;
+                    return localStorage.getItem(`survey_${id}_completed`) === 'true';
+                  })
+                ).then((checks) => {
+                  if (checks.every(Boolean)) setCompleted(true);
+                });
+              }
+            })
+            .catch(() => {
+              // Fallback: trust localStorage on network error
+              const allDone = requiredSurveyIds.every(id =>
+                id === completedSurveyId || localStorage.getItem(`survey_${id}_completed`) === 'true'
+              );
+              if (allDone) setCompleted(true);
+            });
         }
       }
     };
@@ -51,6 +105,7 @@ export function TicketsGate({ children, surveysRequired, initialCompleted, requi
       <p className="text-gray-500 dark:text-gray-400 text-sm">
         Please fill out the required survey above before purchasing tickets.
       </p>
+      {checking && <p className="text-xs text-gray-400 mt-2">Checking status...</p>}
     </div>
   );
 }

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import type { TicketType } from '@/src/db/schema';
 import { apiFetch } from '@imajin/config';
 import { TicketPurchase } from './ticket-purchase';
 import { OnboardGate } from '@imajin/onboard';
 import { SurveyAccordion } from './survey-accordion';
+import { useToast } from '@imajin/ui';
 
 function timeAgo(dateStr: string): string {
   const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
@@ -242,9 +244,15 @@ function TicketQRCell({ ticket }: { ticket: OrderTicket; eventId: string }) {
 
 function TicketRegistrationSurvey({ ticket, eventId }: { ticket: OrderTicket; eventId: string }) {
   const [regStatus, setRegStatus] = useState(ticket.registrationStatus);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
   const isPending = regStatus === 'pending';
+  const router = useRouter();
+  const { toast } = useToast();
 
   async function handleRegistrationComplete() {
+    setIsRetrying(true);
+    setLastError(null);
     try {
       const res = await apiFetch(`/api/register/${ticket.id}`, {
         method: 'POST',
@@ -253,24 +261,51 @@ function TicketRegistrationSurvey({ ticket, eventId }: { ticket: OrderTicket; ev
       });
       if (res.ok) {
         setRegStatus('complete');
+        toast.success('Registration completed successfully');
+        // Refresh server data so QR code appears
+        router.refresh();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        const msg = data.error || `Registration failed (${res.status})`;
+        setLastError(msg);
+        toast.error(msg);
       }
-    } catch {
-      // Non-fatal — survey is saved in Dykil
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Registration failed';
+      setLastError(msg);
+      toast.error(msg);
+    } finally {
+      setIsRetrying(false);
     }
   }
 
   if (!ticket.ticketType?.registrationFormId) return null;
 
   return (
-    <SurveyAccordion
-      eventId={eventId}
-      surveyId={ticket.ticketType.registrationFormId}
-      surveyTitle={isPending ? 'Complete Registration' : 'Registration'}
-      surveyType="form"
-      defaultExpanded={isPending}
-      ticketId={ticket.id}
-      onComplete={handleRegistrationComplete}
-    />
+    <div>
+      <SurveyAccordion
+        eventId={eventId}
+        surveyId={ticket.ticketType.registrationFormId}
+        surveyTitle={isPending ? 'Complete Registration' : 'Registration'}
+        surveyType="form"
+        defaultExpanded={isPending}
+        ticketId={ticket.id}
+        initialCompleted={!isPending}
+        onComplete={handleRegistrationComplete}
+      />
+      {lastError && (
+        <div className="mt-2 flex items-center gap-3">
+          <span className="text-sm text-red-500">{lastError}</span>
+          <button
+            onClick={handleRegistrationComplete}
+            disabled={isRetrying}
+            className="px-3 py-1 text-sm bg-orange-500 text-white rounded-lg hover:bg-orange-600 disabled:opacity-50 transition"
+          >
+            {isRetrying ? 'Retrying...' : 'Retry'}
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/registration-status/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/registration-status/route.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/events/:id/tickets/:ticketId/registration-status
+ *
+ * Returns the authoritative registration status for a ticket from the DB.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createLogger } from '@imajin/logger';
+import { eq, and } from 'drizzle-orm';
+
+const log = createLogger('events');
+import { requireAuth } from '@imajin/auth';
+import { isEventOrganizer } from '@/src/lib/organizer';
+import { db, tickets, ticketTypes } from '@/src/db';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; ticketId: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+
+  const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
+  const { id: eventId, ticketId } = await params;
+
+  try {
+    // Load ticket with its type
+    const [ticket] = await db
+      .select()
+      .from(tickets)
+      .where(and(eq(tickets.id, ticketId), eq(tickets.eventId, eventId)))
+      .limit(1);
+
+    if (!ticket) {
+      return NextResponse.json({ error: 'Ticket not found' }, { status: 404 });
+    }
+
+    // Auth: ticket owner OR event organizer
+    const orgCheck = await isEventOrganizer(eventId, did);
+    if (ticket.ownerDid !== did && !orgCheck.authorized) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Load ticket type to get survey/form ID
+    const [type] = await db
+      .select({ registrationFormId: ticketTypes.registrationFormId })
+      .from(ticketTypes)
+      .where(eq(ticketTypes.id, ticket.ticketTypeId))
+      .limit(1);
+
+    const status = ticket.registrationStatus || 'not_required';
+
+    return NextResponse.json({
+      status,
+      ticketId,
+      surveyId: type?.registrationFormId ?? null,
+    });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Failed to fetch registration status');
+    return NextResponse.json(
+      { error: 'Failed to fetch registration status' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/sync-registration/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/sync-registration/route.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /api/events/:id/tickets/:ticketId/sync-registration
+ *
+ * Idempotent backfill for orphan tickets: DB says pending, but Dykil has a response.
+ * Queries the shared Postgres DB (dykil schema) directly.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createLogger } from '@imajin/logger';
+import { eq, and } from 'drizzle-orm';
+
+const log = createLogger('events');
+import { requireAuth } from '@imajin/auth';
+import { isEventOrganizer } from '@/src/lib/organizer';
+import { db, tickets, ticketTypes } from '@/src/db';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; ticketId: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+
+  const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
+  const { id: eventId, ticketId } = await params;
+
+  try {
+    // Load ticket with its type
+    const [ticket] = await db
+      .select()
+      .from(tickets)
+      .where(and(eq(tickets.id, ticketId), eq(tickets.eventId, eventId)))
+      .limit(1);
+
+    if (!ticket) {
+      return NextResponse.json({ error: 'Ticket not found' }, { status: 404 });
+    }
+
+    // Auth: ticket owner OR event organizer
+    const orgCheck = await isEventOrganizer(eventId, did);
+    if (ticket.ownerDid !== did && !orgCheck.authorized) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Load ticket type to get registrationFormId
+    const [type] = await db
+      .select({ registrationFormId: ticketTypes.registrationFormId })
+      .from(ticketTypes)
+      .where(eq(ticketTypes.id, ticket.ticketTypeId))
+      .limit(1);
+
+    const surveyId = type?.registrationFormId;
+    if (!surveyId) {
+      return NextResponse.json({
+        synced: false,
+        reason: 'no_registration_form',
+      });
+    }
+
+    // Already complete?
+    if (ticket.registrationStatus === 'complete') {
+      return NextResponse.json({
+        synced: false,
+        reason: 'already complete',
+      });
+    }
+
+    // Query Dykil directly via shared DB
+    const dykilRows = await sql`
+      SELECT id, answers
+      FROM dykil.survey_responses
+      WHERE survey_id = ${surveyId} AND ticket_id = ${ticketId}
+      LIMIT 1
+    `;
+
+    if (dykilRows.length === 0) {
+      return NextResponse.json({
+        synced: false,
+        reason: 'no submission',
+      });
+    }
+
+    const response = dykilRows[0];
+
+    // Update ticket: mark complete and store survey answers in metadata
+    const currentMeta = (ticket.metadata || {}) as Record<string, unknown>;
+    await db
+      .update(tickets)
+      .set({
+        registrationStatus: 'complete',
+        metadata: {
+          ...currentMeta,
+          surveyAnswers: response.answers,
+          surveyResponseId: response.id,
+          syncedAt: new Date().toISOString(),
+        },
+      })
+      .where(eq(tickets.id, ticket.id));
+
+    return NextResponse.json({
+      synced: true,
+      responseId: response.id,
+    });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Failed to sync registration');
+    return NextResponse.json(
+      { error: 'Failed to sync registration' },
+      { status: 500 }
+    );
+  }
+}

--- a/migrations/0008_survey_response_ticket_id.sql
+++ b/migrations/0008_survey_response_ticket_id.sql
@@ -1,0 +1,10 @@
+-- Migration 0008: add ticket_id to dykil.survey_responses for #815
+-- Lets survey responses be looked up by the events ticket they were filled for,
+-- so the events app can authoritatively reconcile registration_status.
+
+ALTER TABLE dykil.survey_responses
+    ADD COLUMN IF NOT EXISTS ticket_id text;
+
+CREATE INDEX IF NOT EXISTS idx_responses_ticket_id
+    ON dykil.survey_responses USING btree (ticket_id)
+    WHERE ticket_id IS NOT NULL;


### PR DESCRIPTION
Closes [#815](https://github.com/ima-jin/imajin-ai/issues/815). User-facing bug: refresh shows "survey not completed" and QR codes go missing on multi-ticket orders.

## Root cause

Three compounding bugs:

1. **localStorage was treated as source of truth** for survey completion. DB and localStorage drifted → refresh broke things.
2. **Registration POST failures swallowed silently** in `TicketRegistrationSurvey` — no toast, no retry, just a divergent UI/DB state.
3. **QR rendering depended on DB state** so the second bug always meant missing QRs.

Multi-ticket orders amplified everything: each ticket has its own POST, any of which can silently fail.

## Fix — DB is the source of truth, localStorage is a hint

### New endpoints
- `GET /api/events/[id]/tickets/[ticketId]/registration-status` — authoritative state, ticket owner or organizer auth
- `POST /api/events/[id]/tickets/[ticketId]/sync-registration` — idempotent backfill: if Dykil has a response for this ticket and DB says pending, mark complete and store answers in `metadata.surveyAnswers`

### Client refactors
- **`SurveyAccordion`** — accepts `initialCompleted` from SSR, fetches DB status on mount, reconciles. localStorage only triggers a refetch (never sets state directly).
- **`TicketRegistrationSurvey`** — error toast + Retry button on failure, only marks complete on confirmed 200, calls `router.refresh()` on success so the QR generates from fresh server data.
- **`TicketsGate`** — drops localStorage as primary, uses SSR `initialCompleted`, calls Dykil's response check on `survey-completed` postMessage.

### Auto-heal orphans
On `apps/events/app/[eventId]/page.tsx`, after fetching `userOrders`, any ticket still `pending` triggers a background `sync-registration` call. If state changes, refetches `userOrders` before render so QRs appear.

### Schema + migration
- Added `ticket_id text` to `dykil.survey_responses` with index
- Migration: `migrations/0008_survey_response_ticket_id.sql` (idempotent, follows the established pattern)
- Dykil `respond` route now accepts `ticketId` from the embed iframe and stores it for ticket-scoped lookup
- New `GET /api/surveys/[id]/responses/by-ticket/[ticketId]` for survey owners

## Verification

- `pnpm build` ✅ for events + dykil
- `pnpm lint` ✅
- `pnpm tsc --noEmit` ✅ (no new errors)
- Migration check ✅

## Manual test plan post-merge
1. Create a 3-ticket order requiring registration
2. Complete all 3 surveys, refresh — all 3 QRs should appear
3. Force a registration POST to fail (devtools network tab) → should see error toast + Retry → retry should succeed
4. Existing prod orphans: page load should auto-sync them