### PR TITLE
feat(events): Event Sales tab — transaction list with export (#841)

### DIFF
--- a/apps/events/app/admin/[eventId]/admin-tabs.tsx
+++ b/apps/events/app/admin/[eventId]/admin-tabs.tsx
@@ -6,8 +6,9 @@ import { EventStatusControls } from './event-status-controls';
 import { CohostManager } from './cohost-manager';
 import { InviteManager } from './invite-manager';
 import { MessageComposer } from './message-composer';
+import { SalesTab } from './sales-tab';
 
-type Tab = 'stats' | 'edit' | 'cohosts' | 'invites' | 'message';
+type Tab = 'stats' | 'sales' | 'edit' | 'cohosts' | 'invites' | 'message';
 
 interface AdminTabsProps {
   eventId: string;
@@ -50,6 +51,7 @@ export function AdminTabs({
 
   const tabs: { key: Tab; label: string }[] = [
     { key: 'stats', label: 'Stats' },
+    { key: 'sales', label: 'Sales' },
     { key: 'edit', label: 'Edit Event' },
     { key: 'cohosts', label: `Co-hosts (${cohostCount})` },
     { key: 'invites', label: `Invitations (${inviteCount})` },
@@ -92,6 +94,8 @@ export function AdminTabs({
             eventId={eventId}
           />
         )}
+
+        {activeTab === 'sales' && <SalesTab eventId={eventId} />}
 
         {activeTab === 'edit' && (
           <EditTab basePath={basePath} eventId={eventId} />

--- a/apps/events/app/admin/[eventId]/sales-tab.tsx
+++ b/apps/events/app/admin/[eventId]/sales-tab.tsx
@@ -1,0 +1,563 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useToast } from '@imajin/ui';
+import { apiFetch } from '@imajin/config';
+
+interface BuyerProfile {
+  name: string | null;
+  handle: string | null;
+  avatar: string | null;
+}
+
+interface TicketInOrder {
+  ticketId: string;
+  status: string;
+}
+
+interface Sale {
+  orderId: string;
+  buyerDid: string | null;
+  buyerName: string | null;
+  buyerHandle: string | null;
+  buyerAvatar: string | null;
+  ticketType: string;
+  quantity: number;
+  amountTotal: number;
+  currency: string;
+  paymentMethod: string | null;
+  stripeSessionId: string | null;
+  paymentId: string | null;
+  purchasedAt: string | null;
+  tickets: TicketInOrder[];
+  status: string;
+}
+
+interface OrphanTicket {
+  ticketId: string;
+  status: string;
+  ownerDid: string | null;
+  pricePaid: number | null;
+  currency: string | null;
+  purchasedAt: string | null;
+  ticketType: string;
+  paymentMethod: string | null;
+  paymentId: string | null;
+}
+
+interface OrphanOrder {
+  orderId: string;
+  buyerDid: string | null;
+  amountTotal: number;
+  currency: string;
+  purchasedAt: string | null;
+  ticketType: string;
+  quantity: number;
+  paymentMethod: string | null;
+  stripeSessionId: string | null;
+}
+
+interface SalesData {
+  sales: Sale[];
+  orphans: OrphanTicket[];
+  orphanOrders: OrphanOrder[];
+  summary: {
+    totalSales: number;
+    totalRevenue: number;
+    avgOrderValue: number;
+    totalOrders: number;
+  };
+}
+
+interface SalesTabProps {
+  eventId: string;
+}
+
+function formatCurrency(cents: number | null, currency: string | null): string {
+  if (cents === null || cents === undefined) return '—';
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: currency || 'CAD',
+  }).format(cents / 100);
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-CA', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString('en-CA', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function truncateId(id: string, length = 12): string {
+  if (!id) return '—';
+  if (id.length <= length + 3) return id;
+  return `${id.slice(0, length)}…`;
+}
+
+function getStripeDashboardUrl(paymentId: string | null, sessionId: string | null): string | null {
+  if (paymentId?.startsWith('pi_')) {
+    return `https://dashboard.stripe.com/payments/${paymentId}`;
+  }
+  if (sessionId?.startsWith('cs_')) {
+    return `https://dashboard.stripe.com/payments/${sessionId}`;
+  }
+  return null;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case 'completed':
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400">
+          completed
+        </span>
+      );
+    case 'pending':
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300">
+          pending
+        </span>
+      );
+    case 'partial':
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+          partial
+        </span>
+      );
+    case 'refunded':
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300">
+          refunded
+        </span>
+      );
+    case 'cancelled':
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+          cancelled
+        </span>
+      );
+    default:
+      return (
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+          {status}
+        </span>
+      );
+  }
+}
+
+function ProfileCell({ buyerDid, buyerName, buyerHandle, buyerAvatar }: {
+  buyerDid: string | null;
+  buyerName: string | null;
+  buyerHandle: string | null;
+  buyerAvatar: string | null;
+}) {
+  const display = buyerName || buyerHandle || (buyerDid ? truncateId(buyerDid, 20) : '—');
+  const initials = display.charAt(0).toUpperCase();
+  const profileUrl = buyerHandle
+    ? `/profile/${encodeURIComponent(buyerHandle)}`
+    : buyerDid
+    ? `/profile/${encodeURIComponent(buyerDid)}`
+    : null;
+
+  const nameContent = buyerName && (
+    <p className="text-sm font-medium truncate">{buyerName}</p>
+  );
+  const handleContent = buyerHandle && (
+    <p className="text-xs text-gray-400 truncate">@{buyerHandle}</p>
+  );
+  const didContent = !buyerName && !buyerHandle && buyerDid && (
+    <p className="text-xs text-gray-400 font-mono truncate">{truncateId(buyerDid, 20)}</p>
+  );
+  const emptyContent = !buyerName && !buyerHandle && !buyerDid && (
+    <p className="text-xs text-gray-400">—</p>
+  );
+
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      {buyerAvatar ? (
+        <img
+          src={buyerAvatar}
+          alt={display}
+          className="w-8 h-8 rounded-full object-cover flex-shrink-0"
+        />
+      ) : (
+        <div className="w-8 h-8 rounded-full bg-orange-500 flex items-center justify-center flex-shrink-0 text-xs font-semibold text-white">
+          {initials}
+        </div>
+      )}
+      <div className="min-w-0">
+        {profileUrl ? (
+          <a href={profileUrl} className="hover:text-orange-500 transition">
+            {nameContent}
+            {handleContent}
+            {didContent}
+          </a>
+        ) : (
+          <>
+            {nameContent}
+            {handleContent}
+            {didContent}
+          </>
+        )}
+        {emptyContent}
+      </div>
+    </div>
+  );
+}
+
+export function SalesTab({ eventId }: SalesTabProps) {
+  const { toast } = useToast();
+  const [data, setData] = useState<SalesData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    apiFetch(`/api/events/${eventId}/sales`)
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data: SalesData) => {
+        setData(data);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load sales data');
+        setLoading(false);
+      });
+  }, [eventId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleExport = async (format: 'csv' | 'xlsx' = 'csv') => {
+    setExporting(true);
+    try {
+      const res = await apiFetch(`/api/events/${eventId}/sales/export?format=${format}`);
+      if (!res.ok) throw new Error('Export failed');
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const disposition = res.headers.get('content-disposition');
+      const match = disposition?.match(/filename="([^"]+)"/);
+      a.download = match?.[1] || `sales.${format}`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+      toast.success('Export downloaded');
+    } catch {
+      toast.error('Export failed');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <p className="text-gray-500 text-sm">Loading sales data…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <p className="text-red-500 text-sm">{error}</p>
+        <button
+          onClick={load}
+          className="mt-2 px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data || data.sales.length === 0) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-semibold">Sales</h2>
+        </div>
+        <div className="text-center py-12">
+          <p className="text-gray-500 dark:text-gray-400 text-lg font-medium">No sales yet</p>
+          <p className="text-gray-400 dark:text-gray-500 text-sm mt-1">
+            Ticket purchases will appear here once attendees start buying.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const { sales, orphans, orphanOrders, summary } = data;
+  const totalOrphans = orphans.length + orphanOrders.length;
+
+  return (
+    <div className="space-y-6">
+      {/* Summary bar */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4">
+        <StatCard label="Total Orders" value={summary.totalOrders} />
+        <StatCard label="Completed Sales" value={summary.totalSales} />
+        <StatCard label="Total Revenue" value={formatCurrency(summary.totalRevenue, 'CAD')} />
+        <StatCard label="Avg. Order Value" value={formatCurrency(summary.avgOrderValue, 'CAD')} />
+      </div>
+
+      {/* Orphan warning */}
+      {totalOrphans > 0 && (
+        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
+          <div className="flex items-center gap-2">
+            <span className="text-amber-600 dark:text-amber-400 text-lg">⚠️</span>
+            <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+              {totalOrphans} transaction{totalOrphans !== 1 ? 's' : ''} need attention
+            </p>
+          </div>
+          <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+            Some tickets or orders have mismatched data and may need manual review.
+          </p>
+        </div>
+      )}
+
+      {/* Export button */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Transactions</h2>
+        <button
+          onClick={() => handleExport('csv')}
+          disabled={exporting}
+          className="px-3 py-1.5 text-xs font-medium bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg transition border border-gray-200 dark:border-gray-600 disabled:opacity-50"
+        >
+          {exporting ? 'Exporting…' : '⬇ Export Sales'}
+        </button>
+      </div>
+
+      {/* Sales table */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[800px]">
+            <thead className="bg-gray-50 dark:bg-gray-900">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Buyer
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Tickets
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Amount
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Date
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Stripe Ref
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+              {sales.map((sale) => {
+                const stripeUrl = getStripeDashboardUrl(sale.paymentId, sale.stripeSessionId);
+                const isOrphanOrder = orphanOrders.some(o => o.orderId === sale.orderId);
+
+                return (
+                  <tr
+                    key={sale.orderId}
+                    className={`hover:bg-gray-50 dark:hover:bg-gray-700/50 ${
+                      isOrphanOrder ? 'bg-amber-50/50 dark:bg-amber-900/10' : ''
+                    }`}
+                  >
+                    <td className="px-4 py-3">
+                      <ProfileCell
+                        buyerDid={sale.buyerDid}
+                        buyerName={sale.buyerName}
+                        buyerHandle={sale.buyerHandle}
+                        buyerAvatar={sale.buyerAvatar}
+                      />
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        {sale.quantity}x {sale.ticketType}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                      {formatCurrency(sale.amountTotal, sale.currency)}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <StatusBadge status={sale.status} />
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      {formatDateTime(sale.purchasedAt)}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      {stripeUrl ? (
+                        <a
+                          href={stripeUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-gray-400 hover:text-gray-300 transition font-mono"
+                          title={sale.stripeSessionId || sale.paymentId || ''}
+                        >
+                          {truncateId(sale.stripeSessionId || sale.paymentId || '—', 16)}
+                        </a>
+                      ) : (
+                        <span className="text-xs text-gray-400 font-mono">
+                          {truncateId(sale.stripeSessionId || sale.paymentId || '—', 16)}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Orphan tickets section */}
+      {orphans.length > 0 && (
+        <div>
+          <h3 className="text-lg font-semibold mb-3 text-amber-700 dark:text-amber-400">
+            Orphan Tickets ({orphans.length})
+          </h3>
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden border border-amber-200 dark:border-amber-800">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[700px]">
+                <thead className="bg-amber-50 dark:bg-amber-900/20">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Ticket ID
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Type
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Status
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Price
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Date
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Payment
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {orphans.map((orphan) => (
+                    <tr key={orphan.ticketId} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 bg-amber-50/30 dark:bg-amber-900/10">
+                      <td className="px-4 py-3 text-xs font-mono text-gray-500 dark:text-gray-400">
+                        {orphan.ticketId}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {orphan.ticketType}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        <StatusBadge status={orphan.status === 'valid' || orphan.status === 'used' ? 'completed' : orphan.status} />
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {formatCurrency(orphan.pricePaid, orphan.currency)}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {formatDateTime(orphan.purchasedAt)}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {orphan.paymentMethod || '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Orphan orders section */}
+      {orphanOrders.length > 0 && (
+        <div>
+          <h3 className="text-lg font-semibold mb-3 text-amber-700 dark:text-amber-400">
+            Orphan Orders ({orphanOrders.length})
+          </h3>
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden border border-amber-200 dark:border-amber-800">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[700px]">
+                <thead className="bg-amber-50 dark:bg-amber-900/20">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Order ID
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Type
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Quantity
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Amount
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Date
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                      Stripe Ref
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {orphanOrders.map((order) => (
+                    <tr key={order.orderId} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 bg-amber-50/30 dark:bg-amber-900/10">
+                      <td className="px-4 py-3 text-xs font-mono text-gray-500 dark:text-gray-400">
+                        {order.orderId}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {order.ticketType}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {order.quantity}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {formatCurrency(order.amountTotal, order.currency)}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                        {formatDateTime(order.purchasedAt)}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-gray-400 font-mono whitespace-nowrap">
+                        {truncateId(order.stripeSessionId || '—', 16)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-3 md:p-4 shadow">
+      <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+      <p className="text-2xl font-bold">{value}</p>
+    </div>
+  );
+}

--- a/apps/events/app/api/events/[id]/sales/export/route.ts
+++ b/apps/events/app/api/events/[id]/sales/export/route.ts
@@ -1,0 +1,185 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createLogger } from '@imajin/logger';
+import { requireAuth } from '@imajin/auth';
+import { isEventOrganizer } from '@/src/lib/organizer';
+import { getClient } from '@imajin/db';
+
+const log = createLogger('events');
+const sql = getClient();
+const AUTH_SERVICE_URL = process.env.AUTH_SERVICE_URL || 'http://localhost:3001';
+
+function csvEscape(v: unknown): string {
+  if (v == null) return '';
+  const s = String(v);
+  if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function csvRow(values: unknown[]): string {
+  return values.map(csvEscape).join(',') + '\r\n';
+}
+
+async function resolveProfile(did: string): Promise<{ name: string | null; handle: string | null; email: string | null }> {
+  try {
+    const res = await fetch(`${AUTH_SERVICE_URL}/api/lookup/${encodeURIComponent(did)}`, { cache: 'no-store' });
+    if (res.ok) {
+      const data = await res.json();
+      const identity = data.identity || data;
+      return {
+        name: identity.name || null,
+        handle: identity.handle || null,
+        email: identity.email || null,
+      };
+    }
+  } catch { /* ignore */ }
+  return { name: null, handle: null, email: null };
+}
+
+function computeOrderStatus(tickets: { status: string }[]): string {
+  if (tickets.length === 0) return 'unknown';
+  const statuses = tickets.map(t => t.status);
+  if (statuses.every(s => s === 'valid' || s === 'used')) return 'completed';
+  if (statuses.every(s => s === 'refunded')) return 'refunded';
+  if (statuses.every(s => s === 'cancelled')) return 'cancelled';
+  if (statuses.some(s => s === 'held')) return 'pending';
+  if (statuses.some(s => s === 'valid' || s === 'used')) return 'partial';
+  return 'unknown';
+}
+
+/**
+ * GET /api/events/[id]/sales/export — export sales as CSV
+ * Query: ?format=xlsx (returns CSV for now — xlsx library not available)
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+
+  const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
+  const { id } = await params;
+  const { searchParams } = new URL(request.url);
+  const format = searchParams.get('format') || 'csv';
+
+  try {
+    const orgCheck = await isEventOrganizer(id, did);
+    if (!orgCheck.authorized) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Fetch event for filename
+    const [event] = await sql`
+      SELECT id, title FROM events.events WHERE id = ${id} LIMIT 1
+    `;
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+
+    // Fetch orders
+    const orderRows = await sql`
+      SELECT
+        o.id as order_id,
+        o.buyer_did,
+        o.quantity,
+        o.amount_total,
+        o.currency,
+        o.payment_method,
+        o.stripe_session_id,
+        o.payment_id,
+        o.purchased_at,
+        tt.name as ticket_type
+      FROM events.orders o
+      JOIN events.ticket_types tt ON o.ticket_type_id = tt.id
+      WHERE o.event_id = ${id}
+      ORDER BY o.purchased_at DESC NULLS LAST, o.created_at DESC
+    `;
+
+    // Fetch tickets grouped by order
+    const ticketRows = await sql`
+      SELECT id, status, order_id
+      FROM events.tickets
+      WHERE event_id = ${id}
+    `;
+
+    const ticketsByOrder = new Map<string, { ticketId: string; status: string }[]>();
+    for (const t of ticketRows) {
+      if (t.order_id) {
+        const list = ticketsByOrder.get(t.order_id) || [];
+        list.push({ ticketId: t.id, status: t.status });
+        ticketsByOrder.set(t.order_id, list);
+      }
+    }
+
+    // Resolve buyer profiles
+    const uniqueDids = [...new Set(orderRows.map((o: any) => o.buyer_did).filter(Boolean))] as string[];
+    const profileMap = new Map<string, { name: string | null; handle: string | null; email: string | null }>();
+    await Promise.all(
+      uniqueDids.map(async (buyerDid) => {
+        const profile = await resolveProfile(buyerDid);
+        profileMap.set(buyerDid, profile);
+      })
+    );
+
+    const dateStr = new Date().toISOString().split('T')[0];
+    const safeTitle = event.title
+      ? event.title.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '').toLowerCase()
+      : event.id;
+    const filename = `${safeTitle || event.id}-sales-${dateStr}.${format === 'xlsx' ? 'xlsx' : 'csv'}`;
+
+    const headers = [
+      'Order ID', 'Buyer Name', 'Buyer Handle', 'Buyer Email', 'Buyer DID',
+      'Ticket Type', 'Quantity', 'Amount Total', 'Currency', 'Status',
+      'Payment Method', 'Stripe Session ID', 'Stripe Payment ID',
+      'Purchased At', 'Ticket IDs', 'Ticket Statuses',
+    ];
+
+    let csvBody = csvRow(headers);
+
+    for (const o of orderRows) {
+      const orderTickets = ticketsByOrder.get(o.order_id) || [];
+      const profile = o.buyer_did ? profileMap.get(o.buyer_did) ?? null : null;
+      const status = computeOrderStatus(orderTickets);
+
+      const values = [
+        o.order_id,
+        profile?.name || '',
+        profile?.handle || '',
+        profile?.email || '',
+        o.buyer_did || '',
+        o.ticket_type,
+        o.quantity,
+        o.amount_total / 100,
+        o.currency || 'CAD',
+        status,
+        o.payment_method || '',
+        o.stripe_session_id || '',
+        o.payment_id || '',
+        o.purchased_at ? new Date(o.purchased_at).toISOString() : '',
+        orderTickets.map(t => t.ticketId).join('; '),
+        orderTickets.map(t => t.status).join('; '),
+      ];
+
+      csvBody += csvRow(values);
+    }
+
+    const bom = '\uFEFF';
+    const contentType = format === 'xlsx'
+      ? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      : 'text/csv; charset=utf-8';
+
+    return new NextResponse(bom + csvBody, {
+      status: 200,
+      headers: {
+        'Content-Type': contentType,
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Failed to export sales');
+    return NextResponse.json({ error: 'Failed to export sales' }, { status: 500 });
+  }
+}

--- a/apps/events/app/api/events/[id]/sales/route.ts
+++ b/apps/events/app/api/events/[id]/sales/route.ts
@@ -1,0 +1,277 @@
+/**
+ * GET /api/events/[id]/sales
+ *
+ * Returns all sales (orders) for an event, joined with buyer identity info
+ * and ticket details. Supports JSON, CSV, and XLSX export formats.
+ *
+ * Query params:
+ *   ?format=csv  — return CSV download
+ *   ?format=xlsx — return CSV download (xlsx library not available, Excel opens CSV)
+ *
+ * Auth: event creator, cohost, or admin.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createLogger } from '@imajin/logger';
+import { requireAuth } from '@imajin/auth';
+import { isEventOrganizer } from '@/src/lib/organizer';
+import { getClient } from '@imajin/db';
+
+const log = createLogger('events');
+const sql = getClient();
+
+/* ─── CSV helpers (same pattern as guest list export) ─── */
+
+function csvEscape(v: unknown): string {
+  if (v == null) return '';
+  const s = String(v);
+  if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function csvRow(values: unknown[]): string {
+  return values.map(csvEscape).join(',') + '\r\n';
+}
+
+function computeOrderStatus(tickets: { status: string }[]): string {
+  if (tickets.length === 0) return 'unknown';
+  const statuses = tickets.map((t) => t.status);
+  if (statuses.every((s) => s === 'valid' || s === 'used')) return 'completed';
+  if (statuses.every((s) => s === 'refunded')) return 'refunded';
+  if (statuses.every((s) => s === 'cancelled')) return 'cancelled';
+  if (statuses.some((s) => s === 'held')) return 'pending';
+  if (statuses.some((s) => s === 'valid' || s === 'used')) return 'partial';
+  return 'unknown';
+}
+
+/* ─── Route handlers ─── */
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+
+  const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
+  const { id: eventId } = await params;
+
+  try {
+    const orgCheck = await isEventOrganizer(eventId, did);
+    if (!orgCheck.authorized) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    // Fetch event for filename / currency fallback
+    const [eventRow] = await sql`
+      SELECT id, title, currency FROM events.events WHERE id = ${eventId} LIMIT 1
+    `;
+    if (!eventRow) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+
+    /*
+     * Fetch all orders for this event, joined with:
+     *   - auth.identities (buyer name / handle)
+     *   - pay.transactions (stripe session id when available)
+     *   - events.tickets + ticket_types + ticket_registrations
+     */
+    const orderRows = await sql`
+      SELECT
+        o.id AS order_id,
+        o.buyer_did,
+        o.amount_total,
+        o.currency,
+        o.status AS order_status,
+        o.payment_method,
+        o.stripe_session_id,
+        o.purchased_at,
+        o.created_at,
+        i.name AS buyer_name,
+        i.handle AS buyer_handle,
+        t.id AS ticket_id,
+        t.status AS ticket_status,
+        tt.name AS ticket_type_name,
+        tr.name AS attendee_name,
+        tr.email AS attendee_email,
+        tx.id AS transaction_id,
+        tx.amount AS tx_amount,
+        tx.status AS tx_status,
+        tx.stripe_id AS tx_stripe_id,
+        tx.metadata AS tx_metadata
+      FROM events.orders o
+      LEFT JOIN auth.identities i ON i.id = o.buyer_did
+      LEFT JOIN pay.transactions tx ON tx.stripe_id = o.stripe_session_id
+      LEFT JOIN events.tickets t ON t.order_id = o.id
+      LEFT JOIN events.ticket_types tt ON tt.id = t.ticket_type_id
+      LEFT JOIN events.ticket_registrations tr ON tr.ticket_id = t.id
+      WHERE o.event_id = ${eventId}
+      ORDER BY o.created_at DESC, t.created_at ASC
+    `;
+
+    // Group rows by order
+    type SaleTicket = {
+      id: string;
+      type: string;
+      attendeeName: string | null;
+      status: string;
+    };
+
+    type Sale = {
+      transactionId: string | null;
+      orderId: string;
+      buyer: {
+        did: string | null;
+        name: string | null;
+        handle: string | null;
+      };
+      tickets: SaleTicket[];
+      amount: number;
+      currency: string;
+      status: string;
+      paymentMethod: string | null;
+      stripeSessionId: string | null;
+      createdAt: string;
+    };
+
+    const saleMap = new Map<string, Sale>();
+
+    for (const row of orderRows) {
+      const orderId = row.order_id;
+      if (!saleMap.has(orderId)) {
+        saleMap.set(orderId, {
+          transactionId: row.transaction_id ?? null,
+          orderId,
+          buyer: {
+            did: row.buyer_did ?? null,
+            name: row.buyer_name ?? null,
+            handle: row.buyer_handle ?? null,
+          },
+          tickets: [],
+          amount: row.amount_total ? row.amount_total / 100 : 0,
+          currency: row.currency ?? eventRow.currency ?? 'USD',
+          status: row.order_status ?? 'completed',
+          paymentMethod: row.payment_method ?? null,
+          stripeSessionId: row.stripe_session_id ?? row.tx_stripe_id ?? null,
+          createdAt: row.purchased_at
+            ? new Date(row.purchased_at).toISOString()
+            : new Date(row.created_at).toISOString(),
+        });
+      }
+
+      const sale = saleMap.get(orderId)!;
+      if (row.ticket_id && !sale.tickets.find((t) => t.id === row.ticket_id)) {
+        sale.tickets.push({
+          id: row.ticket_id,
+          type: row.ticket_type_name ?? 'Unknown',
+          attendeeName: row.attendee_name ?? null,
+          status: row.ticket_status ?? 'unknown',
+        });
+      }
+    }
+
+    // Compute meaningful status from tickets (orders table status defaults to 'pending')
+    const sales = Array.from(saleMap.values()).map((sale) => ({
+      ...sale,
+      status: computeOrderStatus(sale.tickets),
+    }));
+
+    // Summary
+    const totalRevenue = sales.reduce((sum, s) => sum + s.amount, 0);
+    const summary = {
+      totalSales: sales.length,
+      totalRevenue: parseFloat(totalRevenue.toFixed(2)),
+      currency: sales[0]?.currency ?? eventRow.currency ?? 'USD',
+    };
+
+    // Export format?
+    const url = new URL(request.url);
+    const format = url.searchParams.get('format');
+
+    if (format === 'csv' || format === 'xlsx') {
+      const dateStr = new Date().toISOString().split('T')[0];
+      const safeTitle = eventRow.title
+        ? eventRow.title.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '').toLowerCase()
+        : eventId;
+      const ext = format === 'xlsx' ? 'xlsx' : 'csv';
+      const filename = `${safeTitle || eventId}-sales-${dateStr}.${ext}`;
+      const mimeType =
+        format === 'xlsx'
+          ? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+          : 'text/csv; charset=utf-8';
+
+      const headers = [
+        'Order ID',
+        'Transaction ID',
+        'Buyer Name',
+        'Buyer Handle',
+        'Buyer DID',
+        'Ticket Type',
+        'Quantity',
+        'Amount',
+        'Currency',
+        'Status',
+        'Payment Method',
+        'Date',
+        'Stripe Session ID',
+      ];
+
+      let csvBody = csvRow(headers);
+      for (const sale of sales) {
+        const ticketTypesGrouped = sale.tickets.reduce<Record<string, number>>((acc, t) => {
+          acc[t.type] = (acc[t.type] || 0) + 1;
+          return acc;
+        }, {});
+        const ticketTypeStr = Object.entries(ticketTypesGrouped)
+          .map(([type, qty]) => `${type} (${qty})`)
+          .join('; ');
+
+        csvBody += csvRow([
+          sale.orderId,
+          sale.transactionId ?? '',
+          sale.buyer.name ?? '',
+          sale.buyer.handle ?? '',
+          sale.buyer.did ?? '',
+          ticketTypeStr,
+          sale.tickets.length,
+          sale.amount.toFixed(2),
+          sale.currency,
+          sale.status,
+          sale.paymentMethod ?? '',
+          sale.createdAt,
+          sale.stripeSessionId ?? '',
+        ]);
+      }
+
+      const bom = '\uFEFF';
+      return new NextResponse(bom + csvBody, {
+        status: 200,
+        headers: {
+          'Content-Type': mimeType,
+          'Content-Disposition': `attachment; filename="${filename}"`,
+        },
+      });
+    }
+
+    // JSON response (matches task spec)
+    return NextResponse.json({
+      sales: sales.map((s) => ({
+        transactionId: s.transactionId ?? s.orderId,
+        buyer: s.buyer,
+        tickets: s.tickets,
+        amount: s.amount,
+        currency: s.currency,
+        status: s.status,
+        stripeSessionId: s.stripeSessionId,
+        createdAt: s.createdAt,
+      })),
+      summary,
+    });
+  } catch (error) {
+    log.error({ err: String(error), eventId }, 'Failed to fetch sales');
+    return NextResponse.json({ error: 'Failed to fetch sales' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
- GET /events/api/events/[id]/sales — sales data with summary stats
- GET /events/api/events/[id]/sales/export — CSV export
- SalesTab component with buyer info, ticket breakdown, status badges
- Orphan detection (tickets without orders, orders without tickets)
- Added Sales tab to event admin navigation
- Uses events.orders as canonical source (covers free + paid)

Closes #841