### PR TITLE
feat(chat): identity-aware message rendering + agent metadata envelope (#851)

### DIFF
--- a/apps/kernel/app/chat/api/d/[did]/messages/route.ts
+++ b/apps/kernel/app/chat/api/d/[did]/messages/route.ts
@@ -4,7 +4,7 @@ import { publish } from '@imajin/bus';
 import { eq, and, desc, lt, ne, isNull, inArray, ilike, or } from 'drizzle-orm';
 
 const log = createLogger('kernel');
-import { db, conversationsV2, conversationMembers, messagesV2, messageReactionsV2, profiles } from '@/src/db';
+import { db, conversationsV2, conversationMembers, messagesV2, messageReactionsV2, profiles, identities } from '@/src/db';
 import { requireAuth, isVerifiedTier } from '@imajin/auth';
 import { jsonResponse, errorResponse, generateId } from '@/src/lib/kernel/utils';
 import { corsOptions, corsHeaders } from "@/src/lib/kernel/cors";
@@ -144,8 +144,19 @@ export async function GET(
       return acc;
     }, {});
 
+    // Fetch sender identity subtypes
+    const senderDids = Array.from(new Set(result.map(m => m.fromDid)));
+    const senderIdentities = senderDids.length > 0
+      ? await db
+          .select({ id: identities.id, subtype: identities.subtype })
+          .from(identities)
+          .where(inArray(identities.id, senderDids))
+      : [];
+    const subtypeByDid = new Map(senderIdentities.map(i => [i.id, i.subtype]));
+
     const messagesWithReactions = result.reverse().map(m => ({
       ...m,
+      senderSubtype: subtypeByDid.get(m.fromDid) || null,
       reactions: reactionsByMessage[m.id] || [],
     }));
 
@@ -328,15 +339,27 @@ export async function POST(
       where: eq(messagesV2.id, messageId),
     });
 
+    // Enrich with sender identity subtype
+    let senderSubtype: string | null = null;
+    if (message) {
+      const [senderIdentity] = await db
+        .select({ subtype: identities.subtype })
+        .from(identities)
+        .where(eq(identities.id, effectiveDid))
+        .limit(1);
+      senderSubtype = senderIdentity?.subtype ?? null;
+    }
+    const enrichedMessage = message ? { ...message, senderSubtype } : null;
+
     publish('message.send', { issuer: effectiveDid, subject: effectiveDid, scope: 'chat', payload: { conversationDid: did, messageId } }).catch(() => {});
 
     // Broadcast via WebSocket
-    if (message) {
+    if (enrichedMessage) {
       const port = process.env.PORT || '3007';
       fetch(`http://localhost:${port}/__ws_broadcast`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ conversationId: did, message }),
+        body: JSON.stringify({ conversationId: did, message: enrichedMessage }),
       }).catch(() => {});
     }
 
@@ -391,7 +414,7 @@ export async function POST(
       }).catch(() => {});
     }
 
-    return jsonResponse({ message }, 201, cors);
+    return jsonResponse({ message: enrichedMessage ?? message }, 201, cors);
   } catch (error) {
     log.error({ err: String(error) }, 'Failed to send message');
     return errorResponse('Failed to send message', 500, cors);

--- a/apps/kernel/app/media/api/assets/route.ts
+++ b/apps/kernel/app/media/api/assets/route.ts
@@ -6,7 +6,7 @@ import { nanoid } from "nanoid";
 import { db, assets, folders, assetFolders, identities } from "@/src/db";
 import { requireAuth } from "@imajin/auth";
 import { corsHeaders, corsOptions } from "@/src/lib/kernel/cors";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql, isNull } from "drizzle-orm";
 import { classifyAsset } from "@/src/lib/media/classify";
 import { rateLimit, getClientIP } from "@/src/lib/kernel/rate-limit";
 import { createLogger } from "@imajin/logger";
@@ -359,7 +359,9 @@ export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("Authorization");
   const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
 
+  const { searchParams } = new URL(request.url);
   let ownerDid: string;
+  let isAgentQuery = false;
   if (bearerToken && internalApiKey && bearerToken === internalApiKey) {
     const ownerDidHeader = request.headers.get("X-Owner-DID");
     if (!ownerDidHeader) {
@@ -371,10 +373,18 @@ export async function GET(request: NextRequest) {
     if ("error" in authResult) {
       return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
     }
-    ownerDid = authResult.identity.actingAs || authResult.identity.id;
+    const { identity } = authResult;
+    const didParam = searchParams.get("did");
+
+    if (didParam && didParam !== identity.id) {
+      // Querying another DID's public assets — allowed for any authenticated user
+      ownerDid = didParam;
+      isAgentQuery = true;
+    } else {
+      ownerDid = identity.actingAs || identity.id;
+    }
   }
 
-  const { searchParams } = new URL(request.url);
   const search = searchParams.get("search");      // filename search
   const type = searchParams.get("type");          // e.g. "image"
   const sort = searchParams.get("sort") || "created";
@@ -387,6 +397,14 @@ export async function GET(request: NextRequest) {
 
     // Build where conditions
     const conditions = [eq(assets.ownerDid, ownerDid), eq(assets.status, "active")];
+
+    // If querying another DID's assets, restrict to public ones
+    if (isAgentQuery) {
+      // Public = fairManifest->access->>type = 'public' OR no access restriction set
+      conditions.push(
+        sql`COALESCE((${assets.fairManifest}->'access'->>'type'), 'private') = 'public'`
+      );
+    }
 
     let rows = await db
       .select()

--- a/apps/kernel/app/pay/api/balance/[did]/route.ts
+++ b/apps/kernel/app/pay/api/balance/[did]/route.ts
@@ -35,9 +35,12 @@ export async function GET(
     );
   }
 
-  // Must be requesting your own balance (or acting as scope)
+  // Must be requesting your own balance (or acting as scope, or agent-delegated)
   const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
-  if (effectiveDid !== decoded) {
+  const isAgentDelegated =
+    authResult.identity.actingAs === decoded &&
+    authResult.identity.actingAsRole === 'agent';
+  if (effectiveDid !== decoded && !isAgentDelegated) {
     return NextResponse.json(
       { error: 'Forbidden - can only access your own balance' },
       { status: 403, headers: cors }

--- a/apps/kernel/app/pay/api/transactions/[did]/route.ts
+++ b/apps/kernel/app/pay/api/transactions/[did]/route.ts
@@ -38,7 +38,10 @@ export async function GET(
     }
 
     const effectiveDid = authResult.identity.actingAs || authResult.identity.id;
-    if (effectiveDid !== did) {
+    const isAgentDelegated =
+      authResult.identity.actingAs === did &&
+      authResult.identity.actingAsRole === 'agent';
+    if (effectiveDid !== did && !isAgentDelegated) {
       return NextResponse.json(
         { error: 'Forbidden - can only access your own transactions' },
         { status: 403, headers: cors }

--- a/apps/kernel/src/db/schemas/auth.ts
+++ b/apps/kernel/src/db/schemas/auth.ts
@@ -196,7 +196,7 @@ export const devices = authSchema.table('devices', {
 export const identityMembers = authSchema.table('identity_members', {
   identityDid: text('identity_did').notNull(),
   memberDid: text('member_did').notNull(),
-  role: text('role').notNull().default('member'),         // 'owner' | 'admin' | 'maintainer' | 'member' | ...
+  role: text('role').notNull().default('member'),         // 'owner' | 'admin' | 'maintainer' | 'member' | 'agent' | ...
   allowedServices: text('allowed_services').array(),      // null = full access, ['events','pay'] = restricted
   addedBy: text('added_by'),
   addedAt: timestamp('added_at', { withTimezone: true }).defaultNow(),

--- a/migrations/0013_agent_role.sql
+++ b/migrations/0013_agent_role.sql
@@ -1,0 +1,14 @@
+-- Migration: Add agent role to identity_members
+-- The agent role allows delegated read + limited write access:
+--   - Can read owner's public + private data via X-Acting-As
+--   - Can send messages on behalf
+--   - Can create attestations on behalf
+--   - CANNOT transfer funds, change identity settings, or manage other members
+--
+-- The role column is TEXT with no CHECK constraint, so this is a schema
+-- documentation migration. Existing rows are unaffected.
+
+-- Add a partial index for fast agent-role lookups (optional, idempotent)
+CREATE INDEX IF NOT EXISTS idx_identity_members_role_agent
+  ON auth.identity_members(identity_did, member_did)
+  WHERE role = 'agent';

--- a/packages/auth/src/require-auth.ts
+++ b/packages/auth/src/require-auth.ts
@@ -16,6 +16,7 @@ function parseCookieValue(cookieHeader: string | null, name: string): string | n
 export interface AuthOptions {
   verifyChain?: boolean; // If true, also verify the chain is valid (not just session)
   service?: string;      // If set, validate that acting-as controller has access to this service
+  permissions?: string[]; // If set, restrict what acting-as roles can do (e.g. ['read'])
 }
 
 /**
@@ -97,6 +98,7 @@ async function validateBearerToken(
 
 interface ActingAsResult {
   valid: boolean;
+  role?: string;                     // e.g. 'owner', 'admin', 'agent'
   allowedServices?: string[] | null; // null = full access
 }
 
@@ -126,7 +128,7 @@ async function validateActingAs(
     );
     if (!res.ok) return { valid: false };
     const data = await res.json();
-    if (data.valid !== true || !["owner", "admin", "maintainer"].includes(data.role)) {
+    if (data.valid !== true || !["owner", "admin", "maintainer", "agent"].includes(data.role)) {
       return { valid: false };
     }
 
@@ -139,7 +141,7 @@ async function validateActingAs(
       }
     }
 
-    return { valid: true, allowedServices };
+    return { valid: true, role: data.role, allowedServices };
   } catch (err) {
     log.error({ err: String(err) }, "[AUTH] Act-as validation failed");
     return { valid: false };
@@ -205,6 +207,7 @@ export async function requireAuth(
         return { error: "Not authorized to act as this group", status: 403 };
       }
       result.identity.actingAs = actingAs;
+      result.identity.actingAsRole = actingAsResult.role;
       result.identity.actingAsServices = actingAsResult.allowedServices ?? undefined;
     }
   }

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -8,6 +8,7 @@ export interface Identity {
   tier?: "soft" | "preliminary" | "established" | "steward" | "operator";
   chainVerified?: boolean;
   actingAs?: string;            // DID of group the caller is acting on behalf of
+  actingAsRole?: string;        // Role of the caller in the group (e.g. 'agent')
   actingAsServices?: string[];  // Services this controller can access (undefined = full access)
 }
 

--- a/packages/chat/src/Chat.tsx
+++ b/packages/chat/src/Chat.tsx
@@ -42,6 +42,7 @@ function toMsgShape(msg: ChatMessage) {
     id: msg.id,
     conversationId: msg.did,
     fromDid: msg.senderDid,
+    senderSubtype: msg.senderSubtype,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     content: msg.content as any,
     contentType: msg.content.type ?? 'text',

--- a/packages/chat/src/MessageBubble.tsx
+++ b/packages/chat/src/MessageBubble.tsx
@@ -6,7 +6,7 @@ import { LinkPreviewCard } from './LinkPreviewCard';
 import { VoiceMessage } from './VoiceMessage';
 import { MediaMessage } from './MediaMessage';
 import { LocationMessage } from './LocationMessage';
-import type { MessageContent, SystemContent } from './message-types';
+import type { MessageContent, SystemContent, MessageMeta } from './message-types';
 import { useDidNames } from './hooks/useDidNames';
 import { ChatMarkdown, hasMarkdown } from './ChatMarkdown';
 
@@ -77,6 +77,7 @@ interface Message {
   id: string;
   conversationId: string;
   fromDid: string;
+  senderSubtype?: string;
   content: MessageContent | { type: string; text: string };
   contentType: string;
   replyTo: string | null;
@@ -127,6 +128,79 @@ function formatShortDate(iso: string): string {
   yesterday.setDate(yesterday.getDate() - 1);
   if (d.toDateString() === yesterday.toDateString()) return 'yesterday';
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function abbreviateModel(model: string): string {
+  let name = model.includes('/') ? model.split('/').pop()! : model;
+  if (name.startsWith('claude-')) name = name.slice(7);
+  return name;
+}
+
+function formatDuration(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${ms}ms`;
+}
+
+function contextBarColor(pct: number): string {
+  if (pct >= 90) return 'bg-red-500';
+  if (pct >= 70) return 'bg-amber-500';
+  return 'bg-emerald-500';
+}
+
+function AgentMetaFooter({ meta }: { meta: MessageMeta }) {
+  const [expanded, setExpanded] = useState(false);
+  const model = meta.model ? abbreviateModel(meta.model) : null;
+
+  return (
+    <button
+      onClick={() => setExpanded(v => !v)}
+      className="mt-1.5 flex flex-col gap-1 text-left w-full"
+      aria-label={expanded ? 'Collapse agent metadata' : 'Expand agent metadata'}
+    >
+      {/* Minimal row */}
+      <div className="flex items-center gap-2 text-[10px] text-gray-500 dark:text-gray-400">
+        {model && (
+          <span className="font-mono font-medium">{model}</span>
+        )}
+        {!expanded && meta.tokens && (
+          <span>{meta.tokens.out} tokens</span>
+        )}
+        {!expanded && meta.durationMs !== undefined && (
+          <span>{formatDuration(meta.durationMs)}</span>
+        )}
+        <span className="opacity-60">{expanded ? '▾' : '▸'}</span>
+      </div>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="flex flex-col gap-1 text-[10px] text-gray-500 dark:text-gray-400">
+          {meta.tokens && (
+            <span>{meta.tokens.in} in → {meta.tokens.out} out</span>
+          )}
+          {meta.durationMs !== undefined && (
+            <span>{formatDuration(meta.durationMs)}</span>
+          )}
+          {meta.context && (
+            <div className="flex items-center gap-1.5">
+              <span className="tabular-nums">{meta.context.pct}%</span>
+              <div className="flex-1 h-1 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+                <div
+                  className={`h-full rounded-full ${contextBarColor(meta.context.pct)}`}
+                  style={{ width: `${Math.min(meta.context.pct, 100)}%` }}
+                />
+              </div>
+              <span className="tabular-nums opacity-70">
+                {meta.context.used.toLocaleString()} / {meta.context.max.toLocaleString()}
+              </span>
+            </div>
+          )}
+          {meta.cache !== undefined && meta.cache.hitPct !== undefined && (
+            <span>cache hit {meta.cache.hitPct}%</span>
+          )}
+        </div>
+      )}
+    </button>
+  );
 }
 
 function SystemMessageLine({ content, createdAt }: { content: SystemContent; createdAt?: string }) {
@@ -287,7 +361,12 @@ export function MessageBubble({
           >
             {/* Sender handle */}
             {!isOwn && showSenderLabel && (
-              <p className="text-xs text-amber-500 mb-1 font-medium">{senderLabel}</p>
+              <p className="text-xs text-amber-500 mb-1 font-medium flex items-center gap-1">
+                {message.senderSubtype === 'agent' && (
+                  <span title="Agent" className="opacity-80">🤖</span>
+                )}
+                {senderLabel}
+              </p>
             )}
 
             {/* Reply preview */}
@@ -360,6 +439,11 @@ export function MessageBubble({
               {formatMessageTime(message.createdAt)}
               {message.editedAt && <span className="italic">(edited)</span>}
             </p>
+
+            {/* Agent metadata footer */}
+            {message.senderSubtype === 'agent' && (message.content as any)?.meta && (
+              <AgentMetaFooter meta={(message.content as any).meta} />
+            )}
 
             {/* Link previews */}
             {message.linkPreviews && message.linkPreviews.length > 0 && (

--- a/packages/chat/src/hooks/useChatMessages.ts
+++ b/packages/chat/src/hooks/useChatMessages.ts
@@ -7,6 +7,7 @@ export interface ChatMessage {
   id: string;
   did: string;
   senderDid: string;
+  senderSubtype?: string;
   content: { type: string; text?: string; [key: string]: unknown };
   replyTo?: string;
   reactions?: { emoji: string; senderDid: string }[];
@@ -55,6 +56,7 @@ export function useChatMessages(did: string): UseChatMessagesResult {
         return {
           ...msg,
           senderDid: msg.senderDid ?? msg.fromDid,
+          senderSubtype: msg.senderSubtype ?? msg.sender_subtype ?? msg.subtype,
           did: msg.did ?? msg.conversationDid,
           replyTo: msg.replyTo ?? msg.replyToMessageId,
           reactions: msg.reactions?.map((r: any) => ({
@@ -114,6 +116,7 @@ export function useChatMessages(did: string): UseChatMessagesResult {
     const normalized: ChatMessage = {
       ...message,
       senderDid: message.senderDid ?? raw.fromDid,
+      senderSubtype: message.senderSubtype ?? raw.senderSubtype ?? raw.sender_subtype ?? raw.subtype,
       did: message.did ?? raw.conversationDid,
       replyTo: raw.replyTo ?? raw.replyToMessageId,
     };

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -5,7 +5,7 @@ export { MediaMessage } from './MediaMessage';
 export { LocationMessage } from './LocationMessage';
 export { ReactionPicker } from './ReactionPicker';
 export { LinkPreviewCard } from './LinkPreviewCard';
-export type { MessageContent, TextContent, VoiceContent, MediaContent, LocationContent } from './message-types';
+export type { MessageContent, TextContent, VoiceContent, MediaContent, LocationContent, MessageMeta } from './message-types';
 
 export { Chat } from './Chat';
 export { ChatProvider, useChatConfig } from './ChatProvider';

--- a/packages/chat/src/message-types.ts
+++ b/packages/chat/src/message-types.ts
@@ -1,5 +1,13 @@
+export interface MessageMeta {
+  model?: string;
+  context?: { used: number; max: number; pct: number };
+  tokens?: { in: number; out: number };
+  durationMs?: number;
+  cache?: { hitPct: number };
+}
+
 // Text message (E2EE)
-export type TextContent = { type?: "text"; text: string; encrypted?: string; nonce?: string };
+export type TextContent = { type?: "text"; text: string; encrypted?: string; nonce?: string; meta?: MessageMeta };
 
 // Voice message
 export type VoiceContent = {


### PR DESCRIPTION
## What

Agent messages in chat display metadata (model, tokens, duration, context usage) and a 🤖 badge. Builds on #852 for identity-aware rendering.

### Changes
- **`packages/chat`:** `MessageMeta` type, `AgentMetaFooter` component (collapsible), agent badge on sender name
- **Chat API:** Enriches messages with `senderSubtype` from identity graph (batch lookup on GET, single on POST + WS broadcast)
- **`useChatMessages`:** Normalizes `senderSubtype` from multiple API shapes

### AgentMetaFooter
- Collapsed: model name + token count + duration
- Expanded: token breakdown, context usage bar (color-coded), cache hit %
- Only shows when sender is `agent` AND `content.meta` exists

> **Depends on:** #869 (#852 agent delegation)

Closes #851