### PR TITLE
feat(.fair): v1.1 foundation — schema + signing + templates rewire (#890 #891 #892)

### DIFF
--- a/apps/kernel/app/media/api/assets/route.ts
+++ b/apps/kernel/app/media/api/assets/route.ts
@@ -10,6 +10,7 @@ import { eq, and, sql, isNull } from "drizzle-orm";
 import { classifyAsset } from "@/src/lib/media/classify";
 import { rateLimit, getClientIP } from "@/src/lib/kernel/rate-limit";
 import { createLogger } from "@imajin/logger";
+import { getDefaultManifest } from "@imajin/fair";
 
 const log = createLogger("kernel");
 
@@ -218,31 +219,11 @@ export async function POST(request: NextRequest) {
   } else {
     accessLevel = "private";
   }
-  const chainProof = identity.chainVerified
-    ? { verified: true, verifiedAt: new Date().toISOString() }
-    : undefined;
-  const fairManifest: Record<string, unknown> = {
-    fair: "1.0",
-    id: assetId,
-    type: mimeType,
-    owner: ownerDid,
-    created: new Date().toISOString(),
-    source: "upload",
-    access: { type: accessLevel },
-    attribution: [{ did: ownerDid, role: "creator", share: 1.0, ...(chainProof ? { chainProof } : {}) }],
-    distribution: {
-      reproduction: "reserved",
-      derivative: "reserved",
-      syndication: "reserved",
-    },
-    transfer: { allowed: false },
-    fees: [
-      { role: "protocol", name: "MJN", rateBps: 100, fixedCents: 0 },
-      { role: "node", name: "Node", rateBps: 50, fixedCents: 0 },
-      { role: "buyer_credit", name: "Buyer Credit", rateBps: 25, fixedCents: 0 },
-      { role: "scope", name: "Scope", rateBps: 25, fixedCents: 0 },
-    ],
-  };
+  // Build v1.1 manifest from templates (single source of truth)
+  const fairManifest = getDefaultManifest(mimeType, ownerDid);
+  fairManifest.id = assetId;
+  fairManifest.created = new Date().toISOString();
+  fairManifest.access = { type: accessLevel };
 
   try {
     await mkdir(dirPath, { recursive: true });

--- a/docs/audits/fair-v1.1-foundation.md
+++ b/docs/audits/fair-v1.1-foundation.md
@@ -1,0 +1,86 @@
+# .fair v1.1 Foundation Audit
+
+Repo: `packages/fair/src/`  
+Branch: `feat/fair-v1.1-foundation`  
+Date: 2026-05-10
+
+---
+
+## D1 — v1.1 schema + validator + canonical + upgradeToV1_1 (#890)
+
+### Existing files audited
+
+| File | What exists | Decision |
+|------|-------------|----------|
+| `types.ts` | `FairManifest` (v1.0), `FairEntry`, `FairFee`, `FairTransfer`, `FairAccess`, `FairIntegrity`, `FairIntent`, `FairSignature` | **Extend** — add `Money`, `DidShareList`, `FairDistributionRight`, `FairTraining`, `FairCommercial`, `Signature`, `SignedFairManifest`, `FairManifestV1_0`, `FairManifestV1_1`, union `FairManifest` |
+| `canonical.ts` | Private `canonicalize()` (sorted keys, no whitespace) + public `canonicalizeForSigning()` (strips signatures) | **Extend** — export generic `canonicalize(value): string`. Existing logic is already JCS-equivalent. No replacement needed. |
+| `validate.ts` | `validateManifest()` + `isValidManifest()` — v1.0 only. Share sum check only validates `≤ 1.0001`, not exact `1.0`. | **Extend** — add v1.1 validation path. Keep v1.0 path untouched. New return shape: `{ ok, errors[] }` (aligns with v1.1 convention while preserving old `{ valid, errors[] }` for v1.0). |
+| `create.ts` | `createManifest()` — emits v1.0 manifest | **Leave** — not in scope for D1-D3. Could extend later. |
+| `buildManifest.ts` | `buildFairManifest()` — fee-chain builder for settlements (v0.4.0) | **Leave** — separate concern from asset manifests. |
+| `agent-pricing.ts` | Agent pricing manifest types + calculator | **Leave** — separate concern. |
+| `constants.ts` | Fee constants | **Leave** — unchanged. |
+| `templates.ts` | `TemplateConfig` + `templates` record — UI section visibility flags, NOT manifest generators | **Surprise**: This file is UI-oriented (`sections: { attribution: boolean, ... }`). It does NOT have a `getDefaultManifest(mimeType, ownerDid)` function. D3 will need to add one alongside or repurpose this module. |
+
+### Key type decisions
+
+- `FairEntry.did` made **optional** (was required) so platform entries (no DID, just `name`) work in both v1.0 display code and v1.1 manifests. `DidShareEntry` is structurally identical to `FairEntry` — TypeScript structural typing makes them interchangeable, which keeps `FairAccordion` and `FairEditor` compiling without major rewrites.
+- `FairTransfer` and `FairTransferV1_1` both get each other's optional fields as **backward-compat padding** so the union's `.transfer` property doesn't break component code.
+- `FairManifestV1_0` keeps all original fields including `distributions?: FairEntry[]` (event splits) and `chain?: FairEntry[]` (alias).
+- `FairManifestV1_1` adds `distribution?: { reproduction?, streaming?, derivative?, syndication? }` (rights object) — note singular vs plural to avoid collision with v1.0 `distributions`.
+
+---
+
+## D2 — owner-signed manifest with ed25519 sign/verify (#891)
+
+### Existing files audited
+
+| File | What exists | Decision |
+|------|-------------|----------|
+| `sign.ts` | `signManifest(manifest, privateKeyHex, signerDid)`, `verifyManifest(manifest, resolvePublicKey)`, `platformSign()`, `verifyPlatformSignature()` — all use hex keys, hex signatures, old `FairSignature` shape (`algorithm`, `value`, `publicKeyRef`) | **Extend with overloads** — add new `signManifest(manifest, signer: { did, privateKey })` and `verifyManifest(signed, resolveKey)` that use new `Signature` shape (`signer`, `alg`, `value: base64url`, `signedAt`). Keep old functions intact. Use `@noble/ed25519` which is already a workspace dep. |
+
+### Crypto decisions
+
+- `@noble/ed25519` is already in `dependencies` (v2.3.0). No new deps needed.
+- Old API: keys/signatures are hex strings. New API: keys are `Uint8Array`, signature value is base64url.
+- Old `verifyManifest` returns `{ valid, error? }`. New returns `{ ok, reason? }`.
+- Function overloads distinguish old vs new by argument shape (arg count + types).
+- `canonicalizeForSigning()` from D1 used for both old and new signing paths.
+
+---
+
+## D3 — rewire media upload to use templates as source of truth (#892)
+
+### Existing files audited
+
+| File | What exists | Decision |
+|------|-------------|----------|
+| `templates.ts` | `TemplateConfig` with UI section flags + `templates` record. No `getDefaultManifest()`. | **Replace/extend** — repurpose `templates.ts` to also export `getDefaultManifest(mimeType: string, ownerDid: string): FairManifestV1_1`. The existing `TemplateConfig` and `templates` record stay for UI use. Add a new `defaultManifest.ts`-like behavior within `templates.ts` to keep exports centralized. |
+| `apps/kernel/app/media/api/assets/route.ts:224` | Hand-rolls v1.0 manifest JSON inline | **Replace** — call `getDefaultManifest(mimeType, ownerDid)` from `@imajin/fair`. Remove inline JSON. |
+
+### Default manifest decisions
+
+- `attribution`: `[{ did: ownerDid, role: 'creator', share: 0.99 }, { role: 'platform', name: 'Imajin', share: 0.01 }]`
+- `distribution`: all four rights (reproduction, streaming, derivative, syndication) with `mode: 'allowed'` or `'allow-with-attribution'` depending on type
+- `transfer`: `{ allowed: true, requiresAttribution: true, price: { amount: 100000, currency: 'USD' } }`
+- `training`: `{ allowed: false }` — headline primitive
+- `commercial`: `{ allowed: false, contactRequired: true }`
+- `fees`: same 2% cascade as today (protocol 1% + node 0.5% + buyer_credit 0.25% + scope 0.25%)
+- `tipping`: `{ enabled: true }`
+- Type-aware sub-defaults:
+  - `text/*` → `distribution.reproduction.quote = { maxPercent: 25, maxWords: 200 }`
+  - `image/*` → `distribution.derivative.mode = 'allow-with-attribution'`
+  - `audio/*` → `distribution.derivative.sampling = { allowed: 'allow-with-share', share: 0.05 }`, `distribution.derivative.sync = { allowed: 'reserved' }`
+  - `video/*` → `distribution.derivative.sync = { allowed: 'reserved' }`
+- `resaleRoyaltyBps`: 500 everywhere
+
+### Sanity check
+
+After D3, will `grep -rn "attribution:" apps/ packages/ | grep -iE "creator.*share|fair"` to find every other inline manifest constructor. Each one should use `getDefaultManifest()` or be documented as bespoke.
+
+---
+
+## No schema changes expected
+
+All `.fair` data lives in JSON columns (`assets.fairManifest`, `transactions.fairManifest`) or object storage (`.fair.json` sidecars). No drizzle schema migrations required.
+
+Verification: `bash scripts/check-schema-migration-sync.sh origin/main` should pass.

--- a/packages/fair/src/canonical.ts
+++ b/packages/fair/src/canonical.ts
@@ -2,9 +2,9 @@ import type { FairManifest } from './types';
 
 /**
  * Deterministic JSON canonicalization: sorted keys, no whitespace.
- * Used to produce the byte string that is signed/verified.
+ * Equivalent to RFC 8785 JCS — pure function, no I/O.
  */
-function canonicalize(value: unknown): string {
+export function canonicalize(value: unknown): string {
   if (value === null || typeof value !== 'object') {
     return JSON.stringify(value);
   }

--- a/packages/fair/src/index.ts
+++ b/packages/fair/src/index.ts
@@ -24,7 +24,7 @@ export type {
 export { isFairManifestV1_1 } from './types';
 
 export type { FairTemplate, TemplateConfig } from './templates';
-export { templates } from './templates';
+export { templates, getDefaultManifest } from './templates';
 
 export { validateManifest, isValidManifest } from './validate';
 export { createManifest } from './create';

--- a/packages/fair/src/index.ts
+++ b/packages/fair/src/index.ts
@@ -6,15 +6,27 @@ export type {
   FairIntegrity,
   FairIntent,
   FairManifest,
+  FairManifestV1_0,
+  FairManifestV1_1,
   FairSignature,
+  // v1.1 new types
+  Money,
+  DidShareEntry,
+  DidShareList,
+  FairDistributionRight,
+  FairTraining,
+  FairCommercial,
+  FairTransferV1_1,
+  FairAccessV1_1,
 } from './types';
+export { isFairManifestV1_1 } from './types';
 
 export type { FairTemplate, TemplateConfig } from './templates';
 export { templates } from './templates';
 
 export { validateManifest, isValidManifest } from './validate';
 export { createManifest } from './create';
-export { canonicalizeForSigning } from './canonical';
+export { canonicalize, canonicalizeForSigning } from './canonical';
 export { signManifest, verifyManifest, platformSign, verifyPlatformSignature } from './sign';
 export { FairAccordion } from './components/FairAccordion';
 export { FairEditor } from './components/FairEditor';
@@ -47,3 +59,5 @@ export type {
   AgentPricingManifest,
   AgentCostBreakdown,
 } from './agent-pricing';
+
+export { upgradeToV1_1 } from './upgrade';

--- a/packages/fair/src/index.ts
+++ b/packages/fair/src/index.ts
@@ -18,6 +18,8 @@ export type {
   FairCommercial,
   FairTransferV1_1,
   FairAccessV1_1,
+  Signature,
+  SignedFairManifest,
 } from './types';
 export { isFairManifestV1_1 } from './types';
 

--- a/packages/fair/src/sign.ts
+++ b/packages/fair/src/sign.ts
@@ -1,11 +1,19 @@
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha512';
 import { concatBytes } from '@noble/hashes/utils';
-import type { FairManifest, FairSignature } from './types';
+import type {
+  FairManifest,
+  FairManifestV1_1,
+  FairSignature,
+  SignedFairManifest,
+  Signature,
+} from './types';
 import { canonicalizeForSigning } from './canonical';
 
 // Provide synchronous sha512 so @noble/ed25519 works in all environments
 ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(concatBytes(...m));
+
+// ─── Hex helpers (v1.0) ────────────────────────────────────────────────────
 
 function hexToBytes(hex: string): Uint8Array {
   const bytes = new Uint8Array(hex.length / 2);
@@ -25,36 +33,131 @@ function messageBytes(manifest: FairManifest): Uint8Array {
   return new TextEncoder().encode(canonicalizeForSigning(manifest));
 }
 
-/** Sign a manifest as the creator/signer identified by signerDid. */
+// ─── Base64url helpers (v1.1) ──────────────────────────────────────────────
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  const bin = Array.from(bytes)
+    .map((b) => String.fromCharCode(b))
+    .join('');
+  const base64 = btoa(bin);
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToBytes(b64: string): Uint8Array {
+  const base64 = b64.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = base64.length % 4;
+  const padded = pad ? base64 + '='.repeat(4 - pad) : base64;
+  const bin = atob(padded);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) {
+    bytes[i] = bin.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ─── signManifest overloads ────────────────────────────────────────────────
+
+/** Sign a v1.1 manifest with a Uint8Array private key. */
+export async function signManifest(
+  manifest: FairManifestV1_1,
+  signer: { did: string; privateKey: Uint8Array },
+): Promise<SignedFairManifest>;
+
+/** Sign a manifest (v1.0 API) with a hex private key. */
 export async function signManifest(
   manifest: FairManifest,
   privateKeyHex: string,
   signerDid: string,
-): Promise<FairManifest> {
-  const privateKey = hexToBytes(privateKeyHex);
-  const msg = messageBytes(manifest);
-  const sigBytes = await ed.signAsync(msg, privateKey);
-  const signature: FairSignature = {
-    algorithm: 'ed25519',
-    value: bytesToHex(sigBytes),
-    publicKeyRef: signerDid,
+): Promise<FairManifest>;
+
+export async function signManifest(
+  manifest: FairManifest,
+  ...args: [string, string] | [{ did: string; privateKey: Uint8Array }]
+): Promise<FairManifest | SignedFairManifest> {
+  if (args.length === 2) {
+    // v1.0 path
+    const [privateKeyHex, signerDid] = args;
+    const privateKey = hexToBytes(privateKeyHex);
+    const msg = messageBytes(manifest);
+    const sigBytes = await ed.signAsync(msg, privateKey);
+    const signature: FairSignature = {
+      algorithm: 'ed25519',
+      value: bytesToHex(sigBytes),
+      publicKeyRef: signerDid,
+    };
+    return { ...manifest, signature };
+  }
+
+  // v1.1 path
+  const [signer] = args;
+  const stripped = { ...manifest };
+  delete (stripped as Record<string, unknown>).signature;
+  delete (stripped as Record<string, unknown>).platformSignature;
+
+  const msg = new TextEncoder().encode(canonicalizeForSigning(stripped));
+  const sigBytes = await ed.signAsync(msg, signer.privateKey);
+
+  const signature: Signature = {
+    signer: signer.did,
+    alg: 'ed25519',
+    value: bytesToBase64url(sigBytes),
+    signedAt: new Date().toISOString(),
   };
-  return { ...manifest, signature };
+
+  return { ...stripped, signature } as SignedFairManifest;
 }
 
-/** Verify the creator signature on a manifest. resolvePublicKey maps a DID to a hex public key. */
+// ─── verifyManifest overloads ──────────────────────────────────────────────
+
+/** Verify a v1.0 manifest signature. resolvePublicKey returns a hex string. */
 export async function verifyManifest(
   manifest: FairManifest,
   resolvePublicKey: (did: string) => Promise<string>,
-): Promise<{ valid: boolean; error?: string }> {
-  if (!manifest.signature) {
+): Promise<{ valid: boolean; error?: string }>;
+
+/** Verify a v1.1 signed manifest. resolveKey returns a Uint8Array. */
+export async function verifyManifest(
+  signed: SignedFairManifest,
+  resolveKey: (did: string) => Promise<Uint8Array>,
+): Promise<{ ok: boolean; reason?: string }>;
+
+export async function verifyManifest(
+  manifestOrSigned: FairManifest | SignedFairManifest,
+  resolver: ((did: string) => Promise<string>) | ((did: string) => Promise<Uint8Array>),
+): Promise<{ valid: boolean; error?: string } | { ok: boolean; reason?: string }> {
+  const manifest = manifestOrSigned as FairManifest;
+  const sig = manifest.signature;
+
+  if (!sig) {
     return { valid: false, error: 'No signature present' };
   }
+
+  // v1.1 signature has 'alg' field
+  if ('alg' in sig) {
+    const signed = manifestOrSigned as SignedFairManifest;
+    const v1_1Sig = sig as Signature;
+    if (v1_1Sig.alg !== 'ed25519') {
+      return { ok: false, reason: `Unsupported algorithm: ${v1_1Sig.alg}` };
+    }
+    try {
+      const publicKey = await (resolver as (did: string) => Promise<Uint8Array>)(v1_1Sig.signer);
+      const stripped = { ...signed };
+      delete (stripped as Record<string, unknown>).signature;
+      delete (stripped as Record<string, unknown>).platformSignature;
+      const msg = new TextEncoder().encode(canonicalizeForSigning(stripped as FairManifest));
+      const valid = await ed.verifyAsync(base64urlToBytes(v1_1Sig.value), msg, publicKey);
+      return valid ? { ok: true } : { ok: false, reason: 'Signature verification failed' };
+    } catch (err) {
+      return { ok: false, reason: err instanceof Error ? err.message : 'Verification error' };
+    }
+  }
+
+  // v1.0 path
+  const v1_0Sig = sig as FairSignature;
   try {
-    const { value, publicKeyRef } = manifest.signature;
-    const publicKeyHex = await resolvePublicKey(publicKeyRef);
+    const publicKeyHex = await (resolver as (did: string) => Promise<string>)(v1_0Sig.publicKeyRef);
     const valid = await ed.verifyAsync(
-      hexToBytes(value),
+      hexToBytes(v1_0Sig.value),
       messageBytes(manifest),
       hexToBytes(publicKeyHex),
     );
@@ -63,6 +166,8 @@ export async function verifyManifest(
     return { valid: false, error: err instanceof Error ? err.message : 'Verification error' };
   }
 }
+
+// ─── Platform sign/verify (v1.0 API, preserved) ────────────────────────────
 
 /** Endorse a manifest with a platform signature. */
 export async function platformSign(

--- a/packages/fair/src/templates.ts
+++ b/packages/fair/src/templates.ts
@@ -1,4 +1,4 @@
-import type { FairManifest } from './types';
+import type { FairManifestV1_1, FairDistributionRight, Money } from './types';
 
 export type FairTemplate = "media" | "ticket" | "course" | "module" | "document" | "custom";
 
@@ -14,7 +14,7 @@ export interface TemplateConfig {
     terms: boolean;
     distributions: boolean;
   };
-  defaults?: Partial<FairManifest>;
+  defaults?: Partial<FairManifestV1_1>;
 }
 
 export const templates: Record<FairTemplate, TemplateConfig> = {
@@ -31,7 +31,7 @@ export const templates: Record<FairTemplate, TemplateConfig> = {
       distributions: false,
     },
     defaults: {
-      transfer: { allowed: true, resaleRoyalty: 0.1 },
+      transfer: { allowed: true, requiresAttribution: true, price: { amount: 100000, currency: 'USD' }, resaleRoyaltyBps: 500 },
     },
   },
   ticket: {
@@ -47,7 +47,7 @@ export const templates: Record<FairTemplate, TemplateConfig> = {
       distributions: false,
     },
     defaults: {
-      transfer: { allowed: true, faceValueCap: true },
+      transfer: { allowed: true, faceValueCap: true, resaleRoyaltyBps: 500 },
     },
   },
   course: {
@@ -106,3 +106,89 @@ export const templates: Record<FairTemplate, TemplateConfig> = {
     },
   },
 };
+
+// ─── Default manifest builder (v1.1) ───────────────────────────────────────
+
+function mimeBucket(mimeType: string): 'text' | 'image' | 'audio' | 'video' | 'other' {
+  if (mimeType.startsWith('text/')) return 'text';
+  if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith('audio/')) return 'audio';
+  if (mimeType.startsWith('video/')) return 'video';
+  return 'other';
+}
+
+/**
+ * Build a default v1.1 .fair manifest for a newly-uploaded asset.
+ * This is the single source of truth for upload defaults.
+ *
+ * @param mimeType — e.g. "image/png", "audio/mpeg", "text/markdown"
+ * @param ownerDid — the uploader's DID
+ * @returns a complete FairManifestV1_1
+ */
+export function getDefaultManifest(mimeType: string, ownerDid: string): FairManifestV1_1 {
+  const bucket = mimeBucket(mimeType);
+  const now = new Date().toISOString();
+
+  const transferPrice: Money = { amount: 100000, currency: 'USD' };
+
+  const distribution: NonNullable<FairManifestV1_1['distribution']> = {
+    reproduction: { mode: 'allowed' },
+    streaming: { mode: 'allowed', price: { amount: 1, currency: 'USD' } },
+    derivative: { mode: 'allow-with-attribution' },
+    syndication: { mode: 'allow-with-attribution' },
+  };
+
+  if (bucket === 'text') {
+    distribution.reproduction = {
+      mode: 'quote-with-attribution',
+      quote: { maxPercent: 25, maxWords: 200 },
+    };
+  }
+
+  if (bucket === 'image') {
+    distribution.derivative = { mode: 'allow-with-attribution' };
+  }
+
+  if (bucket === 'audio') {
+    distribution.derivative = {
+      mode: 'allow-with-share',
+      sampling: { allowed: 'allow-with-share', share: 0.05 },
+      sync: { allowed: 'reserved' },
+    };
+  }
+
+  if (bucket === 'video') {
+    distribution.derivative = {
+      mode: 'allow-with-attribution',
+      sync: { allowed: 'reserved' },
+    };
+  }
+
+  const manifest: FairManifestV1_1 = {
+    fair: '1.1',
+    version: '1.1',
+    id: '', // caller fills this after asset ID is generated
+    type: mimeType,
+    owner: ownerDid,
+    created: now,
+    source: 'upload',
+    access: { type: 'private' },
+    attribution: [
+      { did: ownerDid, role: 'creator', share: 0.99 },
+      { role: 'platform', name: 'Imajin', share: 0.01 },
+    ],
+    distribution,
+    transfer: { allowed: true, requiresAttribution: true, price: transferPrice, resaleRoyaltyBps: 500 },
+    fees: [
+      { role: 'protocol', name: 'MJN', rateBps: 100, fixedCents: 0 },
+      { role: 'node', name: 'Node', rateBps: 50, fixedCents: 0 },
+      { role: 'buyer_credit', name: 'Buyer Credit', rateBps: 25, fixedCents: 0 },
+      { role: 'scope', name: 'Scope', rateBps: 25, fixedCents: 0 },
+    ],
+    training: { allowed: false },
+    commercial: { allowed: false, contactRequired: true },
+    tipping: { enabled: true },
+  };
+
+  return manifest;
+}

--- a/packages/fair/src/types.ts
+++ b/packages/fair/src/types.ts
@@ -1,3 +1,7 @@
+// ============================================================================
+// .fair v1.0 types (preserved — backward compatible)
+// ============================================================================
+
 export interface FairSignature {
   algorithm: 'ed25519';
   value: string; // 128 hex chars (64 bytes)
@@ -5,40 +9,45 @@ export interface FairSignature {
 }
 
 export interface FairEntry {
-  did: string;
-  role: string; // creator, collaborator, producer, performer, platform, venue, etc.
-  share: number; // 0.0 to 1.0
+  did?: string;
+  role: string;
+  share: number;
   note?: string;
-  chainProof?: {            // present when contributor has chain identity
-    verified: boolean;      // was chain verified at manifest creation time?
-    verifiedAt?: string;    // ISO timestamp
+  name?: string;
+  chainProof?: {
+    verified: boolean;
+    verifiedAt?: string;
   };
 }
 
 export interface FairFee {
-  role: string;        // 'processor', 'gas', etc.
-  name: string;        // 'Stripe', 'Solana', etc.
-  rateBps: number;     // basis points — upper estimate used for application_fee (370 = 3.7%)
-  minRateBps?: number; // basis points — minimum rate for display (290 = 2.9%)
-  fixedCents: number;  // per-transaction fixed cost in cents (30 = $0.30)
+  role: string;
+  name: string;
+  rateBps: number;
+  minRateBps?: number;
+  fixedCents: number;
 }
 
 export interface FairTransfer {
   allowed: boolean;
   refundable?: boolean;
-  resaleRoyalty?: number; // 0.0 to 1.0, royalty to original creator
-  faceValueCap?: boolean; // prevent scalping above face value
+  resaleRoyalty?: number;
+  faceValueCap?: boolean;
+  // v1.1 optional fields for union compatibility
+  requiresAttribution?: boolean;
+  price?: Money;
+  resaleRoyaltyBps?: number;
 }
 
 export interface FairAccess {
   type: "public" | "private" | "trust-graph" | "conversation";
-  allowedDids?: string[]; // for private access
-  conversationDid?: string; // for conversation-scoped access
+  allowedDids?: string[];
+  conversationDid?: string;
 }
 
 export interface FairIntegrity {
-  hash: string; // sha256:...
-  size: number; // bytes
+  hash: string;
+  size: number;
 }
 
 export interface FairIntent {
@@ -46,24 +55,135 @@ export interface FairIntent {
   constraints?: Record<string, unknown>;
 }
 
-export interface FairManifest {
-  fair: string; // version, e.g. "1.0"
-  id: string; // asset/event ID
-  type: string; // mime type or "event", "ticket", etc.
-  owner: string; // DID of owner
-  created: string; // ISO 8601
-  source?: string; // "upload", "create", etc.
+export interface FairManifestV1_0 {
+  fair: string; // "1.0"
+  id: string;
+  type: string;
+  owner: string;
+  created: string;
+  source?: string;
   access: FairAccess | "public" | "private";
   transfer?: FairTransfer;
   fees?: FairFee[];
   attribution: FairEntry[];
   distributions?: FairEntry[];
   integrity?: FairIntegrity;
-  terms?: string; // license URL or text
-  intent?: FairIntent; // stated purpose and optional constraints
-  signature?: FairSignature; // creator signature (required in Phase 1)
-  platformSignature?: FairSignature; // platform endorsement signature
-  // backward compat with existing events code
+  terms?: string;
+  intent?: FairIntent;
+  signature?: FairSignature;
+  platformSignature?: FairSignature;
   version?: string;
-  chain?: FairEntry[]; // alias for attribution
+  chain?: FairEntry[];
+}
+
+// ============================================================================
+// .fair v1.1 types (new)
+// ============================================================================
+
+export interface Money {
+  amount: number; // non-negative integer, minor units (cents)
+  currency: string; // ISO 4217 3-letter uppercase or 'MJNX'
+}
+
+export interface DidShareEntry {
+  did?: string;
+  role: string;
+  share: number;
+  name?: string;
+  note?: string;
+  chainProof?: {
+    verified: boolean;
+    verifiedAt?: string;
+  };
+}
+
+export type DidShareList = DidShareEntry[];
+
+export interface FairDistributionRight {
+  mode: string;
+  price?: Money;
+  splits?: DidShareList;
+  quote?: { maxPercent?: number; maxWords?: number };
+  sampling?: { allowed?: string; share?: number };
+  sync?: { allowed?: string };
+}
+
+export interface FairTraining {
+  allowed: boolean;
+  grants?: Array<{ purpose: string; scope?: string; expires?: string }>;
+}
+
+export interface FairCommercial {
+  allowed: boolean;
+  contactRequired?: boolean;
+}
+
+export interface FairTransferV1_1 {
+  allowed: boolean;
+  requiresAttribution?: boolean;
+  price?: Money;
+  resaleRoyaltyBps?: number;
+  // v1.0 backward compat padding
+  refundable?: boolean;
+  faceValueCap?: boolean;
+  resaleRoyalty?: number;
+}
+
+export interface FairAccessV1_1 {
+  type: "public" | "private" | "trust-graph" | "conversation";
+  allowedDids?: string[];
+  conversationDid?: string;
+}
+
+export interface Signature {
+  signer: string;
+  alg: 'ed25519';
+  value: string; // base64url
+  signedAt: string; // ISO 8601
+}
+
+export interface SignedFairManifest extends FairManifestV1_1 {
+  signature: Signature;
+}
+
+export interface FairManifestV1_1 {
+  fair: string; // "1.1"
+  version: '1.1';
+  id: string;
+  type: string;
+  owner: string;
+  created: string;
+  source?: string;
+  access: FairAccessV1_1 | "public" | "private";
+  transfer?: FairTransferV1_1;
+  fees?: FairFee[];
+  attribution: DidShareList;
+  distribution?: {
+    reproduction?: FairDistributionRight;
+    streaming?: FairDistributionRight;
+    derivative?: FairDistributionRight;
+    syndication?: FairDistributionRight;
+  };
+  training?: FairTraining;
+  commercial?: FairCommercial;
+  integrity?: FairIntegrity;
+  terms?: string;
+  intent?: FairIntent;
+  signature?: Signature;
+  tipping?: { enabled: boolean };
+  // backward compat aliases
+  distributions?: DidShareList;
+  chain?: DidShareList;
+  platformSignature?: FairSignature;
+}
+
+/** Union type — narrow with `'version' in m && m.version === '1.1'` */
+export type FairManifest = FairManifestV1_0 | FairManifestV1_1;
+
+// ============================================================================
+// Type guards
+// ============================================================================
+
+export function isFairManifestV1_1(m: FairManifest): m is FairManifestV1_1 {
+  return 'version' in m && m.version === '1.1';
 }

--- a/packages/fair/src/upgrade.ts
+++ b/packages/fair/src/upgrade.ts
@@ -1,0 +1,198 @@
+import type { FairManifestV1_0, FairManifestV1_1, FairDistributionRight, Money } from './types';
+
+const PLATFORM_DID = 'did:imajin:platform';
+
+function asDistributionRight(mode: string): FairDistributionRight {
+  return { mode };
+}
+
+function mimeBucket(mimeType: string): 'text' | 'image' | 'audio' | 'video' | 'other' {
+  if (mimeType.startsWith('text/')) return 'text';
+  if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith('audio/')) return 'audio';
+  if (mimeType.startsWith('video/')) return 'video';
+  return 'other';
+}
+
+function buildDefaults(mimeType: string): {
+  distribution: NonNullable<FairManifestV1_1['distribution']>;
+  transfer: NonNullable<FairManifestV1_1['transfer']>;
+  training: NonNullable<FairManifestV1_1['training']>;
+  commercial: NonNullable<FairManifestV1_1['commercial']>;
+  fees: NonNullable<FairManifestV1_1['fees']>;
+  tipping: NonNullable<FairManifestV1_1['tipping']>;
+} {
+  const bucket = mimeBucket(mimeType);
+
+  const transferPrice: Money = { amount: 100000, currency: 'USD' };
+
+  const distribution: NonNullable<FairManifestV1_1['distribution']> = {
+    reproduction: { mode: 'allowed' },
+    streaming: { mode: 'allowed', price: { amount: 1, currency: 'USD' } },
+    derivative: { mode: 'allow-with-attribution' },
+    syndication: { mode: 'allow-with-attribution' },
+  };
+
+  if (bucket === 'text') {
+    distribution.reproduction = {
+      mode: 'quote-with-attribution',
+      quote: { maxPercent: 25, maxWords: 200 },
+    };
+  }
+
+  if (bucket === 'image') {
+    distribution.derivative = { mode: 'allow-with-attribution' };
+  }
+
+  if (bucket === 'audio') {
+    distribution.derivative = {
+      mode: 'allow-with-share',
+      sampling: { allowed: 'allow-with-share', share: 0.05 },
+      sync: { allowed: 'reserved' },
+    };
+  }
+
+  if (bucket === 'video') {
+    distribution.derivative = {
+      mode: 'allow-with-attribution',
+      sync: { allowed: 'reserved' },
+    };
+  }
+
+  const fees: NonNullable<FairManifestV1_1['fees']> = [
+    { role: 'protocol', name: 'MJN', rateBps: 100, fixedCents: 0 },
+    { role: 'node', name: 'Node', rateBps: 50, fixedCents: 0 },
+    { role: 'buyer_credit', name: 'Buyer Credit', rateBps: 25, fixedCents: 0 },
+    { role: 'scope', name: 'Scope', rateBps: 25, fixedCents: 0 },
+  ];
+
+  return {
+    distribution,
+    transfer: { allowed: true, requiresAttribution: true, price: transferPrice, resaleRoyaltyBps: 500 },
+    training: { allowed: false },
+    commercial: { allowed: false, contactRequired: true },
+    fees,
+    tipping: { enabled: true },
+  };
+}
+
+/**
+ * Convert a DidShareList from v1.0 attribution/chain format.
+ * If the v1.0 attribution only has the owner, we apply the new 99/1 default.
+ * Otherwise we preserve all entries and normalize shares if they sum > 1.
+ */
+function convertAttribution(
+  v1_0: FairManifestV1_0,
+): FairManifestV1_1['attribution'] {
+  const entries = v1_0.attribution?.length ? v1_0.attribution : (v1_0.chain ?? []);
+
+  // If only a single creator entry with share=1.0, apply the new 99/1 default
+  if (
+    entries.length === 1 &&
+    entries[0].role === 'creator' &&
+    entries[0].share === 1.0
+  ) {
+    return [
+      { did: v1_0.owner, role: 'creator', share: 0.99 },
+      { role: 'platform', name: 'Imajin', share: 0.01 },
+    ];
+  }
+
+  // Otherwise preserve existing entries (they may not sum to 1.0, but that's user data)
+  return entries.map((e) => ({
+    did: e.did,
+    role: e.role,
+    share: e.share,
+    name: e.name,
+    note: e.note,
+    chainProof: e.chainProof,
+  }));
+}
+
+/**
+ * Convert v1.0 distribution strings to v1.1 distribution rights.
+ */
+function convertDistribution(
+  v1_0: FairManifestV1_0,
+): NonNullable<FairManifestV1_1['distribution']> {
+  const oldDist = v1_0.distribution as Record<string, string> | undefined;
+  const defaults = buildDefaults(v1_0.type);
+
+  const toRight = (key: string): FairDistributionRight => {
+    const mode = oldDist?.[key];
+    if (mode && typeof mode === 'string') {
+      return { mode };
+    }
+    return defaults.distribution[key as keyof typeof defaults.distribution] ?? { mode: 'reserved' };
+  };
+
+  return {
+    reproduction: toRight('reproduction'),
+    streaming: toRight('streaming'),
+    derivative: toRight('derivative'),
+    syndication: toRight('syndication'),
+  };
+}
+
+/**
+ * Upgrade a v1.0 manifest to v1.1.
+ * Idempotent: passing an already-v1.1 manifest returns it unchanged.
+ */
+export function upgradeToV1_1(manifest: FairManifestV1_0 | FairManifestV1_1): FairManifestV1_1 {
+  // Idempotency
+  if ('version' in manifest && manifest.version === '1.1') {
+    return manifest as FairManifestV1_1;
+  }
+
+  const v1_0 = manifest as FairManifestV1_0;
+  const defaults = buildDefaults(v1_0.type);
+
+  const upgraded: FairManifestV1_1 = {
+    fair: '1.1',
+    version: '1.1',
+    id: v1_0.id,
+    type: v1_0.type,
+    owner: v1_0.owner,
+    created: v1_0.created,
+    source: v1_0.source ?? 'upgrade',
+    access:
+      typeof v1_0.access === 'string'
+        ? v1_0.access
+        : { ...(v1_0.access ?? { type: 'private' }) },
+    attribution: convertAttribution(v1_0),
+    distribution: convertDistribution(v1_0),
+    transfer: v1_0.transfer
+      ? {
+          allowed: v1_0.transfer.allowed,
+          requiresAttribution: true,
+          price: defaults.transfer.price,
+          resaleRoyaltyBps: defaults.transfer.resaleRoyaltyBps,
+          refundable: v1_0.transfer.refundable,
+          faceValueCap: v1_0.transfer.faceValueCap,
+          resaleRoyalty: v1_0.transfer.resaleRoyalty,
+        }
+      : defaults.transfer,
+    fees: v1_0.fees ?? defaults.fees,
+    training: defaults.training,
+    commercial: defaults.commercial,
+    integrity: v1_0.integrity,
+    terms: v1_0.terms,
+    intent: v1_0.intent,
+    tipping: defaults.tipping,
+  };
+
+  // Apply type-aware overrides based on mimeType
+  const bucket = mimeBucket(v1_0.type);
+  if (bucket === 'text' && upgraded.distribution?.reproduction) {
+    upgraded.distribution.reproduction.quote = { maxPercent: 25, maxWords: 200 };
+  }
+  if (bucket === 'audio' && upgraded.distribution?.derivative) {
+    upgraded.distribution.derivative.sampling = { allowed: 'allow-with-share', share: 0.05 };
+    upgraded.distribution.derivative.sync = { allowed: 'reserved' };
+  }
+  if (bucket === 'video' && upgraded.distribution?.derivative) {
+    upgraded.distribution.derivative.sync = { allowed: 'reserved' };
+  }
+
+  return upgraded;
+}

--- a/packages/fair/src/validate.ts
+++ b/packages/fair/src/validate.ts
@@ -1,30 +1,195 @@
-import type { FairManifest } from "./types";
+import type { FairManifest, FairManifestV1_1, Money, DidShareList } from "./types";
 
-export function validateManifest(manifest: unknown): { valid: boolean; errors: string[] } {
+const SUM_TOLERANCE = 1e-6;
+
+function validateMoney(m: unknown, path: string): string[] {
+  const errors: string[] = [];
+  if (typeof m !== "object" || m === null) {
+    errors.push(`${path} must be an object`);
+    return errors;
+  }
+  const money = m as Record<string, unknown>;
+  if (typeof money.amount !== "number" || !Number.isInteger(money.amount) || money.amount < 0) {
+    errors.push(`${path}.amount must be a non-negative integer`);
+  }
+  if (typeof money.currency !== "string" || !money.currency) {
+    errors.push(`${path}.currency must be a non-empty string`);
+  } else {
+    const c = money.currency;
+    if (c !== 'MJNX' && !/^[A-Z]{3}$/.test(c)) {
+      errors.push(`${path}.currency must be ISO 4217 3-letter uppercase or 'MJNX'`);
+    }
+  }
+  return errors;
+}
+
+function validateDidShareList(list: unknown, path: string): string[] {
+  const errors: string[] = [];
+  if (!Array.isArray(list)) {
+    errors.push(`${path} must be an array`);
+    return errors;
+  }
+  if (list.length === 0) {
+    errors.push(`${path} must not be empty`);
+  }
+  let shareSum = 0;
+  for (let i = 0; i < list.length; i++) {
+    const entry = list[i] as Record<string, unknown>;
+    if (typeof entry.role !== "string" || !entry.role) {
+      errors.push(`${path}[${i}].role must be a non-empty string`);
+    }
+    if (typeof entry.share !== "number" || entry.share < 0 || entry.share > 1) {
+      errors.push(`${path}[${i}].share must be a number between 0 and 1`);
+    } else {
+      shareSum += entry.share;
+    }
+    if (entry.did !== undefined && (typeof entry.did !== "string" || !entry.did)) {
+      errors.push(`${path}[${i}].did must be a non-empty string when present`);
+    }
+    if (entry.name !== undefined && (typeof entry.name !== "string" || !entry.name)) {
+      errors.push(`${path}[${i}].name must be a non-empty string when present`);
+    }
+  }
+  if (Math.abs(shareSum - 1.0) > SUM_TOLERANCE) {
+    errors.push(`${path} shares sum to ${shareSum.toFixed(6)}, must be 1.0 (±${SUM_TOLERANCE})`);
+  }
+  return errors;
+}
+
+function validateDistributionRight(right: unknown, path: string): string[] {
+  const errors: string[] = [];
+  if (typeof right !== "object" || right === null) {
+    errors.push(`${path} must be an object`);
+    return errors;
+  }
+  const r = right as Record<string, unknown>;
+  if (typeof r.mode !== "string" || !r.mode) {
+    errors.push(`${path}.mode must be a non-empty string`);
+  }
+  if (r.price !== undefined) {
+    errors.push(...validateMoney(r.price, `${path}.price`));
+  }
+  if (r.splits !== undefined) {
+    errors.push(...validateDidShareList(r.splits, `${path}.splits`));
+  }
+  return errors;
+}
+
+function validateV1_1(manifest: Record<string, unknown>): string[] {
   const errors: string[] = [];
 
-  if (typeof manifest !== "object" || manifest === null) {
-    return { valid: false, errors: ["manifest must be an object"] };
-  }
-
-  const m = manifest as Record<string, unknown>;
-
   // Required fields
-  if (typeof m.fair !== "string" || !m.fair) errors.push("fair (version) is required");
-  if (typeof m.id !== "string" || !m.id) errors.push("id is required");
-  if (typeof m.type !== "string" || !m.type) errors.push("type is required");
-  if (typeof m.owner !== "string" || !m.owner) errors.push("owner (DID) is required");
-  if (typeof m.created !== "string" || !m.created) errors.push("created (ISO 8601) is required");
+  if (manifest.fair !== "1.1") errors.push("fair must be \"1.1\"");
+  if (typeof manifest.id !== "string" || !manifest.id) errors.push("id is required");
+  if (typeof manifest.type !== "string" || !manifest.type) errors.push("type is required");
+  if (typeof manifest.owner !== "string" || !manifest.owner) errors.push("owner (DID) is required");
+  if (typeof manifest.created !== "string" || !manifest.created) errors.push("created (ISO 8601) is required");
 
   // Access validation
-  if (m.access === undefined || m.access === null) {
+  if (manifest.access === undefined || manifest.access === null) {
     errors.push("access is required");
-  } else if (typeof m.access === "string") {
-    if (m.access !== "public" && m.access !== "private") {
+  } else if (typeof manifest.access === "string") {
+    if (manifest.access !== "public" && manifest.access !== "private") {
       errors.push('access string must be "public" or "private"');
     }
-  } else if (typeof m.access === "object") {
-    const access = m.access as Record<string, unknown>;
+  } else if (typeof manifest.access === "object") {
+    const access = manifest.access as Record<string, unknown>;
+    const validTypes = ["public", "private", "trust-graph", "conversation"];
+    if (!validTypes.includes(access.type as string)) {
+      errors.push('access.type must be "public", "private", "trust-graph", or "conversation"');
+    }
+    if (access.type === "conversation") {
+      if (typeof access.conversationDid !== "string" || !access.conversationDid) {
+        errors.push('access.conversationDid must be a non-empty string when access.type is "conversation"');
+      }
+    }
+    if (access.allowedDids !== undefined) {
+      if (!Array.isArray(access.allowedDids)) {
+        errors.push("access.allowedDids must be an array");
+      } else {
+        for (const did of access.allowedDids) {
+          if (typeof did !== "string" || !did) errors.push("each allowedDid must be a non-empty string");
+        }
+      }
+    }
+  } else {
+    errors.push("access must be a string or object");
+  }
+
+  // Attribution
+  errors.push(...validateDidShareList(manifest.attribution, "attribution"));
+
+  // Transfer
+  if (manifest.transfer !== undefined) {
+    const t = manifest.transfer as Record<string, unknown>;
+    if (typeof t.allowed !== "boolean") {
+      errors.push("transfer.allowed must be a boolean");
+    }
+    if (t.price !== undefined) {
+      errors.push(...validateMoney(t.price, "transfer.price"));
+    }
+    if (t.resaleRoyaltyBps !== undefined) {
+      if (typeof t.resaleRoyaltyBps !== "number" || t.resaleRoyaltyBps < 0 || t.resaleRoyaltyBps > 10000) {
+        errors.push("transfer.resaleRoyaltyBps must be a number between 0 and 10000");
+      }
+    }
+  }
+
+  // Distribution
+  if (manifest.distribution !== undefined) {
+    const d = manifest.distribution as Record<string, unknown>;
+    for (const key of ["reproduction", "streaming", "derivative", "syndication"] as const) {
+      if (d[key] !== undefined) {
+        errors.push(...validateDistributionRight(d[key], `distribution.${key}`));
+      }
+    }
+  }
+
+  // Training
+  if (manifest.training !== undefined) {
+    const training = manifest.training as Record<string, unknown>;
+    if (typeof training.allowed !== "boolean") {
+      errors.push("training.allowed must be explicitly boolean");
+    }
+  }
+
+  // Commercial
+  if (manifest.commercial !== undefined) {
+    const commercial = manifest.commercial as Record<string, unknown>;
+    if (typeof commercial.allowed !== "boolean") {
+      errors.push("commercial.allowed must be a boolean");
+    }
+  }
+
+  // Fees (optional)
+  if (manifest.fees !== undefined) {
+    if (!Array.isArray(manifest.fees)) {
+      errors.push("fees must be an array");
+    }
+  }
+
+  return errors;
+}
+
+function validateV1_0(manifest: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+
+  // Required fields
+  if (typeof manifest.fair !== "string" || !manifest.fair) errors.push("fair (version) is required");
+  if (typeof manifest.id !== "string" || !manifest.id) errors.push("id is required");
+  if (typeof manifest.type !== "string" || !manifest.type) errors.push("type is required");
+  if (typeof manifest.owner !== "string" || !manifest.owner) errors.push("owner (DID) is required");
+  if (typeof manifest.created !== "string" || !manifest.created) errors.push("created (ISO 8601) is required");
+
+  // Access validation
+  if (manifest.access === undefined || manifest.access === null) {
+    errors.push("access is required");
+  } else if (typeof manifest.access === "string") {
+    if (manifest.access !== "public" && manifest.access !== "private") {
+      errors.push('access string must be "public" or "private"');
+    }
+  } else if (typeof manifest.access === "object") {
+    const access = manifest.access as Record<string, unknown>;
     const validTypes = ["public", "private", "trust-graph", "conversation"];
     if (!validTypes.includes(access.type as string)) {
       errors.push('access.type must be "public", "private", "trust-graph", or "conversation"');
@@ -48,12 +213,12 @@ export function validateManifest(manifest: unknown): { valid: boolean; errors: s
   }
 
   // Attribution validation
-  if (!Array.isArray(m.attribution)) {
+  if (!Array.isArray(manifest.attribution)) {
     errors.push("attribution must be an array");
   } else {
     let shareSum = 0;
-    for (let i = 0; i < m.attribution.length; i++) {
-      const entry = m.attribution[i] as Record<string, unknown>;
+    for (let i = 0; i < manifest.attribution.length; i++) {
+      const entry = manifest.attribution[i] as Record<string, unknown>;
       if (typeof entry.did !== "string" || !entry.did) {
         errors.push(`attribution[${i}].did must be a non-empty string`);
       }
@@ -72,8 +237,8 @@ export function validateManifest(manifest: unknown): { valid: boolean; errors: s
   }
 
   // Transfer validation (optional)
-  if (m.transfer !== undefined) {
-    const t = m.transfer as Record<string, unknown>;
+  if (manifest.transfer !== undefined) {
+    const t = manifest.transfer as Record<string, unknown>;
     if (typeof t.allowed !== "boolean") {
       errors.push("transfer.allowed must be a boolean");
     }
@@ -86,8 +251,8 @@ export function validateManifest(manifest: unknown): { valid: boolean; errors: s
 
   // Signature validation (Phase 1 — validate structure when present)
   for (const field of ["signature", "platformSignature"] as const) {
-    if (m[field] !== undefined) {
-      const sig = m[field] as Record<string, unknown>;
+    if (manifest[field] !== undefined) {
+      const sig = manifest[field] as Record<string, unknown>;
       if (typeof sig !== "object" || sig === null) {
         errors.push(`${field} must be an object`);
       } else {
@@ -105,16 +270,28 @@ export function validateManifest(manifest: unknown): { valid: boolean; errors: s
   }
 
   // Intent validation (optional)
-  if (m.intent !== undefined) {
-    const intent = m.intent as Record<string, unknown>;
+  if (manifest.intent !== undefined) {
+    const intent = manifest.intent as Record<string, unknown>;
     if (typeof intent.purpose !== "string" || !intent.purpose) {
       errors.push("intent.purpose must be a non-empty string");
     }
   }
 
-  return { valid: errors.length === 0, errors };
+  return errors;
+}
+
+export function validateManifest(manifest: unknown): { ok: boolean; valid: boolean; errors: string[] } {
+  if (typeof manifest !== "object" || manifest === null) {
+    return { ok: false, valid: false, errors: ["manifest must be an object"] };
+  }
+
+  const m = manifest as Record<string, unknown>;
+  const isV1_1 = m.fair === "1.1" || m.version === "1.1";
+  const errors = isV1_1 ? validateV1_1(m) : validateV1_0(m);
+  const ok = errors.length === 0;
+  return { ok, valid: ok, errors };
 }
 
 export function isValidManifest(manifest: unknown): manifest is FairManifest {
-  return validateManifest(manifest).valid;
+  return validateManifest(manifest).ok;
 }

--- a/packages/fair/tests/v1_1.test.ts
+++ b/packages/fair/tests/v1_1.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalize,
+  validateManifest,
+  isValidManifest,
+  upgradeToV1_1,
+  getDefaultManifest,
+  signManifest,
+  verifyManifest,
+} from '../src';
+import type { FairManifestV1_1, SignedFairManifest } from '../src';
+import * as ed from '@noble/ed25519';
+
+// ─── Deterministic test keys ────────────────────────────────────────────────
+
+async function generateTestKeypair(): Promise<{ privateKey: Uint8Array; publicKey: Uint8Array; did: string }> {
+  const privateKey = ed.utils.randomPrivateKey();
+  const publicKey = await ed.getPublicKeyAsync(privateKey);
+  return { privateKey, publicKey, did: `did:imajin:${Array.from(publicKey).map(b => b.toString(16).padStart(2, '0')).join('').slice(0, 32)}` };
+}
+
+function makeValidV1_1(overrides?: Partial<FairManifestV1_1>): FairManifestV1_1 {
+  return {
+    fair: '1.1',
+    version: '1.1',
+    id: 'asset_test123',
+    type: 'image/png',
+    owner: 'did:imajin:owner123',
+    created: new Date().toISOString(),
+    access: { type: 'public' },
+    attribution: [
+      { did: 'did:imajin:owner123', role: 'creator', share: 0.99 },
+      { role: 'platform', name: 'Imajin', share: 0.01 },
+    ],
+    distribution: {
+      reproduction: { mode: 'allowed' },
+      streaming: { mode: 'allowed', price: { amount: 1, currency: 'USD' } },
+      derivative: { mode: 'allow-with-attribution' },
+      syndication: { mode: 'allow-with-attribution' },
+    },
+    transfer: { allowed: true, requiresAttribution: true, price: { amount: 100000, currency: 'USD' }, resaleRoyaltyBps: 500 },
+    fees: [
+      { role: 'protocol', name: 'MJN', rateBps: 100, fixedCents: 0 },
+      { role: 'node', name: 'Node', rateBps: 50, fixedCents: 0 },
+      { role: 'buyer_credit', name: 'Buyer Credit', rateBps: 25, fixedCents: 0 },
+      { role: 'scope', name: 'Scope', rateBps: 25, fixedCents: 0 },
+    ],
+    training: { allowed: false },
+    commercial: { allowed: false, contactRequired: true },
+    tipping: { enabled: true },
+    ...overrides,
+  };
+}
+
+// ─── D1: canonicalize ───────────────────────────────────────────────────────
+
+describe('canonicalize', () => {
+  it('produces the same output for the same input', () => {
+    const obj = { b: 2, a: 1 };
+    expect(canonicalize(obj)).toBe(canonicalize(obj));
+  });
+
+  it('is invariant to key ordering', () => {
+    const a = { z: 1, a: 2, m: { c: 3, b: 4 } };
+    const b = { a: 2, m: { b: 4, c: 3 }, z: 1 };
+    expect(canonicalize(a)).toBe(canonicalize(b));
+  });
+
+  it('produces no whitespace', () => {
+    const obj = { a: 1, b: [2, 3] };
+    const out = canonicalize(obj);
+    expect(out).not.toMatch(/\s/);
+  });
+
+  it('handles null and nested objects', () => {
+    const obj = { a: null, b: { c: true, d: 'hello' } };
+    expect(canonicalize(obj)).toBe('{"a":null,"b":{"c":true,"d":"hello"}}');
+  });
+});
+
+// ─── D1: validateManifest (v1.1) ────────────────────────────────────────────
+
+describe('validateManifest v1.1', () => {
+  it('validates a correct manifest', () => {
+    const manifest = makeValidV1_1();
+    const result = validateManifest(manifest);
+    expect(result.ok).toBe(true);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('isValidManifest type guard returns true', () => {
+    expect(isValidManifest(makeValidV1_1())).toBe(true);
+  });
+
+  it('fails when fair is not 1.1', () => {
+    const result = validateManifest(makeValidV1_1({ fair: '1.0' }));
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('fair'))).toBe(true);
+  });
+
+  it('fails when attribution shares do not sum to 1.0', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        attribution: [
+          { did: 'did:imajin:owner', role: 'creator', share: 0.5 },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('sum'))).toBe(true);
+  });
+
+  it('accepts shares that sum to 1.0 within tolerance', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        attribution: [
+          { did: 'did:imajin:owner', role: 'creator', share: 0.333333 },
+          { did: 'did:imajin:collab', role: 'collaborator', share: 0.333333 },
+          { role: 'platform', name: 'Imajin', share: 0.333334 },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails when Money.amount is negative', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        transfer: { allowed: true, price: { amount: -1, currency: 'USD' } },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('amount'))).toBe(true);
+  });
+
+  it('fails when Money.amount is not an integer', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        transfer: { allowed: true, price: { amount: 10.5, currency: 'USD' } },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('integer'))).toBe(true);
+  });
+
+  it('fails when Money.currency is invalid', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        transfer: { allowed: true, price: { amount: 100, currency: 'usd' } },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('currency'))).toBe(true);
+  });
+
+  it('accepts MJNX as currency', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        transfer: { allowed: true, price: { amount: 100, currency: 'MJNX' } },
+      }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails when training.allowed is not boolean', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        training: { allowed: 'false' as unknown as boolean },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('training.allowed'))).toBe(true);
+  });
+
+  it('fails when distribution mode is empty', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        distribution: {
+          reproduction: { mode: '' },
+        },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('mode'))).toBe(true);
+  });
+
+  it('validates distribution splits sum to 1.0', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        distribution: {
+          reproduction: {
+            mode: 'allowed',
+            splits: [
+              { did: 'did:imajin:a', role: 'creator', share: 0.6 },
+              { did: 'did:imajin:b', role: 'platform', share: 0.3 },
+            ],
+          },
+        },
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('sum'))).toBe(true);
+  });
+});
+
+// ─── D1: upgradeToV1_1 ──────────────────────────────────────────────────────
+
+describe('upgradeToV1_1', () => {
+  it('is idempotent on already-v1.1 input', () => {
+    const v1_1 = makeValidV1_1();
+    const result = upgradeToV1_1(v1_1);
+    expect(result).toBe(v1_1);
+  });
+
+  it('upgrades a minimal v1.0 manifest', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'image/png',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: { type: 'public' },
+      attribution: [{ did: 'did:imajin:owner', role: 'creator', share: 1.0 }],
+      transfer: { allowed: false },
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    expect(result.version).toBe('1.1');
+    expect(result.attribution).toHaveLength(2);
+    expect(result.attribution[0].share).toBe(0.99);
+    expect(result.attribution[1].share).toBe(0.01);
+    expect(result.training?.allowed).toBe(false);
+    expect(result.commercial?.allowed).toBe(false);
+    expect(result.distribution?.reproduction?.mode).toBe('allowed');
+  });
+
+  it('preserves existing multi-party attribution', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'image/png',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: { type: 'public' },
+      attribution: [
+        { did: 'did:imajin:a', role: 'creator', share: 0.7 },
+        { did: 'did:imajin:b', role: 'collaborator', share: 0.3 },
+      ],
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    expect(result.attribution).toHaveLength(2);
+    expect(result.attribution[0].share).toBe(0.7);
+    expect(result.attribution[1].share).toBe(0.3);
+  });
+
+  it('applies text-aware defaults for text/*', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'text/markdown',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: 'public',
+      attribution: [{ did: 'did:imajin:owner', role: 'creator', share: 1.0 }],
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    expect(result.distribution?.reproduction?.quote?.maxPercent).toBe(25);
+    expect(result.distribution?.reproduction?.quote?.maxWords).toBe(200);
+  });
+
+  it('applies audio-aware defaults for audio/*', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'audio/mpeg',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: 'public',
+      attribution: [{ did: 'did:imajin:owner', role: 'creator', share: 1.0 }],
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    expect(result.distribution?.derivative?.sampling?.allowed).toBe('allow-with-share');
+    expect(result.distribution?.derivative?.sampling?.share).toBe(0.05);
+    expect(result.distribution?.derivative?.sync?.allowed).toBe('reserved');
+  });
+
+  it('applies video-aware defaults for video/*', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'video/mp4',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: 'public',
+      attribution: [{ did: 'did:imajin:owner', role: 'creator', share: 1.0 }],
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    expect(result.distribution?.derivative?.sync?.allowed).toBe('reserved');
+  });
+});
+
+// ─── D2: sign/verify ────────────────────────────────────────────────────────
+
+describe('signManifest / verifyManifest v1.1', () => {
+  it('round-trips sign → verify successfully', async () => {
+    const { privateKey, publicKey, did } = await generateTestKeypair();
+    const manifest = makeValidV1_1();
+    const signed = await signManifest(manifest, { did, privateKey });
+
+    expect(signed.signature).toBeDefined();
+    expect(signed.signature.alg).toBe('ed25519');
+    expect(signed.signature.signer).toBe(did);
+    expect(signed.signature.signedAt).toBeTruthy();
+
+    const result = await verifyManifest(signed, async () => publicKey);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('fails verification after tampering', async () => {
+    const { privateKey, publicKey, did } = await generateTestKeypair();
+    const manifest = makeValidV1_1();
+    const signed = await signManifest(manifest, { did, privateKey });
+
+    signed.owner = 'did:imajin:attacker';
+
+    const result = await verifyManifest(signed, async () => publicKey);
+    expect(result).toEqual({ ok: false, reason: 'Signature verification failed' });
+  });
+
+  it('fails verification with wrong key', async () => {
+    const { privateKey, did } = await generateTestKeypair();
+    const wrongKeypair = await generateTestKeypair();
+    const manifest = makeValidV1_1();
+    const signed = await signManifest(manifest, { did, privateKey });
+
+    const result = await verifyManifest(signed, async () => wrongKeypair.publicKey);
+    expect(result).toEqual({ ok: false, reason: 'Signature verification failed' });
+  });
+
+  it('fails verification when signature is missing', async () => {
+    const manifest = makeValidV1_1();
+    const result = await verifyManifest(manifest as SignedFairManifest, async () => new Uint8Array(32));
+    expect('valid' in result && result.valid === false).toBe(true);
+  });
+});
+
+// ─── D3: getDefaultManifest ─────────────────────────────────────────────────
+
+describe('getDefaultManifest', () => {
+  it('produces a valid v1.1 manifest for image/*', () => {
+    const manifest = getDefaultManifest('image/png', 'did:imajin:owner');
+    manifest.id = 'asset_img_001';
+    const result = validateManifest(manifest);
+    expect(result.ok).toBe(true);
+    expect(manifest.version).toBe('1.1');
+    expect(manifest.training?.allowed).toBe(false);
+  });
+
+  it('produces a valid v1.1 manifest for text/*', () => {
+    const manifest = getDefaultManifest('text/markdown', 'did:imajin:owner');
+    manifest.id = 'asset_txt_001';
+    const result = validateManifest(manifest);
+    expect(result.ok).toBe(true);
+    expect(manifest.distribution?.reproduction?.quote?.maxPercent).toBe(25);
+    expect(manifest.distribution?.reproduction?.quote?.maxWords).toBe(200);
+  });
+
+  it('produces a valid v1.1 manifest for audio/*', () => {
+    const manifest = getDefaultManifest('audio/mpeg', 'did:imajin:owner');
+    manifest.id = 'asset_aud_001';
+    const result = validateManifest(manifest);
+    expect(result.ok).toBe(true);
+    expect(manifest.distribution?.derivative?.sampling?.allowed).toBe('allow-with-share');
+    expect(manifest.distribution?.derivative?.sync?.allowed).toBe('reserved');
+  });
+
+  it('produces a valid v1.1 manifest for video/*', () => {
+    const manifest = getDefaultManifest('video/mp4', 'did:imajin:owner');
+    manifest.id = 'asset_vid_001';
+    const result = validateManifest(manifest);
+    expect(result.ok).toBe(true);
+    expect(manifest.distribution?.derivative?.sync?.allowed).toBe('reserved');
+  });
+
+  it('has attribution shares summing to 1.0', () => {
+    const manifest = getDefaultManifest('image/png', 'did:imajin:owner');
+    const sum = manifest.attribution.reduce((s, e) => s + e.share, 0);
+    expect(sum).toBeCloseTo(1, 10);
+  });
+
+  it('has training.allowed === false everywhere', () => {
+    for (const mime of ['image/png', 'text/plain', 'audio/mpeg', 'video/mp4', 'application/pdf']) {
+      const manifest = getDefaultManifest(mime, 'did:imajin:owner');
+      expect(manifest.training?.allowed).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #890
Closes #891
Closes #892

Parent #881 stays open — UI work (D4 #893) and upgrade button (D5 #894) follow in separate PRs.

## What each commit shipped

### Commit 1 — `feat(fair): D1 v1.1 schema + validator + canonical + upgradeToV1_1 (#890)`
- **Types** (`packages/fair/src/types.ts`): `DidShareList`, `Money`, `FairDistributionRight`, `FairTraining`, `FairCommercial`, `FairManifestV1_1`, union `FairManifest = FairManifestV1_0 | FairManifestV1_1`, `isFairManifestV1_1()` type guard. `FairEntry.did` made optional so platform entries (no DID, just `name`) compile across both versions.
- **Canonicalize** (`packages/fair/src/canonical.ts`): exported generic `canonicalize(value): string`. Existing private function was already JCS-equivalent (sorted keys, no whitespace) — no replacement needed.
- **Validator** (`packages/fair/src/validate.ts`): `validateManifest()` now dispatches v1.0 vs v1.1 based on `fair`/`version` field. v1.1 rules: DidShareList sums to 1.0 (±1e-6), `Money.amount` non-negative integer, `training.allowed` explicitly boolean, distribution modes validated, splits sum-checked. Returns `{ ok, valid, errors }` for backward compat with existing `{ valid, errors }` consumers.
- **Upgrade** (`packages/fair/src/upgrade.ts`): `upgradeToV1_1()` preserves explicit values, fills v1.1 defaults (training: false, commercial: contact-required, 99/1 attribution, distribution-friendly rights). Idempotent on already-v1.1 input. Type-aware defaults per mimeType bucket (text quote limits, audio sampling/sync, video sync).
- **Tests** (`packages/fair/tests/v1_1.test.ts`): validator positive+negative, canonical determinism, upgrade idempotency + per-bucket defaults.
- **Audit doc** (`docs/audits/fair-v1.1-foundation.md`): documents what existed vs what was added.

### Commit 2 — `feat(fair): D2 owner-signed manifest with ed25519 sign/verify (#891)`
- **signManifest** / **verifyManifest** (`packages/fair/src/sign.ts`): added v1.1 overloads using `Uint8Array` keys and base64url signatures, new `Signature` shape (`signer`, `alg`, `value`, `signedAt`). Old hex-based v1.0 API preserved via function overloads (distinguished by arg count / resolver return type). `@noble/ed25519` was already a workspace dep — no new deps added.
- **Types** (`packages/fair/src/types.ts`): `Signature`, `SignedFairManifest`.
- **Tests**: round-trip sign→verify ok, tamper→fail, wrong-key→fail, missing-signature→fail.

### Commit 3 — `feat(fair): D3 rewire media upload to use templates as source of truth (#892)`
- **Templates** (`packages/fair/src/templates.ts`): repurposed to export `getDefaultManifest(mimeType, ownerDid): FairManifestV1_1`. Existing `TemplateConfig` / `templates` record kept for UI use. Defaults: 99/1 attribution, distribution-friendly rights, training opt-out (`allowed: false`), commercial gated, resale royalty 5%, tipping enabled. Type-aware sub-defaults per mimeType bucket.
- **Upload route** (`apps/kernel/app/media/api/assets/route.ts`): replaced inline hand-rolled v1.0 JSON with `getDefaultManifest(mimeType, ownerDid)` call. New uploads get v1.1 manifests automatically.
- **Existing assets unchanged** — no retroactive migration. This is explicit per #881.
- **Tests**: each mimeType bucket produces a valid v1.1 manifest (passes validator), attribution sums to 1.0, `training.allowed === false` everywhere.

## Verification steps

1. Upload a new test asset on dev (any MIME type).
2. Inspect its `.fair` manifest (either via DB `assets.fairManifest` or the `.fair.json` sidecar on disk).
3. Confirm it has:
   - `fair: "1.1"` and `version: "1.1"`
   - `training.allowed: false`
   - `distribution: { reproduction, streaming, derivative, syndication }` with object-shaped rights
   - `attribution` with 99% creator + 1% platform

## Decisions made during audit

- Extended `canonical.ts` rather than replacing — existing logic was already JCS-compliant.
- `templates.ts` was UI-oriented (section visibility flags), not a manifest generator. Added `getDefaultManifest()` alongside rather than replacing the existing `TemplateConfig` system.
- Found one other inline manifest constructor (`apps/kernel/app/media/api/seed/presence/route.ts`) — it's a seed/dev route and remains bespoke by design.
- `create.ts` still emits v1.0 manifests — not in scope for this PR, can be upgraded later.

## Schema changes

None. `.fair` lives in JSON columns / object storage. `scripts/check-schema-migration-sync.sh origin/main` passes.
