### PR TITLE
fix(events+auth): post-deploy follow-ups #3

### DIFF
--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -88,6 +88,34 @@ export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], 
     hasTicket ? 'my-tickets' : 'buy-tickets'
   );
 
+  // Issue #14: read hash on mount so external links / router.refresh can target a tab
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const hash = window.location.hash.replace('#', '');
+      if (hash === 'my-tickets' || hash === 'buy-tickets') {
+        setActiveTab(hash);
+      }
+    }
+  }, []);
+
+  const handleTabChange = (tab: 'my-tickets' | 'buy-tickets') => {
+    setActiveTab(tab);
+    if (typeof window !== 'undefined') {
+      window.location.hash = tab;
+    }
+  };
+
+  const handleJumpToMyTickets = () => {
+    handleTabChange('my-tickets');
+    // Scroll to the first pending registration row after the tab switch renders
+    setTimeout(() => {
+      const el = document.querySelector('[data-registration-pending]');
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }, 50);
+  };
+
   // If no tickets available at all
   if (tickets.length === 0) {
     return (
@@ -109,7 +137,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], 
       {/* Tabs */}
       <div className="flex gap-2 mb-6 border-b border-gray-200 dark:border-gray-700">
         <button
-          onClick={() => setActiveTab('my-tickets')}
+          onClick={() => handleTabChange('my-tickets')}
           className={`px-4 py-2 font-semibold transition-colors border-b-2 ${
             activeTab === 'my-tickets'
               ? 'border-orange-500 text-orange-500'
@@ -119,7 +147,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], 
           🎫 My Tickets
         </button>
         <button
-          onClick={() => setActiveTab('buy-tickets')}
+          onClick={() => handleTabChange('buy-tickets')}
           className={`px-4 py-2 font-semibold transition-colors border-b-2 ${
             activeTab === 'buy-tickets'
               ? 'border-orange-500 text-orange-500'
@@ -134,7 +162,7 @@ export function TicketsSection({ eventId, eventTitle, tickets, userOrders = [], 
       {activeTab === 'my-tickets' ? (
         <MyTicketsTab userOrders={userOrders} eventId={eventId} />
       ) : (
-        <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} userOrders={userOrders} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sessionContactEmail={sessionContactEmail} sellerConnected={sellerConnected} hasHiddenTiers={hasHiddenTiers} />
+        <PurchaseUI eventId={eventId} eventTitle={eventTitle} tickets={tickets} userOrders={userOrders} inviteToken={inviteToken} etransferEnabled={etransferEnabled} isAuthenticated={isAuthenticated} sessionEmail={sessionEmail} sessionContactEmail={sessionContactEmail} sellerConnected={sellerConnected} hasHiddenTiers={hasHiddenTiers} onJumpToMyTickets={handleJumpToMyTickets} />
       )}
     </div>
   );
@@ -205,7 +233,7 @@ function OrderCard({ order, eventId }: { order: UserOrder; eventId: string }) {
           DB misconfig (registrationFormId set on a type that shouldn't need it)
           doesn't force a form on the buyer. */}
       {order.tickets.filter(t => t.ticketType?.registrationFormId && t.registrationStatus !== 'not_required').map((ticket) => (
-        <div key={`reg-${ticket.id}`} className="mb-4">
+        <div key={`reg-${ticket.id}`} className="mb-4" data-registration-pending={ticket.registrationStatus === 'pending' ? 'true' : undefined}>
           <TicketRegistrationSurvey
             ticket={ticket}
             eventId={eventId}
@@ -430,7 +458,7 @@ function TicketFairReceipt({ settlement }: { settlement: FairSettlement }) {
   );
 }
 
-function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken, etransferEnabled = false, isAuthenticated = false, sessionEmail, sessionContactEmail, sellerConnected = true, hasHiddenTiers = false }: { eventId: string; eventTitle: string; tickets: TicketType[]; userOrders?: UserOrder[]; inviteToken?: string; etransferEnabled?: boolean; isAuthenticated?: boolean; sessionEmail?: string; sessionContactEmail?: string; sellerConnected?: boolean; hasHiddenTiers?: boolean }) {
+function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken, etransferEnabled = false, isAuthenticated = false, sessionEmail, sessionContactEmail, sellerConnected = true, hasHiddenTiers = false, onJumpToMyTickets }: { eventId: string; eventTitle: string; tickets: TicketType[]; userOrders?: UserOrder[]; inviteToken?: string; etransferEnabled?: boolean; isAuthenticated?: boolean; sessionEmail?: string; sessionContactEmail?: string; sellerConnected?: boolean; hasHiddenTiers?: boolean; onJumpToMyTickets?: () => void }) {
   const [unlockedTickets, setUnlockedTickets] = useState<TicketType[]>([]);
   const [unlockCode, setUnlockCode] = useState('');
   const [showUnlock, setShowUnlock] = useState(false);
@@ -612,6 +640,7 @@ function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken
           mixedCurrency={mixedCurrency}
           cartCurrencies={cartCurrencies}
           userOrders={userOrders}
+          onJumpToMyTickets={onJumpToMyTickets}
         />
       )}
 
@@ -673,9 +702,10 @@ interface UnifiedBarProps {
   onError: (msg: string) => void;
   mixedCurrency?: boolean;
   cartCurrencies?: string[];
+  onJumpToMyTickets?: () => void;
 }
 
-function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [] }: UnifiedBarProps & { userOrders?: UserOrder[] }) {
+function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [], onJumpToMyTickets }: UnifiedBarProps & { userOrders?: UserOrder[] }) {
   // Issue #11: count tickets needing registration across all user orders
   const pendingRegistrations = userOrders.flatMap(o =>
     o.tickets.filter(t => t.registrationStatus === 'pending' && t.ticketType?.registrationFormId)
@@ -1005,14 +1035,20 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
               <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
                 You have {totalPendingCount} ticket{totalPendingCount !== 1 ? 's' : ''} that need registration before the event.
               </p>
-              <a
-                href={`/${eventId}`}
-                target="_blank"
-                rel="noopener noreferrer"
+              <button
+                onClick={() => {
+                  if (onJumpToMyTickets) {
+                    onJumpToMyTickets();
+                  } else {
+                    // Fallback for non-tabbed contexts: set hash and reload
+                    window.location.hash = 'my-tickets';
+                    window.location.reload();
+                  }
+                }}
                 className="inline-block mt-1 text-xs font-semibold text-orange-500 hover:text-orange-600 hover:underline"
               >
                 Register now →
-              </a>
+              </button>
             </div>
           </div>
         )}

--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -554,11 +554,6 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
                   </td>
                   <td className="px-4 py-3 whitespace-nowrap">
                     <StatusBadge status={guest.status} paymentMethod={guest.paymentMethod} />
-                    {guest.status === 'held' && guest.paymentMethod === 'etransfer' && (
-                      <span className="mt-1 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
-                        Pending e-Transfer
-                      </span>
-                    )}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
                     {formatDate(guest.purchasedAt)}

--- a/apps/events/app/admin/[eventId]/sales-tab.tsx
+++ b/apps/events/app/admin/[eventId]/sales-tab.tsx
@@ -374,7 +374,7 @@ export function SalesTab({ eventId }: SalesTabProps) {
       {/* Sales table */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[800px]">
+          <table className="w-full">
             <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
                 <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
@@ -419,7 +419,7 @@ export function SalesTab({ eventId }: SalesTabProps) {
                         buyerEmail={sale.buyerEmail}
                       />
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap">
+                    <td className="px-4 py-3">
                       <span className="text-sm text-gray-700 dark:text-gray-300">
                         {sale.quantity}x {sale.ticketType} — {formatCurrency(sale.amountTotal, sale.currency)}
                       </span>

--- a/apps/events/app/api/checkout/etransfer/route.ts
+++ b/apps/events/app/api/checkout/etransfer/route.ts
@@ -124,10 +124,17 @@ export const POST = withLogger('events', async (request, { log }) => {
         if (!onboardRes.ok) {
           const errBody = await onboardRes.text().catch(() => '');
           log.error({ status: onboardRes.status, body: errBody }, 'Magic-link send failed');
-          return NextResponse.json(
-            { error: 'Could not send verification email. Please try again.' },
-            { status: 502 }
-          );
+          // Issue #13: pass through kernel status codes so the client can show
+          // accurate messages (e.g. 429 rate-limit, 410 gone).
+          const propagateStatus = onboardRes.status === 429 || onboardRes.status === 410
+            ? onboardRes.status
+            : 502;
+          let message = 'Could not send verification email. Please try again.';
+          try {
+            const parsed = JSON.parse(errBody);
+            if (parsed.error) message = parsed.error;
+          } catch { /* ignore parse failure, use generic */ }
+          return NextResponse.json({ error: message }, { status: propagateStatus });
         }
         const onboardData = await onboardRes.json();
         pollHandle = onboardData.pollHandle;

--- a/apps/events/app/api/checkout/etransfer/route.ts
+++ b/apps/events/app/api/checkout/etransfer/route.ts
@@ -326,6 +326,7 @@ export const POST = withLogger('events', async (request, { log }) => {
         paymentMethod: 'etransfer',
         status: 'pending',
         metadata: cart.length > 1 ? { cart } : {},
+        buyerEmail,
       })
       .returning();
 

--- a/apps/events/src/db/schema.ts
+++ b/apps/events/src/db/schema.ts
@@ -141,6 +141,8 @@ export const orders = eventsSchema.table('orders', {
   fairSettlement: jsonb('fair_settlement'),                  // resolved .fair receipt
   purchasedAt: timestamp('purchased_at', { withTimezone: true }),
   metadata: jsonb('metadata').default({}),
+  // SQL: ALTER TABLE events.orders ADD COLUMN IF NOT EXISTS buyer_email TEXT;
+  buyerEmail: text('buyer_email'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({
   eventIdx: index('idx_orders_event').on(table.eventId),

--- a/apps/events/src/lib/confirm-payment.ts
+++ b/apps/events/src/lib/confirm-payment.ts
@@ -104,6 +104,22 @@ export async function confirmHeldTickets(
         `;
         customerEmail = rows[0]?.contact_email ?? null;
         customerName = rows[0]?.name ?? null;
+
+        // Fallback 1: auth.credentials (email type, newest first)
+        if (!customerEmail) {
+          const credRows = await authSql<{ value: string }[]>`
+            SELECT value FROM auth.credentials
+            WHERE did = ${buyerDid} AND type = 'email'
+            ORDER BY created_at DESC LIMIT 1
+          `;
+          customerEmail = credRows[0]?.value ?? null;
+        }
+      }
+
+      // Fallback 2: orders.buyer_email (persists the email from checkout time)
+      if (!customerEmail && orderId) {
+        const orderRows = await db.select().from(orders).where(eq(orders.id, orderId)).limit(1);
+        customerEmail = orderRows[0]?.buyerEmail ?? null;
       }
 
       if (customerEmail) {
@@ -231,7 +247,7 @@ export async function confirmHeldTickets(
           }).catch((err) => log.error({ err: String(err) }, 'Ticket confirmation email failed'));
         }
       } else {
-        log.warn({ buyerDid }, 'No buyer email available on EMT confirm; skipping receipt + ticket emails');
+        log.warn({ buyerDid, orderId }, 'No buyer email available on EMT confirm; skipping receipt + ticket emails');
       }
     } catch (emailErr) {
       log.error({ err: String(emailErr) }, 'EMT confirm email block failed');


### PR DESCRIPTION
Follow-up to work order `memory/workorders/2026-05-10-events-followup-3.md`.

This batch addresses Issues #13, #14, #15, #16, #17 surfaced during live-testing of the deployed friction-pass batch (PRs #877, #878).

---

### #16 — Confirm e-Transfer button doesn't trigger receipt + ticket-confirmation emails
**Root cause:** Guest EMT buyers verify via magic link, creating a soft-DID identity. The `auth.identities.contact_email` backfill can fail silently (non-fatal catch block), leaving the identity row with a null email. When the admin later clicks Confirm e-Transfer, `confirm-payment.ts` queries only `contact_email` — gets null — logs a warning and skips all buyer emails.

**Fix:**
- Adds `buyer_email` column to `events.orders` (schema + migration SQL comment).
- Stores `buyerEmail` during e-Transfer checkout so the email persists with the order regardless of auth state.
- In `confirm-payment.ts`, falls back to `auth.credentials` (`type = 'email'`, newest first) when `contact_email` is null, then falls back to `orders.buyer_email`.
- This ensures the buyer always receives their receipt and QR-code email even if the soft-DID identity is incomplete.

### #14 — Cross-tab "Register now" prompt opens a new tab (and 404s)
**Root cause:** The EMT-done bar in `UnifiedCheckoutBar` used `<a href="/${eventId}" target="_blank">`. A fresh tab often 404s due to session/cookie sync race, and it breaks the in-place registration flow Ryan intended.

**Fix:**
- `TicketsSection` now reads `window.location.hash` on mount to set the active tab (`#my-tickets` or `#buy-tickets`).
- Tab switches update `window.location.hash`, so the choice survives `router.refresh()` and back/forward navigation.
- Replaced the external link with a button that calls `onJumpToMyTickets`, switching to the My Tickets tab and scrolling to the first pending registration row.
- Added `data-registration-pending` attribute to pending registration survey containers for scroll targeting.

### #13 — Events EMT route should pass through auth status codes
**Root cause:** When the kernel `/api/onboard` returns 429 (rate-limited), the events EMT route caught it as generic `!ok` and rewrote the response to 502 with a vague message. Buyers saw a server-failure message instead of knowing to wait and retry.

**Fix:**
- Propagates 429 and 410 status codes from the kernel back to the client.
- Passes through the kernel's error message body when present (JSON with `error` field); falls back to the generic message for other codes.
- The client already displays `response.error`, so 429 now surfaces as a clear rate-limit message.

### #17 — Guest list shows "pending e-Transfer" twice
**Root cause:** `StatusBadge` already special-cases `held + etransfer` to render an orange "pending e-Transfer" pill. The muted gray badge added below it in PR #878 was redundant.

**Fix:** Dropped the duplicate muted gray badge. The orange `StatusBadge` remains — consistent with the rest of the status column.

### #15 — Sales tab Confirm e-Transfer button hidden by horizontal scroll
**Status:** Incorporates the already-open PR #879 (`fix/sales-tab-wrap-tickets`) into this batch.
- Removed `min-w-[800px]` from the sales table.
- Dropped `whitespace-nowrap` on the Tickets cell so it can wrap.
- The Actions column (Confirm e-Transfer button) now stays in view without horizontal scroll.

---

**Build verification:** TypeScript compilation verified via file-level review; full `pnpm build` relies on CI (sandbox approval blocks long-running builds).