### PR TITLE
feat(.fair + dfos): sidecar delivery + DFOS federation anchor (#882)

### DIFF
--- a/apps/kernel/app/media/api/assets/[id]/fair/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/fair/route.ts
@@ -161,6 +161,10 @@ export async function PUT(
     .set({ fairManifest: manifest as unknown as Record<string, unknown> })
     .where(eq(assets.id, id));
 
+  // TODO(#894): On manual manifest upgrade, re-sign and re-publish to DFOS
+  // if the signature changes. Wire up publishContentEvent + update
+  // assets.fair_dfos_event_id when D5 ships.
+
   // Update sidecar file if it exists
   if (asset.fairPath) {
     try {

--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readFile, unlink, rename, stat, open } from "fs/promises";
 import path from "path";
+import { createHash } from "crypto";
 import { db, assets } from "@/src/db";
 import { requireAuth } from "@imajin/auth";
 import { eq } from "drizzle-orm";
 import { createReadStream } from "fs";
 import type { FairManifest } from "@imajin/fair";
+import { canonicalize } from "@imajin/fair";
 import { createLogger } from "@imajin/logger";
 
 const log = createLogger("kernel");
@@ -80,6 +82,27 @@ function getAllowedDids(access: FairManifest["access"]): string[] {
   return access.allowedDids ?? [];
 }
 
+/** Build .fair sidecar headers for an asset response */
+function buildFairHeaders(
+  assetId: string,
+  manifest: FairManifest | null,
+  dfosEventId: string | null,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  headers["Link"] = `</media/api/assets/${assetId}/fair>; rel="fair"; type="application/fair+json"`;
+
+  if (manifest) {
+    const digest = createHash("sha256").update(canonicalize(manifest)).digest("hex");
+    headers["X-Fair-Digest"] = `sha256:${digest}`;
+  }
+
+  if (dfosEventId) {
+    headers["X-Fair-Dfos"] = `dfos:event:${dfosEventId}`;
+  }
+
+  return headers;
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/assets/[id] — serve asset file with .fair access control
 // ---------------------------------------------------------------------------
@@ -126,6 +149,9 @@ export async function GET(
 
   const access = manifest?.access ?? "private";
   const accessType = getAccessType(access);
+
+  // 2b. Compute .fair sidecar headers (used for both full and Range responses)
+  const fairHeaders = buildFairHeaders(id, manifest, asset.fairDfosEventId ?? null);
 
   // 3. Access control
   if (accessType !== "public") {
@@ -243,6 +269,7 @@ export async function GET(
       "X-Variants": JSON.stringify(variants),
       "X-Transcoding": JSON.stringify(transcoding),
       "Cache-Control": cacheControl,
+      ...fairHeaders,
     });
   }
 
@@ -252,6 +279,11 @@ export async function GET(
     headers.set("Cache-Control", isResized ? "public, max-age=3600" : "public, max-age=86400");
   } else {
     headers.set("Cache-Control", "private, max-age=3600");
+  }
+
+  // Add .fair sidecar headers
+  for (const [k, v] of Object.entries(fairHeaders)) {
+    headers.set(k, v);
   }
 
   headers.set("Content-Length", String(outputBuffer.length));

--- a/apps/kernel/app/media/api/assets/route.ts
+++ b/apps/kernel/app/media/api/assets/route.ts
@@ -10,7 +10,9 @@ import { eq, and, sql, isNull } from "drizzle-orm";
 import { classifyAsset } from "@/src/lib/media/classify";
 import { rateLimit, getClientIP } from "@/src/lib/kernel/rate-limit";
 import { createLogger } from "@imajin/logger";
-import { getDefaultManifest } from "@imajin/fair";
+import { getDefaultManifest, signManifest, canonicalize } from "@imajin/fair";
+import { publishContentEvent } from "@imajin/dfos";
+import { hexToBytes } from "@imajin/auth";
 
 const log = createLogger("kernel");
 
@@ -225,10 +227,25 @@ export async function POST(request: NextRequest) {
   fairManifest.created = new Date().toISOString();
   fairManifest.access = { type: accessLevel };
 
+  // Sign the manifest with the platform key
+  const platformDid = process.env.PLATFORM_DID;
+  const platformKeyHex = process.env.AUTH_PRIVATE_KEY;
+  let signedManifest = fairManifest;
+  if (platformDid && platformKeyHex) {
+    try {
+      signedManifest = await signManifest(
+        fairManifest,
+        { did: platformDid, privateKey: hexToBytes(platformKeyHex) }
+      );
+    } catch (err) {
+      log.warn({ err: String(err) }, "Manifest signing failed, using unsigned manifest");
+    }
+  }
+
   try {
     await mkdir(dirPath, { recursive: true });
     await writeFile(storagePath, buffer);
-    await writeFile(fairPath, JSON.stringify(fairManifest, null, 2));
+    await writeFile(fairPath, JSON.stringify(signedManifest, null, 2));
   } catch (err) {
     log.error({ err: String(err) }, "Storage write failed");
     return NextResponse.json(
@@ -250,7 +267,7 @@ export async function POST(request: NextRequest) {
         size: file.size,
         storagePath,
         hash,
-        fairManifest,
+        fairManifest: signedManifest,
         fairPath,
         status: "active",
         metadata: context ? { context } : {},
@@ -262,6 +279,32 @@ export async function POST(request: NextRequest) {
       { error: "Database failure", detail: String(err) },
       { status: 500 }
     );
+  }
+
+  // Publish signed manifest to DFOS federation (best-effort, never blocks upload)
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.MEDIA_PUBLIC_URL || new URL(request.url).origin;
+  const manifestUrl = `${baseUrl}/media/api/assets/${assetId}/fair`;
+  const manifestDigest = createHash("sha256").update(canonicalize(signedManifest)).digest("hex");
+
+  try {
+    const dfosResult = await publishContentEvent({
+      topic: "fair.manifest.published",
+      payload: {
+        assetId,
+        ownerDid,
+        manifestDigest: `sha256:${manifestDigest}`,
+        manifestUrl,
+        fairVersion: (signedManifest as { fair?: string }).fair || "1.1",
+        signedAt: new Date().toISOString(),
+      },
+    });
+    // Store the DFOS event ID on the asset record
+    await db
+      .update(assets)
+      .set({ fairDfosEventId: dfosResult.eventId })
+      .where(eq(assets.id, assetId));
+  } catch (err) {
+    log.error({ err: String(err), assetId }, "DFOS publish failed (non-fatal)");
   }
 
   // Auto-assign to folder based on context
@@ -298,7 +341,6 @@ export async function POST(request: NextRequest) {
   }
 
   // Build public URL — use configured base URL, not request origin (which may be localhost behind reverse proxy)
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.MEDIA_PUBLIC_URL || new URL(request.url).origin;
   const url = `${baseUrl}/media/api/assets/${record.id}`;
 
   const response = NextResponse.json(

--- a/apps/kernel/src/db/schemas/media.ts
+++ b/apps/kernel/src/db/schemas/media.ts
@@ -28,6 +28,9 @@ export const assets = mediaSchema.table(
     fairManifest: jsonb("fair_manifest").default({}),          // inline .fair JSON
     fairPath: text("fair_path"),                               // path to .fair.json file
 
+    // DFOS federation anchor
+    fairDfosEventId: text("fair_dfos_event_id"),               // DFOS event ID for signed manifest anchor
+
     // Organization
     folderId: text("folder_id"),                               // virtual folder (future #187)
     tags: jsonb("tags").default([]),

--- a/docs/audits/fair-dfos-sidecar.md
+++ b/docs/audits/fair-dfos-sidecar.md
@@ -1,0 +1,90 @@
+# Audit: .fair Sidecar Delivery + DFOS-Native Publication (#882)
+
+## 1. What in `packages/dfos/` to Consume vs. Extend
+
+### Consume (existing)
+- `createSigner(privateKeyHex)` — produces a DFOS-compatible `Signer = (message: Uint8Array) => Promise<Uint8Array>`.
+- `getPublicKeyBytes(privateKeyHex)` — derives raw Ed25519 public key bytes from a hex private key.
+- `@metalabel/dfos-protocol`'s `signContentOperation` and `verifyContentChain` — used in existing tests for content-chain signing/verification.
+
+### Extend (new code)
+- **New file: `packages/dfos/src/content-publish.ts`**
+  - `publishContentEvent({ topic, payload })` — publishes a signed content event to the DFOS relay.
+  - `getContentEvent(eventId)` — fetches a published event by ID for verification.
+  - Uses `createSigner` for signing the event payload.
+  - Uses `process.env.DFOS_RELAY_URL` for the relay endpoint.
+  - Event signing follows the same pattern as `signContentOperation` in tests: sign a canonical payload and POST to relay.
+
+**Decision:** Create a new file `content-publish.ts` rather than extending `bridge.ts`, because:
+- `bridge.ts` is focused on identity-chain operations (create/update/verify).
+- Content publishing is a distinct concern — it operates on content events, not identity chains.
+- Keeps the public API surface clean and separable.
+
+## 2. Headers on Asset Response Route
+
+Added to every byte response (full GET + Range responses) in `apps/kernel/app/media/api/assets/[id]/route.ts`:
+
+| Header | Value | Condition |
+|--------|-------|-----------|
+| `Link` | `</media/api/assets/{id}/fair>; rel="fair"; type="application/fair+json"` | Always |
+| `X-Fair-Digest` | `sha256:<hex>` | Always |
+| `X-Fair-Dfos` | `dfos:event:<eventId>` | Only if `fair_dfos_event_id` is non-NULL |
+
+**Digest encoding:** Hex (lowercase). SHA-256 of the canonical JSON of the signed manifest. This matches the existing `hash` column on assets (which is also hex). Using hex for consistency across the codebase.
+
+**Existing headers preserved:** `X-Fair-Access`, `ETag`, `Cache-Control`, `Content-Type`, `Accept-Ranges`, `Content-Range`, `Content-Length`, `X-Variants`, `X-Transcoding`.
+
+## 3. DFOS Event Topic + Payload Shape
+
+**Topic:** `fair.manifest.published`
+
+**Payload:**
+```json
+{
+  "assetId": "asset_xxx",
+  "ownerDid": "did:imajin:...",
+  "manifestDigest": "sha256:abc123...",
+  "manifestUrl": "https://dev-media.imajin.ai/media/api/assets/asset_xxx/fair",
+  "fairVersion": "1.1",
+  "signedAt": "2026-05-10T20:38:00.000Z"
+}
+```
+
+**Return value from `publishContentEvent`:**
+```ts
+{
+  eventId: string;      // DFOS-assigned event identifier
+  anchoredAt: string;   // ISO timestamp from DFOS relay
+}
+```
+
+**Fetch return value from `getContentEvent`:**
+```ts
+{
+  topic: string;
+  payload: unknown;
+  anchoredAt: string;
+  signature: string;    // JWS token or raw signature
+} | null
+```
+
+## 4. Schema Column Decision
+
+**Column name:** `fair_dfos_event_id` (confirmed)
+
+**Type:** `TEXT` (nullable)
+
+**Location:** `media.assets` table in `apps/kernel/src/db/schemas/media.ts`
+
+**Migration:** `migrations/0022_assets_fair_dfos_event_id.sql`
+
+**Rationale:**
+- TEXT is appropriate because DFOS event IDs are alphanumeric strings (similar to CIDs or custom base32 identifiers).
+- Nullable because not all assets will be anchored to DFOS (DFOS publish is best-effort, and legacy assets won't have it).
+- No separate `manifestDigest` cache column: the digest is computed on-the-fly from `fairManifest` JSONB. The overhead of re-canonicalizing and hashing a small JSON object is negligible compared to I/O. Keeps the schema minimal.
+
+## Out of Scope (this PR)
+- UI surfacing of verification result on AssetDetail (→ #893 D4)
+- Manual upgrade flow's DFOS re-publish (→ #894 D5, with TODO comment)
+- Layer 3 in-band metadata (XMP/ID3/MP4 atoms)
+- Layer 4 composite download container

--- a/migrations/0022_assets_fair_dfos_event_id.sql
+++ b/migrations/0022_assets_fair_dfos_event_id.sql
@@ -1,0 +1,2 @@
+-- Add DFOS event ID column to media.assets for .fair manifest federation anchor
+ALTER TABLE media.assets ADD COLUMN IF NOT EXISTS fair_dfos_event_id TEXT;

--- a/packages/dfos/package.json
+++ b/packages/dfos/package.json
@@ -7,9 +7,15 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "scripts": {
+    "test": "vitest"
+  },
   "dependencies": {
     "@imajin/auth": "workspace:*",
     "@metalabel/dfos-protocol": "^0.9.0",
     "@noble/curves": "^1.8.1"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
   }
 }

--- a/packages/dfos/src/content-publish.ts
+++ b/packages/dfos/src/content-publish.ts
@@ -54,9 +54,9 @@ export async function publishContentEvent(
     throw new Error('DFOS_RELAY_URL is not configured');
   }
 
-  const privateKeyHex = process.env.DFOS_PRIVATE_KEY_HEX;
+  const privateKeyHex = process.env.DFOS_PRIVATE_KEY_HEX || process.env.AUTH_PRIVATE_KEY;
   if (!privateKeyHex) {
-    throw new Error('DFOS_PRIVATE_KEY_HEX is not configured');
+    throw new Error('DFOS_PRIVATE_KEY_HEX (or AUTH_PRIVATE_KEY) is not configured');
   }
 
   const signer = createSigner(privateKeyHex);

--- a/packages/dfos/src/content-publish.ts
+++ b/packages/dfos/src/content-publish.ts
@@ -1,0 +1,156 @@
+/**
+ * DFOS content event publishing.
+ *
+ * Publishes signed content events to the DFOS federation relay and
+ * provides retrieval for verification.
+ */
+
+import { createSigner } from './signer';
+
+/** Payload for a published fair manifest event */
+export interface FairManifestPublishedPayload {
+  assetId: string;
+  ownerDid: string;
+  manifestDigest: string;
+  manifestUrl: string;
+  fairVersion: string;
+  signedAt: string;
+}
+
+/** Generic DFOS content event payload */
+export type ContentEventPayload = FairManifestPublishedPayload | Record<string, unknown>;
+
+/** Input to publishContentEvent */
+export interface PublishContentEventInput {
+  topic: string;
+  payload: ContentEventPayload;
+}
+
+/** Result of a successful publish */
+export interface PublishedContentEvent {
+  eventId: string;
+  anchoredAt: string;
+}
+
+/** Retrieved content event from DFOS relay */
+export interface ContentEvent {
+  topic: string;
+  payload: ContentEventPayload;
+  anchoredAt: string;
+  signature: string;
+}
+
+/**
+ * Publish a signed content event to the DFOS federation relay.
+ *
+ * Uses the identity's private key (from DFOS_PRIVATE_KEY_HEX env) to sign
+ * the event payload. The relay anchors the event and returns an eventId.
+ */
+export async function publishContentEvent(
+  input: PublishContentEventInput,
+): Promise<PublishedContentEvent> {
+  const relayUrl = process.env.DFOS_RELAY_URL;
+  if (!relayUrl) {
+    throw new Error('DFOS_RELAY_URL is not configured');
+  }
+
+  const privateKeyHex = process.env.DFOS_PRIVATE_KEY_HEX;
+  if (!privateKeyHex) {
+    throw new Error('DFOS_PRIVATE_KEY_HEX is not configured');
+  }
+
+  const signer = createSigner(privateKeyHex);
+
+  // Canonical payload: sorted keys, no whitespace
+  const canonicalPayload = canonicalize(input.payload);
+  const payloadBytes = new TextEncoder().encode(canonicalPayload);
+
+  // Sign the canonical payload
+  const signature = await signer(payloadBytes);
+  const signatureHex = bytesToHex(signature);
+
+  const body = {
+    topic: input.topic,
+    payload: input.payload,
+    signature: signatureHex,
+    timestamp: new Date().toISOString(),
+  };
+
+  const response = await fetch(`${relayUrl}/api/v1/events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => 'Unknown error');
+    throw new Error(`DFOS relay returned ${response.status}: ${text}`);
+  }
+
+  const result = (await response.json()) as {
+    eventId: string;
+    anchoredAt: string;
+  };
+
+  return {
+    eventId: result.eventId,
+    anchoredAt: result.anchoredAt,
+  };
+}
+
+/**
+ * Fetch a published content event from the DFOS relay by eventId.
+ *
+ * Returns null if the event is not found.
+ */
+export async function getContentEvent(
+  eventId: string,
+): Promise<ContentEvent | null> {
+  const relayUrl = process.env.DFOS_RELAY_URL;
+  if (!relayUrl) {
+    throw new Error('DFOS_RELAY_URL is not configured');
+  }
+
+  const response = await fetch(`${relayUrl}/api/v1/events/${encodeURIComponent(eventId)}`, {
+    method: 'GET',
+    headers: {
+      'Accept': 'application/json',
+    },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => 'Unknown error');
+    throw new Error(`DFOS relay returned ${response.status}: ${text}`);
+  }
+
+  const result = (await response.json()) as ContentEvent;
+  return result;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/** Deterministic JSON canonicalization: sorted keys, no whitespace */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalize).join(',') + ']';
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const parts = keys.map((key) => JSON.stringify(key) + ':' + canonicalize(obj[key]));
+  return '{' + parts.join(',') + '}';
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/packages/dfos/src/index.ts
+++ b/packages/dfos/src/index.ts
@@ -1,3 +1,11 @@
 export { createSigner, getPublicKeyBytes } from './signer';
 export { createIdentityChain, updateIdentityChain, verifyChain, DFOS_DID_PREFIX } from './bridge';
 export type { VerifiedIdentity } from './bridge';
+export { publishContentEvent, getContentEvent } from './content-publish';
+export type {
+  FairManifestPublishedPayload,
+  ContentEventPayload,
+  PublishContentEventInput,
+  PublishedContentEvent,
+  ContentEvent,
+} from './content-publish';

--- a/packages/dfos/tests/content-publish.test.ts
+++ b/packages/dfos/tests/content-publish.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeAll, vi, beforeEach, afterEach } from 'vitest';
+import { publishContentEvent, getContentEvent } from '@imajin/dfos';
+import { generateKeypair } from '@imajin/auth';
+
+// ─── Setup ─────────────────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
+
+beforeAll(() => {
+  process.env.DFOS_RELAY_URL = 'https://relay.test.dfos';
+});
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.DFOS_PRIVATE_KEY_HEX;
+});
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function mockFetchResponse(status: number, body: unknown) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response);
+}
+
+// ─── publishContentEvent ───────────────────────────────────────────────────
+
+describe('publishContentEvent', () => {
+  it('publishes a fair.manifest.published event and returns eventId + anchoredAt', async () => {
+    const keypair = generateKeypair();
+    process.env.DFOS_PRIVATE_KEY_HEX = keypair.privateKey;
+
+    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockReturnValueOnce(
+      mockFetchResponse(200, {
+        eventId: 'evt_test1234567890',
+        anchoredAt: '2026-05-10T20:38:00.000Z',
+      })
+    );
+
+    const result = await publishContentEvent({
+      topic: 'fair.manifest.published',
+      payload: {
+        assetId: 'asset_abc123',
+        ownerDid: 'did:imajin:test',
+        manifestDigest: 'sha256:abc123',
+        manifestUrl: 'https://dev-media.imajin.ai/media/api/assets/asset_abc123/fair',
+        fairVersion: '1.1',
+        signedAt: '2026-05-10T20:38:00.000Z',
+      },
+    });
+
+    expect(result.eventId).toBe('evt_test1234567890');
+    expect(result.anchoredAt).toBe('2026-05-10T20:38:00.000Z');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://relay.test.dfos/api/v1/events');
+    expect(init?.method).toBe('POST');
+
+    const body = JSON.parse(init?.body as string);
+    expect(body.topic).toBe('fair.manifest.published');
+    expect(body.payload.assetId).toBe('asset_abc123');
+    expect(body.signature).toMatch(/^[0-9a-f]{128}$/); // 64-byte hex = 128 chars
+    expect(body.timestamp).toBeTruthy();
+  });
+
+  it('throws if DFOS_RELAY_URL is missing', async () => {
+    const originalRelay = process.env.DFOS_RELAY_URL;
+    delete process.env.DFOS_RELAY_URL;
+
+    await expect(
+      publishContentEvent({ topic: 'test', payload: {} })
+    ).rejects.toThrow('DFOS_RELAY_URL is not configured');
+
+    process.env.DFOS_RELAY_URL = originalRelay;
+  });
+
+  it('throws if DFOS_PRIVATE_KEY_HEX is missing', async () => {
+    await expect(
+      publishContentEvent({ topic: 'test', payload: {} })
+    ).rejects.toThrow('DFOS_PRIVATE_KEY_HEX is not configured');
+  });
+
+  it('throws on relay error response', async () => {
+    const keypair = generateKeypair();
+    process.env.DFOS_PRIVATE_KEY_HEX = keypair.privateKey;
+
+    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockReturnValueOnce(
+      mockFetchResponse(500, { error: 'Internal error' })
+    );
+
+    await expect(
+      publishContentEvent({ topic: 'test', payload: {} })
+    ).rejects.toThrow('DFOS relay returned 500');
+  });
+});
+
+// ─── getContentEvent ───────────────────────────────────────────────────────
+
+describe('getContentEvent', () => {
+  it('fetches an event by id', async () => {
+    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockReturnValueOnce(
+      mockFetchResponse(200, {
+        topic: 'fair.manifest.published',
+        payload: { assetId: 'asset_abc' },
+        anchoredAt: '2026-05-10T20:38:00.000Z',
+        signature: 'sig_123',
+      })
+    );
+
+    const result = await getContentEvent('evt_test123');
+
+    expect(result).not.toBeNull();
+    expect(result?.topic).toBe('fair.manifest.published');
+    expect(result?.payload.assetId).toBe('asset_abc');
+    expect(result?.anchoredAt).toBe('2026-05-10T20:38:00.000Z');
+    expect(result?.signature).toBe('sig_123');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://relay.test.dfos/api/v1/events/evt_test123');
+  });
+
+  it('returns null for 404', async () => {
+    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockReturnValueOnce(
+      mockFetchResponse(404, { error: 'Not found' })
+    );
+
+    const result = await getContentEvent('evt_missing');
+    expect(result).toBeNull();
+  });
+
+  it('throws on relay error response', async () => {
+    const mockFetch = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mockFetch.mockReturnValueOnce(
+      mockFetchResponse(503, { error: 'Unavailable' })
+    );
+
+    await expect(getContentEvent('evt_err')).rejects.toThrow('DFOS relay returned 503');
+  });
+});

--- a/packages/dfos/tests/content-publish.test.ts
+++ b/packages/dfos/tests/content-publish.test.ts
@@ -86,7 +86,7 @@ describe('publishContentEvent', () => {
   it('throws if DFOS_PRIVATE_KEY_HEX is missing', async () => {
     await expect(
       publishContentEvent({ topic: 'test', payload: {} })
-    ).rejects.toThrow('DFOS_PRIVATE_KEY_HEX is not configured');
+    ).rejects.toThrow('DFOS_PRIVATE_KEY_HEX (or AUTH_PRIVATE_KEY) is not configured');
   });
 
   it('throws on relay error response', async () => {

--- a/packages/fair/src/index.ts
+++ b/packages/fair/src/index.ts
@@ -63,3 +63,9 @@ export type {
 } from './agent-pricing';
 
 export { upgradeToV1_1 } from './upgrade';
+export { verifyManifestFromAsset } from './verify-from-asset';
+export type {
+  VerificationResult,
+  VerifyManifestFromAssetOptions,
+  FetchResponse,
+} from './verify-from-asset';

--- a/packages/fair/src/verify-from-asset.ts
+++ b/packages/fair/src/verify-from-asset.ts
@@ -1,0 +1,163 @@
+/**
+ * Verify a .fair manifest from an asset's sidecar delivery headers.
+ *
+ * Pure injection-based: no global fetch is used. The caller provides
+ * fetchers for the asset, the manifest, and the DFOS event.
+ */
+
+import { verifyManifest } from './sign';
+import { canonicalize } from './canonical';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+import type { SignedFairManifest } from './types';
+
+/** Minimal fetch response interface for injection */
+export interface FetchResponse {
+  ok: boolean;
+  headers: Headers;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}
+
+/** Result of manifest verification */
+export interface VerificationResult {
+  valid: boolean;
+  signedAt?: string;
+  anchorTimestamp?: string;
+  owner?: string;
+  reason?: string;
+}
+
+/** Options for verifyManifestFromAsset */
+export interface VerifyManifestFromAssetOptions {
+  /** Resolve a DID to its Ed25519 public key bytes */
+  resolveOwnerKey: (did: string) => Promise<Uint8Array>;
+  /** Fetch a DFOS event by ID (return null if not found) */
+  fetchDfosEvent: (eventId: string) => Promise<{
+    topic: string;
+    payload: unknown;
+    anchoredAt: string;
+    signature: string;
+  } | null>;
+  /** Fetch a URL and return a minimal response interface */
+  fetchAsset: (url: string) => Promise<FetchResponse>;
+}
+
+/**
+ * Verify a .fair manifest from an asset URL.
+ *
+ * 1. Fetch the asset, read Link: rel="fair" header
+ * 2. Fetch the manifest from the Link target
+ * 3. Verify the manifest signature
+ * 4. Check X-Fair-Digest matches the recomputed digest
+ * 5. If X-Fair-Dfos header is present, fetch and verify the DFOS anchor
+ */
+export async function verifyManifestFromAsset(
+  assetUrl: string,
+  opts: VerifyManifestFromAssetOptions,
+): Promise<VerificationResult> {
+  // 1. Fetch asset and read Link header
+  let assetResponse: FetchResponse;
+  try {
+    assetResponse = await opts.fetchAsset(assetUrl);
+  } catch (err) {
+    return { valid: false, reason: `Failed to fetch asset: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  if (!assetResponse.ok) {
+    return { valid: false, reason: `Asset fetch failed with status: ${assetResponse.ok === false ? 'non-ok' : 'unknown'}` };
+  }
+
+  const linkHeader = assetResponse.headers.get('link') || '';
+  const fairMatch = linkHeader.match(/<([^>]+)>\s*;\s*rel="fair"/);
+  if (!fairMatch) {
+    return { valid: false, reason: 'Missing Link: rel="fair" header on asset response' };
+  }
+
+  const manifestUrl = new URL(fairMatch[1], assetUrl).toString();
+
+  // 2. Fetch manifest
+  let manifestResponse: FetchResponse;
+  try {
+    manifestResponse = await opts.fetchAsset(manifestUrl);
+  } catch (err) {
+    return { valid: false, reason: `Failed to fetch manifest: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  if (!manifestResponse.ok) {
+    return { valid: false, reason: 'Manifest fetch failed with non-ok status' };
+  }
+
+  let manifest: SignedFairManifest;
+  try {
+    manifest = (await manifestResponse.json()) as SignedFairManifest;
+  } catch {
+    return { valid: false, reason: 'Manifest response is not valid JSON' };
+  }
+
+  // 3. Verify signature
+  const sig = manifest.signature;
+  if (!sig || typeof sig !== 'object' || !('alg' in sig)) {
+    return { valid: false, reason: 'Manifest is not a v1.1 signed manifest' };
+  }
+
+  const verifyResult = await verifyManifest(manifest, opts.resolveOwnerKey);
+  if ('ok' in verifyResult && !verifyResult.ok) {
+    return { valid: false, reason: verifyResult.reason || 'Signature verification failed' };
+  }
+  if ('valid' in verifyResult && !verifyResult.valid) {
+    return { valid: false, reason: verifyResult.error || 'Signature verification failed' };
+  }
+
+  const signedAt = sig && 'signedAt' in sig ? (sig as { signedAt?: string }).signedAt : undefined;
+
+  // 4. Check X-Fair-Digest
+  const digestHeader = assetResponse.headers.get('x-fair-digest') || '';
+  if (digestHeader) {
+    const expectedDigest = bytesToHex(sha256(new TextEncoder().encode(canonicalize(manifest))));
+    const expected = `sha256:${expectedDigest}`;
+    if (digestHeader !== expected) {
+      return { valid: false, signedAt, reason: `Digest mismatch: expected ${expected}, got ${digestHeader}` };
+    }
+  }
+
+  // 5. Verify DFOS anchor if present
+  const dfosHeader = assetResponse.headers.get('x-fair-dfos') || '';
+  let anchorTimestamp: string | undefined;
+  if (dfosHeader) {
+    const eventMatch = dfosHeader.match(/^dfos:event:(.+)$/);
+    if (!eventMatch) {
+      return { valid: false, signedAt, reason: `Invalid X-Fair-Dfos header format: ${dfosHeader}` };
+    }
+
+    const eventId = eventMatch[1];
+    const event = await opts.fetchDfosEvent(eventId);
+    if (!event) {
+      return { valid: false, signedAt, reason: `DFOS event not found: ${eventId}` };
+    }
+
+    // Verify the DFOS payload matches the manifest
+    const payload = event.payload as {
+      assetId?: string;
+      ownerDid?: string;
+      manifestDigest?: string;
+      manifestUrl?: string;
+      fairVersion?: string;
+      signedAt?: string;
+    };
+
+    const manifestDigest = bytesToHex(sha256(new TextEncoder().encode(canonicalize(manifest))));
+    if (payload.manifestDigest !== `sha256:${manifestDigest}`) {
+      return { valid: false, signedAt, reason: 'DFOS event manifestDigest does not match recomputed digest' };
+    }
+
+    anchorTimestamp = event.anchoredAt;
+  }
+
+  return {
+    valid: true,
+    signedAt,
+    anchorTimestamp,
+    owner: manifest.creator,
+  };
+}

--- a/packages/fair/tests/verify-from-asset.test.ts
+++ b/packages/fair/tests/verify-from-asset.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from 'vitest';
+import { verifyManifestFromAsset } from '@imajin/fair';
+import { signManifest, canonicalize } from '@imajin/fair';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+import { concatBytes } from '@noble/hashes/utils';
+
+// Enable sync sha512 for ed25519 key generation
+ed.etc.sha512Sync = (...m: Uint8Array[]) => sha512(concatBytes(...m));
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+async function generateKeypair(): Promise<{ did: string; privateKey: Uint8Array; publicKey: Uint8Array }> {
+  const privateKey = ed.utils.randomPrivateKey();
+  const publicKey = ed.getPublicKey(privateKey);
+  return {
+    did: `did:imajin:test_${bytesToHex(publicKey).slice(0, 16)}`,
+    privateKey,
+    publicKey,
+  };
+}
+
+function mockResponse(opts: {
+  ok?: boolean;
+  headers?: Record<string, string>;
+  body?: unknown;
+}): Response {
+  const headers = new Headers(opts.headers ?? {});
+  return {
+    ok: opts.ok ?? true,
+    headers,
+    text: () => Promise.resolve(JSON.stringify(opts.body)),
+    json: () => Promise.resolve(opts.body),
+  } as Response;
+}
+
+function makeDigest(manifest: unknown): string {
+  return `sha256:${bytesToHex(sha256(new TextEncoder().encode(canonicalize(manifest))))}`;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('verifyManifestFromAsset', () => {
+  it('happy path: verifies signed manifest with DFOS anchor', async () => {
+    const signer = await generateKeypair();
+    const manifest = {
+      fair: '1.1',
+      id: 'asset_test123',
+      kind: 'image',
+      creator: signer.did,
+      created: '2026-05-10T20:00:00.000Z',
+      access: { type: 'public' },
+    };
+
+    const signed = await signManifest(manifest, signer);
+    const digest = makeDigest(signed);
+
+    const fetchAsset = async (url: string) => {
+      if (url === 'https://example.com/media/api/assets/asset_test123') {
+        return mockResponse({
+          ok: true,
+          headers: {
+            link: '</media/api/assets/asset_test123/fair>; rel="fair"; type="application/fair+json"',
+            'x-fair-digest': digest,
+            'x-fair-dfos': 'dfos:event:evt_abc123',
+          },
+        });
+      }
+      if (url.includes('/fair')) {
+        return mockResponse({ ok: true, body: signed });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    };
+
+    const result = await verifyManifestFromAsset(
+      'https://example.com/media/api/assets/asset_test123',
+      {
+        fetchAsset,
+        resolveOwnerKey: async () => signer.publicKey,
+        fetchDfosEvent: async () => ({
+          topic: 'fair.manifest.published',
+          payload: {
+            assetId: 'asset_test123',
+            ownerDid: signer.did,
+            manifestDigest: digest,
+            manifestUrl: 'https://example.com/media/api/assets/asset_test123/fair',
+            fairVersion: '1.1',
+            signedAt: '2026-05-10T20:00:00.000Z',
+          },
+          anchoredAt: '2026-05-10T20:01:00.000Z',
+          signature: 'sig_placeholder',
+        }),
+      },
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.signedAt).toBeTruthy();
+    expect(result.anchorTimestamp).toBe('2026-05-10T20:01:00.000Z');
+    expect(result.owner).toBe(signer.did);
+  });
+
+  it('rejects when Link header is missing', async () => {
+    const fetchAsset = async () =>
+      mockResponse({
+        ok: true,
+        headers: {},
+      });
+
+    const result = await verifyManifestFromAsset('https://example.com/asset', {
+      fetchAsset,
+      resolveOwnerKey: async () => new Uint8Array(32),
+      fetchDfosEvent: async () => null,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Missing Link');
+  });
+
+  it('rejects when manifest signature is tampered', async () => {
+    const signer = await generateKeypair();
+    const manifest = {
+      fair: '1.1',
+      id: 'asset_test123',
+      kind: 'image',
+      creator: signer.did,
+      created: '2026-05-10T20:00:00.000Z',
+      access: { type: 'public' },
+    };
+
+    const signed = await signManifest(manifest, signer);
+    // Tamper with the manifest
+    signed.id = 'asset_tampered';
+    const digest = makeDigest(signed);
+
+    const fetchAsset = async (url: string) => {
+      if (!url.includes('/fair')) {
+        return mockResponse({
+          ok: true,
+          headers: {
+            link: '</media/api/assets/asset_test123/fair>; rel="fair"',
+            'x-fair-digest': digest,
+          },
+        });
+      }
+      return mockResponse({ ok: true, body: signed });
+    };
+
+    const result = await verifyManifestFromAsset('https://example.com/asset', {
+      fetchAsset,
+      resolveOwnerKey: async () => signer.publicKey,
+      fetchDfosEvent: async () => null,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Signature verification failed');
+  });
+
+  it('rejects when digest does not match', async () => {
+    const signer = await generateKeypair();
+    const manifest = {
+      fair: '1.1',
+      id: 'asset_test123',
+      kind: 'image',
+      creator: signer.did,
+      created: '2026-05-10T20:00:00.000Z',
+      access: { type: 'public' },
+    };
+
+    const signed = await signManifest(manifest, signer);
+
+    const fetchAsset = async (url: string) => {
+      if (!url.includes('/fair')) {
+        return mockResponse({
+          ok: true,
+          headers: {
+            link: '</media/api/assets/asset_test123/fair>; rel="fair"',
+            'x-fair-digest': 'sha256:bad000000000000000000000000000000000000000000000000000000000bad',
+          },
+        });
+      }
+      return mockResponse({ ok: true, body: signed });
+    };
+
+    const result = await verifyManifestFromAsset('https://example.com/asset', {
+      fetchAsset,
+      resolveOwnerKey: async () => signer.publicKey,
+      fetchDfosEvent: async () => null,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('Digest mismatch');
+  });
+
+  it('passes without DFOS anchor when header is absent', async () => {
+    const signer = await generateKeypair();
+    const manifest = {
+      fair: '1.1',
+      id: 'asset_test123',
+      kind: 'image',
+      creator: signer.did,
+      created: '2026-05-10T20:00:00.000Z',
+      access: { type: 'public' },
+    };
+
+    const signed = await signManifest(manifest, signer);
+    const digest = makeDigest(signed);
+
+    const fetchAsset = async (url: string) => {
+      if (!url.includes('/fair')) {
+        return mockResponse({
+          ok: true,
+          headers: {
+            link: '</media/api/assets/asset_test123/fair>; rel="fair"',
+            'x-fair-digest': digest,
+            // No x-fair-dfos
+          },
+        });
+      }
+      return mockResponse({ ok: true, body: signed });
+    };
+
+    const result = await verifyManifestFromAsset('https://example.com/asset', {
+      fetchAsset,
+      resolveOwnerKey: async () => signer.publicKey,
+      fetchDfosEvent: async () => null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.anchorTimestamp).toBeUndefined();
+  });
+
+  it('rejects when DFOS event digest mismatches', async () => {
+    const signer = await generateKeypair();
+    const manifest = {
+      fair: '1.1',
+      id: 'asset_test123',
+      kind: 'image',
+      creator: signer.did,
+      created: '2026-05-10T20:00:00.000Z',
+      access: { type: 'public' },
+    };
+
+    const signed = await signManifest(manifest, signer);
+    const digest = makeDigest(signed);
+
+    const fetchAsset = async (url: string) => {
+      if (!url.includes('/fair')) {
+        return mockResponse({
+          ok: true,
+          headers: {
+            link: '</media/api/assets/asset_test123/fair>; rel="fair"',
+            'x-fair-digest': digest,
+            'x-fair-dfos': 'dfos:event:evt_abc123',
+          },
+        });
+      }
+      return mockResponse({ ok: true, body: signed });
+    };
+
+    const result = await verifyManifestFromAsset('https://example.com/asset', {
+      fetchAsset,
+      resolveOwnerKey: async () => signer.publicKey,
+      fetchDfosEvent: async () => ({
+        topic: 'fair.manifest.published',
+        payload: {
+          manifestDigest: 'sha256:wrongdigest0000000000000000000000000000000000000000000000000000',
+        },
+        anchoredAt: '2026-05-10T20:01:00.000Z',
+        signature: 'sig_placeholder',
+      }),
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('DFOS event manifestDigest does not match');
+  });
+});


### PR DESCRIPTION
## feat(.fair + dfos): sidecar delivery + DFOS federation anchor (#882)

Closes #882

Depends on #896 (rebase to main once that merges)

---

### Five-commit summary

1. **`feat(dfos): extend packages/dfos with content-chain publish helpers (#882)`**
   - New `packages/dfos/src/content-publish.ts` with `publishContentEvent()` and `getContentEvent()`
   - Uses existing `createSigner` + env vars `DFOS_RELAY_URL` / `DFOS_PRIVATE_KEY_HEX` (falls back to `AUTH_PRIVATE_KEY`)
   - Tests in `packages/dfos/tests/content-publish.test.ts` (7 tests, all passing)

2. **`feat(kernel): assets.fair_dfos_event_id schema + migration (#882)`**
   - Added `fairDfosEventId TEXT` (nullable) to `media.assets` in `apps/kernel/src/db/schemas/media.ts`
   - Migration: `migrations/0022_assets_fair_dfos_event_id.sql` (idempotent `ADD COLUMN IF NOT EXISTS`)

3. **`feat(media): publish signed fair manifest to DFOS on asset upload (#882)`**
   - Upload handler signs manifest with platform key (`PLATFORM_DID` + `AUTH_PRIVATE_KEY`)
   - Computes `sha256:` digest of canonicalized signed manifest
   - Publishes to DFOS via `publishContentEvent({ topic: 'fair.manifest.published', payload: { assetId, ownerDid, manifestDigest, manifestUrl, fairVersion, signedAt } })`
   - Stores returned `eventId` in `assets.fair_dfos_event_id`
   - Wrapped in try/catch — **upload never fails if DFOS is unavailable**
   - `TODO(#894)` comment left in fair PUT route for manual upgrade re-publish

4. **`feat(media): add Link + X-Fair-Digest + X-Fair-Dfos headers on asset responses (#882)`**
   - `Link: </media/api/assets/{id}/fair>; rel="fair"; type="application/fair+json"` (always)
   - `X-Fair-Digest: sha256:<hex>` (always, computed from `fairManifest` JSONB)
   - `X-Fair-Dfos: dfos:event:<eventId>` (only when `fair_dfos_event_id` is non-NULL)
   - Added to both full GET and Range (206) video responses
   - Existing `X-Fair-Access` preserved

5. **`feat(fair): verifyManifestFromAsset utility (#882)`**
   - New `packages/fair/src/verify-from-asset.ts` with `verifyManifestFromAsset(assetUrl, opts)`
   - Pure injection-based (no baked-in fetch): caller provides `fetchAsset`, `resolveOwnerKey`, `fetchDfosEvent`
   - Verifies `Link` header, manifest signature via `verifyManifest()`, digest match, and DFOS anchor
   - Tests in `packages/fair/tests/verify-from-asset.test.ts` (6 tests, all passing)

---

### New DFOS topic + payload shape

**Topic:** `fair.manifest.published`

**Payload:**
```ts
{
  assetId: string;
  ownerDid: string;
  manifestDigest: string;   // sha256:<hex>
  manifestUrl: string;      // absolute URL to /media/api/assets/{id}/fair
  fairVersion: string;
  signedAt: string;         // ISO timestamp
}
```

### New schema column + migration

- **Column:** `media.assets.fair_dfos_event_id` (TEXT, nullable)
- **Migration:** `migrations/0022_assets_fair_dfos_event_id.sql`

### Headers added to asset response

| Header | Value | Condition |
|--------|-------|-----------|
| `Link` | `</media/api/assets/{id}/fair>; rel="fair"; type="application/fair+json"` | Always |
| `X-Fair-Digest` | `sha256:<hex>` | Always |
| `X-Fair-Dfos` | `dfos:event:<eventId>` | If `fair_dfos_event_id` is set |

### Test counts

| Package | File | Tests | Status |
|---------|------|-------|--------|
| `@imajin/dfos` | `tests/content-publish.test.ts` | 7 new | ✅ passing |
| `@imajin/dfos` | `tests/bridge.test.ts` | 12 existing | ✅ passing |
| `@imajin/dfos` | `tests/rotation.test.ts` | existing | ✅ passing |
| `@imajin/fair` | `tests/verify-from-asset.test.ts` | 6 new | ✅ passing |
| `@imajin/fair` | all existing tests | 65 existing | ✅ passing |

### Verification steps

1. Upload a new asset on dev:
   ```bash
   curl -X POST -F "file=@test.jpg" -H "Authorization: Bearer $TOKEN" \
     https://dev-media.imajin.ai/media/api/assets
   ```

2. GET the asset URL and confirm headers:
   ```bash
   curl -I -H "Authorization: Bearer $TOKEN" \
     https://dev-media.imajin.ai/media/api/assets/{asset_id}
   ```
   Expect:
   - `Link: </media/api/assets/{id}/fair>; rel="fair"; type="application/fair+json"`
   - `X-Fair-Digest: sha256:...`
   - `X-Fair-Dfos: dfos:event:...` (if DFOS publish succeeded)

3. GET the linked `/fair` endpoint and verify signature:
   ```bash
   curl -s -H "Authorization: Bearer $TOKEN" \
     https://dev-media.imajin.ai/media/api/assets/{asset_id}/fair | jq .
   ```

4. Verify digest matches:
   ```bash
   curl -s .../fair | jq . > manifest.json
   # compute sha256 of canonical JSON and compare to X-Fair-Digest header
   ```

---

### Out of scope (deferred)

- UI surfacing of verification result on AssetDetail → #893 D4
- Manual upgrade flow's DFOS re-publish → #894 D5 (TODO comment left)
- Layer 3 in-band metadata (XMP/ID3/MP4 atoms)
- Layer 4 composite download container
