### PR TITLE
feat(email): configurable email provider — SendGrid, Postal, SMTP (#858)

### DIFF
--- a/apps/kernel/.env.example
+++ b/apps/kernel/.env.example
@@ -29,10 +29,26 @@ SOLANA_RPC_URL="https://api.mainnet-beta.solana.com"
 PLATFORM_DID=did:imajin:platform
 PLATFORM_FEE_PERCENT=0.2
 
-# --- Email (SendGrid) ---
+# --- Email ---
+# Provider: sendgrid | postal | smtp (default: sendgrid)
+EMAIL_PROVIDER=sendgrid
+
+# SendGrid
 SENDGRID_API_KEY=""
 SENDGRID_FROM="Name <email@example.com>"
 SENDGRID_FROM_EMAIL=notifications@example.com
+
+# Postal
+POSTAL_API_URL=""
+POSTAL_API_KEY=""
+POSTAL_FROM=""
+
+# SMTP
+SMTP_HOST=""
+SMTP_PORT=587
+SMTP_USER=""
+SMTP_PASS=""
+SMTP_FROM=""
 
 # --- Media ---
 MEDIA_ROOT=/mnt/media

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@imajin/logger": "workspace:*",
     "marked": "^12.0.0",
-    "qrcode": "^1.5.4"
+    "qrcode": "^1.5.4",
+    "nodemailer": "^6.9.15"
   },
   "devDependencies": {
     "@types/qrcode": "^1.5.5",
+    "@types/nodemailer": "^6.4.16",
     "typescript": "^5.3.0"
   }
 }

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,5 +1,5 @@
 export { sendEmail, parseSender, stripHtml } from './send';
-export type { SendEmailOptions } from './send';
+export type { SendEmailOptions } from './types';
 export { generateQRCode } from './qr';
 export { emailWrapper } from './templates/base';
 export { trustGraphInviteEmail } from './templates/invite';

--- a/packages/email/src/providers/index.ts
+++ b/packages/email/src/providers/index.ts
@@ -1,0 +1,19 @@
+import { SendGridProvider } from './sendgrid';
+import { PostalProvider } from './postal';
+import { SmtpProvider } from './smtp';
+import type { EmailProvider } from './types';
+
+export { SendGridProvider, PostalProvider, SmtpProvider };
+export type { EmailProvider };
+export type { SendEmailOptions } from '../types';
+
+export function getProvider(): EmailProvider {
+  const provider = process.env.EMAIL_PROVIDER || 'sendgrid';
+  switch (provider) {
+    case 'postal': return new PostalProvider();
+    case 'smtp': return new SmtpProvider();
+    case 'sendgrid':
+    default:
+      return new SendGridProvider();
+  }
+}

--- a/packages/email/src/providers/postal.ts
+++ b/packages/email/src/providers/postal.ts
@@ -1,0 +1,63 @@
+import { createLogger } from '@imajin/logger';
+import type { EmailProvider } from './types';
+import type { SendEmailOptions } from '../types';
+
+const log = createLogger('email:postal');
+
+const POSTAL_API_URL = process.env.POSTAL_API_URL;
+const POSTAL_API_KEY = process.env.POSTAL_API_KEY;
+const POSTAL_FROM = process.env.POSTAL_FROM || process.env.EMAIL_FROM || 'Jin <jin@imajin.ai>';
+
+export class PostalProvider implements EmailProvider {
+  async send(options: SendEmailOptions): Promise<{ success: boolean; error?: any; messageId?: string }> {
+    if (!POSTAL_API_URL) {
+      log.warn({ to: options.to }, 'POSTAL_API_URL not set — skipping email');
+      return { success: false, error: 'POSTAL_API_URL not configured' };
+    }
+    if (!POSTAL_API_KEY) {
+      log.warn({ to: options.to }, 'POSTAL_API_KEY not set — skipping email');
+      return { success: false, error: 'POSTAL_API_KEY not configured' };
+    }
+
+    const fromMatch = POSTAL_FROM.match(/^(.+)\s*<(.+)>$/);
+    const fromName = fromMatch ? fromMatch[1].trim() : undefined;
+    const fromEmail = fromMatch ? fromMatch[2].trim() : POSTAL_FROM;
+
+    const body: Record<string, any> = {
+      to: [options.to],
+      from: fromName ? `${fromName} <${fromEmail}>` : fromEmail,
+      sender: fromEmail,
+      subject: options.subject,
+      html_body: options.html,
+      plain_body: options.text || '',
+    };
+
+    if (options.replyTo) {
+      body.reply_to = options.replyTo;
+    }
+
+    try {
+      const res = await fetch(`${POSTAL_API_URL.replace(/\/$/, '')}/api/v1/send/message`, {
+        method: 'POST',
+        headers: {
+          'X-Server-API-Key': POSTAL_API_KEY,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      const resBody = await res.json().catch(() => null);
+
+      if (res.status === 200 && resBody?.status === 'success') {
+        log.info({ to: options.to, messageId: resBody.data?.message_id }, 'Email sent via Postal');
+        return { success: true, messageId: resBody.data?.message_id };
+      } else {
+        log.error({ status: res.status, body: resBody }, 'Postal error');
+        return { success: false, error: `Postal ${res.status}: ${JSON.stringify(resBody)}` };
+      }
+    } catch (error) {
+      log.error({ err: String(error) }, 'Postal send failed');
+      return { success: false, error };
+    }
+  }
+}

--- a/packages/email/src/providers/sendgrid.ts
+++ b/packages/email/src/providers/sendgrid.ts
@@ -1,0 +1,57 @@
+import { createLogger } from '@imajin/logger';
+import type { EmailProvider } from './types';
+import type { SendEmailOptions } from '../types';
+import { parseSender } from '../types';
+
+const log = createLogger('email:sendgrid');
+
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
+const SENDGRID_FROM = process.env.SENDGRID_FROM || 'Jin <jin@imajin.ai>';
+
+export class SendGridProvider implements EmailProvider {
+  async send(options: SendEmailOptions): Promise<{ success: boolean; error?: any; messageId?: string }> {
+    if (!SENDGRID_API_KEY) {
+      log.warn({ to: options.to }, 'SENDGRID_API_KEY not set — skipping email');
+      return { success: false, error: 'No API key configured' };
+    }
+
+    const headers: Record<string, string> = {};
+    if (options.unsubscribeUrl) {
+      headers['List-Unsubscribe'] = `<${options.unsubscribeUrl}>`;
+      headers['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click';
+    }
+
+    try {
+      const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${SENDGRID_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          personalizations: [{ to: [{ email: options.to }] }],
+          from: parseSender(SENDGRID_FROM),
+          ...(options.replyTo && { reply_to: { email: options.replyTo } }),
+          subject: options.subject,
+          content: [
+            { type: 'text/plain', value: options.text || '' },
+            { type: 'text/html', value: options.html },
+          ],
+          ...(Object.keys(headers).length > 0 && { headers }),
+        }),
+      });
+
+      if (res.status === 202) {
+        log.info({ to: options.to }, 'Email sent via SendGrid');
+        return { success: true, messageId: res.headers.get('x-message-id') ?? undefined };
+      } else {
+        const body = await res.text();
+        log.error({ status: res.status, body }, 'SendGrid error');
+        return { success: false, error: `SendGrid ${res.status}: ${body}` };
+      }
+    } catch (error) {
+      log.error({ err: String(error) }, 'SendGrid send failed');
+      return { success: false, error };
+    }
+  }
+}

--- a/packages/email/src/providers/smtp.ts
+++ b/packages/email/src/providers/smtp.ts
@@ -1,0 +1,56 @@
+import { createLogger } from '@imajin/logger';
+import type { EmailProvider } from './types';
+import type { SendEmailOptions } from '../types';
+import nodemailer from 'nodemailer';
+
+const log = createLogger('email:smtp');
+
+const SMTP_HOST = process.env.SMTP_HOST;
+const SMTP_PORT = parseInt(process.env.SMTP_PORT || '587', 10);
+const SMTP_USER = process.env.SMTP_USER;
+const SMTP_PASS = process.env.SMTP_PASS;
+const SMTP_FROM = process.env.SMTP_FROM || process.env.EMAIL_FROM || 'Jin <jin@imajin.ai>';
+
+export class SmtpProvider implements EmailProvider {
+  async send(options: SendEmailOptions): Promise<{ success: boolean; error?: any; messageId?: string }> {
+    if (!SMTP_HOST || !SMTP_USER || !SMTP_PASS) {
+      log.warn({ to: options.to }, 'SMTP_HOST, SMTP_USER, or SMTP_PASS not set — skipping email');
+      return { success: false, error: 'SMTP not fully configured' };
+    }
+
+    const transporter = nodemailer.createTransport({
+      host: SMTP_HOST,
+      port: SMTP_PORT,
+      secure: SMTP_PORT === 465,
+      auth: {
+        user: SMTP_USER,
+        pass: SMTP_PASS,
+      },
+    });
+
+    try {
+      const info = await transporter.sendMail({
+        from: SMTP_FROM,
+        to: options.to,
+        subject: options.subject,
+        text: options.text || '',
+        html: options.html,
+        ...(options.replyTo && { replyTo: options.replyTo }),
+        ...(options.unsubscribeUrl && {
+          list: {
+            unsubscribe: {
+              url: options.unsubscribeUrl,
+              comment: 'Unsubscribe from this mailing list',
+            },
+          },
+        }),
+      });
+
+      log.info({ to: options.to, messageId: info.messageId }, 'Email sent via SMTP');
+      return { success: true, messageId: info.messageId };
+    } catch (error) {
+      log.error({ err: String(error) }, 'SMTP send failed');
+      return { success: false, error };
+    }
+  }
+}

--- a/packages/email/src/providers/types.ts
+++ b/packages/email/src/providers/types.ts
@@ -1,0 +1,5 @@
+import type { SendEmailOptions } from '../types';
+
+export interface EmailProvider {
+  send(options: SendEmailOptions): Promise<{ success: boolean; error?: any; messageId?: string }>;
+}

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -1,34 +1,16 @@
 import { createLogger } from '@imajin/logger';
-const log = createLogger('email');
+import { getProvider } from './providers';
+import type { SendEmailOptions } from './types';
 
-const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
-const SENDGRID_FROM = process.env.SENDGRID_FROM || 'Jin <jin@imajin.ai>';
+const log = createLogger('email');
 
 // CAN-SPAM required physical address
 const PHYSICAL_ADDRESS = 'Imajin Inc., 118 Sheridan Ave, Toronto, ON, Canada';
 
-export interface SendEmailOptions {
-  to: string;
-  subject: string;
-  html: string;
-  text?: string;
-  /** When set, adds List-Unsubscribe / List-Unsubscribe-Post headers and a footer link */
-  unsubscribeUrl?: string;
-  /** Reply-To address (e.g. event organizer email) */
-  replyTo?: string;
-}
+export type { SendEmailOptions } from './types';
 
 export async function sendEmail(options: SendEmailOptions): Promise<{ success: boolean; error?: any; messageId?: string }> {
-  if (!SENDGRID_API_KEY) {
-    log.warn({ to: options.to }, 'SENDGRID_API_KEY not set — skipping email');
-    return { success: false, error: 'No API key configured' };
-  }
-
-  const headers: Record<string, string> = {};
-  if (options.unsubscribeUrl) {
-    headers['List-Unsubscribe'] = `<${options.unsubscribeUrl}>`;
-    headers['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click';
-  }
+  const provider = getProvider();
 
   // Append unsubscribe footer to HTML when an unsubscribe URL is provided
   const htmlBody = options.unsubscribeUrl
@@ -39,38 +21,11 @@ export async function sendEmail(options: SendEmailOptions): Promise<{ success: b
     ? (options.unsubscribeUrl ? `${options.text}\n\n---\nTo unsubscribe: ${options.unsubscribeUrl}\n${PHYSICAL_ADDRESS}` : options.text)
     : stripHtml(htmlBody);
 
-  try {
-    const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${SENDGRID_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        personalizations: [{ to: [{ email: options.to }] }],
-        from: parseSender(SENDGRID_FROM),
-        ...(options.replyTo && { reply_to: { email: options.replyTo } }),
-        subject: options.subject,
-        content: [
-          { type: 'text/plain', value: textBody },
-          { type: 'text/html', value: htmlBody },
-        ],
-        ...(Object.keys(headers).length > 0 && { headers }),
-      }),
-    });
-
-    if (res.status === 202) {
-      log.info({ to: options.to }, 'Email sent via SendGrid');
-      return { success: true, messageId: res.headers.get('x-message-id') ?? undefined };
-    } else {
-      const body = await res.text();
-      log.error({ status: res.status, body }, 'SendGrid error');
-      return { success: false, error: `SendGrid ${res.status}: ${body}` };
-    }
-  } catch (error) {
-    log.error({ err: String(error) }, 'Email send failed');
-    return { success: false, error };
-  }
+  return provider.send({
+    ...options,
+    html: htmlBody,
+    text: textBody,
+  });
 }
 
 function appendUnsubscribeFooter(html: string, unsubscribeUrl: string): string {
@@ -87,11 +42,8 @@ function appendUnsubscribeFooter(html: string, unsubscribeUrl: string): string {
   return html + footer;
 }
 
-export function parseSender(from: string): { email: string; name?: string } {
-  const match = from.match(/^(.+)\s*<(.+)>$/);
-  if (match) return { name: match[1].trim(), email: match[2].trim() };
-  return { email: from };
-}
+// Re-export parseSender from types for backward compatibility
+export { parseSender } from './types';
 
 export function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();

--- a/packages/email/src/types.ts
+++ b/packages/email/src/types.ts
@@ -1,0 +1,16 @@
+export interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+  /** When set, adds List-Unsubscribe / List-Unsubscribe-Post headers and a footer link */
+  unsubscribeUrl?: string;
+  /** Reply-To address (e.g. event organizer email) */
+  replyTo?: string;
+}
+
+export function parseSender(from: string): { email: string; name?: string } {
+  const match = from.match(/^(.+)\s*<(.+)>$/);
+  if (match) return { name: match[1].trim(), email: match[2].trim() };
+  return { email: from };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,10 +49,6 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.19.17)
 
-  ../imajin-fixready: {}
-
-  ../imajin-karaoke: {}
-
   apps/coffee:
     dependencies:
       '@imajin/auth':
@@ -818,10 +814,16 @@ importers:
       marked:
         specifier: ^12.0.0
         version: 12.0.2
+      nodemailer:
+        specifier: ^6.9.15
+        version: 6.10.1
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
     devDependencies:
+      '@types/nodemailer':
+        specifier: ^6.4.16
+        version: 6.4.23
       '@types/qrcode':
         specifier: ^1.5.5
         version: 1.5.6
@@ -3108,6 +3110,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/nodemailer@6.4.23':
+    resolution: {integrity: sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==}
+
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
 
@@ -5252,6 +5257,10 @@ packages:
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  nodemailer@6.10.1:
+    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+    engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -8724,6 +8733,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/nodemailer@6.4.23':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/prismjs@1.26.6': {}
 
   '@types/prop-types@15.7.15': {}
@@ -11404,6 +11417,8 @@ snapshots:
     optional: true
 
   node-releases@2.0.37: {}
+
+  nodemailer@6.10.1: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Summary

Refactors `@imajin/email` to support multiple email providers via `EMAIL_PROVIDER` env var. Currently hardcoded to SendGrid — this adds Postal and SMTP as alternatives.

## What Changed

- **`packages/email/src/providers/`** — new directory with provider implementations:
  - `sendgrid.ts` — extracted from original `send.ts`, no behavior change
  - `postal.ts` — HTTP API provider for self-hosted [Postal](https://github.com/postalserver/postal)
  - `smtp.ts` — generic SMTP via nodemailer (works with any relay)
  - `types.ts` — shared `EmailProvider` interface
  - `index.ts` — `getProvider()` factory based on `EMAIL_PROVIDER` env
- **`packages/email/src/types.ts`** — `SendEmailOptions` + `parseSender` extracted (breaks circular dep)
- **`packages/email/src/send.ts`** — simplified to orchestrate provider + shared footer/unsubscribe logic
- **`apps/kernel/.env.example`** — all new env vars documented

## No Caller Changes

All 7 callers use `sendEmail()` from `@imajin/email` — interface unchanged:
- `notify/api/broadcast`, `notify/api/send`, `auth/api/register`, `auth/api/onboard`, `auth/api/mfa/email`, `auth/api/magic/send`, `api/subscribe`

## Env Vars

```bash
# Provider selection
EMAIL_PROVIDER=sendgrid|postal|smtp

# Postal
POSTAL_API_URL=https://postal.imajin.ai
POSTAL_API_KEY=your-api-key
POSTAL_FROM="Jin <jin@imajin.ai>"

# SMTP
SMTP_HOST=localhost
SMTP_PORT=587
SMTP_USER=user
SMTP_PASS=pass
SMTP_FROM="Jin <jin@imajin.ai>"
```

## Context

Postal is now deployed at `postal.imajin.ai` (Scaleway VPS, Docker, Caddy HTTPS). This PR lets us switch to it by changing one env var.

Closes #858