### PR TITLE
feat(events): wire requireAppAuth into events service routes

### DIFF
--- a/apps/events/app/api/events/[id]/guests/route.ts
+++ b/apps/events/app/api/events/[id]/guests/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createLogger } from '@imajin/logger';
-import { requireAuth } from '@imajin/auth';
+import { requireAuth, requireAppAuth } from '@imajin/auth';
+import { corsHeaders } from '@imajin/config';
 
 const log = createLogger('events');
 import { isEventOrganizer } from '@/src/lib/organizer';
@@ -34,13 +35,25 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const authResult = await requireAuth(request);
-  if ('error' in authResult) {
-    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  const cors = corsHeaders(request);
+  let did: string;
+
+  // App auth path
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'events:read' });
+    if ('error' in appResult) {
+      return NextResponse.json({ error: appResult.error }, { status: appResult.status, headers: cors });
+    }
+    did = appResult.appAuth.userDid;
+  } else {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+    const { identity } = authResult;
+    did = identity.actingAs || identity.id;
   }
 
-  const { identity } = authResult;
-  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {

--- a/apps/events/app/api/events/[id]/route.ts
+++ b/apps/events/app/api/events/[id]/route.ts
@@ -6,9 +6,16 @@ import { revalidatePath } from 'next/cache';
 const log = createLogger('events');
 
 import { db, events, ticketTypes } from '@/src/db';
-import { requireAuth } from '@imajin/auth';
+import { requireAuth, requireAppAuth } from '@imajin/auth';
+import { corsHeaders } from '@imajin/config';
 import { isEventOrganizer } from '@/src/lib/organizer';
 import { eq } from 'drizzle-orm';
+
+/** Fields safe to return for events:read app scope */
+function filterEventForApp(event: Record<string, any>): Record<string, any> {
+  const { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, createdAt, updatedAt } = event;
+  return { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, createdAt, updatedAt };
+}
 
 /**
  * GET /api/events/[id] - Get event details with ticket types
@@ -17,6 +24,45 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cors = corsHeaders(request);
+
+  // App auth path
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'events:read' });
+    if ('error' in appResult) {
+      return NextResponse.json({ error: appResult.error }, { status: appResult.status, headers: cors });
+    }
+    try {
+      const { id } = await params;
+      const [event] = await db
+        .select()
+        .from(events)
+        .where(eq(events.id, id))
+        .limit(1);
+
+      if (!event) {
+        return NextResponse.json({ error: 'Event not found' }, { status: 404, headers: cors });
+      }
+
+      // Get ticket types with availability
+      const types = await db
+        .select()
+        .from(ticketTypes)
+        .where(eq(ticketTypes.eventId, id));
+
+      return NextResponse.json({
+        event: filterEventForApp(event as Record<string, any>),
+        ticketTypes: types.map(t => ({
+          ...t,
+          available: t.quantity ? t.quantity - (t.sold || 0) : null,
+        })),
+      }, { headers: cors });
+    } catch (error) {
+      log.error({ err: String(error) }, 'Failed to get event (app auth)');
+      return NextResponse.json({ error: 'Failed to get event' }, { status: 500, headers: cors });
+    }
+  }
+
   try {
     const { id } = await params;
     const [event] = await db
@@ -66,13 +112,25 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const authResult = await requireAuth(request);
-  if ('error' in authResult) {
-    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  const cors = corsHeaders(request);
+  let did: string;
+
+  // App auth path
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'events:write' });
+    if ('error' in appResult) {
+      return NextResponse.json({ error: appResult.error }, { status: appResult.status, headers: cors });
+    }
+    did = appResult.appAuth.userDid;
+  } else {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+    const { identity } = authResult;
+    did = identity.actingAs || identity.id;
   }
 
-  const { identity } = authResult;
-  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {
@@ -137,13 +195,25 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const authResult = await requireAuth(request);
-  if ('error' in authResult) {
-    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  const cors = corsHeaders(request);
+  let did: string;
+
+  // App auth path
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'events:write' });
+    if ('error' in appResult) {
+      return NextResponse.json({ error: appResult.error }, { status: appResult.status, headers: cors });
+    }
+    did = appResult.appAuth.userDid;
+  } else {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+    const { identity } = authResult;
+    did = identity.actingAs || identity.id;
   }
 
-  const { identity } = authResult;
-  const did = identity.actingAs || identity.id;
   const { id } = await params;
 
   try {

--- a/apps/events/app/api/events/[id]/tiers/route.ts
+++ b/apps/events/app/api/events/[id]/tiers/route.ts
@@ -4,7 +4,8 @@ import { revalidatePath } from 'next/cache';
 
 const log = createLogger('events');
 import { db, events, ticketTypes } from '@/src/db';
-import { requireAuth } from '@imajin/auth';
+import { requireAuth, requireAppAuth } from '@imajin/auth';
+import { corsHeaders } from '@imajin/config';
 import { isEventOrganizer } from '@/src/lib/organizer';
 import { eq, and, asc, isNull } from 'drizzle-orm';
 import { randomBytes } from 'crypto';
@@ -16,7 +17,33 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const cors = corsHeaders(request);
   const { id } = await params;
+
+  // App auth path
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'events:read' });
+    if ('error' in appResult) {
+      return NextResponse.json({ error: appResult.error }, { status: appResult.status, headers: cors });
+    }
+    try {
+      const tiers = await db
+        .select()
+        .from(ticketTypes)
+        .where(and(eq(ticketTypes.eventId, id), isNull(ticketTypes.accessCode)))
+        .orderBy(asc(ticketTypes.sortOrder));
+
+      return NextResponse.json({
+        tiers: tiers.map(t => ({
+          ...t,
+          available: t.quantity !== null ? t.quantity - (t.sold || 0) : null,
+        })),
+      }, { headers: cors });
+    } catch (error) {
+      log.error({ err: String(error) }, 'Failed to list tiers (app auth)');
+      return NextResponse.json({ error: 'Failed to list tiers' }, { status: 500, headers: cors });
+    }
+  }
 
   try {
     const tiers = await db

--- a/apps/events/app/api/events/route.ts
+++ b/apps/events/app/api/events/route.ts
@@ -2,9 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withLogger } from '@imajin/logger';
 import { publish } from '@imajin/bus';
 import { db, events, ticketTypes } from '@/src/db';
-
-
-import { requireHardDID } from '@imajin/auth';
+import { requireHardDID, requireAppAuth } from '@imajin/auth';
+import { corsHeaders } from '@imajin/config';
 import { getClient } from '@imajin/db';
 import { buildFairManifest } from '@imajin/fair';
 import { and, asc, desc, eq, gt } from 'drizzle-orm';
@@ -17,14 +16,27 @@ const AUTH_URL = process.env.AUTH_SERVICE_URL!;
  * Requires hard DID (keypair-based identity)
  */
 export const POST = withLogger('events', async (request, { log, correlationId }) => {
-  // Require hard DID authentication
-  const authResult = await requireHardDID(request);
-  if ('error' in authResult) {
-    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
-  }
+  const cors = corsHeaders(request);
+  let did: string;
+  let identity: { id: string; actingAs?: string | null };
 
-  const { identity } = authResult;
-  const did = identity.actingAs || identity.id;
+  // App auth path
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'events:write' });
+    if ('error' in appResult) {
+      return NextResponse.json({ error: appResult.error }, { status: appResult.status, headers: cors });
+    }
+    did = appResult.appAuth.userDid;
+    identity = { id: did, actingAs: null };
+  } else {
+    // Require hard DID authentication
+    const authResult = await requireHardDID(request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+    identity = authResult.identity;
+    did = identity.actingAs || identity.id;
+  }
 
   try {
     const body = await request.json();
@@ -237,12 +249,44 @@ export const POST = withLogger('events', async (request, { log, correlationId })
  * GET /api/events - List events
  * Supports: ?courseSlug=intro-to-ai&upcoming=true&status=published&limit=20
  */
+/** Fields safe to return for events:read app scope */
+function filterEventForApp(event: Record<string, any>): Record<string, any> {
+  const { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, createdAt, updatedAt } = event;
+  return { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, createdAt, updatedAt };
+}
+
 export const GET = withLogger('events', async (request, { log }) => {
+  const cors = corsHeaders(request);
   const { searchParams } = new URL(request.url);
   const status = searchParams.get('status') || 'published';
   const limit = parseInt(searchParams.get('limit') || '20');
   const courseSlug = searchParams.get('courseSlug');
   const upcoming = searchParams.get('upcoming') === 'true';
+
+  // App auth path
+  if (request.headers.get('x-app-did')) {
+    const appResult = await requireAppAuth(request, { scope: 'events:read' });
+    if ('error' in appResult) {
+      return NextResponse.json({ error: appResult.error }, { status: appResult.status, headers: cors });
+    }
+    try {
+      const conditions = [eq(events.status, status)];
+      if (courseSlug) conditions.push(eq(events.courseSlug, courseSlug));
+      if (upcoming) conditions.push(gt(events.startsAt, new Date()));
+
+      const eventList = await db
+        .select()
+        .from(events)
+        .where(and(...conditions))
+        .orderBy(upcoming ? asc(events.startsAt) : desc(events.startsAt))
+        .limit(limit);
+
+      return NextResponse.json({ events: eventList.map(e => filterEventForApp(e as Record<string, any>)) }, { headers: cors });
+    } catch (error) {
+      log.error({ err: String(error) }, 'Failed to list events (app auth)');
+      return NextResponse.json({ error: 'Failed to list events' }, { status: 500, headers: cors });
+    }
+  }
 
   try {
     const conditions = [eq(events.status, status)];


### PR DESCRIPTION
Adds delegated app auth to events service. External apps can now call events API with X-App-DID + X-App-Authorization headers. 6 routes wired (events list/create/get/update, tiers, guests). Additive — existing cookie auth untouched. Unblocks imajin-karaoke#2.