### PR TITLE
fix(events): mixed-order confirm sends QR bundle for no-reg tickets + correct CTA (#898)

### DIFF
--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -475,9 +475,17 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     currency: currency.toUpperCase(),
   }).format(amountTotal / 100 / quantity);
 
-  // Deep link: if registration required, go to the registration form; otherwise my-tickets
-  const registrationUrl = ticketType.requiresRegistration
-    ? `${EVENTS_URL}/${event.id}/register/${createdTickets[0].id}`
+  // Split tickets by whether their type requires registration
+  const bundleTickets = createdTickets.filter((t) => !ticketType.requiresRegistration);
+  const registrationPendingTickets = createdTickets.filter(
+    (t) => ticketType.requiresRegistration && t.registrationStatus !== 'complete'
+  );
+
+  // CTA targets: the first pending-and-required ticket, falling back to my-tickets
+  const ctaTicket = registrationPendingTickets[0] ?? null;
+  const anyPendingRegistration = registrationPendingTickets.length > 0;
+  const registrationUrl = ctaTicket
+    ? `${EVENTS_URL}/${event.id}/register/${ctaTicket.id}`
     : `${EVENTS_URL}/${event.id}/my-tickets`;
 
   // Always publish a purchase receipt to the buyer
@@ -497,7 +505,7 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
         paymentMethod: paymentId ? 'Credit Card' : 'E-Transfer',
         registrationUrl,
         eventImageUrl,
-        hasRegistrationRequired: ticketType.requiresRegistration,
+        hasRegistrationRequired: anyPendingRegistration,
         context_id: event.id,
         context_type: 'event',
       },
@@ -506,31 +514,38 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     log.error({ customerEmail, err: String(emailError) }, '[webhook] Purchase receipt publish failed');
   }
 
-  // Only publish the ticket confirmation (with QR) immediately for non-registration tickets
-  if (!ticketType.requiresRegistration) {
+  // Only publish the ticket confirmation (with QR) immediately for no-registration tickets
+  if (bundleTickets.length > 0) {
     try {
-      // Generate QR codes for ALL tickets in the order
+      // Generate QR codes for the bundle subset
       const ticketsWithQr = await Promise.all(
-        createdTickets.map(async (t) => ({
+        bundleTickets.map(async (t) => ({
           id: t.id,
           qrCodeDataUri: await generateQRCode(t.id),
         }))
       );
+      // Recompute formatted price for the bundle subset
+      const bundleCents = bundleTickets.reduce((sum, t) => sum + (t.pricePaid ?? 0), 0);
+      const bundleFormatted = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: currency.toUpperCase(),
+      }).format(bundleCents / 100);
 
       publish('ticket.confirmed', {
         issuer: ownerDid,
         subject: ownerDid,
         scope: 'events',
         payload: {
+          to: customerEmail,
           email: customerEmail,
           eventTitle: event.title,
           ticketType: ticketType.name,
-          ticketId: createdTickets[0].id,
+          ticketId: bundleTickets[0].id,
           eventDate: formattedEventDate,
           eventTime: formattedEventTime,
           isVirtual: event.isVirtual ?? false,
           venue: event.venue ?? undefined,
-          price: formattedTotal,
+          price: bundleFormatted,
           magicLink,
           eventImageUrl,
           eventUrl: `${EVENTS_URL}/${event.id}`,

--- a/apps/events/src/lib/confirm-payment.ts
+++ b/apps/events/src/lib/confirm-payment.ts
@@ -189,11 +189,21 @@ export async function confirmHeldTickets(
           ? `${AUTH_URL}/api/onboard/verify?token=${onboardToken}`
           : `${EVENTS_URL}/${event.id}/my-tickets`;
 
-        const anyRegistrationRequired = Array.from(typesById.values()).some(
-          (tt) => tt.requiresRegistration
-        );
-        const registrationUrl = anyRegistrationRequired
-          ? `${EVENTS_URL}/${event.id}/register/${confirmedTickets[0].id}`
+        // Split tickets by whether their type requires registration
+        const bundleTickets = confirmedTickets.filter((t) => {
+          const tt = typesById.get(t.ticketTypeId);
+          return tt && !tt.requiresRegistration;
+        });
+        const registrationPendingTickets = confirmedTickets.filter((t) => {
+          const tt = typesById.get(t.ticketTypeId);
+          return tt?.requiresRegistration && t.registrationStatus !== 'complete';
+        });
+
+        // CTA targets: the first pending-and-required ticket, falling back to my-tickets
+        const ctaTicket = registrationPendingTickets[0] ?? null;
+        const anyPendingRegistration = registrationPendingTickets.length > 0;
+        const registrationUrl = ctaTicket
+          ? `${EVENTS_URL}/${event.id}/register/${ctaTicket.id}`
           : `${EVENTS_URL}/${event.id}/my-tickets`;
 
         // 1. Purchase receipt (always)
@@ -216,35 +226,39 @@ export async function confirmHeldTickets(
             paymentMethod: 'E-Transfer',
             registrationUrl,
             eventImageUrl,
-            hasRegistrationRequired: anyRegistrationRequired,
+            hasRegistrationRequired: anyPendingRegistration,
             context_id: event.id,
             context_type: 'event',
           },
         }).catch((err) => log.error({ err: String(err) }, 'Receipt publish error'));
 
-        // 2. Ticket confirmation with QR codes (only if no registration required)
-        if (!anyRegistrationRequired) {
+        // 2. Ticket confirmation with QR codes for no-registration tickets
+        if (bundleTickets.length > 0) {
           const ticketsWithQr = await Promise.all(
-            confirmedTickets.map(async (t) => ({
+            bundleTickets.map(async (t) => ({
               id: t.id,
               qrCodeDataUri: await generateQRCode(t.id),
             }))
           );
-          const primaryType = typesById.get(confirmedTickets[0].ticketTypeId);
+          const primaryType = typesById.get(bundleTickets[0].ticketTypeId);
+          // Recompute formatted price for the bundle subset (sum of bundleTickets pricePaid)
+          const bundleCents = bundleTickets.reduce((sum, t) => sum + (t.pricePaid ?? 0), 0);
+          const bundleFormatted = fmt(bundleCents);
           publish('ticket.confirmed', {
-            issuer: buyerDid || '',
-            subject: buyerDid || '',
+            issuer: bundleTickets[0].ownerDid || '',
+            subject: bundleTickets[0].ownerDid || customerEmail,
             scope: 'events',
             payload: {
+              to: customerEmail,
               email: customerEmail,
               eventTitle: event.title,
               ticketType: primaryType?.name ?? 'Ticket',
-              ticketId: confirmedTickets[0].id,
+              ticketId: bundleTickets[0].id,
               eventDate: formattedEventDate,
               eventTime: formattedEventTime,
               isVirtual: event.isVirtual ?? false,
               venue: event.venue ?? undefined,
-              price: totalFormatted,
+              price: bundleFormatted,
               magicLink,
               eventImageUrl,
               eventUrl: `${EVENTS_URL}/${event.id}`,
@@ -252,7 +266,7 @@ export async function confirmHeldTickets(
               context_id: event.id,
               context_type: 'event',
             },
-          }).catch((err) => log.error({ err: String(err) }, 'Ticket confirmed publish error'));
+          }).catch((err) => log.error({ err: String(err) }, 'Failed to publish ticket confirmed event'));
         }
       } else {
         log.warn({ buyerDid, orderId }, 'No buyer email available on EMT confirm; skipping receipt + ticket emails');


### PR DESCRIPTION
Closes #898

## Bug
On mixed orders (some tickets require registration, some don't), the no-registration tickets never got their QR confirmation email. The all-or-nothing check suppressed the bundle entirely if ANY ticket type required registration. The receipt CTA also pointed at the first ticket unconditionally, which could be a already-complete registration ticket.

## Fix
- Split `confirmedTickets` into `bundleTickets` (no registration required) and `registrationPendingTickets` (requires registration AND status !== 'complete').
- Send the QR bundle email only for `bundleTickets`.
- Drive `hasRegistrationRequired` from `anyPendingRegistration` (pending + required) rather than `anyRegistrationRequired` (required at all).
- `registrationUrl` now targets the first pending-and-required ticket, falling back to `/my-tickets` if none.
- Applied the same logic to both the e-Transfer confirm path and the Stripe webhook success path.

## Acceptance cases covered
1. Mixed order (no-reg + reg-required): receipt arrives, QR for no-reg arrives, CTA points at reg-required ticket.
2. All-reg-required with one complete + one pending: receipt arrives, CTA points at pending one.
3. All-reg-required where all are already complete: receipt arrives, no CTA shown.
4. All no-reg order: receipt arrives, QR bundle for all tickets arrives, no CTA.
