### PR TITLE
fix(events): cohost admin permissions + CSV export basePath

### DIFF
--- a/apps/events/app/[eventId]/edit/form.tsx
+++ b/apps/events/app/[eventId]/edit/form.tsx
@@ -26,6 +26,7 @@ interface TicketTier {
   sold?: number;
   requiresRegistration: boolean;
   registrationFormId: string;
+  accessCode?: string;
 }
 
 interface Survey {
@@ -134,11 +135,12 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
       sold: t.sold || 0,
       requiresRegistration: t.requiresRegistration || false,
       registrationFormId: t.registrationFormId || '',
+      accessCode: (t as any).accessCode || '',
     }))
   );
 
   function addTier() {
-    setTiers([...tiers, { name: '', price: 0, quantity: null, description: '', requiresRegistration: false, registrationFormId: '' }]);
+    setTiers([...tiers, { name: '', price: 0, quantity: null, description: '', requiresRegistration: false, registrationFormId: '', accessCode: '' }]);
   }
 
   function updateTier(index: number, field: keyof TicketTier, value: any) {
@@ -236,6 +238,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               sortOrder: i,
               requiresRegistration: tier.requiresRegistration,
               registrationFormId: tier.registrationFormId || null,
+              accessCode: tier.accessCode?.trim() || undefined,
             }),
           });
           if (!tierRes.ok) {
@@ -257,6 +260,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               sortOrder: i,
               requiresRegistration: tier.requiresRegistration,
               registrationFormId: tier.registrationFormId || null,
+              accessCode: tier.accessCode?.trim() || undefined,
             }),
           });
           if (!tierRes.ok) {
@@ -735,6 +739,24 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                   )}
                 </div>
               )}
+            </div>
+            <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+              <label className="block text-sm font-medium mb-1">Access Code (optional)</label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={tier.accessCode || ''}
+                  onChange={(e) => updateTier(index, 'accessCode', e.target.value)}
+                  placeholder="e.g. STAFF2026"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm focus:ring-2 focus:ring-orange-500"
+                />
+                {tier.accessCode?.trim() && (
+                  <span className="text-lg" title="This tier is hidden behind an access code">🔒</span>
+                )}
+              </div>
+              <p className="text-xs text-gray-500 mt-1">
+                If set, this ticket type is hidden until someone enters this code on the event page.
+              </p>
             </div>
             {!tier.id && tiers.length > 1 && (
               <button

--- a/apps/events/app/[eventId]/edit/page.tsx
+++ b/apps/events/app/[eventId]/edit/page.tsx
@@ -68,7 +68,7 @@ export default async function EditEventPage({ params }: Props) {
             You don't have permission to edit this event.
           </p>
           <a
-            href={`/${eventId}`}
+            href={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/${eventId}`}
             className="inline-block px-6 py-2 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-lg transition"
           >
             View Event
@@ -110,7 +110,7 @@ export default async function EditEventPage({ params }: Props) {
           <div className="flex items-center justify-between">
             <h1 className="text-3xl font-bold mb-2">Edit Event</h1>
             <a
-              href={`/${eventId}`}
+              href={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/${eventId}`}
               className="text-sm text-orange-500 hover:text-orange-600 font-medium flex items-center gap-1"
             >
               ← View Live Event

--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -143,6 +143,11 @@ async function getTicketTypes(eventId: string) {
     .orderBy(ticketTypes.sortOrder);
 }
 
+function filterPublicTiers(allTiers: Awaited<ReturnType<typeof getTicketTypes>>, isOrganizer: boolean) {
+  if (isOrganizer) return allTiers;
+  return allTiers.filter(t => !t.accessCode);
+}
+
 async function getUserOrders(eventId: string, userDid: string) {
   const rows = await db
     .select({
@@ -294,7 +299,9 @@ export default async function EventPage({ params, searchParams }: Props) {
     notFound();
   }
 
-  const ticketTypesList = await getTicketTypes(event.id);
+  const allTicketTypes = await getTicketTypes(event.id);
+  const ticketTypesList = filterPublicTiers(allTicketTypes, isOrganizer);
+  const hasHiddenTiers = allTicketTypes.some(t => !!t.accessCode);
   const canPurchaseTickets = status === 'published';
 
   // Invite-only access check
@@ -792,6 +799,7 @@ export default async function EventPage({ params, searchParams }: Props) {
                 isAuthenticated={!!session}
                 sessionEmail={session?.email ?? undefined}
                 sellerConnected={sellerConnected}
+                hasHiddenTiers={hasHiddenTiers}
               />
             </TicketsGate>
           ) : (

--- a/apps/events/app/[eventId]/share-button.tsx
+++ b/apps/events/app/[eventId]/share-button.tsx
@@ -1,17 +1,28 @@
 'use client';
 
+import { useState } from 'react';
+
 export function ShareButton() {
+  const [copied, setCopied] = useState(false);
+
   return (
     <button
       onClick={() => {
         navigator.clipboard.writeText(window.location.href);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
       }}
-      className="flex-shrink-0 p-2.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition"
+      className="flex-shrink-0 p-2.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition relative"
       title="Copy link"
     >
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
       </svg>
+      {copied && (
+        <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-gray-900 text-white text-xs rounded shadow-lg whitespace-nowrap">
+          Copied!
+        </span>
+      )}
     </button>
   );
 }

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -78,9 +78,10 @@ interface Props {
   isAuthenticated?: boolean;
   sessionEmail?: string;
   sellerConnected?: boolean;
+  hasHiddenTiers?: boolean;
 }
 
-export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], hasTicket = false, inviteToken, etransferEnabled = false, isAuthenticated = false, sessionEmail, sellerConnected = true }: Props) {
+export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], hasTicket = false, inviteToken, etransferEnabled = false, isAuthenticated = false, sessionEmail, sellerConnected = true, hasHiddenTiers = false }: Props) {
   const [activeTab, setActiveTab] = useState<'my-tickets' | 'buy-tickets'>(
     hasTicket ? 'my-tickets' : 'buy-tickets'
   );
@@ -97,7 +98,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], 
 
   // If user doesn't have tickets, show purchase UI only
   if (!hasTicket || userOrders.length === 0) {
-    return <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sellerConnected={sellerConnected} />;
+    return <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sellerConnected={sellerConnected} hasHiddenTiers={hasHiddenTiers} />;
   }
 
   // User has tickets - show tabbed interface
@@ -131,7 +132,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], 
       {activeTab === 'my-tickets' ? (
         <MyTicketsTab userOrders={userOrders} eventId={eventId} />
       ) : (
-        <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sellerConnected={sellerConnected} />
+        <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sellerConnected={sellerConnected} hasHiddenTiers={hasHiddenTiers} />
       )}
     </div>
   );
@@ -405,25 +406,71 @@ function TicketFairReceipt({ settlement }: { settlement: FairSettlement }) {
   );
 }
 
-function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnabled = false, isAuthenticated = false, sessionEmail, sellerConnected = true }: { eventId: string; eventTitle: string; tickets: TicketType[]; inviteToken?: string; etransferEnabled?: boolean; isAuthenticated?: boolean; sessionEmail?: string; sellerConnected?: boolean }) {
+function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnabled = false, isAuthenticated = false, sessionEmail, sellerConnected = true, hasHiddenTiers = false }: { eventId: string; eventTitle: string; tickets: TicketType[]; inviteToken?: string; etransferEnabled?: boolean; isAuthenticated?: boolean; sessionEmail?: string; sellerConnected?: boolean; hasHiddenTiers?: boolean }) {
+  const [unlockedTickets, setUnlockedTickets] = useState<TicketType[]>([]);
+  const [unlockCode, setUnlockCode] = useState('');
+  const [showUnlock, setShowUnlock] = useState(false);
+  const [unlockLoading, setUnlockLoading] = useState(false);
+  const [unlockError, setUnlockError] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  const allTickets = [...tickets, ...unlockedTickets];
+
+  async function handleUnlock() {
+    if (!unlockCode.trim()) return;
+    setUnlockLoading(true);
+    setUnlockError(null);
+    try {
+      const res = await fetch(`/api/events/${eventId}/tiers/unlock?code=${encodeURIComponent(unlockCode.trim())}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setUnlockError(data.error || 'Invalid code');
+        return;
+      }
+      const newTiers = (data.tiers || []).filter((t: TicketType) => !allTickets.some(existing => existing.id === t.id));
+      if (newTiers.length === 0) {
+        setUnlockError('No new ticket types found for this code');
+        return;
+      }
+      setUnlockedTickets(prev => [...prev, ...newTiers]);
+      setShowUnlock(false);
+      setUnlockCode('');
+      toast.success(`${newTiers.length} ticket type${newTiers.length > 1 ? 's' : ''} unlocked!`);
+    } catch {
+      setUnlockError('Failed to unlock. Please try again.');
+    } finally {
+      setUnlockLoading(false);
+    }
+  }
+
   return (
     <div className="space-y-3 md:space-y-4">
-      {tickets.map((ticket) => {
+      {allTickets.map((ticket) => {
         const available = ticket.quantity === null
           ? null
           : ticket.quantity - (ticket.sold ?? 0);
         const soldOut = ticket.quantity !== null && (ticket.sold ?? 0) >= ticket.quantity;
         const lowStock = available !== null && available > 0 && available <= 10;
+        const isUnlocked = unlockedTickets.some(t => t.id === ticket.id);
 
         return (
           <div
             key={ticket.id}
-            className="group border-2 border-gray-200 dark:border-gray-700 rounded-xl p-4 md:p-6 hover:border-orange-500 dark:hover:border-orange-500 transition-all"
+            className={`group border-2 rounded-xl p-4 md:p-6 hover:border-orange-500 dark:hover:border-orange-500 transition-all ${
+              isUnlocked
+                ? 'border-amber-300 dark:border-amber-700 bg-amber-50/30 dark:bg-amber-900/10'
+                : 'border-gray-200 dark:border-gray-700'
+            }`}
           >
             <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
               <div className="flex-1">
                 <div className="flex items-start gap-3 mb-2">
                   <h3 className="font-bold text-xl flex-1">{ticket.name}</h3>
+                  {isUnlocked && (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 text-xs font-semibold rounded-full">
+                      🔓 Unlocked
+                    </span>
+                  )}
                   {soldOut && (
                     <span className="px-3 py-1 bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 text-xs font-semibold rounded-full">
                       SOLD OUT
@@ -511,6 +558,49 @@ function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnable
           </div>
         );
       })}
+
+      {/* Unlock hidden tiers */}
+      {hasHiddenTiers && (
+        <div className="pt-4">
+          {!showUnlock ? (
+            <button
+              onClick={() => setShowUnlock(true)}
+              className="text-sm text-orange-500 hover:text-orange-600 font-medium flex items-center gap-1"
+            >
+              🔑 Have an access code?
+            </button>
+          ) : (
+            <div className="flex items-start gap-2">
+              <div className="flex-1">
+                <input
+                  type="text"
+                  value={unlockCode}
+                  onChange={(e) => setUnlockCode(e.target.value)}
+                  placeholder="Enter access code..."
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm focus:ring-2 focus:ring-orange-500"
+                  onKeyDown={(e) => e.key === 'Enter' && handleUnlock()}
+                />
+                {unlockError && (
+                  <p className="text-xs text-red-500 mt-1">{unlockError}</p>
+                )}
+              </div>
+              <button
+                onClick={handleUnlock}
+                disabled={unlockLoading || !unlockCode.trim()}
+                className="px-4 py-2 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition"
+              >
+                {unlockLoading ? '…' : 'Unlock'}
+              </button>
+              <button
+                onClick={() => { setShowUnlock(false); setUnlockError(null); }}
+                className="px-3 py-2 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/events/app/admin/[eventId]/admin-tabs.tsx
+++ b/apps/events/app/admin/[eventId]/admin-tabs.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { useState } from 'react';
+import type { TicketType } from '@/src/db/schema';
+import { EventStatusControls } from './event-status-controls';
+import { CohostManager } from './cohost-manager';
+import { InviteManager } from './invite-manager';
+import { MessageComposer } from './message-composer';
+
+type Tab = 'stats' | 'edit' | 'cohosts' | 'invites' | 'message';
+
+interface AdminTabsProps {
+  eventId: string;
+  eventTitle: string;
+  eventStatus: string;
+  isOwner: boolean;
+  ownerDid?: string;
+  accessMode: string;
+  cohostCount: number;
+  inviteCount: number;
+  confirmedAttendeeCount: number;
+  totalSold: number;
+  confirmedRevenue: number;
+  heldRevenue: number;
+  checkedIn: number;
+  tiers: TicketType[];
+  eventDate: string;
+  basePath: string;
+}
+
+export function AdminTabs({
+  eventId,
+  eventTitle,
+  eventStatus,
+  isOwner,
+  ownerDid,
+  accessMode,
+  cohostCount,
+  inviteCount,
+  confirmedAttendeeCount,
+  totalSold,
+  confirmedRevenue,
+  heldRevenue,
+  checkedIn,
+  tiers,
+  eventDate,
+  basePath,
+}: AdminTabsProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('stats');
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'stats', label: 'Stats' },
+    { key: 'edit', label: 'Edit Event' },
+    { key: 'cohosts', label: `Co-hosts (${cohostCount})` },
+    { key: 'invites', label: `Invitations (${inviteCount})` },
+    { key: 'message', label: 'Message Attendees' },
+  ];
+
+  return (
+    <div>
+      {/* Event Status bar */}
+      <EventStatusControls eventId={eventId} currentStatus={eventStatus} />
+
+      {/* Tab bar */}
+      <div className="flex gap-1 overflow-x-auto border-b border-gray-200 dark:border-gray-700 mb-6">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            className={`px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-colors border-b-2 -mb-[1px] ${
+              activeTab === tab.key
+                ? 'border-orange-500 text-orange-500'
+                : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div className="min-h-[200px]">
+        {activeTab === 'stats' && (
+          <StatsTab
+            totalSold={totalSold}
+            confirmedRevenue={confirmedRevenue}
+            heldRevenue={heldRevenue}
+            checkedIn={checkedIn}
+            eventDate={eventDate}
+            tiers={tiers}
+            basePath={basePath}
+            eventId={eventId}
+          />
+        )}
+
+        {activeTab === 'edit' && (
+          <EditTab basePath={basePath} eventId={eventId} />
+        )}
+
+        {activeTab === 'cohosts' && (
+          <CohostManager eventId={eventId} isOwner={isOwner} ownerDid={ownerDid} />
+        )}
+
+        {activeTab === 'invites' && (
+          <InviteManager eventId={eventId} accessMode={accessMode} />
+        )}
+
+        {activeTab === 'message' && (
+          <MessageComposer
+            eventId={eventId}
+            recipientCount={confirmedAttendeeCount}
+            tiers={tiers}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatsTab({
+  totalSold,
+  confirmedRevenue,
+  heldRevenue,
+  checkedIn,
+  eventDate,
+  tiers,
+  basePath,
+  eventId,
+}: {
+  totalSold: number;
+  confirmedRevenue: number;
+  heldRevenue: number;
+  checkedIn: number;
+  eventDate: string;
+  tiers: TicketType[];
+  basePath: string;
+  eventId: string;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Event Overview</h2>
+        <a
+          href={`${basePath}/${eventId}`}
+          className="text-sm text-orange-500 hover:text-orange-600 font-medium"
+        >
+          View Live Event →
+        </a>
+      </div>
+
+      {/* Stats cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4">
+        <StatCard label="Tickets Sold" value={totalSold} />
+        <StatCard label="Revenue" value={formatRevenue(confirmedRevenue, heldRevenue, 'CAD')} />
+        <StatCard label="Checked In" value={`${checkedIn} / ${totalSold}`} />
+        <StatCard
+          label="Event Date"
+          value={new Date(eventDate).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+          })}
+        />
+      </div>
+
+      {/* Ticket Tiers */}
+      <div>
+        <h2 className="text-xl font-semibold mb-2 md:mb-4">Ticket Tiers</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
+          {tiers.map((tier) => (
+            <div
+              key={tier.id}
+              className="bg-white dark:bg-gray-800 rounded-lg p-3 md:p-4 shadow"
+            >
+              <h3 className="font-semibold">{tier.name}</h3>
+              <p className="text-2xl font-bold mt-2">
+                {tier.sold} <span className="text-sm text-gray-500">/ {tier.quantity ?? '∞'}</span>
+              </p>
+              <p className="text-sm text-gray-500">
+                {formatCurrency(tier.price, tier.currency)} each
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EditTab({ basePath, eventId }: { basePath: string; eventId: string }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow">
+      <h2 className="text-xl font-semibold mb-4">Edit Event</h2>
+      <p className="text-gray-600 dark:text-gray-400 mb-4">
+        Make changes to your event details, ticket tiers, and settings.
+      </p>
+      <a
+        href={`${basePath}/${eventId}/edit`}
+        className="inline-flex items-center px-5 py-2.5 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-lg transition"
+      >
+        Open Edit Page →
+      </a>
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-3 md:p-4 shadow">
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-2xl font-bold">{value}</p>
+    </div>
+  );
+}
+
+function formatCurrency(cents: number, currency: string): string {
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency,
+  }).format(cents / 100);
+}
+
+function formatCurrencyRound(cents: number, currency: string): string {
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+function formatRevenue(confirmedCents: number, heldCents: number, currency: string): string {
+  const confirmed = formatCurrencyRound(confirmedCents, currency);
+  if (heldCents > 0) {
+    return `${confirmed} (+${formatCurrencyRound(heldCents, currency)} pending)`;
+  }
+  return confirmed;
+}

--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -393,7 +393,7 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
           <h2 className="text-xl font-semibold">Guest List</h2>
           <div className="flex items-center gap-2">
             <button
-              onClick={() => { window.location.href = `/api/events/${eventId}/guests/export.csv`; }}
+              onClick={() => { window.location.href = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/events/${eventId}/guests/export.csv`; }}
               className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
             >
               ⬇ Download CSV

--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -53,6 +53,11 @@ interface Guest {
 interface GuestListProps {
   eventId: string;
   isOwner: boolean;
+  summary?: {
+    totalTickets: number;
+    confirmedRevenue: number;
+    checkedIn: number;
+  };
 }
 
 function formatCurrency(cents: number | null, currency: string | null): string {
@@ -141,10 +146,11 @@ function ProfileCell({ ownerDid, profile, paymentMethod, paymentId }: {
 
 type FilterKey = 'type' | 'status' | null;
 
-export function GuestList({ eventId, isOwner }: GuestListProps) {
+export function GuestList({ eventId, isOwner, summary }: GuestListProps) {
   const { toast } = useToast();
+  const [expanded, setExpanded] = useState(false);
   const [guests, setGuests] = useState<Guest[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [filterKey, setFilterKey] = useState<FilterKey>(null);
   const [filterValue, setFilterValue] = useState<string | null>(null);
@@ -176,7 +182,11 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
       });
   }, [eventId]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    if (expanded) {
+      load();
+    }
+  }, [expanded, load]);
 
   const handleCheckIn = async (ticketId: string) => {
     setActionLoading(ticketId);
@@ -368,20 +378,56 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
   const uniqueTypes = Object.keys(typeCounts);
   const uniqueStatuses = Object.keys(statusCounts);
 
+  // Collapsed header with summary
+  const summaryContent = (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-3 flex-wrap">
+        <h2 className="text-xl font-semibold">Guest List</h2>
+        {summary && (
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            {summary.totalTickets} tickets · {formatCurrency(summary.confirmedRevenue, 'CAD')} · {summary.checkedIn} checked in
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setExpanded(v => !v)}
+          className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
+        >
+          {expanded ? 'Hide Attendees' : 'Show Attendees'}
+        </button>
+        <button
+          onClick={() => { window.location.href = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/events/${eventId}/guests/export.csv`; }}
+          className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
+        >
+          ⬇ Download CSV
+        </button>
+      </div>
+    </div>
+  );
+
+  if (!expanded) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        {summaryContent}
+      </div>
+    );
+  }
+
   if (loading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow">
-        <h2 className="text-xl font-semibold mb-2">Guest List</h2>
-        <p className="text-gray-500 text-sm">Loading...</p>
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        {summaryContent}
+        <p className="text-gray-500 text-sm mt-4">Loading attendees...</p>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow">
-        <h2 className="text-xl font-semibold mb-2">Guest List</h2>
-        <p className="text-red-500 text-sm">{error}</p>
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        {summaryContent}
+        <p className="text-red-500 text-sm mt-4">{error}</p>
       </div>
     );
   }
@@ -389,26 +435,10 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
       <div className="px-6 pt-6 pb-4">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-xl font-semibold">Guest List</h2>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => { window.location.href = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/events/${eventId}/guests/export.csv`; }}
-              className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
-            >
-              ⬇ Download CSV
-            </button>
-            <button
-              onClick={() => setScannerOpen(v => !v)}
-              className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600"
-            >
-              {scannerOpen ? '✕ Close Scanner' : '📷 Scan Tickets'}
-            </button>
-          </div>
-        </div>
+        {summaryContent}
 
         {scannerOpen && (
-          <div className="mb-4">
+          <div className="mt-4 mb-4">
             <TicketScanner
               eventId={eventId}
               onCheckIn={handleScannerCheckIn}
@@ -422,7 +452,7 @@ export function GuestList({ eventId, isOwner }: GuestListProps) {
 
         {/* Summary badge */}
         {guests.length > 0 && (
-          <div className="flex flex-wrap gap-2 mb-4">
+          <div className="flex flex-wrap gap-2 mt-4 mb-4">
             <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
               {guests.length} ticket{guests.length !== 1 ? 's' : ''}
             </span>

--- a/apps/events/app/admin/[eventId]/message-composer.tsx
+++ b/apps/events/app/admin/[eventId]/message-composer.tsx
@@ -1,15 +1,24 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { marked } from 'marked';
 import { apiFetch } from '@imajin/config';
+import type { TicketType } from '@/src/db/schema';
+
+type FilterType = 'everyone' | 'ticket_type' | 'registration_complete' | 'registration_incomplete';
+
+interface MessageFilter {
+  type: FilterType;
+  ticketTypeIds?: string[];
+}
 
 interface MessageComposerProps {
   eventId: string;
   recipientCount: number;
+  tiers: TicketType[];
 }
 
-export function MessageComposer({ eventId, recipientCount }: MessageComposerProps) {
+export function MessageComposer({ eventId, recipientCount: initialCount, tiers }: MessageComposerProps) {
   const [subject, setSubject] = useState('');
   const [markdown, setMarkdown] = useState('');
   const [preview, setPreview] = useState(false);
@@ -19,12 +28,43 @@ export function MessageComposer({ eventId, recipientCount }: MessageComposerProp
   const [result, setResult] = useState<{ sent: number; skipped: number; errors: number } | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Filter state
+  const [filterType, setFilterType] = useState<FilterType>('everyone');
+  const [selectedTicketTypes, setSelectedTicketTypes] = useState<Set<string>>(new Set());
+  const [recipientCount, setRecipientCount] = useState(initialCount);
+  const [countLoading, setCountLoading] = useState(false);
+
   // Render preview with marked (same lib the email uses)
   useEffect(() => {
     if (preview && markdown.trim()) {
       setPreviewHtml(marked.parse(markdown) as string);
     }
   }, [preview, markdown]);
+
+  // Fetch recipient count when filter changes
+  const fetchCount = useCallback(async () => {
+    const params = new URLSearchParams();
+    params.set('filterType', filterType);
+    if (filterType === 'ticket_type') {
+      selectedTicketTypes.forEach(id => params.append('ticketTypeId', id));
+    }
+    setCountLoading(true);
+    try {
+      const res = await apiFetch(`/api/events/${eventId}/message?${params.toString()}`);
+      const data = await res.json();
+      if (res.ok) {
+        setRecipientCount(data.count);
+      }
+    } catch {
+      // keep previous count on error
+    } finally {
+      setCountLoading(false);
+    }
+  }, [eventId, filterType, selectedTicketTypes]);
+
+  useEffect(() => {
+    fetchCount();
+  }, [fetchCount]);
 
   function handleSendClick() {
     if (!subject.trim() || !markdown.trim()) return;
@@ -37,11 +77,24 @@ export function MessageComposer({ eventId, recipientCount }: MessageComposerProp
     setError(null);
     setResult(null);
 
+    const filter: MessageFilter | undefined = filterType !== 'everyone'
+      ? {
+          type: filterType,
+          ...(filterType === 'ticket_type' && selectedTicketTypes.size > 0
+            ? { ticketTypeIds: Array.from(selectedTicketTypes) }
+            : {}),
+        }
+      : undefined;
+
     try {
       const res = await apiFetch(`/api/events/${eventId}/message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ subject: subject.trim(), markdown: markdown.trim() }),
+        body: JSON.stringify({
+          subject: subject.trim(),
+          markdown: markdown.trim(),
+          ...(filter ? { filter } : {}),
+        }),
       });
 
       const data = await res.json();
@@ -61,10 +114,10 @@ export function MessageComposer({ eventId, recipientCount }: MessageComposerProp
     }
   }
 
-  const canSend = subject.trim().length > 0 && markdown.trim().length > 0 && !sending;
+  const canSend = subject.trim().length > 0 && markdown.trim().length > 0 && !sending && recipientCount > 0;
 
   return (
-    <div className="mb-8">
+    <div>
       <div className="flex items-center gap-2 mb-4">
         {/* Mail icon */}
         <svg className="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -72,12 +125,59 @@ export function MessageComposer({ eventId, recipientCount }: MessageComposerProp
             d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
         </svg>
         <h2 className="text-xl font-semibold">Message Attendees</h2>
-        <span className="ml-auto text-sm text-gray-500 dark:text-gray-400">
+        <span className="ml-auto text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2">
+          {countLoading && <span className="text-xs">Updating…</span>}
           {recipientCount} recipient{recipientCount !== 1 ? 's' : ''}
         </span>
       </div>
 
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow space-y-4">
+        {/* Recipient filter */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Recipients
+          </label>
+          <select
+            value={filterType}
+            onChange={(e) => {
+              setFilterType(e.target.value as FilterType);
+              setSelectedTicketTypes(new Set());
+            }}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            <option value="everyone">Everyone — all confirmed attendees</option>
+            <option value="ticket_type">By Ticket Type</option>
+            <option value="registration_complete">Registration Complete</option>
+            <option value="registration_incomplete">Registration Incomplete</option>
+          </select>
+        </div>
+
+        {/* Ticket type checkboxes */}
+        {filterType === 'ticket_type' && (
+          <div className="pl-2 border-l-2 border-orange-300 dark:border-orange-700 space-y-2">
+            <p className="text-xs text-gray-500 dark:text-gray-400">Select ticket types:</p>
+            {tiers.map((tier) => (
+              <label key={tier.id} className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={selectedTicketTypes.has(tier.id)}
+                  onChange={(e) => {
+                    const next = new Set(selectedTicketTypes);
+                    if (e.target.checked) {
+                      next.add(tier.id);
+                    } else {
+                      next.delete(tier.id);
+                    }
+                    setSelectedTicketTypes(next);
+                  }}
+                  className="w-4 h-4 text-orange-500 focus:ring-orange-500 rounded"
+                />
+                {tier.name}
+              </label>
+            ))}
+          </div>
+        )}
+
         {/* Subject */}
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">

--- a/apps/events/app/admin/[eventId]/page.tsx
+++ b/apps/events/app/admin/[eventId]/page.tsx
@@ -6,13 +6,10 @@
 import { db, events, tickets, ticketTypes } from '@/src/db';
 import { eq, desc } from 'drizzle-orm';
 import { notFound } from 'next/navigation';
-import { EventStatusControls } from './event-status-controls';
-import { CohostManager } from './cohost-manager';
 import { GuestList } from './guest-list';
-import { InviteManager } from './invite-manager';
-import { MessageComposer } from './message-composer';
 import { getSession } from '@imajin/auth';
 import { getClient } from '@imajin/db';
+import { AdminTabs } from './admin-tabs';
 
 const sql = getClient();
 
@@ -37,12 +34,12 @@ export default async function AdminPage({ params }: Props) {
   // Auth check: viewer must be owner or cohost
   const session = await getSession();
   const isOwner = session?.id === event.creatorDid;
+  const actingDid = session ? (session.actingAs || session.id) : null;
 
-  if (!isOwner && event.podId) {
-    // Check if viewer is a cohost
+  if (!isOwner && event.podId && actingDid) {
     const podRows = await sql`
       SELECT role FROM connections.pod_members
-      WHERE pod_id = ${event.podId} AND did = ${session?.id ?? ''} AND role IN ('owner', 'cohost')
+      WHERE pod_id = ${event.podId} AND did = ${actingDid} AND role IN ('owner', 'cohost')
       LIMIT 1
     `;
     if (!podRows.length) {
@@ -51,13 +48,13 @@ export default async function AdminPage({ params }: Props) {
   } else if (!isOwner) {
     notFound();
   }
-  
+
   // Fetch ticket types with stats
   const tiers = await db
     .select()
     .from(ticketTypes)
     .where(eq(ticketTypes.eventId, eventId));
-  
+
   // Fetch all tickets
   const allTickets = await db
     .select({
@@ -68,7 +65,7 @@ export default async function AdminPage({ params }: Props) {
     .leftJoin(ticketTypes, eq(tickets.ticketTypeId, ticketTypes.id))
     .where(eq(tickets.eventId, eventId))
     .orderBy(desc(tickets.createdAt));
-  
+
   // Calculate stats — exclude cancelled/refunded from "sold" count
   const activeTickets = allTickets.filter(t => !['cancelled', 'refunded'].includes(t.ticket.status));
   const totalSold = activeTickets.length;
@@ -80,6 +77,23 @@ export default async function AdminPage({ params }: Props) {
     .reduce((sum, t) => sum + (t.ticket.pricePaid || 0), 0);
   const checkedIn = allTickets.filter(t => t.ticket.usedAt).length;
 
+  // Count cohosts
+  let cohostCount = 0;
+  if (event.podId) {
+    const cohostRows = await sql`
+      SELECT COUNT(*) as count FROM connections.pod_members
+      WHERE pod_id = ${event.podId} AND role = 'cohost' AND removed_at IS NULL
+    `;
+    cohostCount = Number(cohostRows[0]?.count ?? 0);
+  }
+
+  // Count invites
+  const inviteRows = await sql`
+    SELECT COUNT(*) as count FROM events.event_invites
+    WHERE event_id = ${eventId}
+  `;
+  const inviteCount = Number(inviteRows[0]?.count ?? 0);
+
   // Count distinct confirmed attendees for broadcast
   const confirmedAttendeeRows = await sql`
     SELECT COUNT(DISTINCT owner_did) AS count
@@ -89,128 +103,57 @@ export default async function AdminPage({ params }: Props) {
       AND owner_did IS NOT NULL
   `;
   const confirmedAttendeeCount = Number(confirmedAttendeeRows[0]?.count ?? 0);
-  
+
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
   return (
     <div className="max-w-6xl mx-auto p-4 md:p-8">
       {/* Header */}
-      <div className="mb-4 md:mb-8">
-        <h1 className="text-3xl font-bold">{event.title}</h1>
-        <p className="text-gray-600 dark:text-gray-400">Admin Dashboard</p>
-      </div>
-
-      {/* Status Controls */}
-      <EventStatusControls eventId={event.id} currentStatus={event.status || 'draft'} />
-
-      {/* Name Display Policy */}
-      <div className="mb-4 md:mb-6 flex items-center gap-3">
-        <span className="text-sm text-gray-500 dark:text-gray-400">Attendee name display:</span>
-        <NamePolicyBadge policy={(event as any).nameDisplayPolicy || 'attendee_choice'} />
+      <div className="mb-4 md:mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">{event.title}</h1>
+          <p className="text-gray-600 dark:text-gray-400">Admin Dashboard</p>
+        </div>
         <a
-          href={`/${event.id}/edit`}
-          className="text-xs text-orange-500 hover:text-orange-600 underline"
+          href={`${basePath}/${eventId}`}
+          className="text-sm text-orange-500 hover:text-orange-600 font-medium flex items-center gap-1"
         >
-          Change
+          ← View Live Event
         </a>
       </div>
 
-      {/* Co-host Management */}
-      <div className="mb-4 md:mb-8">
-        <CohostManager eventId={event.id} isOwner={isOwner} />
-      </div>
+      {/* Tabs + Tab Content */}
+      <AdminTabs
+        eventId={eventId}
+        eventTitle={event.title}
+        eventStatus={event.status || 'draft'}
+        isOwner={isOwner}
+        ownerDid={event.creatorDid}
+        accessMode={event.accessMode || 'public'}
+        cohostCount={cohostCount}
+        inviteCount={inviteCount}
+        confirmedAttendeeCount={confirmedAttendeeCount}
+        totalSold={totalSold}
+        confirmedRevenue={confirmedRevenue}
+        heldRevenue={heldRevenue}
+        checkedIn={checkedIn}
+        tiers={tiers}
+        eventDate={event.startsAt.toISOString()}
+        basePath={basePath}
+      />
 
-      {/* Invite Link Management */}
-      <InviteManager eventId={event.id} accessMode={event.accessMode || 'public'} />
-
-      {/* Message Attendees */}
-      <MessageComposer eventId={event.id} recipientCount={confirmedAttendeeCount} />
-
-      {/* Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4 mb-4 md:mb-8">
-        <StatCard label="Tickets Sold" value={totalSold} />
-        <StatCard label="Revenue" value={formatRevenue(confirmedRevenue, heldRevenue, 'CAD')} />
-        <StatCard label="Checked In" value={`${checkedIn} / ${totalSold}`} />
-        <StatCard 
-          label="Event Date" 
-          value={new Date(event.startsAt).toLocaleDateString('en-US', { 
-            month: 'short', 
-            day: 'numeric' 
-          })} 
+      {/* Guest List — always visible below tabs, lazy loaded */}
+      <div className="mt-8">
+        <GuestList
+          eventId={eventId}
+          isOwner={isOwner}
+          summary={{
+            totalTickets: totalSold,
+            confirmedRevenue,
+            checkedIn,
+          }}
         />
       </div>
-      
-      {/* Ticket Tiers */}
-      <div className="mb-4 md:mb-8">
-        <h2 className="text-xl font-semibold mb-2 md:mb-4">Ticket Tiers</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
-          {tiers.map(tier => (
-            <div 
-              key={tier.id} 
-              className="bg-white dark:bg-gray-800 rounded-lg p-3 md:p-4 shadow"
-            >
-              <h3 className="font-semibold">{tier.name}</h3>
-              <p className="text-2xl font-bold mt-2">
-                {tier.sold} <span className="text-sm text-gray-500">/ {tier.quantity ?? '∞'}</span>
-              </p>
-              <p className="text-sm text-gray-500">
-                {formatCurrency(tier.price, tier.currency)} each
-              </p>
-            </div>
-          ))}
-        </div>
-      </div>
-      
-      {/* Guest List */}
-      <GuestList eventId={eventId} isOwner={isOwner} />
     </div>
   );
-}
-
-function StatCard({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg p-3 md:p-4 shadow">
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className="text-2xl font-bold">{value}</p>
-    </div>
-  );
-}
-
-
-const NAME_POLICY_LABELS: Record<string, { label: string; color: string }> = {
-  attendee_choice: { label: 'Attendee choice', color: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' },
-  real_name:       { label: 'Real name',       color: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
-  handle:          { label: 'Handle only',     color: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400' },
-  anonymous:       { label: 'Anonymous',       color: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300' },
-};
-
-function NamePolicyBadge({ policy }: { policy: string }) {
-  const meta = NAME_POLICY_LABELS[policy] ?? NAME_POLICY_LABELS['attendee_choice'];
-  return (
-    <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${meta.color}`}>
-      {meta.label}
-    </span>
-  );
-}
-
-function formatCurrency(cents: number, currency: string): string {
-  return new Intl.NumberFormat('en-CA', {
-    style: 'currency',
-    currency,
-  }).format(cents / 100);
-}
-
-function formatCurrencyRound(cents: number, currency: string): string {
-  return new Intl.NumberFormat('en-CA', {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(cents / 100);
-}
-
-function formatRevenue(confirmedCents: number, heldCents: number, currency: string): string {
-  const confirmed = formatCurrencyRound(confirmedCents, currency);
-  if (heldCents > 0) {
-    return `${confirmed} (+${formatCurrencyRound(heldCents, currency)} pending)`;
-  }
-  return confirmed;
 }

--- a/apps/events/app/admin/page.tsx
+++ b/apps/events/app/admin/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminEventsPage() {
           </p>
         </div>
         <a
-          href="/api/admin/events/export.csv"
+          href={`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/admin/events/export.csv`}
           className="inline-flex items-center px-4 py-2 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-lg transition"
         >
           ⬇ Export Events

--- a/apps/events/app/api/events/[id]/guests/route.ts
+++ b/apps/events/app/api/events/[id]/guests/route.ts
@@ -48,7 +48,7 @@ export async function GET(
     if (!orgCheck.authorized) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
-    const isOwner = orgCheck.role === 'creator';
+    const isOwner = orgCheck.role === 'creator' || orgCheck.role === 'cohost';
 
     const ticketRows = await sql`
       SELECT t.id, t.status, t.owner_did, t.price_paid, t.currency, t.purchased_at, t.used_at,

--- a/apps/events/app/api/events/[id]/message/route.ts
+++ b/apps/events/app/api/events/[id]/message/route.ts
@@ -13,13 +13,120 @@ const sql = getClient();
 const NOTIFY_URL = process.env.NOTIFY_SERVICE_URL || process.env.NOTIFY_URL || 'http://localhost:3008';
 const NOTIFY_WEBHOOK_SECRET = process.env.NOTIFY_WEBHOOK_SECRET;
 
+interface MessageFilter {
+  type: 'everyone' | 'ticket_type' | 'registration_complete' | 'registration_incomplete';
+  ticketTypeIds?: string[];
+}
+
+async function checkAuth(request: NextRequest, eventId: string) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return { error: authResult.error, status: authResult.status };
+  }
+  const did = authResult.identity.actingAs || authResult.identity.id;
+  const orgCheck = await isEventOrganizer(eventId, did);
+  if (!orgCheck.authorized) {
+    return { error: 'Forbidden', status: 403 };
+  }
+  return { identity: authResult.identity };
+}
+
+async function queryRecipients(eventId: string, filter?: MessageFilter) {
+  const baseWhere = sql`event_id = ${eventId} AND status IN ('valid', 'used') AND owner_did IS NOT NULL`;
+
+  if (filter) {
+    switch (filter.type) {
+      case 'ticket_type':
+        if (filter.ticketTypeIds && filter.ticketTypeIds.length > 0) {
+          const rows = await sql`
+            SELECT DISTINCT owner_did
+            FROM events.tickets
+            WHERE event_id = ${eventId}
+              AND status IN ('valid', 'used')
+              AND owner_did IS NOT NULL
+              AND ticket_type_id = ANY(${filter.ticketTypeIds})
+          `;
+          return rows.map((r: any) => r.owner_did as string);
+        }
+        break;
+      case 'registration_complete': {
+        const rows = await sql`
+          SELECT DISTINCT owner_did
+          FROM events.tickets
+          WHERE event_id = ${eventId}
+            AND status IN ('valid', 'used')
+            AND owner_did IS NOT NULL
+            AND registration_status = 'complete'
+        `;
+        return rows.map((r: any) => r.owner_did as string);
+      }
+      case 'registration_incomplete': {
+        const rows = await sql`
+          SELECT DISTINCT owner_did
+          FROM events.tickets
+          WHERE event_id = ${eventId}
+            AND status IN ('valid', 'used')
+            AND owner_did IS NOT NULL
+            AND (registration_status IS NULL OR registration_status != 'complete')
+        `;
+        return rows.map((r: any) => r.owner_did as string);
+      }
+      case 'everyone':
+      default:
+        break;
+    }
+  }
+
+  const rows = await sql`
+    SELECT DISTINCT owner_did
+    FROM events.tickets
+    WHERE event_id = ${eventId}
+      AND status IN ('valid', 'used')
+      AND owner_did IS NOT NULL
+  `;
+  return rows.map((r: any) => r.owner_did as string);
+}
+
+/**
+ * GET /api/events/[id]/message?filterType=...&ticketTypeId=...
+ *
+ * Get recipient count for a given filter. Used by the message composer
+ * to update the displayed count when filters change.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const auth = await checkAuth(request, id);
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const filterType = searchParams.get('filterType') as MessageFilter['type'] | null;
+  const ticketTypeIds = searchParams.getAll('ticketTypeId');
+
+  const filter: MessageFilter | undefined = filterType && filterType !== 'everyone'
+    ? { type: filterType, ticketTypeIds: ticketTypeIds.length > 0 ? ticketTypeIds : undefined }
+    : undefined;
+
+  try {
+    const dids = await queryRecipients(id, filter);
+    return NextResponse.json({ count: dids.length });
+  } catch (err) {
+    log.error({ err: String(err) }, '[message] Failed to count recipients');
+    return NextResponse.json({ error: 'Failed to count recipients' }, { status: 500 });
+  }
+}
+
 /**
  * POST /api/events/[id]/message
  *
- * Send a broadcast message to all confirmed ticket holders for an event.
+ * Send a broadcast message to filtered confirmed ticket holders for an event.
  * Caller must be event organizer (creator or cohost).
  *
- * Body: { subject: string; markdown: string }
+ * Body: { subject: string; markdown: string; filter?: MessageFilter }
  */
 export async function POST(
   request: NextRequest,
@@ -39,14 +146,14 @@ export async function POST(
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  let body: { subject: string; markdown: string };
+  let body: { subject: string; markdown: string; filter?: MessageFilter };
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { subject, markdown } = body;
+  const { subject, markdown, filter } = body;
   if (!subject || !markdown) {
     return NextResponse.json({ error: 'Missing required fields: subject, markdown' }, { status: 400 });
   }
@@ -65,16 +172,8 @@ export async function POST(
     return NextResponse.json({ error: 'Event not found' }, { status: 404 });
   }
 
-  // Fetch distinct attendee DIDs for confirmed (paid) tickets
-  const ticketRows = await sql`
-    SELECT DISTINCT owner_did
-    FROM events.tickets
-    WHERE event_id = ${id}
-      AND status IN ('valid', 'used')
-      AND owner_did IS NOT NULL
-  `;
-
-  const dids = ticketRows.map((r: any) => r.owner_did as string);
+  // Fetch distinct attendee DIDs with optional filter
+  const dids = await queryRecipients(id, filter);
   const total = dids.length;
 
   if (total === 0) {

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/cancel/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/cancel/route.ts
@@ -7,29 +7,28 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { eq, and } from 'drizzle-orm';
 import { db, tickets, events } from '@/src/db';
-import { getSession } from '@imajin/auth';
-import { withLogger } from '@imajin/logger';
+import { requireAuth } from '@imajin/auth';
+import { isEventOrganizer } from '@/src/lib/organizer';
+import { createLogger } from '@imajin/logger';
 
-export const POST = withLogger('events', async (
-  _request: NextRequest,
-  { log, params }: { log: any; params: Promise<{ id: string; ticketId: string }> }
-) => {
-  const session = await getSession();
-  if (!session) {
-    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+const log = createLogger('events');
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; ticketId: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
   }
 
+  const { identity } = authResult;
+  const actingDid = identity.actingAs || identity.id;
   const { id: eventId, ticketId } = await params;
-  const actingDid = session.actingAs || session.id;
 
-  // Verify event ownership
-  const [event] = await db
-    .select({ creatorDid: events.creatorDid })
-    .from(events)
-    .where(eq(events.id, eventId))
-    .limit(1);
-
-  if (!event || event.creatorDid !== actingDid) {
+  // Verify event ownership (creator or cohost)
+  const orgCheck = await isEventOrganizer(eventId, actingDid);
+  if (!orgCheck.authorized) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
   }
 
@@ -65,4 +64,4 @@ export const POST = withLogger('events', async (
   log.info({ ticketId, eventId }, 'Held ticket cancelled');
 
   return NextResponse.json({ ticket: updated });
-});
+}

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/mark-refund-sent/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/mark-refund-sent/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createLogger } from '@imajin/logger';
 import { db, events } from '@/src/db';
+import { isEventOrganizer } from '@/src/lib/organizer';
 
 const log = createLogger('events');
 import { requireAuth } from '@imajin/auth';
@@ -33,8 +34,9 @@ export async function POST(
       return NextResponse.json({ error: 'Event not found' }, { status: 404 });
     }
 
-    if (event.creatorDid !== did) {
-      return NextResponse.json({ error: 'Only the event owner can mark refunds as sent' }, { status: 403 });
+    const orgCheck = await isEventOrganizer(id, did);
+    if (!orgCheck.authorized) {
+      return NextResponse.json({ error: 'Only event organizers can mark refunds as sent' }, { status: 403 });
     }
 
     const [ticket] = await sqlClient`

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/refund/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/refund/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createLogger } from '@imajin/logger';
 import { db, events, ticketTypes, ticketRegistrations } from '@/src/db';
+import { isEventOrganizer } from '@/src/lib/organizer';
 
 const log = createLogger('events');
 import { requireAuth, getEmailForDid } from '@imajin/auth';
@@ -40,9 +41,10 @@ export async function POST(
       return NextResponse.json({ error: 'Event not found' }, { status: 404 });
     }
 
-    // Refund is owner-only (not cohosts)
-    if (event.creatorDid !== did) {
-      return NextResponse.json({ error: 'Only the event owner can issue refunds' }, { status: 403 });
+    // Refund is organizer-only (creator or cohost)
+    const orgCheck = await isEventOrganizer(id, did);
+    if (!orgCheck.authorized) {
+      return NextResponse.json({ error: 'Only event organizers can issue refunds' }, { status: 403 });
     }
 
     const [ticket] = await sqlClient`

--- a/apps/events/app/api/events/[id]/tiers/route.ts
+++ b/apps/events/app/api/events/[id]/tiers/route.ts
@@ -6,23 +6,23 @@ const log = createLogger('events');
 import { db, events, ticketTypes } from '@/src/db';
 import { requireAuth } from '@imajin/auth';
 import { isEventOrganizer } from '@/src/lib/organizer';
-import { eq, and, asc } from 'drizzle-orm';
+import { eq, and, asc, isNull } from 'drizzle-orm';
 import { randomBytes } from 'crypto';
 
 /**
- * GET /api/events/[id]/tiers - List ticket tiers
+ * GET /api/events/[id]/tiers - List public ticket tiers (excludes access-code-protected)
  */
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
-  
+
   try {
     const tiers = await db
       .select()
       .from(ticketTypes)
-      .where(eq(ticketTypes.eventId, id))
+      .where(and(eq(ticketTypes.eventId, id), isNull(ticketTypes.accessCode)))
       .orderBy(asc(ticketTypes.sortOrder));
 
     return NextResponse.json({
@@ -61,7 +61,7 @@ export async function POST(
     }
 
     const body = await request.json();
-    const { name, description, price, currency = 'USD', quantity, perks, sortOrder, requiresRegistration, registrationFormId } = body;
+    const { name, description, price, currency = 'USD', quantity, perks, sortOrder, requiresRegistration, registrationFormId, accessCode } = body;
 
     if (!name) {
       return NextResponse.json({ error: 'name is required' }, { status: 400 });
@@ -84,6 +84,7 @@ export async function POST(
       sortOrder: sortOrder ?? 0,
       requiresRegistration: requiresRegistration ?? false,
       registrationFormId: registrationFormId || null,
+      accessCode: accessCode?.trim() || null,
     }).returning();
 
     revalidatePath(`/${id}`);
@@ -118,7 +119,7 @@ export async function PUT(
     }
 
     const body = await request.json();
-    const { tierId, name, description, price, quantity, perks, sortOrder, requiresRegistration, registrationFormId } = body;
+    const { tierId, name, description, price, quantity, perks, sortOrder, requiresRegistration, registrationFormId, accessCode } = body;
 
     if (!tierId) {
       return NextResponse.json({ error: 'tierId is required' }, { status: 400 });
@@ -147,6 +148,7 @@ export async function PUT(
     if (sortOrder !== undefined) updates.sortOrder = sortOrder;
     if (requiresRegistration !== undefined) updates.requiresRegistration = requiresRegistration;
     if (registrationFormId !== undefined) updates.registrationFormId = registrationFormId || null;
+    if (accessCode !== undefined) updates.accessCode = accessCode?.trim() || null;
 
     // Price - freely editable if no tickets sold, can only decrease after sales
     if (price !== undefined) {

--- a/apps/events/app/api/events/[id]/tiers/unlock/route.ts
+++ b/apps/events/app/api/events/[id]/tiers/unlock/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createLogger } from '@imajin/logger';
+import { db, ticketTypes } from '@/src/db';
+import { eq, and, asc, sql } from 'drizzle-orm';
+
+const log = createLogger('events');
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/events/[id]/tiers/unlock?code=XXXX
+ *
+ * Returns ticket types matching the given access code (case-insensitive).
+ * No auth required. Used to reveal hidden/staff/VIP ticket tiers.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get('code')?.trim();
+
+  if (!code) {
+    return NextResponse.json({ error: 'Missing code parameter' }, { status: 400 });
+  }
+
+  try {
+    // Case-insensitive match using LOWER()
+    const tiers = await db
+      .select()
+      .from(ticketTypes)
+      .where(
+        and(
+          eq(ticketTypes.eventId, id),
+          sql`LOWER(${ticketTypes.accessCode}) = LOWER(${code})`
+        )
+      )
+      .orderBy(asc(ticketTypes.sortOrder));
+
+    if (tiers.length === 0) {
+      return NextResponse.json({ error: 'Invalid access code' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      tiers: tiers.map(t => ({
+        ...t,
+        available: t.quantity !== null ? t.quantity - (t.sold || 0) : null,
+      })),
+    });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Failed to unlock tiers');
+    return NextResponse.json({ error: 'Failed to unlock tiers' }, { status: 500 });
+  }
+}

--- a/apps/events/migrations/005_ticket_type_access_code.sql
+++ b/apps/events/migrations/005_ticket_type_access_code.sql
@@ -1,0 +1,2 @@
+-- Add access_code column to ticket_types for gated/hidden ticket tiers
+ALTER TABLE events.ticket_types ADD COLUMN IF NOT EXISTS access_code TEXT DEFAULT NULL;

--- a/apps/events/src/db/schema.ts
+++ b/apps/events/src/db/schema.ts
@@ -94,6 +94,7 @@ export const ticketTypes = eventsSchema.table('ticket_types', {
   requiresRegistration: boolean('requires_registration').notNull().default(false),
   registrationFormId: text('registration_form_id'),         // Dykil form ID
   maxPerOrder: integer('max_per_order'),                    // null = use event default (10)
+  accessCode: text('access_code'),                          // null = visible to everyone
 
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({

--- a/apps/kernel/app/api/admin/logs/route.ts
+++ b/apps/kernel/app/api/admin/logs/route.ts
@@ -14,6 +14,7 @@ export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
   const service = url.searchParams.get('service') || null;
   const levelParam = url.searchParams.get('level') || null;
   const levels = levelParam ? levelParam.split(',').filter(Boolean) : null;
+  const source = url.searchParams.get('source') || null;
   const correlationId = url.searchParams.get('correlationId') || null;
   const did = url.searchParams.get('did') || null;
   const search = url.searchParams.get('search') || null;
@@ -22,99 +23,37 @@ export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
   const limit = Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10));
   const offset = parseInt(url.searchParams.get('offset') || '0', 10);
 
-  // Source filter: 'requests' | 'app' | null (both)
-  const source = url.searchParams.get('source') || null;
-
-  // Map level filters to status code ranges for request_log
-  const errorsOnly = levels && levels.length > 0 && levels.every(l => l === 'error');
-  const warnsAndErrors = levels && levels.length > 0 && levels.every(l => l === 'error' || l === 'warn');
-
-  // Build unified query from both tables
   const [countRow] = await sql`
-    SELECT COUNT(*)::int AS total FROM (
-      ${source !== 'app' ? sql`
-        SELECT id, created_at
-        FROM registry.request_log
-        WHERE TRUE
-        ${service ? sql`AND service = ${service}` : sql``}
-        ${errorsOnly ? sql`AND status >= 500` : warnsAndErrors ? sql`AND status >= 400` : sql``}
-        ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
-        ${did ? sql`AND did = ${did}` : sql``}
-        ${search ? sql`AND (path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
-        ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
-        ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
-      ` : sql`SELECT NULL::text AS id, NULL::timestamptz AS created_at WHERE FALSE`}
-      ${source === null ? sql`UNION ALL` : sql``}
-      ${source !== 'requests' ? sql`
-        SELECT id, created_at
-        FROM registry.app_logs
-        WHERE TRUE
-        ${service ? sql`AND service = ${service}` : sql``}
-        ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
-        ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
-        ${did ? sql`AND did = ${did}` : sql``}
-        ${search ? sql`AND message ILIKE ${'%' + search + '%'}` : sql``}
-        ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
-        ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
-      ` : sql`SELECT NULL::text AS id, NULL::timestamptz AS created_at WHERE FALSE`}
-    ) unified
+    SELECT COUNT(*)::int AS total
+    FROM registry.logs
+    WHERE TRUE
+    ${service ? sql`AND service = ${service}` : sql``}
+    ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
+    ${source ? sql`AND source = ${source}` : sql``}
+    ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
+    ${did ? sql`AND did = ${did}` : sql``}
+    ${search ? sql`AND (message ILIKE ${'%' + search + '%'} OR path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
+    ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
+    ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
   `;
 
   const rows = await sql`
-    SELECT * FROM (
-      ${source !== 'app' ? sql`
-        SELECT
-          id,
-          service,
-          CASE WHEN status >= 500 THEN 'error' WHEN status >= 400 THEN 'warn' ELSE 'info' END AS level,
-          COALESCE(error_message, method || ' ' || path || ' → ' || status) AS message,
-          correlation_id,
-          did,
-          method,
-          path,
-          json_build_object('status', status, 'duration_ms', duration_ms, 'ip', ip) AS metadata,
-          created_at,
-          'request' AS source
-        FROM registry.request_log
-        WHERE TRUE
-        ${service ? sql`AND service = ${service}` : sql``}
-        ${errorsOnly ? sql`AND status >= 500` : warnsAndErrors ? sql`AND status >= 400` : sql``}
-        ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
-        ${did ? sql`AND did = ${did}` : sql``}
-        ${search ? sql`AND (path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
-        ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
-        ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
-      ` : sql`SELECT NULL::text AS id, NULL::text AS service, NULL::text AS level, NULL::text AS message, NULL::text AS correlation_id, NULL::text AS did, NULL::text AS method, NULL::text AS path, NULL::jsonb AS metadata, NULL::timestamptz AS created_at, NULL::text AS source WHERE FALSE`}
-      ${source === null ? sql`UNION ALL` : sql``}
-      ${source !== 'requests' ? sql`
-        SELECT
-          id,
-          service,
-          level,
-          message,
-          correlation_id,
-          did,
-          method,
-          path,
-          metadata,
-          created_at,
-          'app' AS source
-        FROM registry.app_logs
-        WHERE TRUE
-        ${service ? sql`AND service = ${service}` : sql``}
-        ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
-        ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
-        ${did ? sql`AND did = ${did}` : sql``}
-        ${search ? sql`AND message ILIKE ${'%' + search + '%'}` : sql``}
-        ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
-        ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
-      ` : sql`SELECT NULL::text AS id, NULL::text AS service, NULL::text AS level, NULL::text AS message, NULL::text AS correlation_id, NULL::text AS did, NULL::text AS method, NULL::text AS path, NULL::jsonb AS metadata, NULL::timestamptz AS created_at, NULL::text AS source WHERE FALSE`}
-    ) unified
+    SELECT id, source, service, level, message, correlation_id, did, method, path, status, duration_ms, ip, error_message, metadata, created_at
+    FROM registry.logs
+    WHERE TRUE
+    ${service ? sql`AND service = ${service}` : sql``}
+    ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
+    ${source ? sql`AND source = ${source}` : sql``}
+    ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
+    ${did ? sql`AND did = ${did}` : sql``}
+    ${search ? sql`AND (message ILIKE ${'%' + search + '%'} OR path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
+    ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
+    ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
     ORDER BY created_at DESC
     LIMIT ${limit} OFFSET ${offset}
   `;
 
-  log.info({ service: 'kernel', filterService: service, levels, limit, offset, count: rows.length }, 'admin logs query');
+  log.info({ service: 'kernel', filterService: service, levels, source, limit, offset, count: rows.length }, 'admin logs query');
 
   return NextResponse.json({ rows, total: countRow?.total ?? 0 });
 });

--- a/apps/kernel/app/api/admin/logs/route.ts
+++ b/apps/kernel/app/api/admin/logs/route.ts
@@ -22,28 +22,42 @@ export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
   const limit = Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10));
   const offset = parseInt(url.searchParams.get('offset') || '0', 10);
 
+  // Map level filters to status code ranges
+  const errorsOnly = levels && levels.length > 0 && levels.every(l => l === 'error');
+  const warnsAndErrors = levels && levels.length > 0 && levels.every(l => l === 'error' || l === 'warn');
+
   const [countRow] = await sql`
     SELECT COUNT(*)::int AS total
-    FROM registry.app_logs
+    FROM registry.request_log
     WHERE TRUE
     ${service ? sql`AND service = ${service}` : sql``}
-    ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
+    ${errorsOnly ? sql`AND status >= 500` : warnsAndErrors ? sql`AND status >= 400` : sql``}
     ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
     ${did ? sql`AND did = ${did}` : sql``}
-    ${search ? sql`AND message ILIKE ${'%' + search + '%'}` : sql``}
+    ${search ? sql`AND (path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
     ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
     ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
   `;
 
   const rows = await sql`
-    SELECT id, service, level, message, correlation_id, did, method, path, metadata, created_at
-    FROM registry.app_logs
+    SELECT
+      id,
+      service,
+      CASE WHEN status >= 500 THEN 'error' WHEN status >= 400 THEN 'warn' ELSE 'info' END AS level,
+      COALESCE(error_message, method || ' ' || path || ' → ' || status) AS message,
+      correlation_id,
+      did,
+      method,
+      path,
+      json_build_object('status', status, 'duration_ms', duration_ms, 'ip', ip) AS metadata,
+      created_at
+    FROM registry.request_log
     WHERE TRUE
     ${service ? sql`AND service = ${service}` : sql``}
-    ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
+    ${errorsOnly ? sql`AND status >= 500` : warnsAndErrors ? sql`AND status >= 400` : sql``}
     ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
     ${did ? sql`AND did = ${did}` : sql``}
-    ${search ? sql`AND message ILIKE ${'%' + search + '%'}` : sql``}
+    ${search ? sql`AND (path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
     ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
     ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
     ORDER BY created_at DESC

--- a/apps/kernel/app/api/admin/logs/route.ts
+++ b/apps/kernel/app/api/admin/logs/route.ts
@@ -22,44 +22,94 @@ export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
   const limit = Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10));
   const offset = parseInt(url.searchParams.get('offset') || '0', 10);
 
-  // Map level filters to status code ranges
+  // Source filter: 'requests' | 'app' | null (both)
+  const source = url.searchParams.get('source') || null;
+
+  // Map level filters to status code ranges for request_log
   const errorsOnly = levels && levels.length > 0 && levels.every(l => l === 'error');
   const warnsAndErrors = levels && levels.length > 0 && levels.every(l => l === 'error' || l === 'warn');
 
+  // Build unified query from both tables
   const [countRow] = await sql`
-    SELECT COUNT(*)::int AS total
-    FROM registry.request_log
-    WHERE TRUE
-    ${service ? sql`AND service = ${service}` : sql``}
-    ${errorsOnly ? sql`AND status >= 500` : warnsAndErrors ? sql`AND status >= 400` : sql``}
-    ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
-    ${did ? sql`AND did = ${did}` : sql``}
-    ${search ? sql`AND (path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
-    ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
-    ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
+    SELECT COUNT(*)::int AS total FROM (
+      ${source !== 'app' ? sql`
+        SELECT id, created_at
+        FROM registry.request_log
+        WHERE TRUE
+        ${service ? sql`AND service = ${service}` : sql``}
+        ${errorsOnly ? sql`AND status >= 500` : warnsAndErrors ? sql`AND status >= 400` : sql``}
+        ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
+        ${did ? sql`AND did = ${did}` : sql``}
+        ${search ? sql`AND (path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
+        ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
+        ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
+      ` : sql`SELECT NULL::text AS id, NULL::timestamptz AS created_at WHERE FALSE`}
+      ${source === null ? sql`UNION ALL` : sql``}
+      ${source !== 'requests' ? sql`
+        SELECT id, created_at
+        FROM registry.app_logs
+        WHERE TRUE
+        ${service ? sql`AND service = ${service}` : sql``}
+        ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
+        ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
+        ${did ? sql`AND did = ${did}` : sql``}
+        ${search ? sql`AND message ILIKE ${'%' + search + '%'}` : sql``}
+        ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
+        ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
+      ` : sql`SELECT NULL::text AS id, NULL::timestamptz AS created_at WHERE FALSE`}
+    ) unified
   `;
 
   const rows = await sql`
-    SELECT
-      id,
-      service,
-      CASE WHEN status >= 500 THEN 'error' WHEN status >= 400 THEN 'warn' ELSE 'info' END AS level,
-      COALESCE(error_message, method || ' ' || path || ' → ' || status) AS message,
-      correlation_id,
-      did,
-      method,
-      path,
-      json_build_object('status', status, 'duration_ms', duration_ms, 'ip', ip) AS metadata,
-      created_at
-    FROM registry.request_log
-    WHERE TRUE
-    ${service ? sql`AND service = ${service}` : sql``}
-    ${errorsOnly ? sql`AND status >= 500` : warnsAndErrors ? sql`AND status >= 400` : sql``}
-    ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
-    ${did ? sql`AND did = ${did}` : sql``}
-    ${search ? sql`AND (path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
-    ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
-    ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
+    SELECT * FROM (
+      ${source !== 'app' ? sql`
+        SELECT
+          id,
+          service,
+          CASE WHEN status >= 500 THEN 'error' WHEN status >= 400 THEN 'warn' ELSE 'info' END AS level,
+          COALESCE(error_message, method || ' ' || path || ' → ' || status) AS message,
+          correlation_id,
+          did,
+          method,
+          path,
+          json_build_object('status', status, 'duration_ms', duration_ms, 'ip', ip) AS metadata,
+          created_at,
+          'request' AS source
+        FROM registry.request_log
+        WHERE TRUE
+        ${service ? sql`AND service = ${service}` : sql``}
+        ${errorsOnly ? sql`AND status >= 500` : warnsAndErrors ? sql`AND status >= 400` : sql``}
+        ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
+        ${did ? sql`AND did = ${did}` : sql``}
+        ${search ? sql`AND (path ILIKE ${'%' + search + '%'} OR error_message ILIKE ${'%' + search + '%'})` : sql``}
+        ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
+        ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
+      ` : sql`SELECT NULL::text AS id, NULL::text AS service, NULL::text AS level, NULL::text AS message, NULL::text AS correlation_id, NULL::text AS did, NULL::text AS method, NULL::text AS path, NULL::jsonb AS metadata, NULL::timestamptz AS created_at, NULL::text AS source WHERE FALSE`}
+      ${source === null ? sql`UNION ALL` : sql``}
+      ${source !== 'requests' ? sql`
+        SELECT
+          id,
+          service,
+          level,
+          message,
+          correlation_id,
+          did,
+          method,
+          path,
+          metadata,
+          created_at,
+          'app' AS source
+        FROM registry.app_logs
+        WHERE TRUE
+        ${service ? sql`AND service = ${service}` : sql``}
+        ${levels && levels.length > 0 ? sql`AND level = ANY(${levels})` : sql``}
+        ${correlationId ? sql`AND correlation_id = ${correlationId}` : sql``}
+        ${did ? sql`AND did = ${did}` : sql``}
+        ${search ? sql`AND message ILIKE ${'%' + search + '%'}` : sql``}
+        ${from ? sql`AND created_at >= ${from}::timestamptz` : sql``}
+        ${to ? sql`AND created_at <= ${to}::timestamptz` : sql``}
+      ` : sql`SELECT NULL::text AS id, NULL::text AS service, NULL::text AS level, NULL::text AS message, NULL::text AS correlation_id, NULL::text AS did, NULL::text AS method, NULL::text AS path, NULL::jsonb AS metadata, NULL::timestamptz AS created_at, NULL::text AS source WHERE FALSE`}
+    ) unified
     ORDER BY created_at DESC
     LIMIT ${limit} OFFSET ${offset}
   `;

--- a/migrations/0009_unified_logs.sql
+++ b/migrations/0009_unified_logs.sql
@@ -1,0 +1,50 @@
+-- Unified logs table: replaces request_log + app_logs
+-- Source: 'request' (withLogger HTTP requests) or 'app' (application-level logs)
+
+CREATE TABLE IF NOT EXISTS registry.logs (
+  id             TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  source         TEXT NOT NULL DEFAULT 'request',  -- 'request' | 'app'
+  service        TEXT NOT NULL,
+  level          TEXT NOT NULL DEFAULT 'info',      -- 'error' | 'warn' | 'info' | 'debug'
+  message        TEXT,
+  method         TEXT,
+  path           TEXT,
+  status         INTEGER,
+  duration_ms    INTEGER,
+  did            TEXT,
+  ip             TEXT,
+  correlation_id TEXT,
+  error_message  TEXT,
+  metadata       JSONB,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Primary query pattern: recent logs by service
+CREATE INDEX IF NOT EXISTS idx_logs_service_created
+  ON registry.logs (service, created_at DESC);
+
+-- Error filtering (the main use case Ryan wants)
+CREATE INDEX IF NOT EXISTS idx_logs_errors
+  ON registry.logs (created_at DESC) WHERE level IN ('error', 'warn');
+
+-- Cross-service tracing
+CREATE INDEX IF NOT EXISTS idx_logs_correlation
+  ON registry.logs (correlation_id) WHERE correlation_id IS NOT NULL;
+
+-- Source filtering
+CREATE INDEX IF NOT EXISTS idx_logs_source
+  ON registry.logs (source, created_at DESC);
+
+-- Migrate existing data
+INSERT INTO registry.logs (id, source, service, level, message, method, path, status, duration_ms, did, ip, correlation_id, error_message, created_at)
+  SELECT id, 'request', service,
+    CASE WHEN status >= 500 THEN 'error' WHEN status >= 400 THEN 'warn' ELSE 'info' END,
+    COALESCE(error_message, method || ' ' || path || ' → ' || status),
+    method, path, status, duration_ms, did, ip, correlation_id, error_message, created_at
+  FROM registry.request_log
+  ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO registry.logs (id, source, service, level, message, method, path, did, correlation_id, metadata, created_at)
+  SELECT id, 'app', service, level, message, method, path, did, correlation_id, metadata, created_at
+  FROM registry.app_logs
+  ON CONFLICT (id) DO NOTHING;

--- a/packages/logger/src/middleware.ts
+++ b/packages/logger/src/middleware.ts
@@ -34,13 +34,15 @@ function writeRequestLog(entry: {
     .then(({ getClient }) => {
       const sql = getClient();
       const id = `req_${nanoid(16)}`;
+      const level = entry.status >= 500 ? 'error' : entry.status >= 400 ? 'warn' : 'info';
+      const message = entry.errorMessage || `${entry.method} ${entry.path} → ${entry.status}`;
       return sql`
-        INSERT INTO registry.request_log
-          (id, service, method, path, status, duration_ms, correlation_id, ip, error_message)
+        INSERT INTO registry.logs
+          (id, source, service, level, message, method, path, status, duration_ms, correlation_id, ip, error_message, created_at)
         VALUES
-          (${id}, ${entry.service}, ${entry.method}, ${entry.path}, ${entry.status},
+          (${id}, 'request', ${entry.service}, ${level}, ${message}, ${entry.method}, ${entry.path}, ${entry.status},
            ${entry.durationMs}, ${entry.correlationId}, ${entry.ip},
-           ${entry.errorMessage ?? null})
+           ${entry.errorMessage ?? null}, now())
       `;
     })
     .catch(() => {


### PR DESCRIPTION
**Two bugs fixed:**

1. **Cohost can't see refund/cancel/mark-sent buttons** — `isOwner` in the guests API was `role === 'creator'` only. Cohosts are organizers too — now includes `cohost` role.

2. **CSV export 404 on prod** — download URLs were `/api/events/.../export.csv` but events app runs behind `basePath: '/events'`. Added `NEXT_PUBLIC_BASE_PATH` prefix to both guest list CSV and admin events CSV links.

**Files changed:** 3 files, 3 lines.