### PR TITLE
fix(events): unified cart UX with quantities defaulting to 0 (#835)

### DIFF
--- a/apps/events/app/[eventId]/ticket-purchase.tsx
+++ b/apps/events/app/[eventId]/ticket-purchase.tsx
@@ -14,6 +14,9 @@ interface Props {
   stripeDisabled?: boolean;
   maxPerOrder?: number;
   sessionEmail?: string;
+  quantity?: number;
+  onQuantityChange?: (qty: number) => void;
+  hideCheckoutButton?: boolean;
 }
 
 interface ETransferInstructions {
@@ -28,14 +31,21 @@ interface ETransferInstructions {
 
 type Step = 'button' | 'selector' | 'loading-card' | 'etransfer-confirm' | 'loading-etransfer' | 'etransfer-done' | 'rsvp-form' | 'loading-rsvp' | 'rsvp-done';
 
-export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etransferEnabled = false, stripeDisabled = false, maxPerOrder, sessionEmail }: Props) {
+export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etransferEnabled = false, stripeDisabled = false, maxPerOrder, sessionEmail, quantity: externalQty, onQuantityChange, hideCheckoutButton = false }: Props) {
   const router = useRouter();
   const [step, setStep] = useState<Step>('button');
   const [error, setError] = useState<string | null>(null);
   const [etransfer, setEtransfer] = useState<ETransferInstructions | null>(null);
   const [email, setEmail] = useState(sessionEmail || '');
   const [name, setName] = useState('');
-  const [quantity, setQuantity] = useState(1);
+  const [internalQty, setInternalQty] = useState(0);
+
+  // Use external quantity if controlled by parent, otherwise internal
+  const quantity = externalQty ?? internalQty;
+  const setQuantity = (q: number) => {
+    if (onQuantityChange) onQuantityChange(q);
+    else setInternalQty(q);
+  };
 
   const isFree = ticket.price === 0;
 
@@ -52,7 +62,7 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
   // Effective max: per-type override > prop > default 10, capped at 20
   const resolvedMax = maxPerOrder ?? (ticket as any).maxPerOrder ?? 10;
   const effectiveMax = Math.min(resolvedMax, availableCount ?? 20, 20);
-  const showQuantity = !isFree && effectiveMax > 1;
+  const showQuantity = !isFree && effectiveMax >= 1;
 
   const handleCardPayment = async () => {
     setStep('loading-card');
@@ -432,25 +442,31 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
         <p className="text-red-500 text-xs mb-2">{error}</p>
       )}
       {showQuantity && <QuantityStepper quantity={quantity} setQuantity={setQuantity} max={effectiveMax} price={ticket.price} currency={ticket.currency} />}
-      <button
-        onClick={handleButtonClick}
-        disabled={(step as string) === 'loading-rsvp'}
-        className={`px-6 md:px-8 py-2.5 md:py-3 rounded-lg font-semibold transition whitespace-nowrap ${
-          (step as string) === 'loading-rsvp'
-            ? 'bg-orange-400 text-white cursor-wait'
-            : 'bg-orange-500 text-white hover:bg-orange-600'
-        }`}
-      >
-        {(step as string) === 'loading-rsvp'
-          ? 'Confirming...'
-          : isFree
-          ? 'RSVP'
-          : (stripeDisabled && etransferEnabled)
-          ? '🏦 Pay by e-Transfer'
-          : quantity > 1
-          ? `Get ${quantity} Tickets`
-          : 'Get Ticket'}
-      </button>
+      {!hideCheckoutButton && (
+        <button
+          onClick={handleButtonClick}
+          disabled={(step as string) === 'loading-rsvp' || (!isFree && quantity === 0)}
+          className={`px-6 md:px-8 py-2.5 md:py-3 rounded-lg font-semibold transition whitespace-nowrap ${
+            (step as string) === 'loading-rsvp'
+              ? 'bg-orange-400 text-white cursor-wait'
+              : (!isFree && quantity === 0)
+              ? 'bg-gray-300 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+              : 'bg-orange-500 text-white hover:bg-orange-600'
+          }`}
+        >
+          {(step as string) === 'loading-rsvp'
+            ? 'Confirming...'
+            : isFree
+            ? 'RSVP'
+            : (stripeDisabled && etransferEnabled)
+            ? '🏦 Pay by e-Transfer'
+            : quantity > 1
+            ? `Get ${quantity} Tickets`
+            : quantity === 0
+            ? 'Select quantity'
+            : 'Get Ticket'}
+        </button>
+      )}
     </>
   );
 }
@@ -471,8 +487,8 @@ function QuantityStepper({ quantity, setQuantity, max, price, currency }: {
     <div className="flex items-center gap-3 mb-2">
       <div className="flex items-center border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden">
         <button
-          onClick={() => setQuantity(Math.max(1, quantity - 1))}
-          disabled={quantity <= 1}
+          onClick={() => setQuantity(Math.max(0, quantity - 1))}
+          disabled={quantity <= 0}
           className="px-3 py-1.5 text-lg font-bold hover:bg-gray-100 dark:hover:bg-gray-800 transition disabled:opacity-30 disabled:cursor-not-allowed"
         >
           −
@@ -488,9 +504,9 @@ function QuantityStepper({ quantity, setQuantity, max, price, currency }: {
           +
         </button>
       </div>
-      {quantity > 1 && (
+      {quantity > 0 && (
         <span className="text-sm text-gray-500 dark:text-gray-400">
-          {total} total
+          {quantity > 1 ? `${total} total` : total}
         </span>
       )}
     </div>

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -414,7 +414,21 @@ function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnable
   const [unlockError, setUnlockError] = useState<string | null>(null);
   const { toast } = useToast();
 
+  // Lifted quantity state for unified cart
+  const [quantities, setQuantities] = useState<Record<string, number>>({});
+
   const allTickets = [...tickets, ...unlockedTickets];
+
+  // Compute cart totals
+  const paidTickets = allTickets.filter(t => t.price > 0);
+  const hasPaidTickets = paidTickets.length > 0;
+  const cartItems = paidTickets
+    .filter(t => (quantities[t.id] || 0) > 0)
+    .map(t => ({ ticket: t, qty: quantities[t.id] || 0 }));
+  const totalQty = cartItems.reduce((sum, item) => sum + item.qty, 0);
+  const totalCents = cartItems.reduce((sum, item) => sum + item.ticket.price * item.qty, 0);
+  const cartCurrency = paidTickets[0]?.currency || 'CAD';
+  const formattedTotal = new Intl.NumberFormat('en-CA', { style: 'currency', currency: cartCurrency }).format(totalCents / 100);
 
   async function handleUnlock() {
     if (!unlockCode.trim()) return;
@@ -521,6 +535,9 @@ function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnable
                       etransferEnabled={etransferEnabled}
                       stripeDisabled={true}
                       sessionEmail={sessionEmail}
+                      quantity={quantities[ticket.id] || 0}
+                      onQuantityChange={(q) => setQuantities(prev => ({ ...prev, [ticket.id]: q }))}
+                      hideCheckoutButton={true}
                     />
                   ) : (
                     <p className="text-sm text-gray-500 dark:text-gray-400 italic">
@@ -535,6 +552,9 @@ function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnable
                     inviteToken={inviteToken}
                     etransferEnabled={etransferEnabled}
                     sessionEmail={sessionEmail}
+                    quantity={ticket.price > 0 ? (quantities[ticket.id] || 0) : undefined}
+                    onQuantityChange={ticket.price > 0 ? (q) => setQuantities(prev => ({ ...prev, [ticket.id]: q })) : undefined}
+                    hideCheckoutButton={ticket.price > 0}
                   />
                 ) : (
                   <OnboardGate
@@ -550,6 +570,9 @@ function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnable
                       inviteToken={inviteToken}
                       etransferEnabled={etransferEnabled}
                       sessionEmail={sessionEmail}
+                      quantity={ticket.price > 0 ? (quantities[ticket.id] || 0) : undefined}
+                      onQuantityChange={ticket.price > 0 ? (q) => setQuantities(prev => ({ ...prev, [ticket.id]: q })) : undefined}
+                      hideCheckoutButton={ticket.price > 0}
                     />
                   </OnboardGate>
                 )}
@@ -558,6 +581,63 @@ function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnable
           </div>
         );
       })}
+
+      {/* Unified checkout bar */}
+      {hasPaidTickets && (
+        <div className="sticky bottom-0 -mx-4 px-4 py-4 bg-gray-50/95 dark:bg-gray-900/95 backdrop-blur border-t border-gray-200 dark:border-gray-700 rounded-b-xl">
+          <div className="flex items-center justify-between gap-4">
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              {totalQty === 0 ? (
+                'Select tickets above'
+              ) : (
+                <span className="text-base font-semibold text-white">
+                  {totalQty} ticket{totalQty !== 1 ? 's' : ''} · {formattedTotal}
+                </span>
+              )}
+            </div>
+            <button
+              onClick={() => {
+                // Process first selected type via card checkout
+                if (cartItems.length === 0) return;
+                const first = cartItems[0];
+                // Navigate to checkout for the first type
+                // For multi-type, user will need to come back for additional types
+                apiFetch('/api/checkout', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    eventId,
+                    ticketTypeId: first.ticket.id,
+                    quantity: first.qty,
+                    ...(inviteToken && { invite: inviteToken }),
+                  }),
+                }).then(async (res) => {
+                  if (!res.ok) {
+                    const data = await res.json();
+                    toast.error(data.error || 'Checkout failed');
+                    return;
+                  }
+                  const { url } = await res.json();
+                  window.location.href = url;
+                }).catch(() => toast.error('Checkout failed'));
+              }}
+              disabled={totalQty === 0}
+              className={`px-6 py-3 rounded-lg font-semibold transition whitespace-nowrap ${
+                totalQty === 0
+                  ? 'bg-gray-300 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed'
+                  : 'bg-orange-500 text-white hover:bg-orange-600'
+              }`}
+            >
+              {totalQty === 0 ? 'Checkout' : `Checkout — ${formattedTotal}`}
+            </button>
+          </div>
+          {cartItems.length > 1 && (
+            <p className="text-xs text-amber-500 mt-2">
+              ⚠️ Multi-type cart: you’ll check out {cartItems[0].ticket.name} first, then return for the rest.
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Unlock hidden tiers */}
       {hasHiddenTiers && (


### PR DESCRIPTION
Unified cart experience for ticket purchasing.

### What changed

**Ticket Purchase (ticket-purchase.tsx):**
- Quantity defaults to **0** instead of 1
- Stepper min changed to 0 (was 1)
- New props: `quantity`, `onQuantityChange`, `hideCheckoutButton` for parent control
- Individual 'Get Ticket' button hidden when `hideCheckoutButton=true`
- Button shows 'Select quantity' when qty is 0

**Tickets Section (tickets-section.tsx):**
- Lifted quantity state to `PurchaseUI` via `quantities` record
- Unified sticky checkout bar at bottom of ticket list
- Running total: **'3 tickets · CA$1,840.00'**
- Checkout button disabled when nothing selected
- Multi-type warning when selecting across types (API handles one type per checkout for now)

**Free tickets:** Keep inline RSVP button — no cart needed for free events.

### UX flow
```
[Things are tight]    CA$285   [- 0 +]
[Things are good]     CA$430   [- 2 +]  CA$860 total
[Things are amazing]  CA$880   [- 0 +]

              2 tickets · CA$860.00   [Checkout — CA$860.00]
```

Closes #835