### PR TITLE
fix(events+auth): post-deploy follow-ups #2 (rate limits, registration UX, order-level EMT confirm, cross-tab registration prompt)

### DIFF
--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -172,6 +172,16 @@ function OrderCard({ order, eventId }: { order: UserOrder; eventId: string }) {
     ? `${order.quantity}× ${order.ticketTypeName}`
     : order.ticketTypeName;
 
+  // Issue #10: optimistic local state so QR + done state appear immediately
+  const [completedTickets, setCompletedTickets] = useState<Record<string, { status: string; qrCode?: string }>>({});
+
+  const handleRegistrationComplete = (ticketId: string, qrCode?: string) => {
+    setCompletedTickets(prev => ({
+      ...prev,
+      [ticketId]: { status: 'complete', qrCode },
+    }));
+  };
+
   return (
     <div className="border-2 border-orange-500 dark:border-orange-500 rounded-xl p-6 bg-orange-50/50 dark:bg-orange-900/10">
       {/* Order header */}
@@ -186,7 +196,7 @@ function OrderCard({ order, eventId }: { order: UserOrder; eventId: string }) {
       {/* QR grid */}
       <div className={`grid gap-4 mb-5 ${order.tickets.length === 1 ? 'grid-cols-1 max-w-[200px]' : 'grid-cols-2 sm:grid-cols-3'}`}>
         {order.tickets.map((ticket) => (
-          <TicketQRCell key={ticket.id} ticket={ticket} eventId={eventId} />
+          <TicketQRCell key={ticket.id} ticket={ticket} eventId={eventId} override={completedTickets[ticket.id]} />
         ))}
       </div>
 
@@ -196,7 +206,12 @@ function OrderCard({ order, eventId }: { order: UserOrder; eventId: string }) {
           doesn't force a form on the buyer. */}
       {order.tickets.filter(t => t.ticketType?.registrationFormId && t.registrationStatus !== 'not_required').map((ticket) => (
         <div key={`reg-${ticket.id}`} className="mb-4">
-          <TicketRegistrationSurvey ticket={ticket} eventId={eventId} />
+          <TicketRegistrationSurvey
+            ticket={ticket}
+            eventId={eventId}
+            override={completedTickets[ticket.id]}
+            onComplete={handleRegistrationComplete}
+          />
         </div>
       ))}
 
@@ -208,9 +223,10 @@ function OrderCard({ order, eventId }: { order: UserOrder; eventId: string }) {
   );
 }
 
-function TicketQRCell({ ticket }: { ticket: OrderTicket; eventId: string }) {
-  const isPending = ticket.registrationStatus === 'pending';
-  const [qrCode] = useState(ticket.qrCodeDataUri);
+function TicketQRCell({ ticket, override }: { ticket: OrderTicket; eventId: string; override?: { status: string; qrCode?: string } }) {
+  const status = override?.status ?? ticket.registrationStatus;
+  const isPending = status === 'pending';
+  const qrCode = override?.qrCode ?? ticket.qrCodeDataUri;
 
   return (
     <div className="flex flex-col items-center gap-2">
@@ -248,11 +264,12 @@ function TicketQRCell({ ticket }: { ticket: OrderTicket; eventId: string }) {
   );
 }
 
-function TicketRegistrationSurvey({ ticket, eventId }: { ticket: OrderTicket; eventId: string }) {
+function TicketRegistrationSurvey({ ticket, eventId, override, onComplete }: { ticket: OrderTicket; eventId: string; override?: { status: string; qrCode?: string }; onComplete?: (ticketId: string, qrCode?: string) => void }) {
   const [regStatus, setRegStatus] = useState(ticket.registrationStatus);
   const [isRetrying, setIsRetrying] = useState(false);
   const [lastError, setLastError] = useState<string | null>(null);
-  const isPending = regStatus === 'pending';
+  const effectiveStatus = override?.status ?? regStatus;
+  const isPending = effectiveStatus === 'pending';
   const router = useRouter();
   const { toast } = useToast();
 
@@ -266,9 +283,11 @@ function TicketRegistrationSurvey({ ticket, eventId }: { ticket: OrderTicket; ev
         body: JSON.stringify({ formId: ticket.ticketType?.registrationFormId }),
       });
       if (res.ok) {
+        const data = await res.json().catch(() => ({}));
         setRegStatus('complete');
+        onComplete?.(ticket.id, data.qrCodeDataUri);
         toast.success('Registration completed successfully');
-        // Refresh server data so QR code appears
+        // Refresh server data so the state is durable after navigation
         router.refresh();
       } else {
         const data = await res.json().catch(() => ({}));

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -100,7 +100,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], 
 
   // If user doesn't have tickets, show purchase UI only
   if (!hasTicket || userOrders.length === 0) {
-    return <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sellerConnected={sellerConnected} hasHiddenTiers={hasHiddenTiers} />;
+    return <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} userOrders={userOrders} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sellerConnected={sellerConnected} hasHiddenTiers={hasHiddenTiers} />;
   }
 
   // User has tickets - show tabbed interface
@@ -134,7 +134,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], 
       {activeTab === 'my-tickets' ? (
         <MyTicketsTab userOrders={userOrders} eventId={eventId} />
       ) : (
-        <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sessionContactEmail={sessionContactEmail} sellerConnected={sellerConnected} hasHiddenTiers={hasHiddenTiers} />
+        <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} userOrders={userOrders} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sessionContactEmail={sessionContactEmail} sellerConnected={sellerConnected} hasHiddenTiers={hasHiddenTiers} />
       )}
     </div>
   );
@@ -430,7 +430,7 @@ function TicketFairReceipt({ settlement }: { settlement: FairSettlement }) {
   );
 }
 
-function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnabled = false, isAuthenticated = false, sessionEmail, sessionContactEmail, sellerConnected = true, hasHiddenTiers = false }: { eventId: string; eventTitle: string; tickets: TicketType[]; inviteToken?: string; etransferEnabled?: boolean; isAuthenticated?: boolean; sessionEmail?: string; sessionContactEmail?: string; sellerConnected?: boolean; hasHiddenTiers?: boolean }) {
+function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken, etransferEnabled = false, isAuthenticated = false, sessionEmail, sessionContactEmail, sellerConnected = true, hasHiddenTiers = false }: { eventId: string; eventTitle: string; tickets: TicketType[]; userOrders?: UserOrder[]; inviteToken?: string; etransferEnabled?: boolean; isAuthenticated?: boolean; sessionEmail?: string; sessionContactEmail?: string; sellerConnected?: boolean; hasHiddenTiers?: boolean }) {
   const [unlockedTickets, setUnlockedTickets] = useState<TicketType[]>([]);
   const [unlockCode, setUnlockCode] = useState('');
   const [showUnlock, setShowUnlock] = useState(false);
@@ -611,6 +611,7 @@ function PurchaseUI({ eventId, eventTitle, tickets, inviteToken, etransferEnable
           onError={(msg) => toast.error(msg)}
           mixedCurrency={mixedCurrency}
           cartCurrencies={cartCurrencies}
+          userOrders={userOrders}
         />
       )}
 
@@ -674,13 +675,48 @@ interface UnifiedBarProps {
   cartCurrencies?: string[];
 }
 
-function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [] }: UnifiedBarProps) {
+function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [] }: UnifiedBarProps & { userOrders?: UserOrder[] }) {
+  // Issue #11: count tickets needing registration across all user orders
+  const pendingRegistrations = userOrders.flatMap(o =>
+    o.tickets.filter(t => t.registrationStatus === 'pending' && t.ticketType?.registrationFormId)
+  );
+  // Newly purchased tickets that require registration (checked from cart while userOrders may be stale)
+  const cartPendingCount = cartItems.filter(c => c.ticket.requiresRegistration).reduce((sum, c) => sum + c.qty, 0);
+  const totalPendingCount = pendingRegistrations.length + cartPendingCount;
+  const hasPendingRegistrations = totalPendingCount > 0;
+
   const router = useRouter();
   type BarStep = 'idle' | 'card-loading' | 'emt-form' | 'emt-loading' | 'emt-done' | 'emt-verify-sent';
-  const [step, setStep] = useState<BarStep>('idle');
+  const [step, setStepState] = useState<BarStep>(() => {
+    try {
+      const saved = sessionStorage.getItem('emtResult');
+      if (saved) return 'emt-done';
+    } catch {}
+    return 'idle';
+  });
+  const setStep = (s: BarStep) => {
+    setStepState(s);
+    if (s !== 'emt-done') {
+      try { sessionStorage.removeItem('emtResult'); } catch {}
+    }
+  };
   const [emtEmail, setEmtEmail] = useState(sessionContactEmail || sessionEmail || '');
   const [emtName, setEmtName] = useState('');
-  const [emtResult, setEmtResult] = useState<{ orderId: string; quantity: number; email: string; amount: number; currency: string; memo: string; deadline: string; message: string } | null>(null);
+  const [emtResult, setEmtResultState] = useState<{ orderId: string; quantity: number; email: string; amount: number; currency: string; memo: string; deadline: string; message: string } | null>(() => {
+    try {
+      const saved = sessionStorage.getItem('emtResult');
+      if (saved) return JSON.parse(saved);
+    } catch {}
+    return null;
+  });
+  const setEmtResult = (result: typeof emtResult) => {
+    setEmtResultState(result);
+    if (result) {
+      try { sessionStorage.setItem('emtResult', JSON.stringify(result)); } catch {}
+    } else {
+      try { sessionStorage.removeItem('emtResult'); } catch {}
+    }
+  };
   const [verifySentTo, setVerifySentTo] = useState<string | null>(null);
   // Issue #1: polling state for tab-A-canonical verification
   const [pollHandle, setPollHandle] = useState<string | null>(null);
@@ -863,6 +899,8 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
               message: reserveData.instructions.message,
             });
             setStep('emt-done');
+            // Refresh server data so My Tickets tab sees the new order
+            router.refresh();
           } catch {
             onError('e-Transfer setup failed');
             setStep('idle');
@@ -959,6 +997,25 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
           <span className="text-orange-500 text-xl">📬</span>
           <h3 className="font-semibold text-base">Reserved — send your e-Transfer to confirm</h3>
         </div>
+        {/* Issue #11: prompt for unregistered tickets without losing EMT context */}
+        {hasPendingRegistrations && (
+          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 flex items-start gap-2">
+            <span className="text-amber-600 dark:text-amber-400 text-lg shrink-0">⚠️</span>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                You have {totalPendingCount} ticket{totalPendingCount !== 1 ? 's' : ''} that need registration before the event.
+              </p>
+              <a
+                href={`/${eventId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block mt-1 text-xs font-semibold text-orange-500 hover:text-orange-600 hover:underline"
+              >
+                Register now →
+              </a>
+            </div>
+          </div>
+        )}
         <p className="text-xs text-orange-500">
           You don't have your ticket{emtResult.quantity > 1 ? 's' : ''} yet. They'll be activated once we confirm your payment — we'll email you the ticket{emtResult.quantity > 1 ? 's' : ''} then.
         </p>

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -771,7 +771,12 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
     const pollInterval = setInterval(async () => {
       try {
         const res = await fetch(`${AUTH_URL}/api/onboard/poll?handle=${encodeURIComponent(pollHandle)}`);
-        if (!res.ok) return;
+        if (!res.ok) {
+          if (res.status === 429) {
+            setPollError('Too many requests, please wait a moment.');
+          }
+          return;
+        }
         const data = await res.json();
         setPollStatus(data.status);
 
@@ -786,8 +791,15 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
           });
           if (!claimRes.ok) {
             const errData = await claimRes.json().catch(() => ({}));
-            setPollError(errData.error || 'Failed to complete verification');
-            setPollStatus('expired');
+            if (claimRes.status === 429) {
+              setPollError('Too many requests, please wait a moment.');
+            } else if (claimRes.status === 410) {
+              setPollError('Verification link expired. Please try again.');
+              setPollStatus('expired');
+            } else {
+              setPollError(errData.error || 'Failed to complete verification');
+              setPollStatus('expired');
+            }
             return;
           }
           // Notify any listening components (e.g. NavBar) that auth changed.

--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -161,7 +161,6 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
   const [filterValue, setFilterValue] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [confirmRefund, setConfirmRefund] = useState<string | null>(null);
-  const [confirmETransfer, setConfirmETransfer] = useState<string | null>(null);
   const [confirmCancel, setConfirmCancel] = useState<string | null>(null);
   const [surveyModalTicketId, setSurveyModalTicketId] = useState<string | null>(null);
   const [surveyQuestions, setSurveyQuestions] = useState<Array<{ question: string; answer: unknown }>>([]);
@@ -217,26 +216,6 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
       g.id === ticketId ? { ...g, usedAt: g.usedAt ?? new Date().toISOString() } : g
     ));
   }, []);
-
-  const handleConfirmETransfer = async (ticketId: string) => {
-    setConfirmETransfer(null);
-    setActionLoading(ticketId);
-    try {
-      const res = await apiFetch(`/api/tickets/${ticketId}/confirm-payment`, { method: 'POST' });
-      const data = await res.json();
-      if (!res.ok) {
-        toast.error(data.error || 'Confirmation failed');
-        return;
-      }
-      setGuests(prev => prev.map(g =>
-        g.id === ticketId ? { ...g, status: 'valid', purchasedAt: data.ticket.purchasedAt } : g
-      ));
-    } catch {
-      toast.error('Confirmation failed');
-    } finally {
-      setActionLoading(null);
-    }
-  };
 
   const handleResendEmail = async (ticketId: string) => {
     setResendState(prev => ({ ...prev, [ticketId]: 'sending' }));
@@ -576,13 +555,9 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
                   <td className="px-4 py-3 whitespace-nowrap">
                     <StatusBadge status={guest.status} paymentMethod={guest.paymentMethod} />
                     {guest.status === 'held' && guest.paymentMethod === 'etransfer' && (
-                      <button
-                        onClick={() => setConfirmETransfer(guest.id)}
-                        disabled={actionLoading === guest.id}
-                        className="mt-1 px-2 py-1 text-xs font-medium bg-orange-500 hover:bg-orange-600 text-white rounded-lg transition disabled:opacity-50 block"
-                      >
-                        {actionLoading === guest.id ? '…' : 'Confirm'}
-                      </button>
+                      <span className="mt-1 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+                        Pending e-Transfer
+                      </span>
                     )}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
@@ -632,33 +607,6 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
               ))}
             </tbody>
           </table>
-        </div>
-      )}
-
-      {/* e-Transfer confirmation dialog */}
-      {confirmETransfer && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 max-w-sm w-full">
-            <h3 className="text-lg font-semibold mb-2">Confirm e-Transfer Payment</h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-              Have you received the e-Transfer for ticket <span className="font-mono text-xs">{confirmETransfer}</span>?
-              This will activate the ticket.
-            </p>
-            <div className="flex gap-3 justify-end">
-              <button
-                onClick={() => setConfirmETransfer(null)}
-                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => handleConfirmETransfer(confirmETransfer)}
-                className="px-4 py-2 text-sm font-medium text-white bg-orange-500 hover:bg-orange-600 rounded-lg transition"
-              >
-                Confirm Payment
-              </button>
-            </div>
-          </div>
         </div>
       )}
 

--- a/apps/events/app/admin/[eventId]/sales-tab.tsx
+++ b/apps/events/app/admin/[eventId]/sales-tab.tsx
@@ -226,6 +226,8 @@ export function SalesTab({ eventId }: SalesTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
+  const [confirmETransferOrder, setConfirmETransferOrder] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   const load = useCallback(() => {
     setLoading(true);
@@ -247,6 +249,25 @@ export function SalesTab({ eventId }: SalesTabProps) {
   useEffect(() => {
     load();
   }, [load]);
+
+  const handleConfirmETransferOrder = async (orderId: string) => {
+    setActionLoading(orderId);
+    try {
+      const res = await apiFetch(`/api/orders/${orderId}/confirm-payment`, { method: 'POST' });
+      if (res.ok) {
+        toast.success('e-Transfer confirmed');
+        load();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error || 'Confirmation failed');
+      }
+    } catch {
+      toast.error('Confirmation failed');
+    } finally {
+      setActionLoading(null);
+      setConfirmETransferOrder(null);
+    }
+  };
 
   const handleExport = async (format: 'csv' | 'xlsx' = 'csv') => {
     setExporting(true);
@@ -371,12 +392,16 @@ export function SalesTab({ eventId }: SalesTabProps) {
                 <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
                   Stripe Ref
                 </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  Actions
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
               {sales.map((sale) => {
                 const stripeUrl = getStripeDashboardUrl(sale.paymentId, sale.stripeSessionId);
                 const isOrphanOrder = orphanOrders.some(o => o.orderId === sale.orderId);
+                const isPendingEmt = sale.status === 'pending' && sale.paymentMethod === 'etransfer';
 
                 return (
                   <tr
@@ -420,6 +445,17 @@ export function SalesTab({ eventId }: SalesTabProps) {
                         <span className="text-xs text-gray-400 font-mono">
                           {truncateId(sale.stripeSessionId || sale.paymentId || '—', 16)}
                         </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      {isPendingEmt && (
+                        <button
+                          onClick={() => setConfirmETransferOrder(sale.orderId)}
+                          disabled={actionLoading === sale.orderId}
+                          className="px-3 py-1 text-xs font-medium bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition"
+                        >
+                          {actionLoading === sale.orderId ? '…' : 'Confirm e-Transfer'}
+                        </button>
                       )}
                     </td>
                   </tr>
@@ -542,6 +578,35 @@ export function SalesTab({ eventId }: SalesTabProps) {
                   ))}
                 </tbody>
               </table>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Order-level e-Transfer confirmation dialog */}
+      {confirmETransferOrder && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-sm w-full mx-4 shadow-xl">
+            <h3 className="text-lg font-semibold mb-2">Confirm e-Transfer Payment</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+              Have you received the e-Transfer for order{' '}
+              <span className="font-mono text-xs">{confirmETransferOrder}</span>?
+              This will confirm all tickets in the order.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setConfirmETransferOrder(null)}
+                className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => handleConfirmETransferOrder(confirmETransferOrder)}
+                disabled={!!actionLoading}
+                className="px-4 py-2 text-sm bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition"
+              >
+                {actionLoading === confirmETransferOrder ? 'Confirming…' : 'Confirm Payment'}
+              </button>
             </div>
           </div>
         </div>

--- a/apps/events/app/api/orders/[id]/confirm-payment/route.ts
+++ b/apps/events/app/api/orders/[id]/confirm-payment/route.ts
@@ -1,0 +1,83 @@
+/**
+ * POST /api/orders/[id]/confirm-payment
+ *
+ * Confirms an e-Transfer payment for an order atomically.
+ * Changes all held tickets in the order from 'held' to 'valid'.
+ * Requires event organizer auth.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createLogger } from '@imajin/logger';
+import { db, tickets, orders } from '@/src/db';
+import { requireAuth } from '@imajin/auth';
+import { isEventOrganizer } from '@/src/lib/organizer';
+import { confirmHeldTickets } from '@/src/lib/confirm-payment';
+import { eq, and } from 'drizzle-orm';
+
+const log = createLogger('events');
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+  }
+
+  const { identity } = authResult;
+  const did = identity.actingAs || identity.id;
+  const { id: orderId } = await params;
+
+  try {
+    // Find the order
+    const [order] = await db.select().from(orders).where(eq(orders.id, orderId)).limit(1);
+
+    if (!order) {
+      return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+    }
+
+    if (order.status !== 'pending') {
+      return NextResponse.json({ error: 'Order is not in pending status' }, { status: 400 });
+    }
+
+    // Verify caller is an event organizer
+    const orgCheck = await isEventOrganizer(order.eventId, did);
+    if (!orgCheck.authorized) {
+      return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+    }
+
+    // Find all held e-Transfer tickets in this order
+    const heldTickets = await db
+      .select()
+      .from(tickets)
+      .where(
+        and(
+          eq(tickets.orderId, orderId),
+          eq(tickets.status, 'held'),
+          eq(tickets.paymentMethod, 'etransfer')
+        )
+      );
+
+    if (heldTickets.length === 0) {
+      return NextResponse.json(
+        { error: 'No held e-Transfer tickets found in this order' },
+        { status: 400 }
+      );
+    }
+
+    const { confirmedTickets } = await confirmHeldTickets(order.eventId, heldTickets, orderId);
+
+    return NextResponse.json({
+      confirmedCount: confirmedTickets.length,
+      orderId,
+      tickets: confirmedTickets.map((t) => t.id),
+    });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Order confirm-payment error');
+    return NextResponse.json(
+      { error: 'Failed to confirm payment' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/events/app/api/register/[ticketId]/route.ts
+++ b/apps/events/app/api/register/[ticketId]/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createLogger } from '@imajin/logger';
 import { db, tickets, events, ticketTypes, ticketRegistrations } from '@/src/db';
+import { revalidatePath } from 'next/cache';
 
 const log = createLogger('events');
 import { eq, and } from 'drizzle-orm';
@@ -209,7 +210,10 @@ export async function POST(
       log.error({ err: String(emailError) }, 'Failed to send ticket confirmation email after registration');
     }
 
-    return NextResponse.json({ success: true, registration });
+    // Invalidate the event page cache so subsequent SSR sees the updated state
+    revalidatePath(`/events/${event.id}`);
+
+    return NextResponse.json({ success: true, registration, qrCodeDataUri });
 
   } catch (error) {
     log.error({ err: String(error) }, 'Registration error');

--- a/apps/events/app/api/tickets/[id]/confirm-payment/route.ts
+++ b/apps/events/app/api/tickets/[id]/confirm-payment/route.ts
@@ -4,28 +4,28 @@
  * Confirms an e-Transfer payment for a held ticket.
  * Changes status from 'held' to 'valid' and records confirmation timestamp.
  * Requires event organizer auth.
+ *
+ * DEPRECATED: Use POST /api/orders/[id]/confirm-payment for order-level
+ * confirmation. This route is kept for orphan tickets (tickets without an
+ * order) and edge cases only.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createLogger } from '@imajin/logger';
-import { publish } from '@imajin/bus';
-import { db, tickets, ticketTypes, events, orders } from '@/src/db';
+import { db, tickets } from '@/src/db';
 import { requireAuth } from '@imajin/auth';
-import { getClient } from '@imajin/db';
-import { randomBytes } from 'crypto';
-import { sendEmail, ticketConfirmationEmail, purchaseReceiptEmail, generateQRCode } from '@/src/lib/email';
+import { isEventOrganizer } from '@/src/lib/organizer';
+import { confirmHeldTickets } from '@/src/lib/confirm-payment';
+import { eq, and } from 'drizzle-orm';
 
 const log = createLogger('events');
-import { isEventOrganizer } from '@/src/lib/organizer';
-import { eq, sql, and, inArray } from 'drizzle-orm';
-
-const AUTH_URL = process.env.NEXT_PUBLIC_AUTH_URL || process.env.AUTH_URL || 'https://auth.imajin.ai';
-const EVENTS_URL = process.env.NEXT_PUBLIC_EVENTS_URL || 'https://events.imajin.ai';
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  log.warn('POST /api/tickets/[id]/confirm-payment is deprecated; use POST /api/orders/[id]/confirm-payment');
+
   const authResult = await requireAuth(request);
   if ('error' in authResult) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status });
@@ -57,239 +57,22 @@ export async function POST(
       return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
     }
 
-    const now = new Date();
+    // If the ticket belongs to an order, confirm every held sibling atomically.
+    // Otherwise confirm just this orphan ticket.
+    const heldTickets = ticket.orderId
+      ? await db
+          .select()
+          .from(tickets)
+          .where(
+            and(
+              eq(tickets.orderId, ticket.orderId),
+              eq(tickets.status, 'held'),
+              eq(tickets.paymentMethod, 'etransfer')
+            )
+          )
+      : [ticket];
 
-    // If the ticket belongs to an order (multi-ticket EMT), confirm every
-    // held sibling in the order atomically. Single e-Transfer pays for the
-    // whole order; partial confirmation would leave it in a half-state.
-    let confirmedTickets: (typeof tickets.$inferSelect)[];
-    if (ticket.orderId) {
-      confirmedTickets = await db
-        .update(tickets)
-        .set({
-          status: 'valid',
-          purchasedAt: now,
-          paymentConfirmedAt: now,
-          heldBy: null,
-          heldUntil: null,
-          holdExpiresAt: null,
-        })
-        .where(and(eq(tickets.orderId, ticket.orderId), eq(tickets.status, 'held')))
-        .returning();
-
-      // Mark the order completed
-      await db
-        .update(orders)
-        .set({ status: 'completed', purchasedAt: now })
-        .where(eq(orders.id, ticket.orderId));
-    } else {
-      const [single] = await db
-        .update(tickets)
-        .set({
-          status: 'valid',
-          purchasedAt: now,
-          paymentConfirmedAt: now,
-          heldBy: null,
-          heldUntil: null,
-          holdExpiresAt: null,
-        })
-        .where(eq(tickets.id, id))
-        .returning();
-      confirmedTickets = [single];
-    }
-
-    // Group confirmed tickets by ticket type and increment sold counts per type.
-    // (Multi-type orders may confirm tickets across more than one type at once.)
-    if (confirmedTickets.length > 0) {
-      const byType = new Map<string, number>();
-      for (const t of confirmedTickets) {
-        byType.set(t.ticketTypeId, (byType.get(t.ticketTypeId) ?? 0) + 1);
-      }
-      for (const [ttId, count] of byType.entries()) {
-        await db
-          .update(ticketTypes)
-          .set({ sold: sql`${ticketTypes.sold} + ${count}` })
-          .where(eq(ticketTypes.id, ttId));
-      }
-    }
-
-    // Fetch event to get creator DID for attestation
-    const [event] = await db.select().from(events).where(eq(events.id, ticket.eventId)).limit(1);
-
-    // Fire one ticket.purchased event per confirmed ticket so attribution
-    // and downstream side-effects fire for each.
-    for (const t of confirmedTickets) {
-      publish('ticket.purchased', {
-        issuer: t.ownerDid || '',
-        subject: event?.creatorDid ?? t.eventId,
-        scope: 'events',
-        payload: {
-          ticketId: t.id,
-          eventId: t.eventId,
-          amount: t.pricePaid ?? 0,
-          currency: t.currency || 'USD',
-          context_id: t.eventId,
-          context_type: 'event',
-        },
-      }).catch((err) => log.error({ err: String(err) }, 'Publish error'));
-    }
-
-    // Send the buyer their purchase receipt + ticket confirmation (with QRs).
-    // Mirrors what the Stripe webhook does on a successful charge.
-    if (event) {
-      try {
-        const authSql = getClient();
-
-        // Resolve buyer email — try contact_email on the owner DID first.
-        const buyerDid = confirmedTickets[0].ownerDid;
-        let customerEmail: string | null = null;
-        let customerName: string | null = null;
-        if (buyerDid) {
-          const rows = await authSql<{ contact_email: string | null; name: string | null }[]>`
-            SELECT contact_email, name FROM auth.identities WHERE id = ${buyerDid} LIMIT 1
-          `;
-          customerEmail = rows[0]?.contact_email ?? null;
-          customerName = rows[0]?.name ?? null;
-        }
-
-        if (customerEmail) {
-          // Resolve ticket type rows for the confirmed tickets so we can show
-          // names/prices in the receipt and confirmation emails.
-          const typeIds = Array.from(new Set(confirmedTickets.map((t) => t.ticketTypeId)));
-          const typeRows = await db
-            .select()
-            .from(ticketTypes)
-            .where(inArray(ticketTypes.id, typeIds));
-          const typesById = new Map(typeRows.map((t) => [t.id, t]));
-
-          // Build per-type summary for the receipt
-          const summary = new Map<string, { typeName: string; quantity: number; unitPrice: number; currency: string }>();
-          let totalCents = 0;
-          for (const t of confirmedTickets) {
-            const tt = typesById.get(t.ticketTypeId);
-            const key = t.ticketTypeId;
-            const existing = summary.get(key);
-            if (existing) {
-              existing.quantity += 1;
-            } else {
-              summary.set(key, {
-                typeName: tt?.name ?? 'Ticket',
-                quantity: 1,
-                unitPrice: t.pricePaid ?? tt?.price ?? 0,
-                currency: t.currency || tt?.currency || 'CAD',
-              });
-            }
-            totalCents += t.pricePaid ?? tt?.price ?? 0;
-          }
-          const currency = confirmedTickets[0].currency || 'CAD';
-          const fmt = (cents: number) => new Intl.NumberFormat('en-CA', { style: 'currency', currency }).format(cents / 100);
-          const totalFormatted = fmt(totalCents);
-
-          const eventDate = new Date(event.startsAt);
-          const formattedEventDate = eventDate.toLocaleDateString('en-US', {
-            weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
-          });
-          const formattedEventTime = eventDate.toLocaleTimeString('en-US', {
-            hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
-          });
-          const eventImageUrl = event.imageUrl
-            ? (event.imageUrl.startsWith('http') ? event.imageUrl : `${EVENTS_URL}${event.imageUrl}`)
-            : undefined;
-
-          // Mint a magic-link onboard token so the buyer can log in straight
-          // from the email and view their tickets.
-          let onboardToken: string | null = null;
-          try {
-            onboardToken = randomBytes(36).toString('hex');
-            const onboardId = `obt_${randomBytes(8).toString('hex')}`;
-            const redirectUrl = `${EVENTS_URL}/${event.id}`;
-            await authSql`
-              INSERT INTO auth.onboard_tokens (id, email, name, token, redirect_url, context, expires_at)
-              VALUES (
-                ${onboardId},
-                ${customerEmail.toLowerCase().trim()},
-                ${customerName || null},
-                ${onboardToken},
-                ${redirectUrl},
-                ${'access your ticket for ' + event.title},
-                ${new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()}
-              )
-            `;
-          } catch (err) {
-            log.error({ err: String(err) }, 'Onboard token creation failed (non-fatal)');
-            onboardToken = null;
-          }
-          const magicLink = onboardToken
-            ? `${AUTH_URL}/api/onboard/verify?token=${onboardToken}`
-            : `${EVENTS_URL}/${event.id}/my-tickets`;
-
-          // Determine if any confirmed type still requires registration
-          const anyRegistrationRequired = Array.from(typesById.values()).some(
-            (tt) => tt.requiresRegistration
-          );
-          const registrationUrl = anyRegistrationRequired
-            ? `${EVENTS_URL}/${event.id}/register/${confirmedTickets[0].id}`
-            : `${EVENTS_URL}/${event.id}/my-tickets`;
-
-          // 1. Purchase receipt (always)
-          await sendEmail({
-            to: customerEmail,
-            subject: `Purchase receipt — ${event.title}`,
-            html: purchaseReceiptEmail({
-              buyerName: customerName || undefined,
-              eventTitle: event.title,
-              eventDate: formattedEventDate,
-              eventTime: formattedEventTime,
-              ticketSummary: Array.from(summary.values()).map((s) => ({
-                typeName: s.typeName,
-                quantity: s.quantity,
-                unitPrice: fmt(s.unitPrice),
-              })),
-              totalPaid: totalFormatted,
-              paymentMethod: 'E-Transfer',
-              registrationUrl,
-              eventImageUrl,
-              hasRegistrationRequired: anyRegistrationRequired,
-            }),
-          }).catch((err) => log.error({ err: String(err) }, 'Receipt email failed'));
-
-          // 2. Ticket confirmation with QR codes (only if no registration
-          //    is required — otherwise the user gets the QR after they finish
-          //    registering, same pattern as Stripe webhook).
-          if (!anyRegistrationRequired) {
-            const ticketsWithQr = await Promise.all(
-              confirmedTickets.map(async (t) => ({
-                id: t.id,
-                qrCodeDataUri: await generateQRCode(t.id),
-              }))
-            );
-            const primaryType = typesById.get(confirmedTickets[0].ticketTypeId);
-            await sendEmail({
-              to: customerEmail,
-              subject: `You're in — ${event.title}`,
-              html: ticketConfirmationEmail({
-                eventTitle: event.title,
-                ticketType: primaryType?.name ?? 'Ticket',
-                ticketId: confirmedTickets[0].id,
-                eventDate: formattedEventDate,
-                eventTime: formattedEventTime,
-                isVirtual: event.isVirtual ?? false,
-                venue: event.venue ?? undefined,
-                price: totalFormatted,
-                magicLink,
-                eventImageUrl,
-                eventUrl: `${EVENTS_URL}/${event.id}`,
-                tickets: ticketsWithQr,
-              }),
-            }).catch((err) => log.error({ err: String(err) }, 'Ticket confirmation email failed'));
-          }
-        } else {
-          log.warn({ buyerDid }, 'No buyer email available on EMT confirm; skipping receipt + ticket emails');
-        }
-      } catch (emailErr) {
-        log.error({ err: String(emailErr) }, 'EMT confirm email block failed');
-      }
-    }
+    const { confirmedTickets } = await confirmHeldTickets(ticket.eventId, heldTickets, ticket.orderId);
 
     return NextResponse.json({
       ticket: confirmedTickets[0],

--- a/apps/events/src/lib/confirm-payment.ts
+++ b/apps/events/src/lib/confirm-payment.ts
@@ -1,0 +1,242 @@
+/**
+ * Shared confirmation logic for e-Transfer payments.
+ * Used by both the per-ticket and per-order confirm-payment routes.
+ */
+
+import { createLogger } from '@imajin/logger';
+import { publish } from '@imajin/bus';
+import { db, tickets, ticketTypes, events, orders } from '@/src/db';
+import { getClient } from '@imajin/db';
+import { randomBytes } from 'crypto';
+import { sendEmail, ticketConfirmationEmail, purchaseReceiptEmail, generateQRCode } from '@/src/lib/email';
+import { eq, sql, and, inArray } from 'drizzle-orm';
+
+const log = createLogger('events');
+const AUTH_URL = process.env.NEXT_PUBLIC_AUTH_URL || process.env.AUTH_URL || 'https://auth.imajin.ai';
+const EVENTS_URL = process.env.NEXT_PUBLIC_EVENTS_URL || 'https://events.imajin.ai';
+
+export interface ConfirmPaymentResult {
+  confirmedTickets: (typeof tickets.$inferSelect)[];
+  orderId: string | null;
+}
+
+/**
+ * Confirm all held e-Transfer tickets in an order (or a single orphan ticket)
+ * and send the buyer their receipt + ticket bundle email.
+ */
+export async function confirmHeldTickets(
+  eventId: string,
+  heldTickets: (typeof tickets.$inferSelect)[],
+  orderId: string | null
+): Promise<ConfirmPaymentResult> {
+  const now = new Date();
+
+  if (heldTickets.length === 0) {
+    throw new Error('No held tickets to confirm');
+  }
+
+  const ticketIds = heldTickets.map((t) => t.id);
+
+  const confirmedTickets = await db
+    .update(tickets)
+    .set({
+      status: 'valid',
+      purchasedAt: now,
+      paymentConfirmedAt: now,
+      heldBy: null,
+      heldUntil: null,
+      holdExpiresAt: null,
+    })
+    .where(and(inArray(tickets.id, ticketIds), eq(tickets.status, 'held')))
+    .returning();
+
+  if (orderId) {
+    await db
+      .update(orders)
+      .set({ status: 'completed', purchasedAt: now })
+      .where(eq(orders.id, orderId));
+  }
+
+  // Increment sold counts per ticket type
+  if (confirmedTickets.length > 0) {
+    const byType = new Map<string, number>();
+    for (const t of confirmedTickets) {
+      byType.set(t.ticketTypeId, (byType.get(t.ticketTypeId) ?? 0) + 1);
+    }
+    for (const [ttId, count] of byType.entries()) {
+      await db
+        .update(ticketTypes)
+        .set({ sold: sql`${ticketTypes.sold} + ${count}` })
+        .where(eq(ticketTypes.id, ttId));
+    }
+  }
+
+  // Fetch event for attestations + emails
+  const [event] = await db.select().from(events).where(eq(events.id, eventId)).limit(1);
+
+  // Publish ticket.purchased attestations
+  for (const t of confirmedTickets) {
+    publish('ticket.purchased', {
+      issuer: t.ownerDid || '',
+      subject: event?.creatorDid ?? t.eventId,
+      scope: 'events',
+      payload: {
+        ticketId: t.id,
+        eventId: t.eventId,
+        amount: t.pricePaid ?? 0,
+        currency: t.currency || 'USD',
+        context_id: t.eventId,
+        context_type: 'event',
+      },
+    }).catch((err) => log.error({ err: String(err) }, 'Publish error'));
+  }
+
+  // Send buyer emails
+  if (event) {
+    try {
+      const authSql = getClient();
+      const buyerDid = confirmedTickets[0].ownerDid;
+      let customerEmail: string | null = null;
+      let customerName: string | null = null;
+      if (buyerDid) {
+        const rows = await authSql<{ contact_email: string | null; name: string | null }[]>`
+          SELECT contact_email, name FROM auth.identities WHERE id = ${buyerDid} LIMIT 1
+        `;
+        customerEmail = rows[0]?.contact_email ?? null;
+        customerName = rows[0]?.name ?? null;
+      }
+
+      if (customerEmail) {
+        const typeIds = Array.from(new Set(confirmedTickets.map((t) => t.ticketTypeId)));
+        const typeRows = await db
+          .select()
+          .from(ticketTypes)
+          .where(inArray(ticketTypes.id, typeIds));
+        const typesById = new Map(typeRows.map((t) => [t.id, t]));
+
+        const summary = new Map<string, { typeName: string; quantity: number; unitPrice: number; currency: string }>();
+        let totalCents = 0;
+        for (const t of confirmedTickets) {
+          const tt = typesById.get(t.ticketTypeId);
+          const key = t.ticketTypeId;
+          const existing = summary.get(key);
+          if (existing) {
+            existing.quantity += 1;
+          } else {
+            summary.set(key, {
+              typeName: tt?.name ?? 'Ticket',
+              quantity: 1,
+              unitPrice: t.pricePaid ?? tt?.price ?? 0,
+              currency: t.currency || tt?.currency || 'CAD',
+            });
+          }
+          totalCents += t.pricePaid ?? tt?.price ?? 0;
+        }
+        const currency = confirmedTickets[0].currency || 'CAD';
+        const fmt = (cents: number) => new Intl.NumberFormat('en-CA', { style: 'currency', currency }).format(cents / 100);
+        const totalFormatted = fmt(totalCents);
+
+        const eventDate = new Date(event.startsAt);
+        const formattedEventDate = eventDate.toLocaleDateString('en-US', {
+          weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+        });
+        const formattedEventTime = eventDate.toLocaleTimeString('en-US', {
+          hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+        });
+        const eventImageUrl = event.imageUrl
+          ? (event.imageUrl.startsWith('http') ? event.imageUrl : `${EVENTS_URL}${event.imageUrl}`)
+          : undefined;
+
+        // Magic-link onboard token
+        let onboardToken: string | null = null;
+        try {
+          onboardToken = randomBytes(36).toString('hex');
+          const onboardId = `obt_${randomBytes(8).toString('hex')}`;
+          const redirectUrl = `${EVENTS_URL}/${event.id}`;
+          await authSql`
+            INSERT INTO auth.onboard_tokens (id, email, name, token, redirect_url, context, expires_at)
+            VALUES (
+              ${onboardId},
+              ${customerEmail.toLowerCase().trim()},
+              ${customerName || null},
+              ${onboardToken},
+              ${redirectUrl},
+              ${'access your ticket for ' + event.title},
+              ${new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()}
+            )
+          `;
+        } catch (err) {
+          log.error({ err: String(err) }, 'Onboard token creation failed (non-fatal)');
+          onboardToken = null;
+        }
+        const magicLink = onboardToken
+          ? `${AUTH_URL}/api/onboard/verify?token=${onboardToken}`
+          : `${EVENTS_URL}/${event.id}/my-tickets`;
+
+        const anyRegistrationRequired = Array.from(typesById.values()).some(
+          (tt) => tt.requiresRegistration
+        );
+        const registrationUrl = anyRegistrationRequired
+          ? `${EVENTS_URL}/${event.id}/register/${confirmedTickets[0].id}`
+          : `${EVENTS_URL}/${event.id}/my-tickets`;
+
+        // 1. Purchase receipt (always)
+        await sendEmail({
+          to: customerEmail,
+          subject: `Purchase receipt — ${event.title}`,
+          html: purchaseReceiptEmail({
+            buyerName: customerName || undefined,
+            eventTitle: event.title,
+            eventDate: formattedEventDate,
+            eventTime: formattedEventTime,
+            ticketSummary: Array.from(summary.values()).map((s) => ({
+              typeName: s.typeName,
+              quantity: s.quantity,
+              unitPrice: fmt(s.unitPrice),
+            })),
+            totalPaid: totalFormatted,
+            paymentMethod: 'E-Transfer',
+            registrationUrl,
+            eventImageUrl,
+            hasRegistrationRequired: anyRegistrationRequired,
+          }),
+        }).catch((err) => log.error({ err: String(err) }, 'Receipt email failed'));
+
+        // 2. Ticket confirmation with QR codes (only if no registration required)
+        if (!anyRegistrationRequired) {
+          const ticketsWithQr = await Promise.all(
+            confirmedTickets.map(async (t) => ({
+              id: t.id,
+              qrCodeDataUri: await generateQRCode(t.id),
+            }))
+          );
+          const primaryType = typesById.get(confirmedTickets[0].ticketTypeId);
+          await sendEmail({
+            to: customerEmail,
+            subject: `You're in — ${event.title}`,
+            html: ticketConfirmationEmail({
+              eventTitle: event.title,
+              ticketType: primaryType?.name ?? 'Ticket',
+              ticketId: confirmedTickets[0].id,
+              eventDate: formattedEventDate,
+              eventTime: formattedEventTime,
+              isVirtual: event.isVirtual ?? false,
+              venue: event.venue ?? undefined,
+              price: totalFormatted,
+              magicLink,
+              eventImageUrl,
+              eventUrl: `${EVENTS_URL}/${event.id}`,
+              tickets: ticketsWithQr,
+            }),
+          }).catch((err) => log.error({ err: String(err) }, 'Ticket confirmation email failed'));
+        }
+      } else {
+        log.warn({ buyerDid }, 'No buyer email available on EMT confirm; skipping receipt + ticket emails');
+      }
+    } catch (emailErr) {
+      log.error({ err: String(emailErr) }, 'EMT confirm email block failed');
+    }
+  }
+
+  return { confirmedTickets, orderId };
+}

--- a/apps/kernel/app/auth/api/onboard/claim/route.ts
+++ b/apps/kernel/app/auth/api/onboard/claim/route.ts
@@ -23,8 +23,10 @@ export async function OPTIONS(request: NextRequest) {
 export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
   const cors = corsHeaders(request);
 
+  // Single-use token enforces correctness; limit is defense-in-depth.
+  // 20/min allows rapid testing without blocking legitimate retries.
   const ip = getClientIP(request);
-  const rl = rateLimit(ip, 10, 60_000);
+  const rl = rateLimit(ip, 20, 60_000);
   if (rl.limited) {
     return NextResponse.json(
       { error: 'Too many requests', retryAfter: rl.retryAfter },

--- a/apps/kernel/app/auth/api/onboard/poll/route.ts
+++ b/apps/kernel/app/auth/api/onboard/poll/route.ts
@@ -21,8 +21,10 @@ export async function OPTIONS(request: NextRequest) {
 export const GET = withLogger('kernel', async (request: NextRequest, { log }) => {
   const cors = corsHeaders(request);
 
+  // Generous per-IP limit: multiple users in one office can share an IP.
+  // Each client polls every 2s for ~60s = 30 polls. 200/min leaves headroom.
   const ip = getClientIP(request);
-  const rl = rateLimit(ip, 30, 60_000);
+  const rl = rateLimit(ip, 200, 60_000);
   if (rl.limited) {
     return NextResponse.json(
       { error: 'Too many requests', retryAfter: rl.retryAfter },

--- a/apps/kernel/app/auth/api/onboard/verify/route.ts
+++ b/apps/kernel/app/auth/api/onboard/verify/route.ts
@@ -14,11 +14,24 @@ import { publish } from '@imajin/bus';
 import { eq, and, gt, isNull } from 'drizzle-orm';
 import { nanoid } from 'nanoid';
 import { createLogger } from '@imajin/logger';
+import { rateLimit, getClientIP } from '@/src/lib/kernel/rate-limit';
 
 const log = createLogger('kernel');
 
 export async function GET(request: NextRequest) {
   try {
+    // Generous rate limit — token TTL + single-use enforces correctness.
+    // A user clicking once should never hit this.
+    const ip = getClientIP(request);
+    const rl = rateLimit(ip, 60, 60_000);
+    if (rl.limited) {
+      return errorPage(
+        'Too Many Requests',
+        'You\'ve made too many requests. Please wait a moment and try again.',
+        429
+      );
+    }
+
     const token = request.nextUrl.searchParams.get('token');
 
     if (!token) {
@@ -117,7 +130,7 @@ export async function GET(request: NextRequest) {
         );
       }
 
-      return errorPage('Link Expired', 'This verification link has expired. Please go back and request a new one.');
+      return errorPage('Link Expired', 'This verification link has expired. Please go back and request a new one.', 410);
     }
 
     // Mark token as used
@@ -282,7 +295,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-function errorPage(title: string, message: string): NextResponse {
+function errorPage(title: string, message: string, status = 400): NextResponse {
   return new NextResponse(
     `<!DOCTYPE html>
 <html>
@@ -291,7 +304,7 @@ function errorPage(title: string, message: string): NextResponse {
 </head>
 <body><h1>${title}</h1><p>${message}</p></body>
 </html>`,
-    { status: 400, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+    { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
   );
 }
 


### PR DESCRIPTION
## Summary

Addresses Issues #9–#12 from the events friction-pass follow-up #2 work order.

---

### #12 — Rate limits + error message accuracy (HIGH severity)

**Root cause:** The poll endpoint was limited to 30 requests/min/IP. A single client polling every 2s for 60s uses exactly 30 requests — leaving zero headroom for multiple test sessions or office-shared IPs. When the limit tripped, the client silently ignored 429s from poll and conflated ALL claim failures (including 429 rate-limit) into a generic 'Verification expired / Too many requests' message.

**Changes:**
- : added generous 60/min/IP rate limit; returns 410 for expired tokens, 429 for rate limited
- : raised from 30/min → 200/min/IP
- : raised from 10/min → 20/min/IP
- Client: distinguishes 410 (expired) vs 429 (rate limited) in claim response; surfaces 429 from poll endpoint

### #10 — Registration form completion reveals QR without refresh

**Root cause:**  and  were sibling components receiving static  props from . Registration completion updated local state inside , but  never saw the change.  alone didn't propagate because  is a client component that receives  as server-fetched props — Next.js doesn't re-render a mounted client component with new props unless the parent server component's output tree changes.

**Changes:**
- Lifted completed-ticket state into  via a  map
-  calls  callback with the QR code on success
-  reads from an  prop for reactive status + QR
- Server  now returns  and calls 
- Survey title changes from 'Complete Registration' → 'Registration' when done

### #9 — Move EMT confirm from per-ticket (guest list) to per-order (sales tab)

**Changes:**
- New  — confirms all held e-Transfer tickets in an order atomically, sends one receipt + one ticket bundle email
- Extracted shared  helper into 
- Refactored existing  to use the shared helper and added a deprecation warning log
- Sales tab: added 'Confirm e-Transfer' button in Actions column for pending e-Transfer orders
- Guest list: removed per-ticket confirm button, replaced with muted 'Pending e-Transfer' badge

### #11 — Cross-tab 'you have unregistered tickets' prompt

**Changes:**
- Passed  into / so the EMT success state can check for pending registrations
- Shows an amber alert banner in  when the user has tickets requiring registration (from existing orders + newly purchased cart items)
- Opens registration in a new tab () so EMT instructions stay visible
- Persisted  in  so  doesn't wipe it if the component remounts

---

**Rate limit summary:**
| Endpoint | Old | New |
|----------|-----|-----|
| POST /api/onboard (send) | 5/min | unchanged |
| GET /api/onboard/verify | none | 60/min |
| GET /api/onboard/poll | 30/min | 200/min |
| POST /api/onboard/claim | 10/min | 20/min |