### PR TITLE
fix(events+auth): post-deploy follow-ups (verify polling state, my-tickets grouping, charset, guest list columns)

### DIFF
--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -196,6 +196,17 @@ async function getUserOrders(eventId: string, userDid: string) {
     // Order-level settlement (fairSettlement column) takes precedence; fall back to legacy ticket-level
     const fairSettlement = (orderData?.fairSettlement as any) ?? ticketMeta.fair_settlement ?? null;
 
+    // Count unique ticket types within this order so mixed orders show
+    // e.g. "1× Premium + 2× Bunkie" instead of collapsing to the first type.
+    const typeCounts = new Map<string, number>();
+    for (const { ticketType: tt } of groupRows) {
+      const name = tt?.name || 'Ticket';
+      typeCounts.set(name, (typeCounts.get(name) || 0) + 1);
+    }
+    const ticketTypeName = Array.from(typeCounts.entries())
+      .map(([name, count]) => (count > 1 ? `${count}× ${name}` : name))
+      .join(' + ');
+
     return {
       id: isLegacy ? first.ticket.id : first.ticket.orderId!,
       isLegacy,
@@ -203,7 +214,7 @@ async function getUserOrders(eventId: string, userDid: string) {
       totalAmount: orderData?.amountTotal ?? first.ticket.pricePaid,
       currency: orderData?.currency ?? first.ticket.currency,
       purchasedAt: (first.ticket.purchasedAt || first.ticket.createdAt)?.toISOString() || null,
-      ticketTypeName: first.ticketType?.name || 'Ticket',
+      ticketTypeName,
       fairSettlement,
       tickets: groupRows.map(({ ticket, ticketType, qrCodeDataUri }) => ({
         id: ticket.id,

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -191,7 +191,10 @@ function OrderCard({ order, eventId }: { order: UserOrder; eventId: string }) {
       </div>
 
       {/* Registration surveys — full width, outside the QR grid */}
-      {order.tickets.filter(t => t.ticketType?.registrationFormId).map((ticket) => (
+      {/* Defensive: also exclude tickets explicitly marked not_required so a
+          DB misconfig (registrationFormId set on a type that shouldn't need it)
+          doesn't force a form on the buyer. */}
+      {order.tickets.filter(t => t.ticketType?.registrationFormId && t.registrationStatus !== 'not_required').map((ticket) => (
         <div key={`reg-${ticket.id}`} className="mb-4">
           <TicketRegistrationSurvey ticket={ticket} eventId={eventId} />
         </div>
@@ -787,10 +790,52 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
             setPollStatus('expired');
             return;
           }
-          // Session set — re-fire the EMT reserve
+          // Notify any listening components (e.g. NavBar) that auth changed.
+          if (typeof window !== 'undefined') {
+            window.dispatchEvent(new Event('imajin:session-changed'));
+          }
+          // Re-fire the EMT reserve directly without router.refresh().
+          // Calling startEtransfer() triggers router.refresh() which re-runs
+          // server components, flips hasTicket from false → true, and remounts
+          // PurchaseUI — wiping cart state. We handle the transition client-side.
           setPollStatus(null);
           setPollHandle(null);
-          await startEtransfer();
+          setStep('emt-loading');
+          try {
+            const reserveRes = await apiFetch('/api/checkout/etransfer', {
+              method: 'POST',
+              credentials: 'include',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                eventId,
+                items: cartItems.map((c) => ({ ticketTypeId: c.ticket.id, quantity: c.qty })),
+                ...(inviteToken && { invite: inviteToken }),
+                ...(emtEmail && { email: emtEmail.trim() }),
+                ...(emtName && { name: emtName.trim() }),
+              }),
+            });
+            if (!reserveRes.ok) {
+              const errData = await reserveRes.json().catch(() => ({}));
+              onError(errData.error || 'e-Transfer setup failed');
+              setStep('idle');
+              return;
+            }
+            const reserveData = await reserveRes.json();
+            setEmtResult({
+              orderId: reserveData.orderId,
+              quantity: reserveData.instructions.quantity ?? totalQty,
+              email: reserveData.instructions.email,
+              amount: reserveData.instructions.amount,
+              currency: reserveData.instructions.currency,
+              memo: reserveData.instructions.memo,
+              deadline: reserveData.instructions.deadline,
+              message: reserveData.instructions.message,
+            });
+            setStep('emt-done');
+          } catch {
+            onError('e-Transfer setup failed');
+            setStep('idle');
+          }
         } else if (data.status === 'expired' || data.status === 'claimed') {
           clearInterval(pollInterval);
           setPollError('Verification link expired. Please try again.');

--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -536,9 +536,6 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
                   )}
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                  Price
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
                   Purchased
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
@@ -560,7 +557,20 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
                     <ProfileCell ownerDid={guest.ownerDid} profile={guest.profile} paymentMethod={guest.paymentMethod} paymentId={guest.paymentId} />
                   </td>
                   <td className="px-4 py-3 whitespace-nowrap">
-                    <div className="text-sm text-gray-700 dark:text-gray-300">{guest.ticketType}</div>
+                    <div className="text-sm text-gray-700 dark:text-gray-300">
+                      {guest.ticketType}
+                      {' — '}
+                      <span className="text-gray-500 dark:text-gray-400">{formatCurrency(guest.pricePaid, guest.currency)}</span>
+                      {guest.fairSettlement && (
+                        <button
+                          onClick={() => setExpandedReceipt(prev => prev === guest.id ? null : guest.id)}
+                          className="ml-1 text-base leading-none hover:scale-110 transition-transform"
+                          title=".fair settlement receipt"
+                        >
+                          ⚖️
+                        </button>
+                      )}
+                    </div>
                     <div className="text-xs text-gray-400 dark:text-gray-500 font-mono mt-0.5">{guest.id}</div>
                   </td>
                   <td className="px-4 py-3 whitespace-nowrap">
@@ -574,20 +584,6 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
                         {actionLoading === guest.id ? '…' : 'Confirm'}
                       </button>
                     )}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                    <div className="flex items-center gap-1.5">
-                      {formatCurrency(guest.pricePaid, guest.currency)}
-                      {guest.fairSettlement && (
-                        <button
-                          onClick={() => setExpandedReceipt(prev => prev === guest.id ? null : guest.id)}
-                          className="text-base leading-none hover:scale-110 transition-transform"
-                          title=".fair settlement receipt"
-                        >
-                          ⚖️
-                        </button>
-                      )}
-                    </div>
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
                     {formatDate(guest.purchasedAt)}
@@ -627,7 +623,7 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
                 </tr>
                 {expandedReceipt === guest.id && guest.fairSettlement && (
                   <tr className="bg-gray-50/50 dark:bg-gray-900/30">
-                    <td colSpan={8} className="px-6 pb-3 pt-0">
+                    <td colSpan={7} className="px-6 pb-3 pt-0">
                       <GuestFairReceipt settlement={guest.fairSettlement} />
                     </td>
                   </tr>

--- a/apps/kernel/app/auth/api/onboard/verify/route.ts
+++ b/apps/kernel/app/auth/api/onboard/verify/route.ts
@@ -286,12 +286,12 @@ function errorPage(title: string, message: string): NextResponse {
   return new NextResponse(
     `<!DOCTYPE html>
 <html>
-<head><title>${title}</title><meta name="viewport" content="width=device-width, initial-scale=1">
+<head><title>${title}</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <style>body{font-family:system-ui;max-width:500px;margin:80px auto;padding:20px;text-align:center;background:#000;color:#e4e4e7;}h1{color:#ef4444;font-size:24px;}p{color:#a1a1aa;line-height:1.6;}</style>
 </head>
 <body><h1>${title}</h1><p>${message}</p></body>
 </html>`,
-    { status: 400, headers: { 'Content-Type': 'text/html' } }
+    { status: 400, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
   );
 }
 
@@ -299,11 +299,11 @@ function affirmationPage(): NextResponse {
   return new NextResponse(
     `<!DOCTYPE html>
 <html>
-<head><title>Email Verified</title><meta name="viewport" content="width=device-width, initial-scale=1">
+<head><title>Email Verified</title><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <style>body{font-family:system-ui;max-width:500px;margin:80px auto;padding:20px;text-align:center;background:#000;color:#e4e4e7;}h1{color:#22c55e;font-size:24px;}p{color:#a1a1aa;line-height:1.6;}</style>
 </head>
 <body><h1>✅ Email Verified</h1><p>You can close this tab and return to where you started.</p></body>
 </html>`,
-    { status: 200, headers: { 'Content-Type': 'text/html' } }
+    { status: 200, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
   );
 }

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -151,6 +151,12 @@ function useAutoIdentity(servicePrefix: string, domain: string, overrides?: Serv
     }
 
     checkSession();
+
+    // Re-fetch when another tab or component signals a session change
+    // (e.g. after onboarding claim in a polling flow)
+    const handler = () => checkSession();
+    window.addEventListener('imajin:session-changed', handler);
+    return () => window.removeEventListener('imajin:session-changed', handler);
   }, [servicePrefix, domain, overrides]);
 
   return identity;


### PR DESCRIPTION
Follow-up to work order `memory/workorders/2026-05-09-events-followup.md`.

This batch addresses Issues #5, #6, #7, #8 surfaced during live-testing of the deployed friction-pass batch (PRs #875, #876).

---

### #7 — Affirmation page mojibake (`âœ…` instead of `✅`)
**Root cause:** `Content-Type: text/html` (no charset) causes browsers to interpret UTF-8 emoji bytes as latin-1.
**Fix:** Updated both `errorPage()` and `affirmationPage()` in `apps/kernel/app/auth/api/onboard/verify/route.ts` to return `text/html; charset=utf-8`, plus belt-and-braces `<meta charset="utf-8">` in the HTML `<head>`.

### #8 — Original tab loses cart + shows unauthenticated after verify
**Root cause (cart loss):** After `/claim` succeeded, the polling effect called `startEtransfer()`, which at the end calls `router.refresh()`. This re-ran server components, found the newly created pending EMT order, flipped `hasTicket` from `false` → `true`, and caused `TicketsSection` to switch from rendering `PurchaseUI` directly to rendering the tabbed interface — unmounting `PurchaseUI` and wiping its `quantities` state.

**Root cause (navbar stale):** `NavBar` uses `useAutoIdentity` which fetches `/api/session` once on mount. `router.refresh()` doesn't trigger a re-fetch, so the navbar stayed showing the unauthenticated state.

**Fix:**
- In the polling effect, after `/claim` returns success, dispatch a custom `imajin:session-changed` window event and then make the EMT reserve API call **directly** (bypassing `startEtransfer()`) so `router.refresh()` is never invoked. This preserves all client state.
- Added a listener in `packages/ui/src/nav-bar.tsx` `useAutoIdentity` that re-fetches session when `imajin:session-changed` fires, updating the navbar within ~1s of claim success.

### #6a — My Tickets shows wrong grouping ("3× Bunkie" for mixed order)
**Root cause:** `getUserOrders` in `page.tsx` groups tickets by `orderId` and uses `first.ticketType?.name` as the label for the entire order. An order containing multiple ticket types (e.g. 1× $1,000 + 1× $285 + 1× Bunkie) collapses to the first type name.

**Fix:** Compute `ticketTypeName` from a `Map` counting unique types within each order group, producing labels like `"1× Premium + 2× Bunkie"`.

### #6b — Registration demanded for tickets that shouldn't require it
**Investigation:** The filter `order.tickets.filter(t => t.ticketType?.registrationFormId)` is syntactically correct and checks each ticket individually. If Bunkie truly has no `registrationFormId`, it should be excluded. The most likely explanations are: (1) the three tickets share a single `ticketType` reference due to a data/join issue, or (2) Bunkie's `registrationFormId` is set in the DB.

**Fix (defensive):** Added an additional guard `&& t.registrationStatus !== 'not_required'` to the filter in `OrderCard`. This ensures any ticket explicitly marked as not requiring registration is never shown a form, even if `registrationFormId` is accidentally set in the DB. **If Bunkie still shows a form after this change, it's a DB misconfiguration** — its `registrationFormId` should be cleared.

### #5 — Guest list column reduction
**Fix:** Removed the dedicated `Price` column from `guest-list.tsx` and folded price into the `Type` cell, matching the `sales-tab.tsx` pattern (`Bunkie — $1,000.00`). The `.fair` settlement button (⚖️) moved alongside the price in the same cell. Updated `colSpan` on the expanded receipt row from 8 → 7. CSV export is untouched — price remains a dedicated column there.

**Column audit (for Ryan's review):**
- `Profile` — essential
- `Type` — essential (now includes price)
- `Status` — essential
- `Purchased` — useful for tracking
- `Checked In` — useful at the door
- `Registration` — essential for events with forms
- `Actions` — essential

No additional columns flagged for removal. The row should now fit comfortably at ≥1280px without horizontal scroll.

---

**Build verification:** Sandbox approval blocked long-running builds; relying on CI for compile verification.
