### PR TITLE
docs: developer guide — Imajin as composable agent layer (#865)

### DIFF
--- a/apps/events/app/api/events/[id]/sales/route.ts
+++ b/apps/events/app/api/events/[id]/sales/route.ts
@@ -268,6 +268,8 @@ export async function GET(
         stripeSessionId: s.stripeSessionId,
         createdAt: s.createdAt,
       })),
+      orphans: [],
+      orphanOrders: [],
       summary,
     });
   } catch (error) {

--- a/apps/events/app/api/events/[id]/sales/route.ts
+++ b/apps/events/app/api/events/[id]/sales/route.ts
@@ -256,21 +256,47 @@ export async function GET(
       });
     }
 
-    // JSON response (matches task spec)
+    // JSON response — shape must match SalesTab component interface
+    const totalOrders = sales.length;
+    const avgOrderValue = totalOrders > 0 ? Math.round(totalRevenue * 100 / totalOrders) : 0;
+
     return NextResponse.json({
-      sales: sales.map((s) => ({
-        transactionId: s.transactionId ?? s.orderId,
-        buyer: s.buyer,
-        tickets: s.tickets,
-        amount: s.amount,
-        currency: s.currency,
-        status: s.status,
-        stripeSessionId: s.stripeSessionId,
-        createdAt: s.createdAt,
-      })),
+      sales: sales.map((s) => {
+        // Group tickets by type for display
+        const ticketTypeCounts = s.tickets.reduce<Record<string, number>>((acc, t) => {
+          acc[t.type] = (acc[t.type] || 0) + 1;
+          return acc;
+        }, {});
+        const ticketTypeStr = Object.entries(ticketTypeCounts)
+          .map(([type, qty]) => qty > 1 ? `${type} (${qty})` : type)
+          .join(', ') || 'Unknown';
+
+        return {
+          orderId: s.orderId,
+          buyerDid: s.buyer.did,
+          buyerName: s.buyer.name,
+          buyerHandle: s.buyer.handle,
+          buyerAvatar: null,
+          ticketType: ticketTypeStr,
+          quantity: s.tickets.length,
+          amountTotal: Math.round(s.amount * 100),
+          currency: s.currency,
+          paymentMethod: s.paymentMethod,
+          stripeSessionId: s.stripeSessionId,
+          paymentId: s.transactionId,
+          purchasedAt: s.createdAt,
+          tickets: s.tickets.map((t) => ({ ticketId: t.id, status: t.status })),
+          status: s.status,
+        };
+      }),
       orphans: [],
       orphanOrders: [],
-      summary,
+      summary: {
+        totalSales: totalOrders,
+        totalRevenue: Math.round(totalRevenue * 100),
+        avgOrderValue,
+        totalOrders,
+      },
     });
   } catch (error) {
     log.error({ err: String(error), eventId }, 'Failed to fetch sales');

--- a/apps/events/app/api/events/[id]/sales/route.ts
+++ b/apps/events/app/api/events/[id]/sales/route.ts
@@ -294,46 +294,73 @@ export async function GET(
     }
 
     // JSON response — shape must match SalesTab component interface
-    const totalOrders = sales.length + orphans.length;
-    const totalSalesCount = sales.length;
-    const avgOrderValue = totalOrders > 0 ? Math.round(totalRevenue * 100 / totalOrders) : 0;
+    // Merge order-based sales and orphan tickets into one unified list
+    const orderSales = sales.map((s) => {
+      const ticketTypeCounts = s.tickets.reduce<Record<string, number>>((acc, t) => {
+        acc[t.type] = (acc[t.type] || 0) + 1;
+        return acc;
+      }, {});
+      const ticketTypeStr = Object.entries(ticketTypeCounts)
+        .map(([type, qty]) => qty > 1 ? `${type} (${qty})` : type)
+        .join(', ') || 'Unknown';
+
+      return {
+        orderId: s.orderId,
+        buyerDid: s.buyer.did,
+        buyerName: s.buyer.name,
+        buyerHandle: s.buyer.handle,
+        buyerAvatar: null,
+        ticketType: ticketTypeStr,
+        quantity: s.tickets.length,
+        amountTotal: Math.round(s.amount * 100),
+        currency: s.currency,
+        paymentMethod: s.paymentMethod,
+        stripeSessionId: s.stripeSessionId,
+        paymentId: s.transactionId,
+        purchasedAt: s.createdAt,
+        tickets: s.tickets.map((t) => ({ ticketId: t.id, status: t.status })),
+        status: s.status,
+      };
+    });
+
+    // Convert orphan tickets into the same Sale shape
+    const orphanSales = orphans.map((o: any) => ({
+      orderId: o.ticketId,
+      buyerDid: o.ownerDid,
+      buyerName: o.attendeeName,
+      buyerHandle: null,
+      buyerAvatar: null,
+      ticketType: o.ticketType,
+      quantity: 1,
+      amountTotal: o.pricePaid ?? 0,
+      currency: o.currency,
+      paymentMethod: o.paymentMethod,
+      stripeSessionId: o.paymentId?.startsWith('cs_') ? o.paymentId : null,
+      paymentId: o.paymentId,
+      purchasedAt: o.purchasedAt,
+      tickets: [{ ticketId: o.ticketId, status: o.status }],
+      status: o.status === 'valid' || o.status === 'used' ? 'completed' : o.status,
+    }));
+
+    const allSales = [...orderSales, ...orphanSales]
+      .sort((a, b) => {
+        const da = a.purchasedAt ? new Date(a.purchasedAt).getTime() : 0;
+        const db = b.purchasedAt ? new Date(b.purchasedAt).getTime() : 0;
+        return db - da;
+      });
+
+    const totalCount = allSales.length;
+    const avgOrderValue = totalCount > 0 ? Math.round(totalRevenue * 100 / totalCount) : 0;
 
     return NextResponse.json({
-      sales: sales.map((s) => {
-        // Group tickets by type for display
-        const ticketTypeCounts = s.tickets.reduce<Record<string, number>>((acc, t) => {
-          acc[t.type] = (acc[t.type] || 0) + 1;
-          return acc;
-        }, {});
-        const ticketTypeStr = Object.entries(ticketTypeCounts)
-          .map(([type, qty]) => qty > 1 ? `${type} (${qty})` : type)
-          .join(', ') || 'Unknown';
-
-        return {
-          orderId: s.orderId,
-          buyerDid: s.buyer.did,
-          buyerName: s.buyer.name,
-          buyerHandle: s.buyer.handle,
-          buyerAvatar: null,
-          ticketType: ticketTypeStr,
-          quantity: s.tickets.length,
-          amountTotal: Math.round(s.amount * 100),
-          currency: s.currency,
-          paymentMethod: s.paymentMethod,
-          stripeSessionId: s.stripeSessionId,
-          paymentId: s.transactionId,
-          purchasedAt: s.createdAt,
-          tickets: s.tickets.map((t) => ({ ticketId: t.id, status: t.status })),
-          status: s.status,
-        };
-      }),
-      orphans,
+      sales: allSales,
+      orphans: [],
       orphanOrders: [],
       summary: {
-        totalSales: totalSalesCount,
+        totalSales: totalCount,
         totalRevenue: Math.round(totalRevenue * 100),
         avgOrderValue,
-        totalOrders,
+        totalOrders: totalCount,
       },
     });
   } catch (error) {

--- a/apps/events/app/api/events/[id]/sales/route.ts
+++ b/apps/events/app/api/events/[id]/sales/route.ts
@@ -192,10 +192,13 @@ export async function GET(
         t.payment_id,
         tt.name AS ticket_type_name,
         tr.name AS attendee_name,
-        tr.email AS attendee_email
+        tr.email AS attendee_email,
+        i.name AS owner_name,
+        i.handle AS owner_handle
       FROM events.tickets t
       LEFT JOIN events.ticket_types tt ON tt.id = t.ticket_type_id
       LEFT JOIN events.ticket_registrations tr ON tr.ticket_id = t.id
+      LEFT JOIN auth.identities i ON i.id = t.owner_did
       WHERE t.event_id = ${eventId}
         AND t.order_id IS NULL
       ORDER BY t.purchased_at DESC NULLS LAST, t.created_at DESC
@@ -205,6 +208,8 @@ export async function GET(
       ticketId: r.ticket_id,
       status: r.status ?? 'unknown',
       ownerDid: r.owner_did ?? null,
+      ownerName: r.owner_name ?? r.attendee_name ?? null,
+      ownerHandle: r.owner_handle ?? null,
       pricePaid: r.price_paid ?? null,
       currency: r.currency ?? eventRow.currency ?? 'CAD',
       purchasedAt: r.purchased_at ? new Date(r.purchased_at).toISOString() : null,
@@ -327,8 +332,8 @@ export async function GET(
     const orphanSales = orphans.map((o: any) => ({
       orderId: o.ticketId,
       buyerDid: o.ownerDid,
-      buyerName: o.attendeeName,
-      buyerHandle: null,
+      buyerName: o.ownerName ?? o.attendeeName,
+      buyerHandle: o.ownerHandle,
       buyerAvatar: null,
       ticketType: o.ticketType,
       quantity: 1,

--- a/apps/events/app/api/events/[id]/sales/route.ts
+++ b/apps/events/app/api/events/[id]/sales/route.ts
@@ -179,8 +179,45 @@ export async function GET(
       status: computeOrderStatus(sale.tickets),
     }));
 
-    // Summary
-    const totalRevenue = sales.reduce((sum, s) => sum + s.amount, 0);
+    // Fetch orphan tickets (no order_id) — these predate the orders system
+    const orphanRows = await sql`
+      SELECT
+        t.id AS ticket_id,
+        t.status,
+        t.owner_did,
+        t.price_paid,
+        t.currency,
+        t.purchased_at,
+        t.payment_method,
+        t.payment_id,
+        tt.name AS ticket_type_name,
+        tr.name AS attendee_name,
+        tr.email AS attendee_email
+      FROM events.tickets t
+      LEFT JOIN events.ticket_types tt ON tt.id = t.ticket_type_id
+      LEFT JOIN events.ticket_registrations tr ON tr.ticket_id = t.id
+      WHERE t.event_id = ${eventId}
+        AND t.order_id IS NULL
+      ORDER BY t.purchased_at DESC NULLS LAST, t.created_at DESC
+    `;
+
+    const orphans = orphanRows.map((r: any) => ({
+      ticketId: r.ticket_id,
+      status: r.status ?? 'unknown',
+      ownerDid: r.owner_did ?? null,
+      pricePaid: r.price_paid ?? null,
+      currency: r.currency ?? eventRow.currency ?? 'CAD',
+      purchasedAt: r.purchased_at ? new Date(r.purchased_at).toISOString() : null,
+      ticketType: r.ticket_type_name ?? 'Unknown',
+      paymentMethod: r.payment_method ?? null,
+      paymentId: r.payment_id ?? null,
+      attendeeName: r.attendee_name ?? null,
+      attendeeEmail: r.attendee_email ?? null,
+    }));
+
+    // Summary — include orphan revenue
+    const orphanRevenue = orphans.reduce((sum: number, o: any) => sum + (o.pricePaid ?? 0), 0) / 100;
+    const totalRevenue = sales.reduce((sum, s) => sum + s.amount, 0) + orphanRevenue;
     const summary = {
       totalSales: sales.length,
       totalRevenue: parseFloat(totalRevenue.toFixed(2)),
@@ -257,7 +294,8 @@ export async function GET(
     }
 
     // JSON response — shape must match SalesTab component interface
-    const totalOrders = sales.length;
+    const totalOrders = sales.length + orphans.length;
+    const totalSalesCount = sales.length;
     const avgOrderValue = totalOrders > 0 ? Math.round(totalRevenue * 100 / totalOrders) : 0;
 
     return NextResponse.json({
@@ -289,10 +327,10 @@ export async function GET(
           status: s.status,
         };
       }),
-      orphans: [],
+      orphans,
       orphanOrders: [],
       summary: {
-        totalSales: totalOrders,
+        totalSales: totalSalesCount,
         totalRevenue: Math.round(totalRevenue * 100),
         avgOrderValue,
         totalOrders,

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,0 +1,35 @@
+# Imajin Developer Guide
+
+**The composable agent layer.** Identity, delegation, attestation, and settlement — the infrastructure any agent runtime composes on top of.
+
+---
+
+## The Layer Cake
+
+| # | Doc | What You'll Learn |
+|---|-----|-------------------|
+| 1 | [What is Imajin](./what-is-imajin.md) | What the layer provides, what it doesn't, why a layer instead of a platform |
+| 2 | [Core Concepts](./core-concepts.md) | DIDs, delegation chains, attestations, .fair attribution, the chain, progressive trust |
+| 3 | [Getting Started](./getting-started.md) | Generate keys, register a DID, authenticate, make your first tool call |
+| 4 | [The Interface: ImajinAgentEnv](./the-interface.md) | The universal contract — tool surface, workspace, session, events, wire protocol |
+| 5 | [Adapters](./adapters.md) | Build connectors for external platforms with credential isolation + .fair attribution |
+| 6 | [Integration Guides](./integration-guides.md) | Wire Imajin into OpenClaw, Flue, n8n, or custom TypeScript |
+| 7 | [Examples](./examples.md) | Travel agent, commerce agent, support agent, insurance agent — real patterns |
+
+## Who This Is For
+
+**The forward-deployed engineer.** Someone who walks into a business with six platforms that don't talk to each other and needs to unify identity, data, and agents across all of them. You don't want to rip and replace — you want to wire Imajin in underneath what already exists.
+
+**How to make your own data the source of truth without replacing anything you already use.**
+
+## Quick Links
+
+- **HTTP API reference:** [Developer Guide](../developer-guide.md) (curl-based walkthrough)
+- **Protocol RFCs:** [docs/rfcs/](../rfcs/) (the "why" behind decisions)
+- **Source code:** [github.com/ima-jin/imajin-ai](https://github.com/ima-jin/imajin-ai)
+- **.fair spec:** [github.com/ima-jin/.fair](https://github.com/ima-jin/.fair)
+- **OpenAPI specs:** `https://<service>.imajin.ai/api/spec`
+
+---
+
+*Imajin is open source. The reference implementation runs at [jin.imajin.ai](https://jin.imajin.ai).*

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -1,0 +1,195 @@
+# Adapters
+
+An adapter maps an external platform into Imajin's tool surface. It's how your agent talks to Shopify, Stripe, Salesforce, or any other service — without ever touching API keys.
+
+---
+
+## What an Adapter Is
+
+An adapter is a typed tool surface with:
+
+- **Credential isolation** — the agent calls `shopify.listOrders()`, the gateway injects the API key. The agent never sees credentials.
+- **Schema validation** — inputs and outputs are typed with Valibot. Bad data is caught before it leaves the kernel.
+- **.fair attribution** — when an adapter generates value (a sale, a booking, a lead), the adapter's .fair manifest determines how revenue flows to the adapter's creator.
+- **Grant enforcement** — the kernel checks that the agent is authorized to use this adapter's tools before execution.
+
+Think of adapters as the community-contributed surface area of Imajin. The kernel provides the core tools (identity, chat, media, commerce). Adapters extend the tool surface to the entire ecosystem of external services.
+
+## How Adapters Work
+
+```
+Agent Runtime          Imajin Kernel          Adapter          External Service
+     │                      │                    │                    │
+     │── tool.call ────────>│                    │                    │
+     │   shopify.listOrders │── validate ───────>│                    │
+     │                      │   grant + scope    │                    │
+     │                      │                    │── HTTP + creds ──>│
+     │                      │                    │<── response ──────│
+     │                      │                    │                    │
+     │                      │<── typed result ───│                    │
+     │                      │   + gas consumed   │                    │
+     │<── tool.result ──────│                    │                    │
+     │   typed, validated   │                    │                    │
+```
+
+The agent sees `shopify.listOrders`. The adapter handles the Shopify API, authentication, pagination, error handling. The kernel handles grant checking, gas metering, and chain recording. Nobody trusts the agent with credentials.
+
+## Anatomy of an Adapter
+
+```typescript
+import { defineAdapter, defineTool } from '@imajin/agent-env';
+import * as v from 'valibot';
+
+export default defineAdapter({
+  name: 'shopify',
+  version: '1.0.0',
+  description: 'Shopify store management',
+  
+  // Credentials the adapter needs — injected by kernel, never exposed to agent
+  credentials: {
+    apiKey: { type: 'string', description: 'Shopify API key' },
+    storeDomain: { type: 'string', description: 'mystore.myshopify.com' },
+  },
+  
+  // .fair manifest — adapter creator earns when the adapter generates value
+  fair: {
+    contributors: [
+      { id: 'did:imajin:adapter-creator-did', role: 'developer', weight: 1.0 }
+    ]
+  },
+  
+  tools: [
+    defineTool({
+      name: 'shopify.listOrders',
+      description: 'List recent orders from the Shopify store',
+      grantRequired: 'operator',
+      gasCost: 5,
+      params: v.object({
+        status: v.optional(v.picklist(['open', 'closed', 'cancelled'])),
+        limit: v.optional(v.number()),
+      }),
+      result: v.array(v.object({
+        id: v.string(),
+        email: v.string(),
+        totalPrice: v.string(),
+        createdAt: v.string(),
+      })),
+      execute: async (params, credentials) => {
+        const res = await fetch(
+          `https://${credentials.storeDomain}/admin/api/2024-01/orders.json?status=${params.status || 'any'}&limit=${params.limit || 10}`,
+          { headers: { 'X-Shopify-Access-Token': credentials.apiKey } }
+        );
+        const data = await res.json();
+        return data.orders.map(o => ({
+          id: o.id.toString(),
+          email: o.email,
+          totalPrice: o.total_price,
+          createdAt: o.created_at,
+        }));
+      }
+    }),
+    
+    defineTool({
+      name: 'shopify.createProduct',
+      description: 'Create a new product in the Shopify store',
+      grantRequired: 'operator',
+      gasCost: 10,
+      params: v.object({
+        title: v.string(),
+        bodyHtml: v.optional(v.string()),
+        vendor: v.optional(v.string()),
+        price: v.string(),
+      }),
+      result: v.object({
+        id: v.string(),
+        title: v.string(),
+        handle: v.string(),
+      }),
+      execute: async (params, credentials) => {
+        const res = await fetch(
+          `https://${credentials.storeDomain}/admin/api/2024-01/products.json`,
+          {
+            method: 'POST',
+            headers: {
+              'X-Shopify-Access-Token': credentials.apiKey,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              product: {
+                title: params.title,
+                body_html: params.bodyHtml,
+                vendor: params.vendor,
+                variants: [{ price: params.price }],
+              }
+            }),
+          }
+        );
+        const data = await res.json();
+        return {
+          id: data.product.id.toString(),
+          title: data.product.title,
+          handle: data.product.handle,
+        };
+      }
+    }),
+  ],
+});
+```
+
+## How to Build an Adapter
+
+### 1. Define the Tool Surface
+
+Think about what operations the external service offers, and what an agent would actually need:
+
+- **Read operations** (list, get, search) → `Observer` or `Operator` grant
+- **Write operations** (create, update) → `Operator` grant  
+- **Financial operations** (charge, refund, transfer) → `Transactor` grant
+
+Keep tools focused. `shopify.listOrders` is better than `shopify.query` with a giant params object.
+
+### 2. Type Everything
+
+Params and results use Valibot schemas. This gives:
+- Compile-time type safety for TypeScript runtimes
+- Runtime validation on both sides (kernel validates params, agent validates results)
+- Auto-generated documentation
+
+### 3. Isolate Credentials
+
+The adapter declares what credentials it needs. The user configures them through the Imajin admin UI. The kernel injects them at execution time. The agent never sees them.
+
+This is critical. An agent with `shopify.listOrders` access can list orders. It cannot extract the Shopify API key and use it for something else.
+
+### 4. Set .fair Attribution
+
+When your adapter generates value (a sale through Shopify, a booking through a travel API), the .fair manifest determines how adapter-attributed revenue flows. The adapter creator earns a share — this is the incentive to build and maintain quality adapters.
+
+### 5. Publish
+
+Adapters publish to the Imajin adapter registry. Node operators choose which adapters to enable. Users configure credentials per adapter.
+
+```bash
+# Package and publish
+npm run build
+imajin adapter publish
+```
+
+## Existing Adapters
+
+As adapters ship, they'll be listed here. The first adapters in development:
+
+| Adapter | Service | Status |
+|---------|---------|--------|
+| `imajin-chat` | Imajin chat (OpenClaw plugin) | Live |
+| `imajin-identity` | Imajin identity operations | Live |
+
+## The Contribution Model
+
+Adapter creators earn through .fair when their adapter generates value. This isn't a marketplace with listing fees — it's attribution. If your Shopify adapter processes a $100 sale and the scope fee is 0.25%, the .fair manifest on your adapter determines your cut of that 0.25%.
+
+Build useful adapters. Earn when they're used. No gatekeeping.
+
+---
+
+*Next: [Integration Guides →](./integration-guides.md)*

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -1,0 +1,223 @@
+# Core Concepts
+
+These aren't internal architecture docs. They're the things you need to understand to build on Imajin.
+
+---
+
+## DIDs and Identity Scopes
+
+Every identity on Imajin is a DID (Decentralized Identifier): `did:imajin:5Qn8...`
+
+The DID is derived from an Ed25519 public key. You generate the keypair. Nobody issues you the identity — it's a mathematical fact. The same keypair is one derivation from a Solana wallet address.
+
+### Scopes
+
+Identity has a **scope** that determines governance:
+
+| Scope | What It Is | Example |
+|-------|-----------|---------|
+| `actor` | A single entity | A person, an agent, a device |
+| `family` | A household or close group | A family sharing a node |
+| `community` | A group with shared purpose | A local music scene, a neighborhood |
+| `business` | A commercial entity | A café, a retailer, a festival |
+
+### Subtypes
+
+Within a scope, **subtype** determines presentation and capability:
+
+| Subtype | Scope | What It Is |
+|---------|-------|-----------|
+| `human` | actor | A person |
+| `agent` | actor | An AI agent |
+| `device` | actor | A physical device (node, sensor, kiosk) |
+| `cafe` | business | A coffee shop |
+| `festival` | community | A recurring event series |
+
+**Scope = governance rules. Subtype = what it looks like.** A `business/cafe` and a `business/retailer` follow the same governance rules but present differently.
+
+### Identity Tiers
+
+Trust is progressive. Every DID starts soft and can upgrade without changing:
+
+| Tier | How You Get There | What It Proves |
+|------|-------------------|---------------|
+| **Soft** | Verify an email | "Someone controls this email" |
+| **Preliminary** | Generate a keypair + get invited | "Someone holds these keys and was vouched for" |
+| **Established** | Accumulate attestation history | "This identity has a track record" |
+
+The DID never changes across tiers. All history carries forward. Email is a credential attached to the DID, not the identity itself.
+
+---
+
+## Delegation Chains
+
+An agent doesn't act on its own authority. It acts on behalf of a human, with explicit boundaries.
+
+```
+Human DID (principal)
+  └── delegates to → Agent DID
+        grants: [chat.send, chat.read, media.read]
+        scope: [own-conversations]
+        expires: 2026-06-01
+```
+
+The delegation is cryptographic — signed by the human's Ed25519 key. Every tool call the agent makes carries the delegation chain. The kernel validates the full chain before execution:
+
+1. Is this agent DID registered?
+2. Does the delegation chain trace back to a valid human DID?
+3. Does the grant set include this specific tool?
+4. Is the agent authorized for this data's scope?
+5. Has the delegation expired or been revoked?
+
+If any check fails, the call is rejected. The agent never gets to "try and see."
+
+### Grant Tiers
+
+Pre-built permission levels that cover common patterns:
+
+| Tier | Can Do | Can't Do |
+|------|--------|----------|
+| **Observer** | Read public data, browse profiles | Send messages, create content |
+| **Assistant** | Read + send messages, read media | Create events, make payments |
+| **Operator** | Read + write + create content | Settle payments, modify .fair splits |
+| **Transactor** | Full tool access including payments | Set scope fees, modify delegation (human-only) |
+
+Custom grant sets are also supported — the tiers are convenience, not a constraint.
+
+---
+
+## Attestations
+
+Signed records of things that happened. Not claims — evidence.
+
+```json
+{
+  "type": "transaction.settled",
+  "subject": "did:imajin:5Qn8...",
+  "issuer": "did:imajin:node:abc...",
+  "payload": {
+    "amount": 2500,
+    "currency": "CAD",
+    "fair_manifest": "fair:evt_123",
+    "counterparty": "did:imajin:8Xk2..."
+  },
+  "signature": "...",
+  "timestamp": "2026-05-01T14:30:00Z"
+}
+```
+
+Attestations are bilateral — both parties sign. They're append-only — you can't edit or delete them. And they're the substance of the trust graph.
+
+### Live Attestation Types
+
+| Type | What It Records |
+|------|----------------|
+| `transaction.settled` | Payment processed with .fair chain |
+| `customer` | First transaction with a service |
+| `connection.invited` | Trust link extended |
+| `connection.accepted` | Trust link confirmed |
+| `vouch` | Inviter stands behind the invitee |
+| `session.created` | Authentication event with method metadata |
+
+An agent's chain is its résumé. 50,000 signed attestations can't be faked, bought, or copied. The only way to build a chain is to do real things.
+
+---
+
+## .fair Attribution
+
+A JSON sidecar format that answers two questions: **who made this?** and **who gets paid?**
+
+```json
+{
+  "id": "evt_summer_camp",
+  "type": "event",
+  "version": "0.3.0",
+  "contributors": [
+    { "id": "did:imajin:5Qn8...", "role": "curator", "weight": 0.7 },
+    { "id": "did:imajin:8Xk2...", "role": "artist", "weight": 0.3 }
+  ],
+  "fees": [
+    { "id": "did:imajin:protocol", "label": "MJN", "rate": 0.01 },
+    { "id": "did:imajin:node:abc", "label": "Node", "rate": 0.005 }
+  ],
+  "signature": "...",
+  "platformSignature": "..."
+}
+```
+
+### Three-Layer Cascade
+
+1. **Fees** are deducted first — protocol fee (MJN 1%), node fee (0.5%), buyer credit (0.25%), scope fee (0.25%). These are transaction costs, not revenue.
+2. **Contributors** split the remainder according to weights. The .fair manifest is the source of truth.
+3. **Signatures** are verified cryptographically before settlement. Tampered manifests are rejected.
+
+.fair is a standalone format. You can use it without Imajin — just create `.fair.json` files alongside your content. But when you use it with Imajin, settlement is automatic: the kernel reads the manifest, verifies signatures, and routes payments.
+
+---
+
+## The Chain
+
+Every agent (and every human) has an append-only chain. It's not a blockchain — it's a signed log.
+
+```
+[2026-05-01T14:00] session.started { agent: did:imajin:agent:xyz, principal: did:imajin:5Qn8... }
+[2026-05-01T14:01] tool.called { name: "chat.send", params: {...}, gas: 2 }
+[2026-05-01T14:01] tool.result { name: "chat.send", success: true, gas: 2 }
+[2026-05-01T14:15] tool.called { name: "pay.checkout", params: {...}, gas: 10 }
+[2026-05-01T14:15] tool.result { name: "pay.checkout", success: true, gas: 10 }
+[2026-05-01T14:20] session.ended { total_gas: 14, tools_called: 2 }
+```
+
+Every entry is signed by the actor's Ed25519 key. The chain is:
+
+- **Append-only** — entries can't be modified or deleted
+- **Single-writer** — only the DID owner writes to their chain
+- **Replayable** — give someone the chain and they can verify every entry
+- **Selectively disclosable** — private by default, shared via UCAN-style delegation
+
+### Why This Matters for Agents
+
+Same chain, different configs, measurable outcomes. It's version control for agency.
+
+Run an agent with grant tier "Observer" for a week. Switch to "Operator." Compare the chains. The delta is measurable, auditable, and cryptographically verifiable.
+
+AI audit isn't a feature — it's a consequence of signing everything.
+
+---
+
+## Progressive Trust
+
+Trust isn't binary. It's earned through activity and attestation history.
+
+```
+New agent DID created
+  → Soft trust (exists, has a principal)
+    → Preliminary trust (completed first transactions, vouched by principal)
+      → Established trust (meaningful attestation history, pattern of reliable behavior)
+```
+
+Each tier unlocks capabilities. An established agent can be given broader grants. A soft agent is constrained to safe operations.
+
+The trust model applies to humans too. A new human identity starts soft (email verification) and progresses through the same tiers. The difference: only human DIDs can govern. Agents execute; humans judge.
+
+---
+
+## Key Architectural Decisions
+
+These are the non-obvious choices that shape everything:
+
+1. **Ed25519 = Solana wallet.** Every DID is one derivation from holding MJN tokens. No bridging, no wrapping.
+
+2. **Federated first, decentralized later.** Central registry for discovery today, with an exit door always open. You can run your own node.
+
+3. **Tools, not shells.** Agents call platform-provided tools. No arbitrary code execution against the kernel. The tool surface IS the security boundary.
+
+4. **Agents forget by default.** Session context clears when the session ends. Persistent memory is explicit — write it to your `.jin/` workspace. This is a feature, not a limitation: it means the chain is the canonical record.
+
+5. **Human governance, enforced by math.** Scope fees, .fair splits, consent gates, delegation grants — all set by humans, enforced by the protocol. Agents can't override governance parameters.
+
+6. **The workspace is media.** Agent storage lives in `.jin/` inside the user's existing media folder. Same quotas, same .fair attribution, same DID-pegged access control. No separate allocation.
+
+---
+
+*Next: [Getting Started →](./getting-started.md)*

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -1,0 +1,299 @@
+# Examples
+
+Real-world agent patterns built on Imajin. Each example shows the agent logic and how Imajin's primitives (identity, attestation, settlement, audit) make it work.
+
+---
+
+## Travel Agent with Credential Verification
+
+A travel agent that books hotels and verifies traveler credentials — the SHITSUJI pattern.
+
+### The Scenario
+
+A family is traveling to Hawaii. The travel agent needs to:
+1. Verify the lead traveler's identity
+2. Check passport/visa credentials without storing them
+3. Book accommodations through a partner API
+4. Settle payment with attribution to all parties (agent operator, travel platform, hotel)
+
+### How It Works with Imajin
+
+```typescript
+async function handleBookingRequest(env: ImajinAgentEnv, request: BookingRequest) {
+  // 1. Verify the traveler's identity tier
+  const traveler = await env.callTool('identity.resolve', {
+    did: request.travelerDid
+  });
+  
+  if (traveler.data.tier === 'soft') {
+    await env.callTool('chat.send', {
+      conversation: request.conversationDid,
+      content: 'To book travel, we need verified identity. Would you like to start verification?'
+    });
+    return;
+  }
+  
+  // 2. Request credential via consent-gated release
+  //    The traveler sees exactly what's being requested and approves/denies
+  const credential = await env.callTool('identity.requestCredential', {
+    subject: request.travelerDid,
+    type: 'travel.passport',
+    purpose: 'Hotel booking verification — Hilton Hawaiian Village',
+    retention: 'none'  // Don't store after verification
+  });
+  
+  if (!credential.ok) {
+    // Traveler denied the request — agent can't proceed
+    await env.callTool('chat.send', {
+      conversation: request.conversationDid,
+      content: 'No worries — booking requires passport verification. Let me know if you change your mind.'
+    });
+    return;
+  }
+  
+  // 3. Book through the hotel adapter (credentials injected by kernel)
+  const booking = await env.callTool('hilton.createReservation', {
+    property: 'hawaiian-village',
+    checkIn: request.checkIn,
+    checkOut: request.checkOut,
+    guests: request.guestCount,
+    verificationToken: credential.data.token  // One-time token, not raw data
+  });
+  
+  // 4. Create checkout with .fair attribution
+  const checkout = await env.callTool('commerce.checkout', {
+    amount: booking.data.totalPrice,
+    currency: 'USD',
+    fair: {
+      contributors: [
+        { id: env.principal, role: 'operator', weight: 0.02 },  // Agent operator
+        { id: 'did:imajin:tripian', role: 'platform', weight: 0.03 },  // Travel platform
+        { id: 'did:imajin:hilton-hwv', role: 'vendor', weight: 0.95 }  // Hotel
+      ]
+    }
+  });
+  
+  await env.callTool('chat.send', {
+    conversation: request.conversationDid,
+    content: `Booking confirmed! Complete payment here: ${checkout.data.url}`
+  });
+  
+  // Everything above is on the chain:
+  // - Identity verification request + consent
+  // - Credential check (without storing PII)
+  // - Booking creation
+  // - Payment with .fair attribution
+  // All signed, all auditable, all replayable.
+}
+```
+
+### What Imajin Provides Here
+
+- **Consent-gated credential release** — the traveler approves exactly what data is shared, with whom, and for how long
+- **One-time verification tokens** — the agent proves the credential is valid without holding the raw data
+- **Multi-party .fair settlement** — operator, platform, and vendor all get attributed correctly
+- **Audit trail** — if something goes wrong, replay the chain. Every step is signed.
+
+---
+
+## Commerce Agent with .fair Settlement
+
+An agent that manages a marketplace storefront — listing products, processing orders, settling payments with attribution.
+
+```typescript
+async function processOrder(env: ImajinAgentEnv, order: Order) {
+  // Fetch the .fair manifest for this product
+  const product = await env.callTool('media.read', {
+    asset: order.productId
+  });
+  
+  // The .fair manifest was set by the human seller — the agent can't modify it
+  // It might look like:
+  // {
+  //   contributors: [
+  //     { id: "did:imajin:artisan", role: "creator", weight: 0.80 },
+  //     { id: "did:imajin:photographer", role: "photographer", weight: 0.10 },
+  //     { id: "did:imajin:marketplace", role: "platform", weight: 0.10 }
+  //   ]
+  // }
+  
+  // Create checkout — settlement follows the .fair manifest automatically
+  const checkout = await env.callTool('commerce.checkout', {
+    amount: order.amount,
+    currency: 'CAD',
+    productId: order.productId,
+    // No .fair override — uses the product's manifest
+  });
+  
+  // Notify the buyer
+  await env.callTool('chat.send', {
+    conversation: order.buyerConversation,
+    content: `Order ready! Pay here: ${checkout.data.url}\n\nThis purchase supports: ${product.data.fair.contributors.map(c => c.role).join(', ')}`
+  });
+  
+  // When payment settles (async, via event):
+  env.on('commerce.settled', async (settlement) => {
+    if (settlement.orderId === order.id) {
+      // Settlement has already split revenue per .fair manifest
+      // Creator got 80%, photographer got 10%, platform got 10%
+      // After protocol fees (MJN 1%, node 0.5%, buyer credit 0.25%, scope 0.25%)
+      
+      await env.callTool('chat.send', {
+        conversation: order.buyerConversation,
+        content: 'Payment confirmed! Your order is being prepared.'
+      });
+    }
+  });
+}
+```
+
+### What Imajin Provides Here
+
+- **.fair enforcement** — the agent processes orders but can't alter revenue splits. The human seller set the attribution. The protocol enforces it.
+- **Transparent attribution** — the buyer sees who they're supporting
+- **Automatic settlement** — the kernel handles the math, the Stripe split, and the chain recording
+
+---
+
+## Support Agent with Attestation Trail
+
+An agent that handles customer support — with every resolution attested and auditable.
+
+```typescript
+async function handleSupportTicket(env: ImajinAgentEnv, ticket: SupportTicket) {
+  // Read the customer's attestation history with this business
+  const history = await env.callTool('identity.attestations', {
+    subject: ticket.customerDid,
+    issuer: env.principal,
+    types: ['customer', 'transaction.settled', 'support.resolved']
+  });
+  
+  // Long-time customer with clean history? Different approach than first-timer.
+  const isEstablished = history.data.length > 10;
+  
+  // Agent reasoning happens in your runtime — this is just the tool interaction
+  const resolution = await determineResolution(ticket, history.data, isEstablished);
+  
+  if (resolution.type === 'refund') {
+    // Refunds above threshold need human consent
+    const result = await env.callTool('commerce.refund', {
+      transactionId: ticket.transactionId,
+      amount: resolution.amount,
+      reason: resolution.reason
+    });
+    
+    // If this was above the consent threshold, the principal was asked to approve
+    // The chain records: agent requested refund → human approved → refund processed
+  }
+  
+  // Record the resolution as an attestation
+  await env.callTool('identity.attest', {
+    type: 'support.resolved',
+    subject: ticket.customerDid,
+    payload: {
+      ticketId: ticket.id,
+      resolution: resolution.type,
+      satisfaction: ticket.customerRating
+    }
+  });
+  
+  // The attestation is now part of both the agent's chain AND the customer's history
+  // Next time this customer has an issue, the support agent sees the full trail
+}
+```
+
+### What Imajin Provides Here
+
+- **Attestation-based history** — the agent's decisions are informed by real, verifiable history, not a CRM database that anyone can edit
+- **Consent gate on high-value actions** — refunds above a threshold require human approval
+- **Bidirectional attestations** — both the agent and the customer have the resolution on their chains
+
+---
+
+## Insurance Agent with Audit-Ready Chain
+
+An agent that processes insurance claims — where regulatory compliance requires a complete audit trail.
+
+```typescript
+async function processClaim(env: ImajinAgentEnv, claim: InsuranceClaim) {
+  // Step 1: Verify claimant identity
+  const identity = await env.callTool('identity.resolve', {
+    did: claim.claimantDid
+  });
+  
+  // Step 2: Request relevant credentials (consent-gated)
+  const medicalAuth = await env.callTool('identity.requestCredential', {
+    subject: claim.claimantDid,
+    type: 'medical.authorization',
+    purpose: `Insurance claim ${claim.id} — medical records access`,
+    retention: '90days',  // Regulatory minimum
+    basis: 'contractual'  // Legal basis for processing
+  });
+  
+  // Step 3: Assess claim (agent reasoning in your runtime)
+  const assessment = await assessClaim(claim, medicalAuth.data);
+  
+  // Step 4: Record assessment as attestation
+  await env.callTool('identity.attest', {
+    type: 'insurance.assessed',
+    subject: claim.claimantDid,
+    payload: {
+      claimId: claim.id,
+      assessmentResult: assessment.decision,
+      factors: assessment.factors,
+      modelVersion: assessment.modelVersion  // Which model made this decision
+    }
+  });
+  
+  // Step 5: If approved, settle (always requires human consent for insurance)
+  if (assessment.decision === 'approved') {
+    await env.callTool('commerce.settle', {
+      amount: assessment.approvedAmount,
+      recipient: claim.claimantDid,
+      fair: {
+        contributors: [
+          { id: env.principal, role: 'insurer', weight: 1.0 }
+        ]
+      },
+      reference: `claim:${claim.id}`
+    });
+  }
+  
+  // The complete chain for this claim:
+  // 1. Identity verification
+  // 2. Credential request + consent
+  // 3. Assessment with model version
+  // 4. Human approval (via consent gate)
+  // 5. Settlement
+  //
+  // A regulator can replay this chain end-to-end.
+  // Every step is signed by the agent DID, traceable to the human principal.
+  // The model version is recorded — if the model changes, you can see which
+  // version made which decisions.
+}
+```
+
+### What Imajin Provides Here
+
+- **Regulatory-grade audit trail** — every step signed, timestamped, non-repudiable
+- **Model version recording** — critical for AI governance. Which model version made which decision?
+- **Consent with legal basis** — not just "user clicked OK" but structured consent with purpose, retention period, and legal basis
+- **Chain replay** — give the chain to a regulator and they can verify every step independently
+
+---
+
+## What These Examples Share
+
+Every example above follows the same pattern:
+
+1. **Identity** — resolve DIDs, verify tiers, check attestation history
+2. **Consent** — request credentials through the consent gate, not by scraping
+3. **Action** — call tools through the kernel (signed, scoped, gas-metered)
+4. **Attribution** — .fair manifests determine revenue flow
+5. **Record** — every step on the chain, replayable and auditable
+
+The agent runtime handles reasoning. Imajin handles everything else.
+
+---
+
+*Back to: [What is Imajin](./what-is-imajin.md) · [The Interface](./the-interface.md) · [Developer Guide](../developer-guide.md)*

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,203 @@
+# Getting Started
+
+Connect an agent to Imajin in four steps: generate keys, register a DID, authenticate, and make your first tool call.
+
+---
+
+## Prerequisites
+
+- Node.js 18+ (for the examples — any language works)
+- An invite code (the network is invite-only during early access)
+- A principal DID (the human identity that will delegate to the agent)
+
+## Step 1: Generate an Agent Keypair
+
+Every agent identity starts with an Ed25519 keypair. The agent holds its own keys.
+
+```typescript
+import { getPublicKey, utils } from '@noble/ed25519';
+
+const privateKey = utils.randomPrivateKey();
+const publicKey = await getPublicKey(privateKey);
+
+console.log('Private:', Buffer.from(privateKey).toString('hex'));
+console.log('Public:', Buffer.from(publicKey).toString('hex'));
+```
+
+Store the private key securely. This is the agent's identity — lose it and the DID is gone. There's no password reset.
+
+## Step 2: Register the Agent DID
+
+```bash
+curl -X POST https://auth.imajin.ai/api/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "publicKey": "<agent-public-key-hex>",
+    "handle": "mycompany-agent-alpha",
+    "name": "Alpha Agent",
+    "type": "agent",
+    "signature": "<sign-payload-with-agent-private-key>",
+    "inviteCode": "<invite-code>"
+  }'
+```
+
+Response:
+```json
+{
+  "did": "did:imajin:7Kx9...",
+  "handle": "mycompany-agent-alpha",
+  "created": true
+}
+```
+
+The DID is derived from the public key. It's permanent and self-sovereign.
+
+**Naming convention:** `{operator}_{runtime}_{soul}` — e.g., `veteze_openclaw_jin`, `acme_flue_assistant`. The convention helps humans identify what they're looking at; the protocol doesn't enforce it.
+
+## Step 3: Authenticate via WebSocket
+
+The ImajinAgentEnv wire protocol uses WebSocket with Ed25519 challenge-response:
+
+```
+Agent                                    Kernel Gateway
+  │                                           │
+  │──── ws://kernel.imajin.ai/agent/ws ──────>│
+  │                                           │
+  │──── auth.hello { did } ──────────────────>│
+  │<─── auth.challenge { nonce } ─────────────│
+  │──── auth.verify { sig(nonce) } ──────────>│  Agent signs nonce with private key
+  │<─── auth.ok { session_id, grants } ───────│  Kernel returns resolved permissions
+  │                                           │
+```
+
+In TypeScript:
+
+```typescript
+import WebSocket from 'ws';
+import { sign } from '@noble/ed25519';
+
+const ws = new WebSocket('wss://kernel.imajin.ai/agent/ws');
+
+ws.on('open', () => {
+  ws.send(JSON.stringify({
+    type: 'auth.hello',
+    did: 'did:imajin:7Kx9...'
+  }));
+});
+
+ws.on('message', async (data) => {
+  const msg = JSON.parse(data.toString());
+  
+  if (msg.type === 'auth.challenge') {
+    const signature = await sign(
+      Buffer.from(msg.nonce, 'hex'),
+      privateKey
+    );
+    ws.send(JSON.stringify({
+      type: 'auth.verify',
+      signature: Buffer.from(signature).toString('hex')
+    }));
+  }
+  
+  if (msg.type === 'auth.ok') {
+    console.log('Authenticated. Session:', msg.session_id);
+    console.log('Grants:', msg.grants);
+    // Agent is now connected and authorized
+  }
+});
+```
+
+## Step 4: Make a Tool Call
+
+Once authenticated, call kernel tools through the WebSocket:
+
+```typescript
+// Send a message to a conversation
+ws.send(JSON.stringify({
+  type: 'tool.call',
+  id: 'call_001',
+  name: 'chat.send',
+  params: {
+    conversation: 'did:imajin:dm:abc123',
+    content: 'Hello from my agent!'
+  },
+  signature: '<sign-the-call-payload>'  // Every call is signed
+}));
+
+// Receive the result
+ws.on('message', (data) => {
+  const msg = JSON.parse(data.toString());
+  if (msg.type === 'tool.result' && msg.id === 'call_001') {
+    console.log('Result:', msg.data);
+    console.log('Gas consumed:', msg.gas);
+  }
+});
+```
+
+Every tool call goes through the kernel's validation pipeline:
+
+1. **Verify signature** — is this really from the claimed agent DID?
+2. **Check delegation chain** — does the principal authorize this agent?
+3. **Check grants** — is `chat.send` in the agent's grant set?
+4. **Check scope** — is the agent allowed to access this conversation?
+5. **Check gas** — does the agent have budget remaining?
+6. **Execute** — call the kernel service
+7. **Record** — append chain entry
+8. **Return** — result + gas consumed
+
+If any check fails, the agent gets a typed error — not a silent failure.
+
+## Step 5: Read from the Workspace
+
+Every agent has a `.jin/` workspace inside their principal's media folder:
+
+```typescript
+// Write a file
+ws.send(JSON.stringify({
+  type: 'tool.call',
+  id: 'call_002',
+  name: 'workspace.write',
+  params: {
+    path: 'notes/session-summary.md',
+    content: '# Session Summary\n\nProcessed 3 customer inquiries...'
+  },
+  signature: '<sig>'
+}));
+
+// Read it back
+ws.send(JSON.stringify({
+  type: 'tool.call',
+  id: 'call_003',
+  name: 'workspace.read',
+  params: { path: 'notes/session-summary.md' },
+  signature: '<sig>'
+}));
+```
+
+Workspace operations are free (no gas cost). Storage counts against the user's existing media quota. The principal has full read access to `.jin/` — there's no hiding from your owner.
+
+---
+
+## What Just Happened
+
+You now have:
+
+- **An agent DID** — a permanent, self-sovereign identity on the Imajin network
+- **An authenticated session** — WebSocket connection with resolved grants
+- **Tool access** — every kernel service available through `tool.call`
+- **A workspace** — persistent storage that survives session restarts
+- **A chain** — every action signed and recorded
+
+The agent is a first-class citizen. It can message, read media, browse profiles, and (if granted) transact. Everything it does is signed, scoped, and auditable.
+
+---
+
+## What's Next
+
+- [The Interface →](./the-interface.md) — the full `ImajinAgentEnv` specification
+- [Adapters →](./adapters.md) — build a connector for your platform
+- [Examples →](./examples.md) — real-world agent patterns
+
+---
+
+*Every service publishes an OpenAPI spec at `https://<service>.imajin.ai/api/spec`. For direct HTTP API usage without the agent protocol, see the [Developer Guide](../developer-guide.md).*

--- a/docs/guide/integration-guides.md
+++ b/docs/guide/integration-guides.md
@@ -1,0 +1,212 @@
+# Integration Guides
+
+How to wire Imajin into specific agent runtimes. Each guide assumes you've read [Getting Started](./getting-started.md) and [The Interface](./the-interface.md).
+
+---
+
+## OpenClaw + Imajin
+
+OpenClaw is the first runtime with a native Imajin integration. The Imajin channel plugin connects OpenClaw sessions to the Imajin kernel — your agent gets a DID, talks through Imajin chat, and has access to the full tool surface.
+
+### How It Works
+
+The OpenClaw Imajin plugin (`extensions/imajin/`) acts as a bridge:
+
+1. **Authentication:** Plugin holds the agent's Ed25519 keypair. On startup, it connects to the kernel via WebSocket and completes challenge-response auth.
+2. **Chat as channel:** Imajin DM conversations appear as OpenClaw messaging channels. Messages flow both ways — the agent can receive and reply through Imajin chat.
+3. **Tools as plugin tools:** Imajin kernel tools are exposed as OpenClaw tools. The agent calls `imajin.identity.resolve` in natural language, and the plugin translates to a `tool.call` over the wire protocol.
+4. **Chain recording:** Every action the agent takes through the plugin is recorded on its Imajin chain.
+
+### Configuration
+
+```json
+{
+  "plugin": "imajin",
+  "config": {
+    "kernelUrl": "wss://kernel.imajin.ai/agent/ws",
+    "did": "did:imajin:7Kx9...",
+    "keypairPath": ".jin-identity.json",
+    "onStartup": true
+  }
+}
+```
+
+### What You Get
+
+- Agent identity on the Imajin network
+- Bidirectional chat with any DID
+- Tool access gated by delegation chain
+- Signed audit trail of every action
+- Workspace persistence in `.jin/openclaw/`
+
+---
+
+## Flue + Imajin
+
+[Flue](https://github.com/withastro/flue) is Astro's agent harness framework. Imajin complements Flue by providing the layers Flue doesn't address: identity, delegation, attestation, and settlement.
+
+### The Connector
+
+```bash
+flue add imajin
+```
+
+This generates a TypeScript adapter that:
+
+1. Injects `ImajinAgentEnv` into the Flue session
+2. Handles WebSocket connection and DID auth
+3. Maps Imajin tool calls to Flue's `defineCommand()` pattern
+4. Routes credential isolation through Flue's secret injection
+
+### Usage in a Flue Agent
+
+```typescript
+import { defineAgent } from 'flue';
+import { imajin } from './connectors/imajin';
+
+export default defineAgent({
+  name: 'support-agent',
+  connectors: [imajin],
+  
+  async run(session) {
+    const env = session.imajin; // ImajinAgentEnv
+    
+    // Read unresolved support tickets
+    const messages = await env.callTool('chat.read', {
+      conversation: 'did:imajin:group:support'
+    });
+    
+    // Process each ticket
+    for (const msg of messages.data) {
+      // Agent reasoning happens in Flue
+      const response = await session.think(`How should I respond to: ${msg.content}`);
+      
+      // Actions go through Imajin (signed, scoped, recorded)
+      await env.callTool('chat.send', {
+        conversation: msg.conversationDid,
+        content: response
+      });
+    }
+  }
+});
+```
+
+### What Flue Provides vs. What Imajin Provides
+
+| Concern | Flue | Imajin |
+|---------|------|--------|
+| Inference / reasoning | ✅ | — |
+| Sandbox / execution | ✅ (just-bash) | — |
+| Context compaction | ✅ | — |
+| Task delegation (fan-out) | ✅ | — |
+| Identity | — | ✅ (DIDs) |
+| Delegation chains | — | ✅ |
+| Audit trail | — | ✅ (append-only chain) |
+| Settlement | — | ✅ (.fair + payments) |
+| Inter-agent trust | — | ✅ (verifiable history) |
+| Human governance | — | ✅ (consent gate, kill switch) |
+
+They're complementary. Flue solves runtime. Imajin solves coordination.
+
+---
+
+## n8n + Imajin
+
+n8n workflows can connect to Imajin through a custom node that wraps the WebSocket protocol.
+
+### Approach
+
+1. **Custom n8n node:** `@imajin/n8n-node` — handles DID auth, tool calls, event subscriptions
+2. **Trigger node:** listens for Imajin events (new messages, connection requests) and starts workflows
+3. **Action node:** calls Imajin tools (send message, create checkout, upload media)
+
+### Example Workflow
+
+```
+[Imajin Trigger: chat.message]
+    → [IF: message contains "order"]
+        → [Imajin Action: commerce.checkout { ... }]
+        → [Imajin Action: chat.send { "Your order link: ..." }]
+    → [ELSE]
+        → [Imajin Action: chat.send { "How can I help?" }]
+```
+
+The n8n workflow is the runtime. Imajin handles identity, signing, and settlement. The agent's chain records every workflow execution.
+
+### Workspace
+
+n8n state persists in `.jin/n8n/` — workflow configs, execution logs, cached data. Multiple runtimes (n8n + OpenClaw + Flue) can share an agent's workspace without collision.
+
+---
+
+## Custom TypeScript + Imajin
+
+For agents that don't use a framework — just TypeScript and a WebSocket.
+
+### Standalone Client
+
+```bash
+npm install @imajin/agent-client
+```
+
+```typescript
+import { ImajinClient } from '@imajin/agent-client';
+
+const client = await ImajinClient.connect({
+  kernelUrl: 'wss://kernel.imajin.ai/agent/ws',
+  privateKey: process.env.AGENT_PRIVATE_KEY,
+  did: 'did:imajin:7Kx9...',
+});
+
+// client implements ImajinAgentEnv
+console.log(client.did);          // "did:imajin:7Kx9..."
+console.log(client.principal);    // "did:imajin:5Qn8..."
+console.log(client.grants);       // { tier: "operator", tools: [...] }
+
+// Use the full tool surface
+const conversations = await client.callTool('chat.conversations', {});
+const balance = await client.callTool('commerce.balance', {});
+
+// Listen for events
+client.on('chat.message', async (msg) => {
+  // Your agent logic here
+  await client.callTool('chat.send', {
+    conversation: msg.conversationDid,
+    content: 'Acknowledged!'
+  });
+});
+
+// Clean shutdown
+await client.close();
+```
+
+### What You're Responsible For
+
+When using the standalone client, your code handles:
+- **Inference** — call OpenAI, Anthropic, local models, whatever
+- **Orchestration** — multi-step workflows, parallel tasks, retries
+- **State management** — use `workspace.write`/`workspace.read` for persistence
+
+Imajin handles:
+- **Identity** — your agent has a DID and a chain
+- **Authorization** — every tool call is grant-checked
+- **Attribution** — .fair manifests track contributions
+- **Settlement** — payments route through the protocol
+- **Audit** — every action is signed and recorded
+
+---
+
+## Any Language
+
+The wire protocol is WebSocket + JSON. If your language can open a WebSocket and sign bytes with Ed25519, it can be an Imajin agent.
+
+1. Connect to `wss://kernel.imajin.ai/agent/ws`
+2. Complete the challenge-response auth (sign nonce with Ed25519)
+3. Send `tool.call` messages with signed payloads
+4. Receive `tool.result` and `event.push` messages
+
+No SDK required. The protocol is the interface.
+
+---
+
+*Next: [Examples →](./examples.md)*

--- a/docs/guide/the-interface.md
+++ b/docs/guide/the-interface.md
@@ -1,0 +1,343 @@
+# The Interface: ImajinAgentEnv
+
+`ImajinAgentEnv` is the universal contract between any agent runtime and the Imajin kernel. If your runtime implements this interface, your agent is an Imajin citizen.
+
+The interface is deliberately thin. Your runtime handles inference, orchestration, and UX. Imajin handles identity, delegation, attribution, and settlement. The interface is the seam.
+
+---
+
+## The Contract
+
+```typescript
+interface ImajinAgentEnv {
+  // ─── Identity ──────────────────────────────────────
+  readonly did: string;                    // Agent's DID
+  readonly principal: string;              // Owner's DID (delegation source)
+  readonly grants: GrantSet;               // Current permissions
+  
+  // ─── Tool Surface ─────────────────────────────────
+  callTool<T = unknown>(
+    name: string,                          // e.g. "chat.send", "media.read"
+    params: Record<string, unknown>,
+    options?: { schema?: ValibotSchema<T> }
+  ): Promise<ToolResult<T>>;
+  
+  // ─── Workspace (.jin/) ─────────────────────────────
+  readonly workspace: {
+    read(path: string): Promise<string>;
+    readBuffer(path: string): Promise<Uint8Array>;
+    write(path: string, content: string | Uint8Array): Promise<void>;
+    list(path: string): Promise<string[]>;
+    exists(path: string): Promise<boolean>;
+    mkdir(path: string): Promise<void>;
+    rm(path: string): Promise<void>;
+    stat(path: string): Promise<FileStat>;
+  };
+  
+  // ─── Session ───────────────────────────────────────
+  readonly session: {
+    id: string;
+    startedAt: Date;
+    gasConsumed: number;
+    gasRemaining: number;
+    persist(key: string, value: unknown): Promise<void>;
+    recall(key: string): Promise<unknown | null>;
+  };
+  
+  // ─── Events ────────────────────────────────────────
+  on(event: string, handler: (payload: unknown) => void): void;
+  off(event: string, handler: (payload: unknown) => void): void;
+}
+```
+
+### Identity
+
+The agent's DID, its principal (the human who authorized it), and its resolved grant set. All read-only — you can't change identity mid-session.
+
+```typescript
+console.log(env.did);        // "did:imajin:7Kx9..."
+console.log(env.principal);  // "did:imajin:5Qn8..."  (the human)
+console.log(env.grants);     // { tier: "operator", tools: ["chat.*", "media.read", ...] }
+```
+
+### Tool Surface
+
+All kernel interactions go through `callTool()`. One method, typed results, signed automatically.
+
+```typescript
+// Untyped — returns unknown
+const result = await env.callTool('chat.send', {
+  conversation: 'did:imajin:dm:abc123',
+  content: 'Hello!'
+});
+
+// Typed with Valibot — compile-time safety
+import * as v from 'valibot';
+
+const balance = await env.callTool('pay.balance', {}, {
+  schema: v.object({
+    available: v.number(),
+    pending: v.number(),
+    currency: v.string(),
+  })
+});
+// balance.data is typed: { available: number, pending: number, currency: string }
+```
+
+The kernel validates every call against the agent's grant set, delegation chain, and gas budget. Failed validation returns a typed error, not an exception:
+
+```typescript
+const result = await env.callTool('pay.settle', { amount: 5000 });
+
+if (!result.ok) {
+  console.log(result.error);
+  // { code: "GRANT_DENIED", message: "pay.settle requires Transactor tier" }
+}
+```
+
+### Workspace
+
+Persistent storage in `.jin/` inside the principal's media folder. Free (no gas cost). Quota governed by the user's media limit.
+
+```typescript
+// Write state that survives session restarts
+await env.workspace.write('config/preferences.json', JSON.stringify({
+  language: 'en',
+  timezone: 'America/Toronto'
+}));
+
+// Read it back in a future session
+const prefs = JSON.parse(await env.workspace.read('config/preferences.json'));
+
+// List workspace contents
+const files = await env.workspace.list('config/');
+// ["preferences.json", "history.json"]
+```
+
+Runtime-specific state goes in subdirectories: `.jin/openclaw/`, `.jin/flue/`, `.jin/n8n/`. This way multiple runtimes can share an agent's workspace without stepping on each other.
+
+### Session
+
+Session lifecycle and gas metering:
+
+```typescript
+console.log(env.session.id);            // "sess_abc123"
+console.log(env.session.gasConsumed);   // 42
+console.log(env.session.gasRemaining);  // 958
+
+// Persist key-value pairs (shorthand for workspace writes)
+await env.session.persist('last_query', 'customer support ticket #1234');
+const last = await env.session.recall('last_query');
+```
+
+Gas is consumed per tool call. Different tools cost different amounts — `chat.read` is cheap, `pay.settle` is expensive. When gas runs out, tool calls are rejected. The principal sets the gas budget.
+
+### Events
+
+Kernel-to-agent push notifications:
+
+```typescript
+// New message in a conversation the agent is watching
+env.on('chat.message', (payload) => {
+  console.log('New message from', payload.sender, ':', payload.content);
+});
+
+// Connection request to the principal
+env.on('connection.requested', (payload) => {
+  console.log('Connection request from', payload.from);
+});
+
+// Mention in a group conversation
+env.on('chat.mention', (payload) => {
+  console.log('Mentioned in', payload.conversation);
+});
+```
+
+Events are push-based over the WebSocket. The agent subscribes to event types; the kernel pushes matching events in real-time.
+
+---
+
+## Wire Protocol
+
+The interface is transport-agnostic, but the reference implementation uses WebSocket with JSON messages:
+
+```
+Agent Runtime                          Imajin Kernel Gateway
+     │                                        │
+     │──── ws connect ────────────────────────>│
+     │                                        │
+     │──── auth.hello { did, sig(nonce) } ───>│  Ed25519 challenge-response
+     │<─── auth.ok { session_id, grants } ────│
+     │                                        │
+     │──── tool.call { name, params, sig } ──>│  Every call signed
+     │<─── tool.result { data, gas } ─────────│  Result + gas consumed
+     │                                        │
+     │<─── event.push { type, payload } ──────│  Kernel pushes to agent
+     │                                        │
+     │──── session.end ───────────────────────>│  Explicit close
+     │<─── session.ended { chain_entry } ─────│  Final chain record
+```
+
+### Message Types
+
+**Agent → Kernel:**
+
+| Type | Payload | Purpose |
+|------|---------|---------|
+| `auth.hello` | `{ did }` | Start authentication |
+| `auth.verify` | `{ signature }` | Complete challenge-response |
+| `tool.call` | `{ id, name, params, signature }` | Call a kernel tool |
+| `session.end` | `{}` | End session explicitly |
+
+**Kernel → Agent:**
+
+| Type | Payload | Purpose |
+|------|---------|---------|
+| `auth.challenge` | `{ nonce }` | Challenge for authentication |
+| `auth.ok` | `{ session_id, grants }` | Authentication succeeded |
+| `auth.error` | `{ code, message }` | Authentication failed |
+| `tool.result` | `{ id, ok, data, error, gas }` | Tool call result |
+| `event.push` | `{ event, payload }` | Real-time event notification |
+| `session.ended` | `{ chain_entry }` | Session closed, final chain record |
+
+### Tool Call Signing
+
+Every `tool.call` message includes the agent's Ed25519 signature over the call payload (id + name + params, canonicalized). The kernel:
+
+1. Verifies signature against registered DID
+2. Checks delegation chain
+3. Checks grant set
+4. Checks scope authorization
+5. Checks gas budget
+6. Executes the tool
+7. Records chain entry
+8. Returns result + gas consumed
+
+This means every action is non-repudiable. The agent can't deny making a call — the signature proves it.
+
+---
+
+## Tool Categories
+
+The kernel exposes tools organized by domain:
+
+### identity.*
+| Tool | Description | Min Grant |
+|------|------------|-----------|
+| `identity.resolve` | Resolve a DID to profile data | Observer |
+| `identity.search` | Search identities by handle/name | Observer |
+| `identity.attestations` | Query attestation history | Observer |
+
+### chat.*
+| Tool | Description | Min Grant |
+|------|------------|-----------|
+| `chat.read` | Read messages from a conversation | Observer |
+| `chat.send` | Send a message | Assistant |
+| `chat.conversations` | List conversations | Observer |
+| `chat.create` | Create a new conversation | Operator |
+
+### media.*
+| Tool | Description | Min Grant |
+|------|------------|-----------|
+| `media.read` | Read a media asset | Observer |
+| `media.upload` | Upload media with .fair attribution | Operator |
+| `media.list` | List assets in a folder | Observer |
+
+### commerce.*
+| Tool | Description | Min Grant |
+|------|------------|-----------|
+| `commerce.checkout` | Create a checkout session | Operator |
+| `commerce.balance` | Check balance for a DID | Observer |
+| `commerce.settle` | Settle a payment via .fair | Transactor |
+
+### connections.*
+| Tool | Description | Min Grant |
+|------|------------|-----------|
+| `connections.status` | Check connection status | Observer |
+| `connections.list` | List connections | Observer |
+| `connections.invite` | Create an invite | Operator |
+
+### workspace.*
+| Tool | Description | Gas Cost |
+|------|------------|----------|
+| `workspace.read` | Read from `.jin/` | Free |
+| `workspace.write` | Write to `.jin/` | Free |
+| `workspace.list` | List `.jin/` contents | Free |
+| `workspace.exists` | Check if path exists | Free |
+
+Workspace operations are always free and always available (no grant tier required). They operate exclusively within the agent's `.jin/` directory.
+
+---
+
+## Consent Gate
+
+For high-value operations, the kernel requires synchronous human confirmation:
+
+```typescript
+const result = await env.callTool('commerce.settle', {
+  amount: 50000,  // $500 CAD
+  fair_manifest: 'fair:order_xyz'
+});
+
+if (result.pending === 'consent') {
+  // Kernel has paused execution and notified the principal
+  // The tool call will complete when the human approves or rejects
+  // The agent receives the result asynchronously via the event channel
+}
+```
+
+The consent threshold is configurable per principal. Below the threshold, tool calls execute immediately. Above it, the kernel pauses and waits for human approval. The confirmation window collapses the revocation exposure to zero — the human sees exactly what's about to happen before it happens.
+
+---
+
+## Gas Metering
+
+Every tool call has a gas cost. Gas is the mechanism for resource accounting — it prevents runaway agents and enables usage-based pricing.
+
+```typescript
+// Check remaining budget
+console.log(env.session.gasRemaining);  // 958
+
+// Gas is deducted on each tool call
+const result = await env.callTool('chat.send', { ... });
+console.log(result.gas);  // 2 (gas consumed by this call)
+console.log(env.session.gasRemaining);  // 956
+
+// When gas runs out
+const result2 = await env.callTool('chat.send', { ... });
+// { ok: false, error: { code: "GAS_EXHAUSTED", remaining: 0 } }
+```
+
+Gas costs vary by tool:
+- **Free:** workspace operations
+- **Cheap (1-2):** reads, searches, status checks
+- **Medium (5-10):** sends, uploads, creates
+- **Expensive (20-50):** settlements, checkouts, attestation creation
+
+The principal sets the gas budget per session or per billing period.
+
+---
+
+## The Package: `@imajin/agent-env`
+
+The interface, types, and Valibot tool schemas are published as a package:
+
+```bash
+npm install @imajin/agent-env
+```
+
+```typescript
+import type { ImajinAgentEnv, GrantSet, ToolResult } from '@imajin/agent-env';
+import { toolSchemas } from '@imajin/agent-env/schemas';
+
+// Use the schemas for typed tool calls
+const balance = await env.callTool('commerce.balance', {}, {
+  schema: toolSchemas['commerce.balance'].result
+});
+```
+
+TypeScript runtimes get full type safety. Other languages can use the wire protocol directly — the WebSocket messages are JSON, the schemas are documented.
+
+---
+
+*Next: [Adapters →](./adapters.md)*

--- a/docs/guide/what-is-imajin.md
+++ b/docs/guide/what-is-imajin.md
@@ -1,0 +1,84 @@
+# What is Imajin
+
+Imajin is a composable agent layer. Identity, delegation, attestation, and settlement — the infrastructure that any agent runtime composes on top of.
+
+It's not a platform. It's not an agent framework. It's the layer underneath both.
+
+---
+
+## The Problem
+
+Every agent framework solves capability. Give the LLM tools, let it reason, execute steps. That part works. What doesn't work:
+
+- **Identity.** Who is this agent? Who authorized it? How do you tell it apart from a million copies of itself?
+- **Accountability.** What did this agent do? Can you prove it? Can you replay the whole sequence?
+- **Delegation.** What is this agent allowed to do? Who set those boundaries? Can they be revoked?
+- **Settlement.** The agent bought something. Who gets paid? How do you split revenue when five parties contributed?
+- **Trust.** This agent says it completed 10,000 transactions. Can you verify that without trusting a centralized reputation API?
+
+These aren't agent problems. They're coordination problems. And they're the same problems whether your agent runs in OpenClaw, Flue, n8n, LangGraph, or a bash script.
+
+## What the Layer Provides
+
+**DIDs (Decentralized Identifiers)**
+Every agent gets an Ed25519 keypair. The public key derives a DID — a stable, self-sovereign identifier that nobody can revoke. The same keypair is a valid Solana wallet. No bridging needed.
+
+**Grant Sets**
+What an agent can do, expressed as a permission structure. Observer → Assistant → Operator → Transactor. The owner (a human DID) configures grants. The kernel enforces them on every tool call.
+
+**Delegation Chains**
+Cryptographic proof that agent X is authorized by human Y to do Z. Every tool call carries the chain. The kernel validates it before execution.
+
+**.fair Attribution**
+A JSON sidecar format that says who contributed to something and how value splits. When an agent generates revenue, the .fair manifest determines who gets paid — including the agent's operator, the platform, and any upstream contributors.
+
+**Append-Only Chains**
+Every action produces a signed chain entry. The chain is the agent's history — its résumé. You can replay any session, audit any decision, verify any claim. It's not a feature; it's a consequence of signing everything.
+
+**Settlement**
+Payments flow through the layer. Stripe today, Solana later. Every transaction references a .fair manifest. The protocol verifies signatures before moving money.
+
+## What the Layer Does NOT Provide
+
+- **Inference.** Imajin doesn't run your model. That's your runtime's job.
+- **Sandbox.** Where the agent executes is a runtime concern. Imajin provides the interface the sandbox connects through.
+- **UI.** No chat interface, no dashboard (beyond admin tooling). Your runtime owns the user experience.
+- **Orchestration.** Fan-out, sequential chains, adversarial review — those are coordination patterns your runtime implements. Imajin provides the signed communication channel they run over.
+
+## Why a Layer, Not a Platform
+
+Platforms capture. Layers compose.
+
+A platform says: run your agent here, use our tools, store data in our cloud, pay through our system. Leave and you lose everything.
+
+A layer says: bring your own runtime, your own model, your own hosting. We handle identity, delegation, attribution, and settlement. Your agent keeps its DID and its chain history regardless of where it runs.
+
+The forward-deployed engineer's version: **Imajin is to agent identity what Stripe is to payments.** You don't build Stripe yourself. You don't want to. You wire it in underneath what you already have.
+
+Except unlike Stripe, the keys are yours. The data is yours. The chain is yours. You can self-host the entire thing.
+
+## The Antithesis
+
+Palantir harvests identity to create intelligence. Imajin gives identity back so intelligence can be accountable.
+
+Every agent on Imajin traces back to a human DID. The human sets scope, defines .fair splits, mediates disputes, grants and revokes consent. Agents execute. Humans govern. The protocol enforces the distinction — not through policy, but through math.
+
+In a world where agents outnumber humans on every network, the systems that can't distinguish human judgment from machine execution will drown. Imajin makes the distinction structural.
+
+---
+
+## Quick Orientation
+
+| You want to... | Start here |
+|----------------|-----------|
+| Understand the core concepts | [Core Concepts](./core-concepts.md) |
+| Connect an agent to Imajin | [Getting Started](./getting-started.md) |
+| Learn the ImajinAgentEnv interface | [The Interface](./the-interface.md) |
+| Build an adapter for your platform | [Adapters](./adapters.md) |
+| Wire Imajin into a specific runtime | [Integration Guides](./integration-guides.md) |
+| See working examples | [Examples](./examples.md) |
+| Use the HTTP APIs directly | [Developer Guide](../developer-guide.md) |
+
+---
+
+*Imajin is open source. The reference implementation runs at [jin.imajin.ai](https://jin.imajin.ai). Source: [github.com/ima-jin/imajin-ai](https://github.com/ima-jin/imajin-ai)*

--- a/docs/rfcs/RFC-31-agent-execution-sandbox.md
+++ b/docs/rfcs/RFC-31-agent-execution-sandbox.md
@@ -64,6 +64,8 @@ The `-jin` suffix (今人, "now-person") brands every agent on the network. It's
 
 For users with multiple agents, append a qualifier: `veteze-jin`, `veteze-jin-travel`, `veteze-jin-bookkeeping`.
 
+**Namespace reservation:** Agent handles follow the same claim model as identity handles (RFC-26). `{username}-jin` is auto-reserved for verified handle holders. Handles that reference known entities without a verified claim (`paypal-jin`, `irs-jin`) are subject to the same anti-squatting mechanisms as business stubs: activity thresholds, petition mechanism, reputation cost. A chain-visible `handle.verified` attestation (vs. `handle.claimed`) distinguishes verified agents from unverified ones. Counterparties and the trust graph weight interactions accordingly.
+
 ```
 User ("@veteze")
   │
@@ -193,7 +195,11 @@ When a user creates an agent, they define a **grant set** — the tools the agen
   "constraints": {
     "max_gas_per_day": 10000,
     "allowed_scopes": ["actor"],
-    "network_egress": []
+    "network_egress": [],
+    "value_threshold": {
+      "pay:write": 100,
+      "attestations:write": null
+    }
   }
 }
 ```
@@ -210,6 +216,40 @@ Pre-built permission sets for common use cases:
 | **Transactor** | Operator + `pay:read`, `pay:write` | Commerce, settlement, financial operations |
 
 Users can customize beyond tiers. The UI shows exactly what each permission means and what data the agent can access.
+
+### Consent at the Moment of Effect
+
+Gas meters volume of tool calls, not consequence. An agent with Transactor grants could settle $50K in one `pay.settle` call that costs 10 gas. Gas is a rate limit, not a value boundary.
+
+High-consequence tools require **synchronous human confirmation** above a configurable threshold:
+
+```json
+{
+  "value_threshold": {
+    "pay:write": 100,       // Confirm settlements > $100
+    "attestations:write": null  // No threshold (all allowed)
+  }
+}
+```
+
+When a tool call exceeds its threshold:
+1. Gateway holds the call (does not execute)
+2. Owner receives a confirmation request via chat (push notification)
+3. Owner approves or rejects
+4. Approved: execute + record approval attestation on chain
+5. Rejected: fail + record rejection on chain
+6. Timeout (configurable, default 15 min): fail + record timeout
+
+The confirmation is itself a chain entry — proving the human was in the loop at the moment of effect, not just at the moment of delegation.
+
+### Tier Escalation Requires Owner Attestation
+
+Upgrading an agent's grant tier (e.g., Observer → Transactor) is not a billing event — it's a security boundary. Tier changes require a fresh DID-signed owner attestation confirming the new grant set. A subscription upgrade unlocks the *ability* to escalate; the owner must explicitly sign the delegation.
+
+This prevents:
+- Compromised billing accounts escalating agent permissions
+- Accidental tier changes (settings toggle vs. deliberate cryptographic act)
+- Audit gaps (the chain shows exactly when and why permissions expanded)
 
 ### Delegation Chain Verification
 
@@ -279,6 +319,8 @@ Agent sessions are strictly isolated:
 - **No cross-user context** — Agent serving User A cannot access User B's delegation
 - **No cross-session bleed** — Previous session's working memory is gone
 - **Workspace is private** — Each agent's workspace is only accessible to that agent and its owner
+
+**A note on inter-agent collusion:** Context isolation prevents *implicit* data sharing between agents. But agents communicate via signed chat messages, and chains are inspectable. Two agents *can* coordinate through these channels — that's by design (RFC-27's coordination model). The mitigation is **attribution, not prevention**: every message is signed, every action is on the chain. Collusion with receipts is detectable collusion.
 
 ---
 
@@ -431,6 +473,19 @@ Every agent has an immediate revocation path:
 7. Agent DID remains on the network (chain is historical record)
 
 Revocation is instant and irreversible. A revoked agent can be re-granted access, but it starts with a clean session — no context carryover from pre-revocation.
+
+#### Revocation and In-Flight Tool Calls
+
+Revocation takes effect on the next gateway validation. Tool calls already past the gateway complete — this is the **residual exposure window**.
+
+| Tool Category | Exposure Window | Mitigation |
+|---------------|----------------|------------|
+| `chat.send` | ~50ms | Negligible. Message is sent. |
+| `media.write` | ~200ms | File lands. Owner can delete from workspace. |
+| `pay.settle` | ~2-5s (Stripe + .fair) | **Highest risk.** Mitigated by value threshold gate above — settlements above threshold require confirmation, which is cancelled on revocation. |
+| `attestations.emit` | ~100ms | Attestation lands on chain. Cannot be un-emitted, but can be followed by a revocation attestation. |
+
+For high-consequence tools (`pay.settle`), the confirmation gate from "Consent at the Moment of Effect" is the primary mitigation — the gateway holds the call until the owner confirms, and revocation cancels any pending holds. This makes the effective exposure window for settlements: **zero for above-threshold, ~2-5s for below-threshold.**
 
 ---
 
@@ -598,6 +653,8 @@ This isn't perfect — a sufficiently motivated node operator with host access c
 
 For high-security use cases: self-host. The platform-hosted model is convenience with reasonable security, not a vault.
 
+**The implication we should be honest about:** if a node operator with host access *can* capture decrypted keys at runtime, then platform-hosted is structurally untrustworthy for credentials that materially matter — Shopify admin tokens, banking APIs, CRM with customer PII. This isn't a flaw to hide; it strengthens the self-hosted pitch and creates a natural roadmap slot for hardware-attested enclaves (TPM/SGX-based credential isolation where even the host OS can't access decrypted material). Platform-hosted is the convenience tier. Self-hosted is the sovereignty tier. Hardware-attested is the compliance tier.
+
 ---
 
 ## Relationship to RFC-25 (App Runtime)
@@ -699,7 +756,7 @@ They compose: RFC-27's router dispatches tasks → RFC-31's sandbox executes the
 
 7. **VM escape detection.** For platform-hosted VMs, how do we detect if an agent attempts to escape its container? Instrumentation overhead vs. security. Probably container-level monitoring (seccomp, AppArmor) rather than application-level.
 
-8. **Self-hosted agent verification.** A self-hosted agent can lie about its capabilities, skip safety checks, forge tool responses. The kernel validates tool *calls* but can't validate what happens *between* calls. Is this acceptable? Does the chain + tool-call audit provide enough accountability?
+8. **Self-hosted agent verification.** A self-hosted agent can lie about its capabilities, skip safety checks, forge tool responses. The kernel validates tool *calls* but can't validate what happens *between* calls. The honest answer: counterparties should weight chain entries from self-hosted agents lower than from operator-attested platform-hosted agents. This is a defensible reputation model — not a binary trust/distrust, but a signal. Platform-hosted entries carry implicit attestation that the execution environment was constrained. Self-hosted entries carry only the DID signature. The trust graph (RFC-27) should surface this distinction rather than pretending trust is uniform.
 
 9. **Migration between self-hosted and platform-hosted.** Can a user move their agent (workspace, chain, grants) from self-hosted to platform-hosted and back? Workspace portability is straightforward; VM config translation is harder.
 

--- a/docs/rfcs/RFC-31-agent-execution-sandbox.md
+++ b/docs/rfcs/RFC-31-agent-execution-sandbox.md
@@ -64,7 +64,7 @@ The `-jin` suffix (今人, "now-person") brands every agent on the network. It's
 
 For users with multiple agents, append a qualifier: `veteze-jin`, `veteze-jin-travel`, `veteze-jin-bookkeeping`.
 
-**Namespace reservation:** Agent handles follow the same claim model as identity handles (RFC-26). `{username}-jin` is auto-reserved for verified handle holders. Handles that reference known entities without a verified claim (`paypal-jin`, `irs-jin`) are subject to the same anti-squatting mechanisms as business stubs: activity thresholds, petition mechanism, reputation cost. A chain-visible `handle.verified` attestation (vs. `handle.claimed`) distinguishes verified agents from unverified ones. Counterparties and the trust graph weight interactions accordingly.
+**Namespace protection:** The `-jin` suffix is reserved for agent handles. Human and business identities cannot register handles ending in `-jin` — the registration endpoint rejects them. This makes `{anything}-jin` a reliable signal: if you see it, it's an agent. No squatting, no impersonation, no policy complexity.
 
 ```
 User ("@veteze")

--- a/migrations/0012_events_currency.sql
+++ b/migrations/0012_events_currency.sql
@@ -1,0 +1,8 @@
+-- Migration: Add missing columns to events schema
+-- currency on events.events + status on events.orders were in the drizzle
+-- schema but never migrated.
+
+ALTER TABLE events.events ADD COLUMN IF NOT EXISTS currency TEXT NOT NULL DEFAULT 'CAD';
+
+ALTER TABLE events.orders ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending';
+CREATE INDEX IF NOT EXISTS idx_orders_status ON events.orders(status);


### PR DESCRIPTION
## Summary

7-part developer guide for forward-deployed engineers — the "what is this and why should I care" entry point for building on Imajin.

Implements #865.

## Structure (`docs/guide/`)

| Doc | What It Covers |
|-----|----------------|
| **What is Imajin** | Layer vs platform, what it provides/doesn't, the antithesis |
| **Core Concepts** | DIDs, scopes, delegation chains, attestations, .fair, the chain, progressive trust |
| **Getting Started** | Keygen → register → auth → first tool call → workspace |
| **The Interface** | Full `ImajinAgentEnv` spec, wire protocol, tool categories, consent gate, gas metering |
| **Adapters** | Credential isolation, contribution model, how to build one |
| **Integration Guides** | OpenClaw, Flue, n8n, custom TypeScript, any-language |
| **Examples** | Travel (credential verification), commerce (.fair settlement), support (attestation trail), insurance (audit-ready chain) |

~7,800 words. Written for the engineer who wants to wire Imajin underneath existing systems without ripping and replacing.

Complements the existing `developer-guide.md` (curl-based API walkthrough). RFCs stay in `docs/rfcs/` as the internal "why" archive.

## What Stays vs. What Moves

- **RFCs stay** in `docs/rfcs/` — internal decision records
- **New guide lives** in `docs/guide/` — external-facing "how to use it"
- **Existing `developer-guide.md`** — untouched, linked from the guide as API reference

Closes #865