### PR TITLE
feat(admin): unified log viewer — Postgres transport + raw pm2 tail

### DIFF
--- a/apps/kernel/app/admin/logs/logs-client.tsx
+++ b/apps/kernel/app/admin/logs/logs-client.tsx
@@ -3,17 +3,29 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 
-interface AppLog {
+interface LogEntry {
   id: string;
+  source: string;
   service: string;
   level: string;
   message: string;
-  correlation_id: string | null;
-  did: string | null;
   method: string | null;
   path: string | null;
+  status: number | null;
+  duration_ms: number | null;
+  did: string | null;
+  ip: string | null;
+  correlation_id: string | null;
+  error_message: string | null;
   metadata: Record<string, unknown> | null;
   created_at: string;
+}
+
+interface RawLogResponse {
+  service: string;
+  lines: number;
+  out: { path: string; content: string } | null;
+  err: { path: string; content: string } | null;
 }
 
 interface Filters {
@@ -37,6 +49,14 @@ const SERVICE_COLORS: Record<string, string> = {
   registry: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-400',
   market: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-400',
   notify: 'bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-400',
+  input: 'bg-lime-100 dark:bg-lime-900/40 text-lime-700 dark:text-lime-400',
+  media: 'bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-400',
+  coffee: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400',
+  dykil: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-400',
+  learn: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400',
+  links: 'bg-fuchsia-100 dark:bg-fuchsia-900/40 text-fuchsia-700 dark:text-fuchsia-400',
+  fixready: 'bg-slate-100 dark:bg-slate-900/40 text-slate-700 dark:text-slate-400',
+  karaoke: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400',
 };
 
 const LEVEL_COLORS: Record<string, string> = {
@@ -47,6 +67,7 @@ const LEVEL_COLORS: Record<string, string> = {
 };
 
 const ALL_LEVELS = ['debug', 'info', 'warn', 'error'];
+const KNOWN_SERVICES = Object.keys(SERVICE_COLORS);
 
 function serviceBadgeClass(service: string): string {
   return SERVICE_COLORS[service] ?? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400';
@@ -76,17 +97,27 @@ const EMPTY_FILTERS: Filters = {
 const LIMIT = 50;
 
 export default function LogsClient() {
+  const [activeTab, setActiveTab] = useState<'structured' | 'raw'>('structured');
+
+  // Structured logs state
   const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
   const [pendingFilters, setPendingFilters] = useState<Filters>(EMPTY_FILTERS);
-  const [rows, setRows] = useState<AppLog[]>([]);
+  const [rows, setRows] = useState<LogEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(true);
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const [autoRefresh, setAutoRefresh] = useState(false);
-  const [cleanupDays, setCleanupDays] = useState(14);
+  const [cleanupDays, setCleanupDays] = useState(30);
   const [cleanupMsg, setCleanupMsg] = useState('');
   const autoRefreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Raw logs state
+  const [rawService, setRawService] = useState('kernel');
+  const [rawLines, setRawLines] = useState(100);
+  const [rawLoading, setRawLoading] = useState(false);
+  const [rawData, setRawData] = useState<RawLogResponse | null>(null);
+  const [rawError, setRawError] = useState('');
 
   const fetchLogs = useCallback(async (f: Filters, off: number) => {
     setLoading(true);
@@ -114,19 +145,19 @@ export default function LogsClient() {
 
   useEffect(() => {
     fetchLogs(filters, offset);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     if (autoRefresh) {
-      autoRefreshRef.current = setInterval(() => fetchLogs(filters, offset), 5000);
+      autoRefreshRef.current = setInterval(() => fetchLogs(filters, offset), 10000);
     } else {
       if (autoRefreshRef.current) clearInterval(autoRefreshRef.current);
     }
     return () => {
       if (autoRefreshRef.current) clearInterval(autoRefreshRef.current);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoRefresh, filters, offset]);
 
   function applyFilters() {
@@ -193,6 +224,25 @@ export default function LogsClient() {
     setTimeout(() => setCleanupMsg(''), 4000);
   }
 
+  async function fetchRawLogs() {
+    setRawLoading(true);
+    setRawError('');
+    try {
+      const res = await fetch(`/api/admin/logs/raw?service=${encodeURIComponent(rawService)}&lines=${rawLines}`);
+      if (res.ok) {
+        const data = await res.json();
+        setRawData(data);
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setRawError(err.error || 'Failed to fetch raw logs');
+      }
+    } catch {
+      setRawError('Network error');
+    } finally {
+      setRawLoading(false);
+    }
+  }
+
   const hasFilters = Object.entries(pendingFilters).some(([k, v]) =>
     k === 'levels' ? (v as string[]).length > 0 : Boolean(v)
   );
@@ -210,7 +260,7 @@ export default function LogsClient() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Application Logs</h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Structured log entries from @imajin/logger — persisted when ENABLE_APP_LOG=true
+            Structured logs from @imajin/logger — persisted when LOG_DB_TRANSPORT=true
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -233,252 +283,380 @@ export default function LogsClient() {
         </div>
       </div>
 
-      {/* Filters */}
-      <div className="mb-4 flex flex-wrap gap-2 items-end">
-        {/* Service */}
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">Service</label>
-          <input
-            type="text"
-            value={pendingFilters.service}
-            onChange={(e) => setPendingFilters({ ...pendingFilters, service: e.target.value })}
-            placeholder="e.g. kernel"
-            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-36"
-          />
-        </div>
-
-        {/* Level pills */}
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">Level</label>
-          <div className="flex gap-1">
-            {ALL_LEVELS.map((level) => {
-              const active = pendingFilters.levels.includes(level);
-              return (
-                <button
-                  key={level}
-                  onClick={() => toggleLevel(level)}
-                  className={`text-xs px-2 py-1 rounded font-medium transition-opacity ${
-                    active
-                      ? LEVEL_COLORS[level]
-                      : 'bg-gray-100 dark:bg-gray-800 text-gray-400 opacity-50 hover:opacity-75'
-                  }`}
-                >
-                  {level}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Search */}
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">Search</label>
-          <input
-            type="text"
-            value={pendingFilters.search}
-            onChange={(e) => setPendingFilters({ ...pendingFilters, search: e.target.value })}
-            placeholder="message contains…"
-            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-44"
-          />
-        </div>
-
-        {/* Correlation ID */}
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">Correlation ID</label>
-          <input
-            type="text"
-            value={pendingFilters.correlationId}
-            onChange={(e) => setPendingFilters({ ...pendingFilters, correlationId: e.target.value })}
-            placeholder="cor_…"
-            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-44"
-          />
-        </div>
-
-        {/* DID */}
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">DID</label>
-          <input
-            type="text"
-            value={pendingFilters.did}
-            onChange={(e) => setPendingFilters({ ...pendingFilters, did: e.target.value })}
-            placeholder="did:key:…"
-            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-44"
-          />
-        </div>
-
-        {/* From / To */}
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
-          <input
-            type="datetime-local"
-            value={pendingFilters.from}
-            onChange={(e) => setPendingFilters({ ...pendingFilters, from: e.target.value })}
-            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
-          <input
-            type="datetime-local"
-            value={pendingFilters.to}
-            onChange={(e) => setPendingFilters({ ...pendingFilters, to: e.target.value })}
-            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
-          />
-        </div>
-
+      {/* Tabs */}
+      <div className="mb-4 flex gap-1 border-b border-gray-200 dark:border-gray-700">
         <button
-          onClick={applyFilters}
-          className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium self-end"
+          onClick={() => setActiveTab('structured')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'structured'
+              ? 'border-orange-500 text-orange-600 dark:text-orange-400'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+          }`}
         >
-          Filter
+          Structured Logs
         </button>
-        {(hasFilters || hasActiveFilters) && (
-          <button
-            onClick={clearFilters}
-            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 self-end py-1.5"
-          >
-            Clear
-          </button>
-        )}
+        <button
+          onClick={() => setActiveTab('raw')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === 'raw'
+              ? 'border-orange-500 text-orange-600 dark:text-orange-400'
+              : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+          }`}
+        >
+          Raw Logs
+        </button>
       </div>
 
-      {/* Total count */}
-      <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-        {loading ? 'Loading…' : `${total.toLocaleString()} logs`}
-      </p>
+      {activeTab === 'structured' ? (
+        <>
+          {/* Filters */}
+          <div className="mb-4 flex flex-wrap gap-2 items-end">
+            {/* Service */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">Service</label>
+              <select
+                value={pendingFilters.service}
+                onChange={(e) => setPendingFilters({ ...pendingFilters, service: e.target.value })}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-36"
+              >
+                <option value="">All</option>
+                {KNOWN_SERVICES.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
 
-      {/* Table */}
-      <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
-        {!loading && rows.length === 0 ? (
-          <p className="px-6 py-10 text-sm text-gray-400 dark:text-gray-500 text-center">
-            No logs found
-          </p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Time</th>
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Service</th>
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Level</th>
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Message</th>
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">DID</th>
-                  <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Trace</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
-                {rows.map((row) => {
-                  const isExpanded = expandedRows.has(row.id);
-                  const hasMetadata = row.metadata && Object.keys(row.metadata).length > 0;
-                  const isError = row.level === 'error';
-                  const isWarn = row.level === 'warn';
+            {/* Level pills */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">Level</label>
+              <div className="flex gap-1">
+                {ALL_LEVELS.map((level) => {
+                  const active = pendingFilters.levels.includes(level);
                   return (
-                    <>
-                      <tr
-                        key={row.id}
-                        onClick={() => hasMetadata && toggleRow(row.id)}
-                        className={`hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors ${hasMetadata ? 'cursor-pointer' : ''} ${isError ? 'bg-red-50/40 dark:bg-red-900/10' : isWarn ? 'bg-amber-50/40 dark:bg-amber-900/10' : ''}`}
-                      >
-                        <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap font-mono">
-                          {formatTs(row.created_at)}
-                        </td>
-                        <td className="px-4 py-3">
-                          <span className={`text-xs px-2 py-0.5 rounded font-medium ${serviceBadgeClass(row.service)}`}>
-                            {row.service}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3">
-                          <span className={`text-xs px-2 py-0.5 rounded font-medium ${LEVEL_COLORS[row.level] ?? 'bg-gray-100 text-gray-500'}`}>
-                            {row.level}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3 text-xs text-gray-700 dark:text-gray-300 max-w-xs">
-                          <span className="truncate block" title={row.message}>{row.message}</span>
-                          {row.path && (
-                            <span className="text-gray-400 font-mono">{row.method} {row.path}</span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3 text-xs font-mono text-gray-500 dark:text-gray-400">
-                          <span title={row.did ?? undefined}>{truncateDid(row.did)}</span>
-                        </td>
-                        <td className="px-4 py-3">
-                          {row.correlation_id ? (
-                            <Link
-                              href={`/admin/telemetry/trace/${encodeURIComponent(row.correlation_id)}`}
-                              className="text-xs font-mono text-orange-600 dark:text-orange-400 hover:underline"
-                              onClick={(e) => e.stopPropagation()}
-                              title={row.correlation_id}
-                            >
-                              {row.correlation_id.slice(0, 12)}…
-                            </Link>
-                          ) : (
-                            <span className="text-xs text-gray-400">—</span>
-                          )}
-                        </td>
-                      </tr>
-                      {isExpanded && hasMetadata && (
-                        <tr key={`${row.id}-meta`} className="bg-gray-50 dark:bg-gray-900/40">
-                          <td colSpan={6} className="px-6 py-3">
-                            <pre className="text-xs font-mono text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-all">
-                              {JSON.stringify(row.metadata, null, 2)}
-                            </pre>
-                          </td>
-                        </tr>
-                      )}
-                    </>
+                    <button
+                      key={level}
+                      onClick={() => toggleLevel(level)}
+                      className={`text-xs px-2 py-1 rounded font-medium transition-opacity ${
+                        active
+                          ? LEVEL_COLORS[level]
+                          : 'bg-gray-100 dark:bg-gray-800 text-gray-400 opacity-50 hover:opacity-75'
+                      }`}
+                    >
+                      {level}
+                    </button>
                   );
                 })}
-              </tbody>
-            </table>
+              </div>
+            </div>
+
+            {/* Search */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">Search</label>
+              <input
+                type="text"
+                value={pendingFilters.search}
+                onChange={(e) => setPendingFilters({ ...pendingFilters, search: e.target.value })}
+                placeholder="message / error / path…"
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-48"
+              />
+            </div>
+
+            {/* Correlation ID */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">Correlation ID</label>
+              <input
+                type="text"
+                value={pendingFilters.correlationId}
+                onChange={(e) => setPendingFilters({ ...pendingFilters, correlationId: e.target.value })}
+                placeholder="cor_…"
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-44"
+              />
+            </div>
+
+            {/* DID */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">DID</label>
+              <input
+                type="text"
+                value={pendingFilters.did}
+                onChange={(e) => setPendingFilters({ ...pendingFilters, did: e.target.value })}
+                placeholder="did:key:…"
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-44"
+              />
+            </div>
+
+            {/* From / To */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
+              <input
+                type="datetime-local"
+                value={pendingFilters.from}
+                onChange={(e) => setPendingFilters({ ...pendingFilters, from: e.target.value })}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
+              <input
+                type="datetime-local"
+                value={pendingFilters.to}
+                onChange={(e) => setPendingFilters({ ...pendingFilters, to: e.target.value })}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </div>
+
+            <button
+              onClick={applyFilters}
+              className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium self-end"
+            >
+              Filter
+            </button>
+            {(hasFilters || hasActiveFilters) && (
+              <button
+                onClick={clearFilters}
+                className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 self-end py-1.5"
+              >
+                Clear
+              </button>
+            )}
           </div>
-        )}
-      </div>
 
-      {/* Pagination */}
-      <div className="mt-4 flex items-center gap-3">
-        <button
-          onClick={prevPage}
-          disabled={!hasPrev}
-          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          ← Previous
-        </button>
-        <span className="text-sm text-gray-500 dark:text-gray-400">
-          Page {page} — Showing {Math.min(offset + 1, total)}–{Math.min(offset + LIMIT, total)} of {total.toLocaleString()}
-        </span>
-        <button
-          onClick={nextPage}
-          disabled={!hasNext}
-          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          Next →
-        </button>
-      </div>
+          {/* Total count */}
+          <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+            {loading ? 'Loading…' : `${total.toLocaleString()} logs`}
+          </p>
 
-      {/* Cleanup section */}
-      <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-700">
-        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Log Retention Cleanup</h2>
-        <div className="flex items-center gap-3">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Delete logs older than</span>
-          <input
-            type="number"
-            min={1}
-            value={cleanupDays}
-            onChange={(e) => setCleanupDays(Math.max(1, parseInt(e.target.value, 10) || 14))}
-            className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-20"
-          />
-          <span className="text-sm text-gray-500 dark:text-gray-400">days</span>
-          <button
-            onClick={runCleanup}
-            className="rounded-lg bg-red-500 hover:bg-red-600 text-white px-3 py-1.5 text-sm font-medium"
-          >
-            Run cleanup
-          </button>
-          {cleanupMsg && (
-            <span className="text-sm text-gray-600 dark:text-gray-400">{cleanupMsg}</span>
+          {/* Table */}
+          <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+            {!loading && rows.length === 0 ? (
+              <p className="px-6 py-10 text-sm text-gray-400 dark:text-gray-500 text-center">
+                No logs found
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                      <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Time</th>
+                      <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Service</th>
+                      <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Level</th>
+                      <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Message</th>
+                      <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">DID</th>
+                      <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Trace</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+                    {rows.map((row) => {
+                      const isExpanded = expandedRows.has(row.id);
+                      const hasDetails = !!(row.metadata && Object.keys(row.metadata).length > 0) || !!row.error_message || !!row.status || !!row.duration_ms || !!row.ip;
+                      const isError = row.level === 'error';
+                      const isWarn = row.level === 'warn';
+                      return (
+                        <React.Fragment key={row.id}>
+                          <tr
+                            onClick={() => hasDetails && toggleRow(row.id)}
+                            className={`hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors ${hasDetails ? 'cursor-pointer' : ''} ${isError ? 'bg-red-50/40 dark:bg-red-900/10' : isWarn ? 'bg-amber-50/40 dark:bg-amber-900/10' : ''}`}
+                          >
+                            <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap font-mono">
+                              {formatTs(row.created_at)}
+                            </td>
+                            <td className="px-4 py-3">
+                              <span className={`text-xs px-2 py-0.5 rounded font-medium ${serviceBadgeClass(row.service)}`}>
+                                {row.service}
+                              </span>
+                            </td>
+                            <td className="px-4 py-3">
+                              <span className={`text-xs px-2 py-0.5 rounded font-medium ${LEVEL_COLORS[row.level] ?? 'bg-gray-100 text-gray-500'}`}>
+                                {row.level}
+                              </span>
+                            </td>
+                            <td className="px-4 py-3 text-xs text-gray-700 dark:text-gray-300 max-w-xs">
+                              <span className="truncate block" title={row.message}>{row.message}</span>
+                              {row.path && (
+                                <span className="text-gray-400 font-mono">{row.method} {row.path}</span>
+                              )}
+                              {row.error_message && (
+                                <span className="block text-red-500 dark:text-red-400 mt-0.5 truncate" title={row.error_message}>
+                                  {row.error_message}
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 text-xs font-mono text-gray-500 dark:text-gray-400">
+                              <span title={row.did ?? undefined}>{truncateDid(row.did)}</span>
+                            </td>
+                            <td className="px-4 py-3">
+                              {row.correlation_id ? (
+                                <Link
+                                  href={`/admin/telemetry/trace/${encodeURIComponent(row.correlation_id)}`}
+                                  className="text-xs font-mono text-orange-600 dark:text-orange-400 hover:underline"
+                                  onClick={(e) => e.stopPropagation()}
+                                  title={row.correlation_id}
+                                >
+                                  {row.correlation_id.slice(0, 12)}…
+                                </Link>
+                              ) : (
+                                <span className="text-xs text-gray-400">—</span>
+                              )}
+                            </td>
+                          </tr>
+                          {isExpanded && hasDetails && (
+                            <tr className="bg-gray-50 dark:bg-gray-900/40">
+                              <td colSpan={6} className="px-6 py-3">
+                                <div className="space-y-2">
+                                  {row.error_message && (
+                                    <div>
+                                      <span className="text-xs font-semibold text-red-600 dark:text-red-400">Error:</span>
+                                      <pre className="mt-1 text-xs font-mono text-red-700 dark:text-red-300 whitespace-pre-wrap break-all">
+                                        {row.error_message}
+                                      </pre>
+                                    </div>
+                                  )}
+                                  {row.status && (
+                                    <div className="text-xs text-gray-600 dark:text-gray-400">
+                                      <span className="font-semibold">Status:</span> {row.status}
+                                      {row.duration_ms !== null && ` · ${row.duration_ms}ms`}
+                                      {row.ip && ` · ${row.ip}`}
+                                    </div>
+                                  )}
+                                  {row.metadata && Object.keys(row.metadata).length > 0 && (
+                                    <pre className="text-xs font-mono text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-all">
+                                      {JSON.stringify(row.metadata, null, 2)}
+                                    </pre>
+                                  )}
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                        </React.Fragment>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          {/* Pagination */}
+          <div className="mt-4 flex items-center gap-3">
+            <button
+              onClick={prevPage}
+              disabled={!hasPrev}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              ← Previous
+            </button>
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              Page {page} — Showing {Math.min(offset + 1, total)}–{Math.min(offset + LIMIT, total)} of {total.toLocaleString()}
+            </span>
+            <button
+              onClick={nextPage}
+              disabled={!hasNext}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Next →
+            </button>
+          </div>
+
+          {/* Cleanup section */}
+          <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-700">
+            <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Log Retention Cleanup</h2>
+            <div className="flex items-center gap-3">
+              <span className="text-sm text-gray-500 dark:text-gray-400">Delete logs older than</span>
+              <input
+                type="number"
+                min={1}
+                value={cleanupDays}
+                onChange={(e) => setCleanupDays(Math.max(1, parseInt(e.target.value, 10) || 30))}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-20"
+              />
+              <span className="text-sm text-gray-500 dark:text-gray-400">days</span>
+              <button
+                onClick={runCleanup}
+                className="rounded-lg bg-red-500 hover:bg-red-600 text-white px-3 py-1.5 text-sm font-medium"
+              >
+                Run cleanup
+              </button>
+              {cleanupMsg && (
+                <span className="text-sm text-gray-600 dark:text-gray-400">{cleanupMsg}</span>
+              )}
+            </div>
+          </div>
+        </>
+      ) : (
+        /* Raw Logs Tab */
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-2 items-end">
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">Service</label>
+              <select
+                value={rawService}
+                onChange={(e) => setRawService(e.target.value)}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-40"
+              >
+                {KNOWN_SERVICES.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-gray-500 dark:text-gray-400">Lines</label>
+              <input
+                type="number"
+                min={1}
+                max={500}
+                value={rawLines}
+                onChange={(e) => setRawLines(Math.min(500, Math.max(1, parseInt(e.target.value, 10) || 100)))}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-24"
+              />
+            </div>
+            <button
+              onClick={fetchRawLogs}
+              disabled={rawLoading}
+              className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium self-end disabled:opacity-50"
+            >
+              {rawLoading ? 'Loading…' : 'Tail logs'}
+            </button>
+          </div>
+
+          {rawError && (
+            <div className="rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+              {rawError}
+            </div>
+          )}
+
+          {rawData && (
+            <div className="space-y-4">
+              {rawData.out && (
+                <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+                  <div className="px-4 py-2 bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+                    <span className="text-xs font-semibold text-gray-600 dark:text-gray-300">stdout</span>
+                    <span className="text-xs text-gray-400 font-mono">{rawData.out.path}</span>
+                  </div>
+                  <pre className="p-4 text-xs font-mono text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-all max-h-[500px] overflow-auto">
+                    {rawData.out.content || '(empty)'}
+                  </pre>
+                </div>
+              )}
+              {rawData.err && (
+                <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+                  <div className="px-4 py-2 bg-red-50 dark:bg-red-900/20 border-b border-red-100 dark:border-red-800 flex items-center justify-between">
+                    <span className="text-xs font-semibold text-red-700 dark:text-red-400">stderr</span>
+                    <span className="text-xs text-red-400 font-mono">{rawData.err.path}</span>
+                  </div>
+                  <pre className="p-4 text-xs font-mono text-red-700 dark:text-red-300 whitespace-pre-wrap break-all max-h-[500px] overflow-auto">
+                    {rawData.err.content || '(empty)'}
+                  </pre>
+                </div>
+              )}
+              {!rawData.out && !rawData.err && (
+                <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-8">
+                  No log files found for <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">{rawData.service}</code>
+                </p>
+              )}
+            </div>
           )}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/kernel/app/admin/logs/logs-client.tsx
+++ b/apps/kernel/app/admin/logs/logs-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 
 interface LogEntry {

--- a/apps/kernel/app/api/admin/logs/cleanup/route.ts
+++ b/apps/kernel/app/api/admin/logs/cleanup/route.ts
@@ -14,12 +14,7 @@ export const POST = withLogger('kernel', async (req: NextRequest, { log }) => {
   const days = Math.max(1, parseInt(url.searchParams.get('days') || '14', 10));
 
   const [result] = await sql`
-    WITH deleted AS (
-      DELETE FROM registry.app_logs
-      WHERE created_at < now() - (${days} || ' days')::interval
-      RETURNING id
-    )
-    SELECT COUNT(*)::int AS deleted FROM deleted
+    SELECT registry.cleanup_old_logs(${days}) AS deleted
   `;
 
   const deleted = result?.deleted ?? 0;

--- a/apps/kernel/app/api/admin/logs/raw/route.ts
+++ b/apps/kernel/app/api/admin/logs/raw/route.ts
@@ -25,7 +25,7 @@ function getLogPath(service: string, type: 'out' | 'error'): string | null {
 function tailFile(filePath: string, lines: number): string {
   try {
     // execFileSync bypasses the shell — no injection risk
-    return execFileSync('tail', ['-n', String(lines), filePath], { encoding: 'utf-8', timeout: 5000 });
+    return execFileSync('/usr/bin/tail', ['-n', String(lines), filePath], { encoding: 'utf-8', timeout: 5000 });
   } catch {
     return '';
   }

--- a/apps/kernel/app/api/admin/logs/raw/route.ts
+++ b/apps/kernel/app/api/admin/logs/raw/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withLogger } from '@imajin/logger';
+import { requireAdmin } from '@imajin/auth';
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const PM2_LOGS_DIR = join(homedir(), '.pm2', 'logs');
+
+function getLogPath(service: string, type: 'out' | 'error'): string | null {
+  // Try common pm2 log naming patterns
+  const candidates = [
+    join(PM2_LOGS_DIR, `${service}-${type}.log`),
+    join(PM2_LOGS_DIR, `${service}.log`),
+    join(PM2_LOGS_DIR, `${service}-${type}-0.log`),
+    join(PM2_LOGS_DIR, `${service}-${type}.log.0`),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function tailFile(path: string, lines: number): string {
+  try {
+    return execSync(`tail -n ${lines} ${path}`, { encoding: 'utf-8', timeout: 5000 });
+  } catch {
+    return '';
+  }
+}
+
+export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const service = searchParams.get('service') || '';
+  const lines = Math.min(500, Math.max(1, Number(searchParams.get('lines') || '100')));
+
+  if (!service) {
+    return NextResponse.json({ error: 'Missing service' }, { status: 400 });
+  }
+
+  // Sanitize service name to prevent path traversal
+  if (!/^[a-zA-Z0-9_-]+$/.test(service)) {
+    return NextResponse.json({ error: 'Invalid service name' }, { status: 400 });
+  }
+
+  const outPath = getLogPath(service, 'out');
+  const errPath = getLogPath(service, 'error');
+
+  const out = outPath ? tailFile(outPath, lines) : '';
+  const err = errPath ? tailFile(errPath, lines) : '';
+
+  log.info({ service, lines, outPath: outPath ?? null, errPath: errPath ?? null }, 'raw logs fetched');
+
+  return NextResponse.json({
+    service,
+    lines,
+    out: outPath ? { path: outPath, content: out } : null,
+    err: errPath ? { path: errPath, content: err } : null,
+  });
+});

--- a/apps/kernel/app/api/admin/logs/raw/route.ts
+++ b/apps/kernel/app/api/admin/logs/raw/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withLogger } from '@imajin/logger';
 import { requireAdmin } from '@imajin/auth';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -22,9 +22,10 @@ function getLogPath(service: string, type: 'out' | 'error'): string | null {
   return null;
 }
 
-function tailFile(path: string, lines: number): string {
+function tailFile(filePath: string, lines: number): string {
   try {
-    return execSync(`tail -n ${lines} ${path}`, { encoding: 'utf-8', timeout: 5000 });
+    // execFileSync bypasses the shell — no injection risk
+    return execFileSync('tail', ['-n', String(lines), filePath], { encoding: 'utf-8', timeout: 5000 });
   } catch {
     return '';
   }

--- a/apps/kernel/app/api/admin/telemetry/errors/route.ts
+++ b/apps/kernel/app/api/admin/telemetry/errors/route.ts
@@ -19,16 +19,18 @@ export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
     SELECT
       id, service, method, path, status, duration_ms, did, ip,
       correlation_id, error_message, created_at
-    FROM registry.request_log
-    WHERE status >= 400
+    FROM registry.logs
+    WHERE source = 'request'
+      AND status >= 400
     ORDER BY created_at DESC
     LIMIT ${limit} OFFSET ${offset}
   `;
 
   const [{ count }] = await sql`
     SELECT COUNT(*)::int AS count
-    FROM registry.request_log
-    WHERE status >= 400
+    FROM registry.logs
+    WHERE source = 'request'
+      AND status >= 400
   `;
 
   log.info({ count, limit, offset }, 'error requests fetched');

--- a/apps/kernel/app/api/admin/telemetry/route.ts
+++ b/apps/kernel/app/api/admin/telemetry/route.ts
@@ -12,10 +12,7 @@ async function runCleanup(): Promise<void> {
   const now = Date.now();
   if (now - lastCleanupAt < 60 * 60 * 1000) return;
   lastCleanupAt = now;
-  await sql`
-    DELETE FROM registry.request_log
-    WHERE created_at < now() - interval '30 days'
-  `;
+  await sql`SELECT registry.cleanup_old_logs()`;
 }
 
 export const GET = withLogger('kernel', async (_req, { log }) => {
@@ -33,8 +30,9 @@ export const GET = withLogger('kernel', async (_req, { log }) => {
       SELECT
         date_trunc('hour', created_at) AS hour,
         COUNT(*)::int AS count
-      FROM registry.request_log
-      WHERE created_at >= now() - interval '24 hours'
+      FROM registry.logs
+      WHERE source = 'request'
+        AND created_at >= now() - interval '24 hours'
       GROUP BY 1
       ORDER BY 1
     `,
@@ -47,8 +45,9 @@ export const GET = withLogger('kernel', async (_req, { log }) => {
         PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_ms)::int AS p50,
         PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms)::int AS p95,
         PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY duration_ms)::int AS p99
-      FROM registry.request_log
-      WHERE created_at >= now() - interval '24 hours'
+      FROM registry.logs
+      WHERE source = 'request'
+        AND created_at >= now() - interval '24 hours'
         AND duration_ms IS NOT NULL
       GROUP BY path, method
       ORDER BY p95 DESC
@@ -62,8 +61,9 @@ export const GET = withLogger('kernel', async (_req, { log }) => {
         COUNT(*)::int AS total_requests,
         COUNT(*) FILTER (WHERE status >= 400)::int AS error_count,
         ROUND(COUNT(*) FILTER (WHERE status >= 400) * 100.0 / COUNT(*), 1) AS error_rate
-      FROM registry.request_log
-      WHERE created_at >= now() - interval '24 hours'
+      FROM registry.logs
+      WHERE source = 'request'
+        AND created_at >= now() - interval '24 hours'
       GROUP BY path, method
       HAVING COUNT(*) > 0
       ORDER BY error_rate DESC, total_requests DESC
@@ -77,8 +77,9 @@ export const GET = withLogger('kernel', async (_req, { log }) => {
         COUNT(*)::int AS total_requests,
         PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_ms)::int AS p95,
         MAX(duration_ms)::int AS max_ms
-      FROM registry.request_log
-      WHERE created_at >= now() - interval '24 hours'
+      FROM registry.logs
+      WHERE source = 'request'
+        AND created_at >= now() - interval '24 hours'
         AND duration_ms IS NOT NULL
       GROUP BY path, method
       ORDER BY p95 DESC

--- a/apps/kernel/app/api/admin/telemetry/slow/route.ts
+++ b/apps/kernel/app/api/admin/telemetry/slow/route.ts
@@ -19,16 +19,18 @@ export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
     SELECT
       id, service, method, path, status, duration_ms, did, ip,
       correlation_id, error_message, created_at
-    FROM registry.request_log
-    WHERE duration_ms >= 1000
+    FROM registry.logs
+    WHERE source = 'request'
+      AND duration_ms >= 1000
     ORDER BY duration_ms DESC, created_at DESC
     LIMIT ${limit} OFFSET ${offset}
   `;
 
   const [{ count }] = await sql`
     SELECT COUNT(*)::int AS count
-    FROM registry.request_log
-    WHERE duration_ms >= 1000
+    FROM registry.logs
+    WHERE source = 'request'
+      AND duration_ms >= 1000
   `;
 
   log.info({ count, limit, offset }, 'slow requests fetched');

--- a/apps/kernel/app/api/admin/telemetry/trace/[correlationId]/route.ts
+++ b/apps/kernel/app/api/admin/telemetry/trace/[correlationId]/route.ts
@@ -20,8 +20,9 @@ export const GET = withLogger('kernel', async (req: NextRequest, { log }) => {
     SELECT
       id, service, method, path, status, duration_ms, did, ip,
       correlation_id, error_message, created_at
-    FROM registry.request_log
-    WHERE correlation_id = ${correlationId}
+    FROM registry.logs
+    WHERE source = 'request'
+      AND correlation_id = ${correlationId}
     ORDER BY created_at ASC
   `;
 

--- a/migrations/0010_logs_cleanup.sql
+++ b/migrations/0010_logs_cleanup.sql
@@ -1,0 +1,37 @@
+-- Auto-cleanup function for registry.logs
+-- Deletes entries older than N days (default 30)
+
+CREATE OR REPLACE FUNCTION registry.cleanup_old_logs(p_days INT DEFAULT 30)
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  deleted_count INT;
+BEGIN
+  DELETE FROM registry.logs
+  WHERE created_at < now() - (p_days || ' days')::interval;
+
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$;
+
+-- Also clean up legacy tables that are no longer written to
+CREATE OR REPLACE FUNCTION registry.cleanup_legacy_logs(p_days INT DEFAULT 30)
+RETURNS INT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  deleted_count INT;
+BEGIN
+  DELETE FROM registry.request_log
+  WHERE created_at < now() - (p_days || ' days')::interval;
+
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+  DELETE FROM registry.app_logs
+  WHERE created_at < now() - (p_days || ' days')::interval;
+
+  RETURN deleted_count;
+END;
+$$;

--- a/packages/logger/src/adapters/pino.ts
+++ b/packages/logger/src/adapters/pino.ts
@@ -18,8 +18,26 @@ const MIN_PERSIST_LEVEL = process.env.APP_LOG_LEVEL || 'warn';
 const LEVEL_PRIORITY: Record<string, number> = { debug: 10, info: 20, warn: 30, error: 40 };
 
 function shouldPersist(level: string): boolean {
-  if (process.env.ENABLE_APP_LOG !== 'true') return false;
+  const enabled = process.env.LOG_DB_TRANSPORT === 'true' || process.env.ENABLE_APP_LOG === 'true';
+  if (!enabled) return false;
   return (LEVEL_PRIORITY[level] ?? 0) >= (LEVEL_PRIORITY[MIN_PERSIST_LEVEL] ?? 30);
+}
+
+// Opportunistic cleanup — at most once per hour per process
+let lastCleanupAt = 0;
+
+function runLogCleanup(): void {
+  const now = Date.now();
+  if (now - lastCleanupAt < 60 * 60 * 1000) return;
+  lastCleanupAt = now;
+  import('@imajin/db')
+    .then(({ getClient }) => {
+      const sql = getClient();
+      return sql`SELECT registry.cleanup_old_logs()`;
+    })
+    .catch(() => {
+      // Never block or surface errors from the log sink
+    });
 }
 
 function writeAppLog(entry: {
@@ -30,6 +48,7 @@ function writeAppLog(entry: {
   did?: string;
   method?: string;
   path?: string;
+  errorMessage?: string;
   metadata?: Record<string, unknown>;
 }): void {
   if (!shouldPersist(entry.level)) return;
@@ -39,12 +58,19 @@ function writeAppLog(entry: {
       const sql = getClient();
       const id = `log_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
       return sql`
-        INSERT INTO registry.app_logs (id, service, level, message, correlation_id, did, method, path, metadata)
-        VALUES (${id}, ${entry.service}, ${entry.level}, ${entry.message},
-                ${entry.correlationId ?? null}, ${entry.did ?? null},
-                ${entry.method ?? null}, ${entry.path ?? null},
-                ${entry.metadata ? JSON.stringify(entry.metadata) : null}::jsonb)
+        INSERT INTO registry.logs
+          (id, source, service, level, message, correlation_id, did, method, path, error_message, metadata, created_at)
+        VALUES
+          (${id}, 'app', ${entry.service}, ${entry.level}, ${entry.message},
+           ${entry.correlationId ?? null}, ${entry.did ?? null},
+           ${entry.method ?? null}, ${entry.path ?? null},
+           ${entry.errorMessage ?? null},
+           ${entry.metadata ? JSON.stringify(entry.metadata) : null}::jsonb,
+           now())
       `;
+    })
+    .then(() => {
+      runLogCleanup();
     })
     .catch(() => {
       // Never block or surface errors from the log sink
@@ -53,7 +79,8 @@ function writeAppLog(entry: {
 
 function wrapPino(instance: pino.Logger): Logger {
   function persist(level: string, ctx: LogContext, message: string) {
-    const { service, correlationId, did, method, path, ...rest } = ctx;
+    const { service, correlationId, did, method, path, err, error, ...rest } = ctx;
+    const errorMessage = err ? String(err) : error ? String(error) : undefined;
     writeAppLog({
       service: service || 'unknown',
       level,
@@ -62,6 +89,7 @@ function wrapPino(instance: pino.Logger): Logger {
       did,
       method,
       path,
+      errorMessage,
       metadata: Object.keys(rest).length > 0 ? rest : undefined,
     });
   }

--- a/packages/logger/src/middleware.ts
+++ b/packages/logger/src/middleware.ts
@@ -14,7 +14,7 @@ export type LoggerHandler = (
 ) => Promise<NextResponse>;
 
 /**
- * Fire-and-forget insert into registry.request_log.
+ * Fire-and-forget insert into registry.logs (source='request').
  * Only runs when ENABLE_REQUEST_LOG=true.
  */
 function writeRequestLog(entry: {
@@ -58,7 +58,7 @@ function writeRequestLog(entry: {
  * - Creates a child logger bound to { correlationId, method, path, ip }
  * - Auto-logs request completion with { status, durationMs }
  * - Sets X-Correlation-Id on the response
- * - Optionally writes to registry.request_log when ENABLE_REQUEST_LOG=true
+ * - Optionally writes to registry.logs when ENABLE_REQUEST_LOG=true
  *
  * Usage:
  *   export const GET = withLogger('kernel', async (req, { log, correlationId }) => {


### PR DESCRIPTION
## Summary

Closes #820.

### Phase 1: Postgres log transport (the quick win)
- Switches `@imajin/logger` pino adapter from `registry.app_logs` to unified `registry.logs` (source='app')
- Adds `LOG_DB_TRANSPORT=true` env var as opt-in (falls back to `ENABLE_APP_LOG` for compatibility)
- Extracts `err` / `error` from `LogContext` into the `error_message` column
- Adds opportunistic auto-cleanup: calls `registry.cleanup_old_logs()` at most once per hour
- Adds migration `0010_logs_cleanup.sql` with `registry.cleanup_old_logs(days INT)` function

### Phase 2: Update telemetry APIs
- All telemetry endpoints now query `registry.logs` WHERE `source = 'request'` instead of the legacy `registry.request_log` table
- Cleanup endpoint updated to target `registry.logs`

### Phase 3: Admin logs UI overhaul
- **Structured Logs tab:**
  - Service dropdown with all known services
  - Filter by level, time range, correlation ID, DID
  - Free-text search across message, path, and error_message
  - Color-coded rows (error = red, warn = amber)
  - Expanded rows show error_message, status/duration/ip, and metadata JSON
  - Correlation ID links to telemetry trace
  - Auto-refresh every 10s
- **Raw Logs tab:**
  - Tails pm2 stdout/stderr for any service via new `/api/admin/logs/raw` endpoint
  - Configurable line count (1-500)
  - Fallback for crashes, OOMs, and other unstructured output

### Migration
Run `0010_logs_cleanup.sql` to add the cleanup function.

### Env vars
Per service, add:
```
LOG_DB_TRANSPORT=true
```
(Optional: `APP_LOG_LEVEL=warn` to control minimum level.)
