### PR TITLE
feat(.fair): HTTP 402 native settlement + multi-scheme wire support (#883)

### DIFF
--- a/apps/kernel/app/media/api/assets/[id]/receipts/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/receipts/route.ts
@@ -1,0 +1,65 @@
+/**
+ * GET /media/api/assets/[id]/receipts
+ *
+ * Returns settlement history (audit trail) for the owner's asset.
+ * Requires owner authentication.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { db, assets, settlements, accessLog } from "@/src/db";
+import { requireAuth } from "@imajin/auth";
+import { eq, desc } from "drizzle-orm";
+import { createLogger } from "@imajin/logger";
+
+const log = createLogger("kernel");
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // 1. Authenticate
+  const authResult = await requireAuth(request);
+  if ("error" in authResult) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
+
+  // 2. Look up asset
+  let asset;
+  try {
+    [asset] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  } catch (err) {
+    log.error({ err: String(err) }, "DB lookup failed");
+    return NextResponse.json({ error: "Database failure" }, { status: 500 });
+  }
+
+  if (!asset || asset.status !== "active") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (asset.ownerDid !== requesterDid) {
+    return NextResponse.json({ error: "Forbidden — owner only" }, { status: 403 });
+  }
+
+  // 3. Fetch settlements
+  const settlementRows = await db
+    .select()
+    .from(settlements)
+    .where(eq(settlements.assetId, id))
+    .orderBy(desc(settlements.settledAt));
+
+  // 4. Fetch access log
+  const accessRows = await db
+    .select()
+    .from(accessLog)
+    .where(eq(accessLog.assetId, id))
+    .orderBy(desc(accessLog.at));
+
+  return NextResponse.json({
+    assetId: id,
+    settlements: settlementRows,
+    accessLog: accessRows,
+  });
+}

--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -238,6 +238,23 @@ export async function GET(
       return NextResponse.json({ error: "Receipt action mismatch" }, { status: 402 });
     }
 
+    // Buyer-binding: caller must be authenticated AND match the receipt's buyer DID.
+    // Receipts are non-transferable in v1 — transfer semantics tracked in #904.
+    const buyerAuth = await requireAuth(request);
+    if ("error" in buyerAuth) {
+      return NextResponse.json(
+        { error: "Authentication required to redeem payment receipt" },
+        { status: 401 }
+      );
+    }
+    const callerDid = buyerAuth.identity.actingAs || buyerAuth.identity.id;
+    if (callerDid !== receiptPayload.buyer) {
+      return NextResponse.json(
+        { error: "Receipt is bound to a different identity" },
+        { status: 403 }
+      );
+    }
+
     // Check receipt against database settlement record
     const [settlement] = await db
       .select()

--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readFile, unlink, rename, stat, open } from "fs/promises";
 import path from "path";
-import { db, assets } from "@/src/db";
+import { db, assets, settlements, accessLog } from "@/src/db";
 import { requireAuth } from "@imajin/auth";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { createReadStream } from "fs";
 import type { FairManifest } from "@imajin/fair";
+import { isFairManifestV1_1, build402Response, verifyReceipt, loadVerifyKey } from "@imajin/fair";
+import type { FairAction } from "@imajin/fair";
 import { createLogger } from "@imajin/logger";
 
 const log = createLogger("kernel");
@@ -78,6 +80,35 @@ function getAccessType(
 function getAllowedDids(access: FairManifest["access"]): string[] {
   if (!access || typeof access === "string") return [];
   return access.allowedDids ?? [];
+}
+
+function determineAction(request: NextRequest, mimeType: string): FairAction {
+  const { searchParams } = new URL(request.url);
+  const explicit = searchParams.get("action");
+  if (explicit === 'reproduction' || explicit === 'streaming' || explicit === 'derivative' || explicit === 'syndication') {
+    return explicit;
+  }
+
+  const rangeHeader = request.headers.get("range");
+  if (rangeHeader && (mimeType.startsWith("audio/") || mimeType.startsWith("video/"))) {
+    return 'streaming';
+  }
+
+  return 'reproduction';
+}
+
+// Cache the verify key loaded from AUTH_PRIVATE_KEY
+let verifyKeyPromise: Promise<import('jose').KeyLike> | null = null;
+function getVerifyKey(): Promise<import('jose').KeyLike> {
+  if (!verifyKeyPromise) {
+    const privateKeyHex = process.env.AUTH_PRIVATE_KEY;
+    if (!privateKeyHex) {
+      verifyKeyPromise = Promise.reject(new Error('AUTH_PRIVATE_KEY not configured'));
+    } else {
+      verifyKeyPromise = loadVerifyKey(privateKeyHex);
+    }
+  }
+  return verifyKeyPromise;
 }
 
 // ---------------------------------------------------------------------------
@@ -159,7 +190,91 @@ export async function GET(
     }
   }
 
-  // 4. Read file from storage
+  // 4. Determine action and check for priced distribution
+  const action = determineAction(request, asset.mimeType);
+  const distRight = isFairManifestV1_1(manifest) ? manifest.distribution?.[action] : undefined;
+  const hasPrice = !!distRight?.price;
+
+  // 4a. Price-aware settlement flow
+  if (hasPrice) {
+    const receiptHeader = request.headers.get("X-Payment-Receipt");
+
+    if (!receiptHeader) {
+      // No receipt → 402 with settlement options
+      try {
+        const baseUrl = `${new URL(request.url).origin}/media/api/assets`;
+        const resp = build402Response({
+          manifest: manifest as import("@imajin/fair").FairManifestV1_1,
+          assetId: id,
+          action,
+          supportedSchemes: ['stripe-link', 'mjnx-direct'],
+          baseUrl,
+        });
+        return NextResponse.json(resp.body, { status: 402, headers: resp.headers });
+      } catch (err) {
+        log.error({ err: String(err), assetId: id, action }, "build402Response failed");
+        return NextResponse.json({ error: "Settlement configuration error" }, { status: 500 });
+      }
+    }
+
+    // Verify receipt
+    let receiptPayload;
+    try {
+      const verifyKey = await getVerifyKey();
+      receiptPayload = await verifyReceipt(receiptHeader, verifyKey);
+    } catch {
+      receiptPayload = null;
+    }
+
+    if (!receiptPayload) {
+      return NextResponse.json({ error: "Invalid payment receipt" }, { status: 402 });
+    }
+
+    // Validate receipt claims match this request
+    if (receiptPayload.aud !== `asset:${id}`) {
+      return NextResponse.json({ error: "Receipt audience mismatch" }, { status: 402 });
+    }
+    if (receiptPayload.action !== action) {
+      return NextResponse.json({ error: "Receipt action mismatch" }, { status: 402 });
+    }
+
+    // Check receipt against database settlement record
+    const [settlement] = await db
+      .select()
+      .from(settlements)
+      .where(
+        and(
+          eq(settlements.id, receiptPayload.sub),
+          eq(settlements.assetId, id),
+          eq(settlements.action, action),
+          eq(settlements.receiptToken, receiptHeader)
+        )
+      )
+      .limit(1);
+
+    if (!settlement) {
+      return NextResponse.json({ error: "Settlement not found" }, { status: 402 });
+    }
+
+    // Log access
+    try {
+      const { nanoid } = await import('nanoid');
+      await db.insert(accessLog).values({
+        id: `acc_${nanoid(16)}`,
+        assetId: id,
+        action,
+        settlementId: settlement.id,
+        buyerDid: settlement.buyerDid ?? undefined,
+        ip: request.headers.get("x-forwarded-for") || request.ip || undefined,
+        userAgent: request.headers.get("user-agent") || undefined,
+      });
+    } catch (err) {
+      log.error({ err: String(err), assetId: id }, "Access log insertion failed");
+      // Non-blocking — continue serving
+    }
+  }
+
+  // 5. Read file from storage
   let fileBuffer: Buffer;
   try {
     fileBuffer = await readFile(asset.storagePath);

--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -275,7 +275,6 @@ export async function GET(
         { status: 429 }
       );
     }
-    }
 
     // Log access
     try {

--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -3,7 +3,7 @@ import { readFile, unlink, rename, stat, open } from "fs/promises";
 import path from "path";
 import { db, assets, settlements, accessLog } from "@/src/db";
 import { requireAuth } from "@imajin/auth";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { createReadStream } from "fs";
 import type { FairManifest } from "@imajin/fair";
 import { isFairManifestV1_1, build402Response, verifyReceipt, loadVerifyKey } from "@imajin/fair";
@@ -254,6 +254,27 @@ export async function GET(
 
     if (!settlement) {
       return NextResponse.json({ error: "Settlement not found" }, { status: 402 });
+    }
+
+    // Replay protection: check for excessive access from same settlement
+    const replayWindow = new Date(Date.now() - 60 * 60 * 1000); // 1 hour
+    const recentAccessCount = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(accessLog)
+      .where(
+        and(
+          eq(accessLog.settlementId, settlement.id),
+          sql`${accessLog.at} > ${replayWindow}`
+        )
+      );
+
+    const accessCount = recentAccessCount[0]?.count ?? 0;
+    if (accessCount > 100) {
+      return NextResponse.json(
+        { error: "Rate limit exceeded for this settlement" },
+        { status: 429 }
+      );
+    }
     }
 
     // Log access

--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -207,7 +207,7 @@ export async function GET(
           manifest: manifest as import("@imajin/fair").FairManifestV1_1,
           assetId: id,
           action,
-          supportedSchemes: ['stripe-link', 'mjnx-direct'],
+          supportedSchemes: ['mjnx-direct'],
           baseUrl,
         });
         return NextResponse.json(resp.body, { status: 402, headers: resp.headers });

--- a/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
@@ -13,7 +13,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, settlements } from "@/src/db";
 import { eq } from "drizzle-orm";
-import { signReceipt, loadSigningKey } from "@imajin/fair";
+import { signReceipt, loadSigningKey, receiptExpiryForAction } from "@imajin/fair";
 import { createLogger } from "@imajin/logger";
 import Stripe from "stripe";
 
@@ -131,6 +131,7 @@ async function handleStripeWebhook(request: NextRequest): Promise<NextResponse> 
         amount: settlement.amount,
         currency: settlement.currency,
         manifestDigest: settlement.fairManifestDigest,
+        exp: receiptExpiryForAction(settlement.action),
       },
       signKey
     );
@@ -238,6 +239,7 @@ async function handleMjnxConfirmation(request: NextRequest): Promise<NextRespons
         amount: settlement.amount,
         currency: settlement.currency,
         manifestDigest: settlement.fairManifestDigest,
+        exp: receiptExpiryForAction(settlement.action),
       },
       signKey
     );

--- a/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
@@ -1,0 +1,293 @@
+/**
+ * POST /media/api/assets/[id]/settle/confirm
+ *
+ * Webhook handler for settlement confirmation.
+ *
+ * Stripe: receives checkout.session.completed webhook,
+ * verifies signature, signs receipt, updates settlement row.
+ *
+ * MJNx-direct: accepts a direct POST from the buyer or node
+ * after on-chain confirmation (simplified — no on-chain verification in v1).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { db, settlements } from "@/src/db";
+import { eq } from "drizzle-orm";
+import { signReceipt, loadSigningKey } from "@imajin/fair";
+import { createLogger } from "@imajin/logger";
+import Stripe from "stripe";
+
+const log = createLogger("kernel");
+
+// Lazy Stripe initialization
+let _stripe: Stripe | null = null;
+function getStripe(): Stripe {
+  if (!_stripe) {
+    if (!process.env.STRIPE_SECRET_KEY) {
+      throw new Error("STRIPE_SECRET_KEY not configured");
+    }
+    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: "2024-11-20.acacia" as Stripe.LatestApiVersion,
+    });
+  }
+  return _stripe;
+}
+
+// Cache signing key
+let signKeyPromise: Promise<import("jose").KeyLike> | null = null;
+function getSignKey(): Promise<import("jose").KeyLike> {
+  if (!signKeyPromise) {
+    const privateKeyHex = process.env.AUTH_PRIVATE_KEY;
+    if (!privateKeyHex) {
+      signKeyPromise = Promise.reject(new Error("AUTH_PRIVATE_KEY not configured"));
+    } else {
+      signKeyPromise = loadSigningKey(privateKeyHex);
+    }
+  }
+  return signKeyPromise;
+}
+
+export async function POST(request: NextRequest) {
+  const source = request.headers.get("X-Settle-Source") || "stripe";
+
+  if (source === "stripe") {
+    return handleStripeWebhook(request);
+  }
+
+  if (source === "mjnx") {
+    return handleMjnxConfirmation(request);
+  }
+
+  return NextResponse.json({ error: "Unknown source" }, { status: 400 });
+}
+
+async function handleStripeWebhook(request: NextRequest): Promise<NextResponse> {
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    log.error({}, "STRIPE_WEBHOOK_SECRET not configured");
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
+  }
+
+  const body = await request.text();
+  const signature = request.headers.get("stripe-signature");
+
+  if (!signature) {
+    return NextResponse.json({ error: "Missing stripe-signature" }, { status: 400 });
+  }
+
+  let event: Stripe.Event;
+  try {
+    const stripe = getStripe();
+    event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
+  } catch (err) {
+    log.error({ err: String(err) }, "Stripe webhook signature verification failed");
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  if (event.type !== "checkout.session.completed") {
+    return NextResponse.json({ received: true });
+  }
+
+  const session = event.data.object as Stripe.Checkout.Session;
+  const settlementId = session.metadata?.settlementId;
+  const assetId = session.metadata?.assetId;
+
+  if (!settlementId || !assetId) {
+    log.warn({ sessionId: session.id }, "Missing settlementId or assetId in session metadata");
+    return NextResponse.json({ received: true });
+  }
+
+  // Find the settlement row
+  const [settlement] = await db
+    .select()
+    .from(settlements)
+    .where(eq(settlements.id, settlementId))
+    .limit(1);
+
+  if (!settlement) {
+    log.warn({ settlementId }, "Settlement row not found");
+    return NextResponse.json({ error: "Settlement not found" }, { status: 404 });
+  }
+
+  if (settlement.receiptToken !== "pending") {
+    log.info({ settlementId }, "Settlement already completed — idempotency skip");
+    return NextResponse.json({ received: true, receipt: settlement.receiptToken });
+  }
+
+  // Sign receipt
+  const paymentId =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id || session.id;
+
+  let receiptToken: string;
+  try {
+    const signKey = await getSignKey();
+    receiptToken = await signReceipt(
+      {
+        aud: `asset:${assetId}`,
+        sub: settlementId,
+        action: settlement.action,
+        amount: settlement.amount,
+        currency: settlement.currency,
+        manifestDigest: settlement.fairManifestDigest,
+      },
+      signKey
+    );
+  } catch (err) {
+    log.error({ err: String(err), settlementId }, "Receipt signing failed");
+    return NextResponse.json({ error: "Receipt signing failed" }, { status: 500 });
+  }
+
+  // Update settlement row
+  try {
+    await db
+      .update(settlements)
+      .set({
+        receiptToken,
+        externalReceiptId: paymentId,
+        settledAt: new Date(),
+      })
+      .where(eq(settlements.id, settlementId));
+  } catch (err) {
+    log.error({ err: String(err), settlementId }, "Failed to update settlement row");
+    return NextResponse.json({ error: "Database failure" }, { status: 500 });
+  }
+
+  // Publish to DFOS if available (feature-detect)
+  let dfosEventId: string | null = null;
+  try {
+    const { publishContentEvent } = await import("@imajin/dfos");
+    const result = await publishContentEvent({
+      topic: "fair.settlement.completed",
+      payload: {
+        assetId,
+        settlementId,
+        action: settlement.action,
+        amount: settlement.amount,
+        currency: settlement.currency,
+        scheme: settlement.scheme,
+        buyerDid: settlement.buyerDid,
+        externalReceiptId: paymentId,
+        manifestDigest: settlement.fairManifestDigest,
+        settledAt: new Date().toISOString(),
+      },
+    });
+    dfosEventId = result.eventId;
+  } catch (err) {
+    log.warn({ err: String(err), settlementId }, "DFOS publish failed (non-fatal)");
+    // Non-blocking — don't fail the webhook
+  }
+
+  if (dfosEventId) {
+    try {
+      await db
+        .update(settlements)
+        .set({ dfosEventId })
+        .where(eq(settlements.id, settlementId));
+    } catch (err) {
+      log.warn({ err: String(err), settlementId, dfosEventId }, "Failed to store DFOS eventId");
+    }
+  }
+
+  log.info({ settlementId, assetId, paymentId }, "Settlement completed via Stripe");
+
+  return NextResponse.json({ received: true, receipt: receiptToken });
+}
+
+async function handleMjnxConfirmation(request: NextRequest): Promise<NextResponse> {
+  let body: {
+    settlementId?: unknown;
+    txHash?: unknown;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const settlementId = typeof body.settlementId === "string" ? body.settlementId : undefined;
+  const txHash = typeof body.txHash === "string" ? body.txHash : undefined;
+
+  if (!settlementId) {
+    return NextResponse.json({ error: "Missing settlementId" }, { status: 400 });
+  }
+
+  const [settlement] = await db
+    .select()
+    .from(settlements)
+    .where(eq(settlements.id, settlementId))
+    .limit(1);
+
+  if (!settlement) {
+    return NextResponse.json({ error: "Settlement not found" }, { status: 404 });
+  }
+
+  if (settlement.receiptToken !== "pending") {
+    return NextResponse.json({ received: true, receipt: settlement.receiptToken });
+  }
+
+  let receiptToken: string;
+  try {
+    const signKey = await getSignKey();
+    receiptToken = await signReceipt(
+      {
+        aud: `asset:${settlement.assetId}`,
+        sub: settlementId,
+        action: settlement.action,
+        amount: settlement.amount,
+        currency: settlement.currency,
+        manifestDigest: settlement.fairManifestDigest,
+      },
+      signKey
+    );
+  } catch (err) {
+    log.error({ err: String(err), settlementId }, "Receipt signing failed");
+    return NextResponse.json({ error: "Receipt signing failed" }, { status: 500 });
+  }
+
+  await db
+    .update(settlements)
+    .set({
+      receiptToken,
+      externalReceiptId: txHash || "mjnx-confirmed",
+      settledAt: new Date(),
+    })
+    .where(eq(settlements.id, settlementId));
+
+  // DFOS publish (feature-detect)
+  let dfosEventId: string | null = null;
+  try {
+    const { publishContentEvent } = await import("@imajin/dfos");
+    const result = await publishContentEvent({
+      topic: "fair.settlement.completed",
+      payload: {
+        assetId: settlement.assetId,
+        settlementId,
+        action: settlement.action,
+        amount: settlement.amount,
+        currency: settlement.currency,
+        scheme: settlement.scheme,
+        buyerDid: settlement.buyerDid,
+        externalReceiptId: txHash || "mjnx-confirmed",
+        manifestDigest: settlement.fairManifestDigest,
+        settledAt: new Date().toISOString(),
+      },
+    });
+    dfosEventId = result.eventId;
+  } catch (err) {
+    log.warn({ err: String(err), settlementId }, "DFOS publish failed (non-fatal)");
+  }
+
+  if (dfosEventId) {
+    try {
+      await db.update(settlements).set({ dfosEventId }).where(eq(settlements.id, settlementId));
+    } catch (err) {
+      log.warn({ err: String(err), settlementId }, "Failed to store DFOS eventId");
+    }
+  }
+
+  log.info({ settlementId, txHash }, "Settlement completed via MJNx");
+
+  return NextResponse.json({ received: true, receipt: receiptToken });
+}

--- a/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
@@ -17,10 +17,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { db, assets, settlements } from "@/src/db";
 import { eq } from "drizzle-orm";
 import { requireAuth } from "@imajin/auth";
-import { canonicalize } from "@imajin/auth";
 import { signReceipt, loadSigningKey, receiptExpiryForAction } from "@imajin/fair";
 import { createLogger } from "@imajin/logger";
-import { createHash } from "crypto";
 
 const log = createLogger("kernel");
 
@@ -96,7 +94,13 @@ export async function POST(
     return NextResponse.json({ received: true, receipt: settlement.receiptToken });
   }
 
-  // Sign receipt
+  // Settlement must have a buyer for buyer-bound receipts
+  if (!settlement.buyerDid) {
+    log.error({ settlementId }, "Settlement has no buyer DID — cannot mint receipt");
+    return NextResponse.json({ error: "Settlement missing buyer" }, { status: 400 });
+  }
+
+  // Sign receipt — bound to the buyer DID (non-transferable in v1)
   let receiptToken: string;
   try {
     const signKey = await getSignKey();
@@ -104,6 +108,7 @@ export async function POST(
       {
         aud: `asset:${settlement.assetId}`,
         sub: settlementId,
+        buyer: settlement.buyerDid,
         action: settlement.action,
         amount: settlement.amount,
         currency: settlement.currency,

--- a/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
@@ -1,37 +1,28 @@
+// TODO(#904): Replace owner-confirms-receipt with atomic node-ledger debit when MJNx balance system lands. Until then, settlement is operator-mediated.
+
 /**
  * POST /media/api/assets/[id]/settle/confirm
  *
- * Webhook handler for settlement confirmation.
+ * Owner-mediated settlement confirmation for MJNx-direct.
  *
- * Stripe: receives checkout.session.completed webhook,
- * verifies signature, signs receipt, updates settlement row.
+ * The asset owner (authenticated) confirms receipt of an MJNx payment,
+ * triggering receipt JWT signing and DFOS event publication.
  *
- * MJNx-direct: accepts a direct POST from the buyer or node
- * after on-chain confirmation (simplified — no on-chain verification in v1).
+ * Full ledger integration (buyer-side atomic debit) is tracked in #904.
+ *
+ * Body: { settlementId, txHash? }
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { db, settlements } from "@/src/db";
+import { db, assets, settlements } from "@/src/db";
 import { eq } from "drizzle-orm";
+import { requireAuth } from "@imajin/auth";
+import { canonicalize } from "@imajin/auth";
 import { signReceipt, loadSigningKey, receiptExpiryForAction } from "@imajin/fair";
 import { createLogger } from "@imajin/logger";
-import Stripe from "stripe";
+import { createHash } from "crypto";
 
 const log = createLogger("kernel");
-
-// Lazy Stripe initialization
-let _stripe: Stripe | null = null;
-function getStripe(): Stripe {
-  if (!_stripe) {
-    if (!process.env.STRIPE_SECRET_KEY) {
-      throw new Error("STRIPE_SECRET_KEY not configured");
-    }
-    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: "2024-11-20.acacia" as Stripe.LatestApiVersion,
-    });
-  }
-  return _stripe;
-}
 
 // Cache signing key
 let signKeyPromise: Promise<import("jose").KeyLike> | null = null;
@@ -47,156 +38,20 @@ function getSignKey(): Promise<import("jose").KeyLike> {
   return signKeyPromise;
 }
 
-export async function POST(request: NextRequest) {
-  const source = request.headers.get("X-Settle-Source") || "stripe";
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
 
-  if (source === "stripe") {
-    return handleStripeWebhook(request);
+  // Require authentication — caller must be the asset owner
+  const authResult = await requireAuth(request);
+  if ("error" in authResult) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
 
-  if (source === "mjnx") {
-    return handleMjnxConfirmation(request);
-  }
-
-  return NextResponse.json({ error: "Unknown source" }, { status: 400 });
-}
-
-async function handleStripeWebhook(request: NextRequest): Promise<NextResponse> {
-  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-  if (!webhookSecret) {
-    log.error({}, "STRIPE_WEBHOOK_SECRET not configured");
-    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
-  }
-
-  const body = await request.text();
-  const signature = request.headers.get("stripe-signature");
-
-  if (!signature) {
-    return NextResponse.json({ error: "Missing stripe-signature" }, { status: 400 });
-  }
-
-  let event: Stripe.Event;
-  try {
-    const stripe = getStripe();
-    event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
-  } catch (err) {
-    log.error({ err: String(err) }, "Stripe webhook signature verification failed");
-    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
-  }
-
-  if (event.type !== "checkout.session.completed") {
-    return NextResponse.json({ received: true });
-  }
-
-  const session = event.data.object as Stripe.Checkout.Session;
-  const settlementId = session.metadata?.settlementId;
-  const assetId = session.metadata?.assetId;
-
-  if (!settlementId || !assetId) {
-    log.warn({ sessionId: session.id }, "Missing settlementId or assetId in session metadata");
-    return NextResponse.json({ received: true });
-  }
-
-  // Find the settlement row
-  const [settlement] = await db
-    .select()
-    .from(settlements)
-    .where(eq(settlements.id, settlementId))
-    .limit(1);
-
-  if (!settlement) {
-    log.warn({ settlementId }, "Settlement row not found");
-    return NextResponse.json({ error: "Settlement not found" }, { status: 404 });
-  }
-
-  if (settlement.receiptToken !== "pending") {
-    log.info({ settlementId }, "Settlement already completed — idempotency skip");
-    return NextResponse.json({ received: true, receipt: settlement.receiptToken });
-  }
-
-  // Sign receipt
-  const paymentId =
-    typeof session.payment_intent === "string"
-      ? session.payment_intent
-      : session.payment_intent?.id || session.id;
-
-  let receiptToken: string;
-  try {
-    const signKey = await getSignKey();
-    receiptToken = await signReceipt(
-      {
-        aud: `asset:${assetId}`,
-        sub: settlementId,
-        action: settlement.action,
-        amount: settlement.amount,
-        currency: settlement.currency,
-        manifestDigest: settlement.fairManifestDigest,
-        exp: receiptExpiryForAction(settlement.action),
-      },
-      signKey
-    );
-  } catch (err) {
-    log.error({ err: String(err), settlementId }, "Receipt signing failed");
-    return NextResponse.json({ error: "Receipt signing failed" }, { status: 500 });
-  }
-
-  // Update settlement row
-  try {
-    await db
-      .update(settlements)
-      .set({
-        receiptToken,
-        externalReceiptId: paymentId,
-        settledAt: new Date(),
-      })
-      .where(eq(settlements.id, settlementId));
-  } catch (err) {
-    log.error({ err: String(err), settlementId }, "Failed to update settlement row");
-    return NextResponse.json({ error: "Database failure" }, { status: 500 });
-  }
-
-  // Publish to DFOS if available (feature-detect)
-  let dfosEventId: string | null = null;
-  try {
-    const { publishContentEvent } = await import("@imajin/dfos");
-    const result = await publishContentEvent({
-      topic: "fair.settlement.completed",
-      payload: {
-        assetId,
-        settlementId,
-        action: settlement.action,
-        amount: settlement.amount,
-        currency: settlement.currency,
-        scheme: settlement.scheme,
-        buyerDid: settlement.buyerDid,
-        externalReceiptId: paymentId,
-        manifestDigest: settlement.fairManifestDigest,
-        settledAt: new Date().toISOString(),
-      },
-    });
-    dfosEventId = result.eventId;
-  } catch (err) {
-    log.warn({ err: String(err), settlementId }, "DFOS publish failed (non-fatal)");
-    // Non-blocking — don't fail the webhook
-  }
-
-  if (dfosEventId) {
-    try {
-      await db
-        .update(settlements)
-        .set({ dfosEventId })
-        .where(eq(settlements.id, settlementId));
-    } catch (err) {
-      log.warn({ err: String(err), settlementId, dfosEventId }, "Failed to store DFOS eventId");
-    }
-  }
-
-  log.info({ settlementId, assetId, paymentId }, "Settlement completed via Stripe");
-
-  return NextResponse.json({ received: true, receipt: receiptToken });
-}
-
-async function handleMjnxConfirmation(request: NextRequest): Promise<NextResponse> {
+  // Parse body
   let body: {
     settlementId?: unknown;
     txHash?: unknown;
@@ -214,6 +69,7 @@ async function handleMjnxConfirmation(request: NextRequest): Promise<NextRespons
     return NextResponse.json({ error: "Missing settlementId" }, { status: 400 });
   }
 
+  // Look up settlement
   const [settlement] = await db
     .select()
     .from(settlements)
@@ -224,10 +80,23 @@ async function handleMjnxConfirmation(request: NextRequest): Promise<NextRespons
     return NextResponse.json({ error: "Settlement not found" }, { status: 404 });
   }
 
-  if (settlement.receiptToken !== "pending") {
+  // Verify the requester is the asset owner
+  const [asset] = await db
+    .select()
+    .from(assets)
+    .where(eq(assets.id, settlement.assetId))
+    .limit(1);
+
+  if (!asset || asset.ownerDid !== requesterDid) {
+    return NextResponse.json({ error: "Forbidden — only the asset owner can confirm settlement" }, { status: 403 });
+  }
+
+  // Idempotency: already completed
+  if (settlement.status === "completed") {
     return NextResponse.json({ received: true, receipt: settlement.receiptToken });
   }
 
+  // Sign receipt
   let receiptToken: string;
   try {
     const signKey = await getSignKey();
@@ -248,16 +117,23 @@ async function handleMjnxConfirmation(request: NextRequest): Promise<NextRespons
     return NextResponse.json({ error: "Receipt signing failed" }, { status: 500 });
   }
 
-  await db
-    .update(settlements)
-    .set({
-      receiptToken,
-      externalReceiptId: txHash || "mjnx-confirmed",
-      settledAt: new Date(),
-    })
-    .where(eq(settlements.id, settlementId));
+  // Update settlement row
+  try {
+    await db
+      .update(settlements)
+      .set({
+        receiptToken,
+        status: "completed",
+        externalReceiptId: txHash || "mjnx-confirmed",
+        settledAt: new Date(),
+      })
+      .where(eq(settlements.id, settlementId));
+  } catch (err) {
+    log.error({ err: String(err), settlementId }, "Failed to update settlement row");
+    return NextResponse.json({ error: "Database failure" }, { status: 500 });
+  }
 
-  // DFOS publish (feature-detect)
+  // Publish to DFOS if available (feature-detect)
   let dfosEventId: string | null = null;
   try {
     const { publishContentEvent } = await import("@imajin/dfos");
@@ -289,7 +165,7 @@ async function handleMjnxConfirmation(request: NextRequest): Promise<NextRespons
     }
   }
 
-  log.info({ settlementId, txHash }, "Settlement completed via MJNx");
+  log.info({ settlementId, txHash, assetId: settlement.assetId }, "Settlement confirmed by owner via MJNx");
 
   return NextResponse.json({ received: true, receipt: receiptToken });
 }

--- a/apps/kernel/app/media/api/assets/[id]/settle/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/settle/route.ts
@@ -3,31 +3,25 @@
  *
  * Initiate settlement for a priced asset action.
  *
- * Body: { action?, scheme, returnUrl? }
+ * Body: { action?, scheme: "mjnx-direct" }
  * - action defaults to "reproduction"
- * - scheme: "stripe-link" | "mjnx-direct" | "x402" | "solana-pay" | "lightning"
+ * - scheme: must be "mjnx-direct" (fiat rails deferred to #904)
  *
- * Returns: { settlementId, url } for stripe-link, { settlementId, uri } for mjnx-direct
+ * Returns: { settlementId, uri } where uri is the mjnx:pay deep link
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { db, assets, settlements } from "@/src/db";
 import { requireAuth } from "@imajin/auth";
+import { canonicalize } from "@imajin/auth";
 import { eq } from "drizzle-orm";
 import { isFairManifestV1_1 } from "@imajin/fair";
-import type { FairManifestV1_1, SettlementScheme } from "@imajin/fair";
-import { getPaymentService } from "@/src/lib/pay/pay";
+import type { FairManifestV1_1 } from "@imajin/fair";
 import { createLogger } from "@imajin/logger";
 import { nanoid } from "nanoid";
+import { createHash } from "crypto";
 
 const log = createLogger("kernel");
-
-function isValidScheme(s: unknown): s is SettlementScheme {
-  return (
-    typeof s === "string" &&
-    ["x402", "stripe-link", "mjnx-direct", "solana-pay", "lightning"].includes(s)
-  );
-}
 
 function isValidAction(s: unknown): s is "reproduction" | "streaming" | "derivative" | "syndication" {
   return (
@@ -46,7 +40,6 @@ export async function POST(
   let body: {
     action?: unknown;
     scheme?: unknown;
-    returnUrl?: unknown;
   };
   try {
     body = await request.json();
@@ -56,10 +49,15 @@ export async function POST(
 
   const action = isValidAction(body.action) ? body.action : "reproduction";
   const scheme = body.scheme;
-  const returnUrl = typeof body.returnUrl === "string" ? body.returnUrl : undefined;
 
-  if (!isValidScheme(scheme)) {
-    return NextResponse.json({ error: "Invalid or missing scheme" }, { status: 400 });
+  if (scheme !== "mjnx-direct") {
+    return NextResponse.json(
+      {
+        error: "Only mjnx-direct settlement is supported on this node. Fiat rails are tracked in #904.",
+        scheme,
+      },
+      { status: 400 }
+    );
   }
 
   // 2. Look up asset
@@ -98,34 +96,29 @@ export async function POST(
     );
   }
 
-  // 4. Auth check
-  // Anonymous settlement allowed for reproduction; required for derivative if commercial not allowed
+  // 4. Auth — single attempt; capture buyerDid if present.
+  // Derivative + commercial-not-allowed requires authentication.
+  const authResult = await requireAuth(request);
   let buyerDid: string | null = null;
-  if (action === "derivative" && manifest.commercial?.allowed === false) {
-    const authResult = await requireAuth(request);
-    if ("error" in authResult) {
-      return NextResponse.json(
-        { error: "Authentication required for derivative settlement" },
-        { status: 401 }
-      );
-    }
+  if (!("error" in authResult)) {
     buyerDid = authResult.identity.actingAs || authResult.identity.id;
+  } else if (action === "derivative" && manifest.commercial?.allowed === false) {
+    return NextResponse.json(
+      { error: "Authentication required for derivative settlement" },
+      { status: 401 }
+    );
   }
 
-  // Optional auth for other actions (capture buyer DID if available)
-  if (!buyerDid) {
-    const authResult = await requireAuth(request);
-    if (!("error" in authResult)) {
-      buyerDid = authResult.identity.actingAs || authResult.identity.id;
-    }
+  // 5. Validate manifest.owner is a DID before interpolating into URI
+  if (!manifest.owner || !manifest.owner.startsWith("did:")) {
+    log.error({ assetId: id, owner: manifest.owner }, "manifest.owner is not a valid DID");
+    return NextResponse.json({ error: "Asset manifest has invalid owner DID" }, { status: 500 });
   }
 
-  // 5. Create settlement row
+  // 6. Create settlement row
   const settlementId = `stl_${nanoid(16)}`;
   const price = distRight.price;
-
-  // Compute manifest digest (simple sha256 of canonical JSON)
-  const manifestDigest = `sha256:${await sha256Text(JSON.stringify(manifest))}`;
+  const manifestDigest = `sha256:${createHash('sha256').update(canonicalize(manifest)).digest('hex')}`;
 
   try {
     await db.insert(settlements).values({
@@ -135,8 +128,9 @@ export async function POST(
       buyerDid,
       amount: price.amount,
       currency: price.currency,
-      scheme,
-      receiptToken: "pending", // will be updated on confirmation
+      scheme: "mjnx-direct",
+      status: "pending",
+      receiptToken: "pending",
       fairManifestDigest: manifestDigest,
     });
   } catch (err) {
@@ -144,73 +138,12 @@ export async function POST(
     return NextResponse.json({ error: "Database failure" }, { status: 500 });
   }
 
-  // 6. Scheme-specific handling
-  if (scheme === "stripe-link") {
-    try {
-      const pay = getPaymentService();
-      const baseUrl = `${new URL(request.url).origin}/media/api/assets`;
-      const successUrl = returnUrl || `${baseUrl}/${id}?settlement=${settlementId}`;
-      const cancelUrl = `${baseUrl}/${id}?settlement=${settlementId}&canceled=true`;
+  // 7. Build MJNx deep-link URI
+  const uri = `mjnx:pay?to=${encodeURIComponent(manifest.owner)}&amount=${price.amount}&currency=${encodeURIComponent(price.currency)}&memo=settle:${settlementId}`;
 
-      const splitsJson = distRight.splits ? JSON.stringify(distRight.splits) : undefined;
-
-      const checkout = await pay.checkout({
-        items: [
-          {
-            name: `${manifest.type} — ${action}`,
-            amount: price.amount,
-            quantity: 1,
-          },
-        ],
-        currency: price.currency as "USD" | "CAD" | "EUR" | "GBP",
-        successUrl,
-        cancelUrl,
-        metadata: {
-          settlementId,
-          assetId: id,
-          action,
-          buyerDid: buyerDid || "",
-          splits: splitsJson || "",
-          manifestDigest,
-          service: "media",
-        },
-      });
-
-      return NextResponse.json({
-        settlementId,
-        url: checkout.url,
-        scheme: "stripe-link",
-      });
-    } catch (err) {
-      log.error({ err: String(err), settlementId }, "Stripe checkout creation failed");
-      return NextResponse.json({ error: "Payment provider error" }, { status: 500 });
-    }
-  }
-
-  if (scheme === "mjnx-direct") {
-    const uri = `mjnx:pay?to=${encodeURIComponent(manifest.owner)}&amount=${price.amount}&currency=${encodeURIComponent(price.currency)}&memo=settle:${settlementId}`;
-    return NextResponse.json({
-      settlementId,
-      uri,
-      scheme: "mjnx-direct",
-    });
-  }
-
-  // Stubs for not-yet-supported schemes
-  if (scheme === "x402" || scheme === "solana-pay" || scheme === "lightning") {
-    return NextResponse.json(
-      { error: "Scheme not supported on this node", scheme },
-      { status: 501 }
-    );
-  }
-
-  return NextResponse.json({ error: "Unknown scheme" }, { status: 400 });
-}
-
-async function sha256Text(text: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(text);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  return NextResponse.json({
+    settlementId,
+    uri,
+    scheme: "mjnx-direct",
+  });
 }

--- a/apps/kernel/app/media/api/assets/[id]/settle/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/settle/route.ts
@@ -14,7 +14,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db, assets, settlements } from "@/src/db";
 import { requireAuth } from "@imajin/auth";
 import { canonicalize } from "@imajin/auth";
-import { eq } from "drizzle-orm";
+import { and, eq, gte, sql } from "drizzle-orm";
 import { isFairManifestV1_1 } from "@imajin/fair";
 import type { FairManifestV1_1 } from "@imajin/fair";
 import { createLogger } from "@imajin/logger";
@@ -96,18 +96,16 @@ export async function POST(
     );
   }
 
-  // 4. Auth — single attempt; capture buyerDid if present.
-  // Derivative + commercial-not-allowed requires authentication.
+  // 4. Auth required — receipts are buyer-bound (non-transferable in v1).
+  // Buyer DID is embedded in the receipt JWT and verified at asset access time.
   const authResult = await requireAuth(request);
-  let buyerDid: string | null = null;
-  if (!("error" in authResult)) {
-    buyerDid = authResult.identity.actingAs || authResult.identity.id;
-  } else if (action === "derivative" && manifest.commercial?.allowed === false) {
+  if ("error" in authResult) {
     return NextResponse.json(
-      { error: "Authentication required for derivative settlement" },
+      { error: "Authentication required to settle" },
       { status: 401 }
     );
   }
+  const buyerDid = authResult.identity.actingAs || authResult.identity.id;
 
   // 5. Validate manifest.owner is a DID before interpolating into URI
   if (!manifest.owner || !manifest.owner.startsWith("did:")) {
@@ -115,9 +113,56 @@ export async function POST(
     return NextResponse.json({ error: "Asset manifest has invalid owner DID" }, { status: 500 });
   }
 
-  // 6. Create settlement row
-  const settlementId = `stl_${nanoid(16)}`;
+  // 6. Rate limit + idempotent dedup of pending settlements for this buyer.
+  // - Reuse an existing pending row for the same (buyer, asset, action) within 30 min
+  //   so client retries return the same settlementId instead of piling up rows.
+  // - Hard cap: more than 10 pending settlements created by this buyer in the last 5 min → 429.
+  const dedupWindow = new Date(Date.now() - 30 * 60 * 1000);
+  const [existing] = await db
+    .select()
+    .from(settlements)
+    .where(
+      and(
+        eq(settlements.buyerDid, buyerDid),
+        eq(settlements.assetId, id),
+        eq(settlements.action, action),
+        eq(settlements.status, "pending"),
+        gte(settlements.settledAt, dedupWindow)
+      )
+    )
+    .limit(1);
+
   const price = distRight.price;
+
+  if (existing) {
+    const uri = `mjnx:pay?to=${encodeURIComponent(manifest.owner)}&amount=${price.amount}&currency=${encodeURIComponent(price.currency)}&memo=settle:${existing.id}`;
+    return NextResponse.json({
+      settlementId: existing.id,
+      uri,
+      scheme: "mjnx-direct",
+      reused: true,
+    });
+  }
+
+  const rateWindow = new Date(Date.now() - 5 * 60 * 1000);
+  const recent = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(settlements)
+    .where(
+      and(
+        eq(settlements.buyerDid, buyerDid),
+        gte(settlements.settledAt, rateWindow)
+      )
+    );
+  if ((recent[0]?.count ?? 0) > 10) {
+    return NextResponse.json(
+      { error: "Settlement rate limit exceeded — try again in a few minutes" },
+      { status: 429 }
+    );
+  }
+
+  // 7. Create settlement row
+  const settlementId = `stl_${nanoid(16)}`;
   const manifestDigest = `sha256:${createHash('sha256').update(canonicalize(manifest)).digest('hex')}`;
 
   try {
@@ -130,7 +175,7 @@ export async function POST(
       currency: price.currency,
       scheme: "mjnx-direct",
       status: "pending",
-      receiptToken: "pending",
+      receiptToken: "", // filled on confirmation
       fairManifestDigest: manifestDigest,
     });
   } catch (err) {
@@ -138,7 +183,7 @@ export async function POST(
     return NextResponse.json({ error: "Database failure" }, { status: 500 });
   }
 
-  // 7. Build MJNx deep-link URI
+  // 8. Build MJNx deep-link URI
   const uri = `mjnx:pay?to=${encodeURIComponent(manifest.owner)}&amount=${price.amount}&currency=${encodeURIComponent(price.currency)}&memo=settle:${settlementId}`;
 
   return NextResponse.json({

--- a/apps/kernel/app/media/api/assets/[id]/settle/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/settle/route.ts
@@ -1,0 +1,216 @@
+/**
+ * POST /media/api/assets/[id]/settle
+ *
+ * Initiate settlement for a priced asset action.
+ *
+ * Body: { action?, scheme, returnUrl? }
+ * - action defaults to "reproduction"
+ * - scheme: "stripe-link" | "mjnx-direct" | "x402" | "solana-pay" | "lightning"
+ *
+ * Returns: { settlementId, url } for stripe-link, { settlementId, uri } for mjnx-direct
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { db, assets, settlements } from "@/src/db";
+import { requireAuth } from "@imajin/auth";
+import { eq } from "drizzle-orm";
+import { isFairManifestV1_1 } from "@imajin/fair";
+import type { FairManifestV1_1, SettlementScheme } from "@imajin/fair";
+import { getPaymentService } from "@/src/lib/pay/pay";
+import { createLogger } from "@imajin/logger";
+import { nanoid } from "nanoid";
+
+const log = createLogger("kernel");
+
+function isValidScheme(s: unknown): s is SettlementScheme {
+  return (
+    typeof s === "string" &&
+    ["x402", "stripe-link", "mjnx-direct", "solana-pay", "lightning"].includes(s)
+  );
+}
+
+function isValidAction(s: unknown): s is "reproduction" | "streaming" | "derivative" | "syndication" {
+  return (
+    typeof s === "string" &&
+    ["reproduction", "streaming", "derivative", "syndication"].includes(s)
+  );
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // 1. Parse body
+  let body: {
+    action?: unknown;
+    scheme?: unknown;
+    returnUrl?: unknown;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const action = isValidAction(body.action) ? body.action : "reproduction";
+  const scheme = body.scheme;
+  const returnUrl = typeof body.returnUrl === "string" ? body.returnUrl : undefined;
+
+  if (!isValidScheme(scheme)) {
+    return NextResponse.json({ error: "Invalid or missing scheme" }, { status: 400 });
+  }
+
+  // 2. Look up asset
+  let asset;
+  try {
+    [asset] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  } catch (err) {
+    log.error({ err: String(err) }, "DB lookup failed");
+    return NextResponse.json({ error: "Database failure" }, { status: 500 });
+  }
+
+  if (!asset || asset.status !== "active") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // 3. Resolve manifest
+  let manifest: FairManifestV1_1 | null = null;
+  if (
+    asset.fairManifest &&
+    typeof asset.fairManifest === "object" &&
+    Object.keys(asset.fairManifest as object).length > 0 &&
+    isFairManifestV1_1(asset.fairManifest as Record<string, unknown>)
+  ) {
+    manifest = asset.fairManifest as unknown as FairManifestV1_1;
+  }
+
+  if (!manifest) {
+    return NextResponse.json({ error: "No .fair manifest" }, { status: 400 });
+  }
+
+  const distRight = manifest.distribution?.[action];
+  if (!distRight?.price) {
+    return NextResponse.json(
+      { error: `Action "${action}" is not priced` },
+      { status: 400 }
+    );
+  }
+
+  // 4. Auth check
+  // Anonymous settlement allowed for reproduction; required for derivative if commercial not allowed
+  let buyerDid: string | null = null;
+  if (action === "derivative" && manifest.commercial?.allowed === false) {
+    const authResult = await requireAuth(request);
+    if ("error" in authResult) {
+      return NextResponse.json(
+        { error: "Authentication required for derivative settlement" },
+        { status: 401 }
+      );
+    }
+    buyerDid = authResult.identity.actingAs || authResult.identity.id;
+  }
+
+  // Optional auth for other actions (capture buyer DID if available)
+  if (!buyerDid) {
+    const authResult = await requireAuth(request);
+    if (!("error" in authResult)) {
+      buyerDid = authResult.identity.actingAs || authResult.identity.id;
+    }
+  }
+
+  // 5. Create settlement row
+  const settlementId = `stl_${nanoid(16)}`;
+  const price = distRight.price;
+
+  // Compute manifest digest (simple sha256 of canonical JSON)
+  const manifestDigest = `sha256:${await sha256Text(JSON.stringify(manifest))}`;
+
+  try {
+    await db.insert(settlements).values({
+      id: settlementId,
+      assetId: id,
+      action,
+      buyerDid,
+      amount: price.amount,
+      currency: price.currency,
+      scheme,
+      receiptToken: "pending", // will be updated on confirmation
+      fairManifestDigest: manifestDigest,
+    });
+  } catch (err) {
+    log.error({ err: String(err) }, "Failed to create settlement row");
+    return NextResponse.json({ error: "Database failure" }, { status: 500 });
+  }
+
+  // 6. Scheme-specific handling
+  if (scheme === "stripe-link") {
+    try {
+      const pay = getPaymentService();
+      const baseUrl = `${new URL(request.url).origin}/media/api/assets`;
+      const successUrl = returnUrl || `${baseUrl}/${id}?settlement=${settlementId}`;
+      const cancelUrl = `${baseUrl}/${id}?settlement=${settlementId}&canceled=true`;
+
+      const splitsJson = distRight.splits ? JSON.stringify(distRight.splits) : undefined;
+
+      const checkout = await pay.checkout({
+        items: [
+          {
+            name: `${manifest.type} — ${action}`,
+            amount: price.amount,
+            quantity: 1,
+          },
+        ],
+        currency: price.currency as "USD" | "CAD" | "EUR" | "GBP",
+        successUrl,
+        cancelUrl,
+        metadata: {
+          settlementId,
+          assetId: id,
+          action,
+          buyerDid: buyerDid || "",
+          splits: splitsJson || "",
+          manifestDigest,
+          service: "media",
+        },
+      });
+
+      return NextResponse.json({
+        settlementId,
+        url: checkout.url,
+        scheme: "stripe-link",
+      });
+    } catch (err) {
+      log.error({ err: String(err), settlementId }, "Stripe checkout creation failed");
+      return NextResponse.json({ error: "Payment provider error" }, { status: 500 });
+    }
+  }
+
+  if (scheme === "mjnx-direct") {
+    const uri = `mjnx:pay?to=${encodeURIComponent(manifest.owner)}&amount=${price.amount}&currency=${encodeURIComponent(price.currency)}&memo=settle:${settlementId}`;
+    return NextResponse.json({
+      settlementId,
+      uri,
+      scheme: "mjnx-direct",
+    });
+  }
+
+  // Stubs for not-yet-supported schemes
+  if (scheme === "x402" || scheme === "solana-pay" || scheme === "lightning") {
+    return NextResponse.json(
+      { error: "Scheme not supported on this node", scheme },
+      { status: 501 }
+    );
+  }
+
+  return NextResponse.json({ error: "Unknown scheme" }, { status: 400 });
+}
+
+async function sha256Text(text: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(text);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/apps/kernel/src/db/schemas/media.ts
+++ b/apps/kernel/src/db/schemas/media.ts
@@ -95,5 +95,54 @@ export const assetReferences = mediaSchema.table("asset_references", {
   uniq: unique("uq_asset_reference").on(table.assetId, table.service, table.entityType, table.entityId),
 }));
 
+export const settlements = mediaSchema.table(
+  "settlements",
+  {
+    id: text("id").primaryKey(),                              // stl_<nanoid>
+    assetId: text("asset_id").notNull(),
+    action: text("action").notNull(),                         // reproduction | streaming | derivative | syndication
+    buyerDid: text("buyer_did"),                              // nullable (anonymous)
+    amount: integer("amount").notNull(),                      // minor units
+    currency: text("currency").notNull(),
+    scheme: text("scheme").notNull(),                         // x402 | stripe-link | mjnx-direct | ...
+    receiptToken: text("receipt_token").notNull(),            // signed JWT
+    externalReceiptId: text("external_receipt_id"),           // scheme-specific id (Stripe charge id, etc.)
+    fairManifestDigest: text("fair_manifest_digest").notNull(), // sha256: of manifest at time of settle
+    dfosEventId: text("dfos_event_id"),                       // if publishContentEvent succeeded
+    settledAt: timestamp("settled_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    assetIdx: index("idx_settlements_asset").on(table.assetId),
+    buyerIdx: index("idx_settlements_buyer").on(table.buyerDid),
+    dfosIdx: index("idx_settlements_dfos").on(table.dfosEventId),
+    settledAtIdx: index("idx_settlements_settled_at").on(table.settledAt),
+  })
+);
+
+export type Settlement = typeof settlements.$inferSelect;
+export type NewSettlement = typeof settlements.$inferInsert;
+
+export const accessLog = mediaSchema.table(
+  "access_log",
+  {
+    id: text("id").primaryKey(),                              // acc_<nanoid>
+    assetId: text("asset_id").notNull(),
+    action: text("action").notNull(),
+    settlementId: text("settlement_id"),                      // nullable for free access
+    buyerDid: text("buyer_did"),
+    ip: text("ip"),                                           // hashed for privacy if desired
+    userAgent: text("user_agent"),
+    at: timestamp("at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    assetIdx: index("idx_access_log_asset").on(table.assetId),
+    buyerIdx: index("idx_access_log_buyer").on(table.buyerDid),
+    atIdx: index("idx_access_log_at").on(table.at),
+  })
+);
+
+export type AccessLog = typeof accessLog.$inferSelect;
+export type NewAccessLog = typeof accessLog.$inferInsert;
+
 export type AssetReference = typeof assetReferences.$inferSelect;
 export type NewAssetReference = typeof assetReferences.$inferInsert;

--- a/apps/kernel/src/db/schemas/media.ts
+++ b/apps/kernel/src/db/schemas/media.ts
@@ -105,6 +105,7 @@ export const settlements = mediaSchema.table(
     amount: integer("amount").notNull(),                      // minor units
     currency: text("currency").notNull(),
     scheme: text("scheme").notNull(),                         // x402 | stripe-link | mjnx-direct | ...
+    status: text("status").notNull().default("pending"),      // pending | completed
     receiptToken: text("receipt_token").notNull(),            // signed JWT
     externalReceiptId: text("external_receipt_id"),           // scheme-specific id (Stripe charge id, etc.)
     fairManifestDigest: text("fair_manifest_digest").notNull(), // sha256: of manifest at time of settle

--- a/docs/audits/fair-http-402.md
+++ b/docs/audits/fair-http-402.md
@@ -1,4 +1,8 @@
-# Audit: .fair HTTP 402 Native Settlement + Multi-Scheme Wire Support (#883)
+# Audit: .fair HTTP 402 Native Settlement — MJNx-Direct (#883)
+
+> **Scope revision (post-architecture review):** This PR implements MJNx-direct settlement only.
+> Stripe Link and other fiat/chain rails are tracked in **#904** as deposit on-ramps INTO MJNx,
+> not parallel settlement schemes. See "Deferred to #904" section below.
 
 ## Current State of Asset Serve Path (`apps/kernel/app/media/api/assets/[id]/route.ts`)
 
@@ -13,45 +17,38 @@ The existing route handler performs access control in this order:
    - For `private`: only `ownerDid` may access
    - For `trust-graph`: owner or `allowedDids` list
    - Returns `403` if any check fails
-5. **Byte serving** — with Range support for video, ETag, cache headers, thumbnail resize via sharp, variant serving
+5. **Price-aware 402 path** (if manifest has distribution pricing):
+   - Missing receipt → `402` with `mjnx-direct` settlement options
+   - Present receipt → JWT verification + DB lookup + replay protection
+   - Access logged to `media.access_log`
+6. **Byte serving** — with Range support for video, ETag, cache headers, thumbnail resize via sharp, variant serving
 
 ### X-Fair-Access Header
 The route sets `X-Fair-Access: <accessType>` on every response. This is informational only — the actual enforcement happens before byte serving.
 
-### What's Missing
-- No price-aware access control
-- No settlement scheme negotiation
-- No receipt verification
-- No payment-required (402) response path
-- No per-action differentiation (`reproduction` vs `streaming`)
-
 ---
 
-## What `apps/kernel/src/lib/pay/` Provides
+## Settlement Architecture
 
-The payment infrastructure lives inside `apps/kernel` (not a standalone `apps/pay/` app).
+### MJNx-direct is the settlement currency
 
-### Key Components
-- **`PaymentService`** (`service.ts`) — unified facade routing to Stripe or Solana
-- **`StripeProvider`** (`providers/stripe.ts`) — implements:
-  - `charge()` — PaymentIntent creation
-  - `checkout()` — hosted Checkout session creation (returns `url`)
-  - `escrow()` — manual capture PaymentIntent
-  - `refund()`, `createSubscription()`, etc.
-- **`types.ts`** — `CheckoutRequest`, `CheckoutResult`, `CheckoutItem`, etc.
+MJNx is the node's local settlement currency. Fiat rails (Stripe, etc.) are deposit rails INTO
+MJNx, not parallel settlement schemes. Stripe-as-settlement is broken at micro-attribution scale:
+the 30¢ flat fee makes <$2 settlements uneconomic, and Stripe Connect creates activation energy
+(verified business, country gating, webhooks) that is inappropriate for a sovereign identity node.
 
-### What We Need for Stripe Link Creation
-The existing `checkout()` method on `StripeProvider` creates a **Stripe Checkout session** (not a Payment Link). The spec says "Stripe Link" but the provider's `checkout()` returns a redirect URL for a hosted checkout session, which is the correct Stripe primitive for one-time payments.
+### Settlement flow (v1)
 
-We will use `PaymentService.checkout()` with:
-- `items: [{ name, amount, quantity: 1 }]`
-- `currency`
-- `metadata` containing splits JSON + settlementId
-- `successUrl` / `cancelUrl` from caller's `returnUrl`
+1. **GET /media/api/assets/{id}** with a priced action → `402` with `mjnx:pay?...` deep link
+2. Buyer sends MJNx payment out-of-band
+3. **POST /media/api/assets/{id}/settle** — creates `settlements` row (status=pending), returns `{ settlementId, uri }`
+4. **POST /media/api/assets/{id}/settle/confirm** — asset owner confirms receipt, signs JWT, updates row (status=completed)
+5. Buyer presents receipt JWT in `X-Payment-Receipt` header → access granted
 
-### Auth / API Key
-- `STRIPE_SECRET_KEY` env var configured on kernel
-- `PAY_SERVICE_API_KEY` exists but is for internal API calls between services
+### Owner-mediated confirmation (temporary)
+Until the MJNx ledger system (#904) is live, the asset owner mediates confirmation.
+The confirm endpoint requires authentication and checks `asset.ownerDid === requesterDid`.
+Full atomic debit will replace this when the balance system lands.
 
 ---
 
@@ -75,8 +72,12 @@ amount: number                        // minor units
 currency: string                      // ISO 4217 or MJNX
 exp: number                           // Unix timestamp
 iat: number                           // issued at
-manifestDigest: "sha256:..."          // manifest hash at settle time
+manifestDigest: "sha256:..."          // manifest hash at settle time (canonicalized)
 ```
+
+### Manifest Digest
+Uses `canonicalize()` from `@imajin/auth` (RFC 8785 key-ordered JSON) via Node `crypto.createHash('sha256')`.
+This matches the signing convention used throughout the rest of the codebase.
 
 ### Key Source
 `process.env.AUTH_PRIVATE_KEY` (hex) → imported as EdDSA signing key via `jose.importPKCS8`, identical to the existing session JWT flow in `apps/kernel/src/lib/auth/jwt.ts`.
@@ -95,10 +96,11 @@ manifestDigest: "sha256:..."          // manifest hash at settle time
 | `buyer_did` | text nullable | anonymous allowed |
 | `amount` | integer not null | minor units |
 | `currency` | text not null | ISO 4217 or MJNX |
-| `scheme` | text not null | x402 / stripe-link / mjnx-direct / solana-pay / lightning |
+| `scheme` | text not null | mjnx-direct (others deferred to #904) |
+| `status` | text not null default 'pending' | pending \| completed |
 | `receipt_token` | text not null | signed JWT |
-| `external_receipt_id` | text nullable | Stripe charge id, etc. |
-| `fair_manifest_digest` | text not null | sha256: of manifest at settle time |
+| `external_receipt_id` | text nullable | tx hash or "mjnx-confirmed" |
+| `fair_manifest_digest` | text not null | sha256: of canonicalized manifest at settle time |
 | `dfos_event_id` | text nullable | if publishContentEvent succeeded |
 | `settled_at` | timestamp default now() | |
 
@@ -126,11 +128,11 @@ Indexes: `asset_id`, `buyer_did`, `at`
 **Convention path:** `POST /media/api/assets/{id}/settle`
 
 This matches the existing Next.js App Router structure:
-- `apps/kernel/app/media/api/assets/[id]/route.ts` — GET (serve bytes)
+- `apps/kernel/app/media/api/assets/[id]/route.ts` — GET (serve bytes), DELETE, PATCH
 - `apps/kernel/app/media/api/assets/[id]/fair/route.ts` — GET/PUT (manifest)
-- `apps/kernel/app/media/api/assets/[id]/settle/route.ts` — POST (new)
-- `apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts` — POST (webhook)
-- `apps/kernel/app/media/api/assets/[id]/receipts/route.ts` — GET (new, audit trail)
+- `apps/kernel/app/media/api/assets/[id]/settle/route.ts` — POST (initiate settlement)
+- `apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts` — POST (owner-confirm)
+- `apps/kernel/app/media/api/assets/[id]/receipts/route.ts` — GET (audit trail for owner)
 
 The manifest-level override `manifest.settlement?.endpoint` takes precedence if present.
 
@@ -139,8 +141,19 @@ The manifest-level override `manifest.settlement?.endpoint` takes precedence if 
 ## Dependencies
 
 - #896 — `Money`, `DidShareList`, `FairManifestV1_1` with per-action `price` + `splits` ✅ (on base branch)
-- #897 — `publishContentEvent()` from `@imajin/dfos` — will feature-detect, guard with try/catch
+- #897 — `publishContentEvent()` from `@imajin/dfos` — feature-detected, guarded with try/catch
 
-## Next Sequential Migration Number
+---
 
-Current highest: `0021_orders_buyer_email.sql` → next is `0022`
+## Deferred to #904
+
+The following are out of scope for this PR and tracked in **#904** (MJNx on-ramp + balance system):
+
+- **Stripe Link** — fiat checkout via Stripe Checkout sessions
+- **x402** — HTTP 402 native payment protocol
+- **Solana Pay** — on-chain SOL/USDC settlement
+- **Lightning** — Bitcoin Lightning Network settlement
+- **MJNx-direct chain verification** — cryptographic proof-of-payment on the MJNx ledger
+- **Multi-node MJNx interop** — cross-node settlement routing
+- **On-ramp flows** — buyer converting fiat → MJNx before settlement
+- **Atomic node-ledger debit** — replacing owner-mediated confirmation with ledger-level atomicity

--- a/docs/audits/fair-http-402.md
+++ b/docs/audits/fair-http-402.md
@@ -1,0 +1,146 @@
+# Audit: .fair HTTP 402 Native Settlement + Multi-Scheme Wire Support (#883)
+
+## Current State of Asset Serve Path (`apps/kernel/app/media/api/assets/[id]/route.ts`)
+
+### Access Control Logic
+The existing route handler performs access control in this order:
+
+1. **DB lookup** — fetch asset by `id`, check `status === "active"`
+2. **Manifest resolution** — prefer inline `asset.fairManifest` (jsonb), fallback to `asset.fairPath` on disk
+3. **Access type extraction** — `public` | `private` | `trust-graph` | `conversation`
+4. **Auth gate** (if not public):
+   - Calls `requireAuth(request)` from `@imajin/auth`
+   - For `private`: only `ownerDid` may access
+   - For `trust-graph`: owner or `allowedDids` list
+   - Returns `403` if any check fails
+5. **Byte serving** — with Range support for video, ETag, cache headers, thumbnail resize via sharp, variant serving
+
+### X-Fair-Access Header
+The route sets `X-Fair-Access: <accessType>` on every response. This is informational only — the actual enforcement happens before byte serving.
+
+### What's Missing
+- No price-aware access control
+- No settlement scheme negotiation
+- No receipt verification
+- No payment-required (402) response path
+- No per-action differentiation (`reproduction` vs `streaming`)
+
+---
+
+## What `apps/kernel/src/lib/pay/` Provides
+
+The payment infrastructure lives inside `apps/kernel` (not a standalone `apps/pay/` app).
+
+### Key Components
+- **`PaymentService`** (`service.ts`) — unified facade routing to Stripe or Solana
+- **`StripeProvider`** (`providers/stripe.ts`) — implements:
+  - `charge()` — PaymentIntent creation
+  - `checkout()` — hosted Checkout session creation (returns `url`)
+  - `escrow()` — manual capture PaymentIntent
+  - `refund()`, `createSubscription()`, etc.
+- **`types.ts`** — `CheckoutRequest`, `CheckoutResult`, `CheckoutItem`, etc.
+
+### What We Need for Stripe Link Creation
+The existing `checkout()` method on `StripeProvider` creates a **Stripe Checkout session** (not a Payment Link). The spec says "Stripe Link" but the provider's `checkout()` returns a redirect URL for a hosted checkout session, which is the correct Stripe primitive for one-time payments.
+
+We will use `PaymentService.checkout()` with:
+- `items: [{ name, amount, quantity: 1 }]`
+- `currency`
+- `metadata` containing splits JSON + settlementId
+- `successUrl` / `cancelUrl` from caller's `returnUrl`
+
+### Auth / API Key
+- `STRIPE_SECRET_KEY` env var configured on kernel
+- `PAY_SERVICE_API_KEY` exists but is for internal API calls between services
+
+---
+
+## Decision: Receipt Format
+
+**JWT signed by the node key (EdDSA / Ed25519)**
+
+Rationale:
+- `jose` is already a dependency of `@imajin/auth` and the kernel
+- Ed25519 signing keys are already in use (`AUTH_PRIVATE_KEY` hex → PKCS8)
+- JWT is compact, URL-safe, and has standard `iss`, `aud`, `exp` claims
+- No new crypto dependencies needed
+
+### Receipt JWT Claims
+```
+iss: "node"                          // issuer
+aud: "asset:{assetId}"               // audience = asset
+sub: "{settlementId}"                // subject = settlement record
+action: "reproduction" | "streaming" | "derivative" | "syndication"
+amount: number                        // minor units
+currency: string                      // ISO 4217 or MJNX
+exp: number                           // Unix timestamp
+iat: number                           // issued at
+manifestDigest: "sha256:..."          // manifest hash at settle time
+```
+
+### Key Source
+`process.env.AUTH_PRIVATE_KEY` (hex) → imported as EdDSA signing key via `jose.importPKCS8`, identical to the existing session JWT flow in `apps/kernel/src/lib/auth/jwt.ts`.
+
+---
+
+## Schema Additions
+
+### `media.settlements`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | text PK | `stl_<nanoid>` |
+| `asset_id` | text not null | FK to assets |
+| `action` | text not null | reproduction / streaming / derivative / syndication |
+| `buyer_did` | text nullable | anonymous allowed |
+| `amount` | integer not null | minor units |
+| `currency` | text not null | ISO 4217 or MJNX |
+| `scheme` | text not null | x402 / stripe-link / mjnx-direct / solana-pay / lightning |
+| `receipt_token` | text not null | signed JWT |
+| `external_receipt_id` | text nullable | Stripe charge id, etc. |
+| `fair_manifest_digest` | text not null | sha256: of manifest at settle time |
+| `dfos_event_id` | text nullable | if publishContentEvent succeeded |
+| `settled_at` | timestamp default now() | |
+
+Indexes: `asset_id`, `buyer_did`, `dfos_event_id`, `settled_at`
+
+### `media.access_log`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | text PK | `acc_<nanoid>` |
+| `asset_id` | text not null | |
+| `action` | text not null | |
+| `settlement_id` | text nullable | null = free access |
+| `buyer_did` | text nullable | |
+| `ip` | text nullable | store hashed if privacy-sensitive |
+| `user_agent` | text nullable | |
+| `at` | timestamp default now() | |
+
+Indexes: `asset_id`, `buyer_did`, `at`
+
+---
+
+## Convention vs Override for `/settle` URL
+
+**Convention path:** `POST /media/api/assets/{id}/settle`
+
+This matches the existing Next.js App Router structure:
+- `apps/kernel/app/media/api/assets/[id]/route.ts` — GET (serve bytes)
+- `apps/kernel/app/media/api/assets/[id]/fair/route.ts` — GET/PUT (manifest)
+- `apps/kernel/app/media/api/assets/[id]/settle/route.ts` — POST (new)
+- `apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts` — POST (webhook)
+- `apps/kernel/app/media/api/assets/[id]/receipts/route.ts` — GET (new, audit trail)
+
+The manifest-level override `manifest.settlement?.endpoint` takes precedence if present.
+
+---
+
+## Dependencies
+
+- #896 — `Money`, `DidShareList`, `FairManifestV1_1` with per-action `price` + `splits` ✅ (on base branch)
+- #897 — `publishContentEvent()` from `@imajin/dfos` — will feature-detect, guard with try/catch
+
+## Next Sequential Migration Number
+
+Current highest: `0021_orders_buyer_email.sql` → next is `0022`

--- a/migrations/0022_media_settlements_access_log.sql
+++ b/migrations/0022_media_settlements_access_log.sql
@@ -1,0 +1,37 @@
+-- .fair HTTP 402 settlement support (#883)
+-- Creates settlements and access_log tables under media schema
+
+CREATE TABLE IF NOT EXISTS media.settlements (
+    id TEXT PRIMARY KEY,
+    asset_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    buyer_did TEXT,
+    amount INTEGER NOT NULL,
+    currency TEXT NOT NULL,
+    scheme TEXT NOT NULL,
+    receipt_token TEXT NOT NULL,
+    external_receipt_id TEXT,
+    fair_manifest_digest TEXT NOT NULL,
+    dfos_event_id TEXT,
+    settled_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_settlements_asset ON media.settlements(asset_id);
+CREATE INDEX IF NOT EXISTS idx_settlements_buyer ON media.settlements(buyer_did);
+CREATE INDEX IF NOT EXISTS idx_settlements_dfos ON media.settlements(dfos_event_id);
+CREATE INDEX IF NOT EXISTS idx_settlements_settled_at ON media.settlements(settled_at);
+
+CREATE TABLE IF NOT EXISTS media.access_log (
+    id TEXT PRIMARY KEY,
+    asset_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    settlement_id TEXT,
+    buyer_did TEXT,
+    ip TEXT,
+    user_agent TEXT,
+    at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_access_log_asset ON media.access_log(asset_id);
+CREATE INDEX IF NOT EXISTS idx_access_log_buyer ON media.access_log(buyer_did);
+CREATE INDEX IF NOT EXISTS idx_access_log_at ON media.access_log(at);

--- a/migrations/0023_settlements_status.sql
+++ b/migrations/0023_settlements_status.sql
@@ -1,0 +1,6 @@
+-- Add status column to media.settlements (#883)
+-- Separate migration since 0022 may have already run on dev.
+-- Values: 'pending' | 'completed'
+
+ALTER TABLE media.settlements
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending';

--- a/packages/fair/package.json
+++ b/packages/fair/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@noble/ed25519": "^2.3.0",
-    "@noble/hashes": "^1.3.0"
+    "@noble/hashes": "^1.3.0",
+    "jose": "^6.2.3"
   },
   "devDependencies": {
     "@types/react": "^18",

--- a/packages/fair/src/http-402.ts
+++ b/packages/fair/src/http-402.ts
@@ -1,0 +1,112 @@
+import type { FairManifestV1_1, SettlementScheme } from './types';
+
+export type FairAction = 'reproduction' | 'streaming' | 'derivative' | 'syndication';
+
+export interface Build402ResponseOpts {
+  manifest: FairManifestV1_1;
+  assetId: string;
+  action: FairAction;
+  supportedSchemes: SettlementScheme[];
+  baseUrl: string;
+  schemeUrls?: Partial<Record<SettlementScheme, string>>;
+}
+
+export interface Fair402Response {
+  status: 402;
+  headers: Record<string, string>;
+  body: {
+    error: 'payment_required';
+    assetId: string;
+    action: FairAction;
+    price: {
+      amount: number;
+      currency: string;
+    };
+    splits?: Array<{
+      did?: string;
+      role: string;
+      share: number;
+      name?: string;
+    }>;
+    settlement: {
+      endpoint: string;
+      schemes: SettlementScheme[];
+      fallback?: SettlementScheme;
+      urls?: Partial<Record<SettlementScheme, string>>;
+    };
+  };
+}
+
+/**
+ * Build a 402 Payment Required response per the .fair settlement spec.
+ *
+ * Pure function — no I/O. Caller injects scheme-specific URLs.
+ *
+ * @throws if the requested action has no price (caller should not reach here)
+ */
+export function build402Response(opts: Build402ResponseOpts): Fair402Response {
+  const { manifest, assetId, action, supportedSchemes, baseUrl, schemeUrls } = opts;
+
+  const dist = manifest.distribution?.[action];
+  if (!dist?.price) {
+    throw new Error(`Action "${action}" has no price in manifest distribution`);
+  }
+
+  // Intersection of what the node supports and what the manifest allows
+  const manifestSchemes = manifest.settlement?.schemes;
+  const effectiveSchemes = manifestSchemes
+    ? supportedSchemes.filter((s) => manifestSchemes.includes(s))
+    : supportedSchemes;
+
+  if (effectiveSchemes.length === 0) {
+    throw new Error(`No supported settlement schemes overlap with manifest allowed schemes`);
+  }
+
+  const settlementEndpoint = manifest.settlement?.endpoint || `${baseUrl}/${assetId}/settle`;
+  const fallback = manifest.settlement?.fallback;
+
+  // Build X-Settle-* headers for each available scheme
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/fair+json',
+    'Link': `<${baseUrl}/${assetId}/fair>; rel="fair"`,
+    'X-Settle-Endpoint': settlementEndpoint,
+  };
+
+  for (const scheme of effectiveSchemes) {
+    const headerKey = `X-Settle-${schemeToHeader(scheme)}`;
+    const url = schemeUrls?.[scheme];
+    if (url) {
+      headers[headerKey] = url;
+    } else {
+      // Placeholder — caller may not have pre-built URLs for all schemes
+      headers[headerKey] = 'pending';
+    }
+  }
+
+  const body: Fair402Response['body'] = {
+    error: 'payment_required',
+    assetId,
+    action,
+    price: {
+      amount: dist.price.amount,
+      currency: dist.price.currency,
+    },
+    ...(dist.splits ? { splits: dist.splits } : {}),
+    settlement: {
+      endpoint: settlementEndpoint,
+      schemes: effectiveSchemes,
+      ...(fallback ? { fallback } : {}),
+      ...(schemeUrls ? { urls: schemeUrls } : {}),
+    },
+  };
+
+  return { status: 402, headers, body };
+}
+
+function schemeToHeader(scheme: SettlementScheme): string {
+  // x402 → X-402, stripe-link → Stripe, etc.
+  return scheme
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}

--- a/packages/fair/src/index.ts
+++ b/packages/fair/src/index.ts
@@ -65,3 +65,6 @@ export type {
 } from './agent-pricing';
 
 export { upgradeToV1_1 } from './upgrade';
+
+export { build402Response } from './http-402';
+export type { Build402ResponseOpts, Fair402Response, FairAction } from './http-402';

--- a/packages/fair/src/index.ts
+++ b/packages/fair/src/index.ts
@@ -68,3 +68,6 @@ export { upgradeToV1_1 } from './upgrade';
 
 export { build402Response } from './http-402';
 export type { Build402ResponseOpts, Fair402Response, FairAction } from './http-402';
+
+export { signReceipt, verifyReceipt, loadSigningKey, loadVerifyKey, receiptExpiryForAction } from './receipt';
+export type { ReceiptPayload } from './receipt';

--- a/packages/fair/src/index.ts
+++ b/packages/fair/src/index.ts
@@ -20,6 +20,8 @@ export type {
   FairAccessV1_1,
   Signature,
   SignedFairManifest,
+  SettlementScheme,
+  SettlementConfig,
 } from './types';
 export { isFairManifestV1_1 } from './types';
 

--- a/packages/fair/src/receipt.ts
+++ b/packages/fair/src/receipt.ts
@@ -1,9 +1,23 @@
 import * as jose from 'jose';
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+
+// @noble/ed25519 v2 requires sha512 to be wired up explicitly in non-web environments
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(ed.etc as any).sha512Sync = (...m: Uint8Array[]) => sha512(ed.etc.concatBytes(...m));
+
+// PKCS8 prefix for Ed25519 keys (16 bytes, RFC 8410):
+// SEQUENCE { INTEGER 0, SEQUENCE { OID 1.3.101.112 }, OCTET STRING { OCTET STRING { <32 bytes> } } }
+const PKCS8_ED25519_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+// SPKI prefix for Ed25519 public keys (12 bytes, RFC 8410):
+// SEQUENCE { SEQUENCE { OID 1.3.101.112 }, BIT STRING { <32 bytes> } }
+const SPKI_ED25519_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
 
 export interface ReceiptPayload {
   iss: 'node';
   aud: string; // asset:{assetId}
   sub: string; // settlementId
+  buyer: string; // buyer DID — receipt is bound to this identity (non-transferable in v1)
   action: string;
   amount: number;
   currency: string;
@@ -24,6 +38,7 @@ export async function signReceipt(
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const jwt = await new jose.SignJWT({
+    buyer: payload.buyer,
     action: payload.action,
     amount: payload.amount,
     currency: payload.currency,
@@ -68,6 +83,11 @@ export async function verifyReceipt(
       return null;
     }
 
+    const buyer = payload.buyer as unknown;
+    if (typeof buyer !== 'string' || !buyer || !buyer.startsWith('did:')) {
+      return null;
+    }
+
     const action = payload.action as unknown;
     if (typeof action !== 'string' || !action) {
       return null;
@@ -92,6 +112,7 @@ export async function verifyReceipt(
       iss: 'node',
       aud: audStr,
       sub,
+      buyer,
       action,
       amount,
       currency,
@@ -125,36 +146,26 @@ export function receiptExpiryForAction(action: string): number {
 }
 
 export async function loadSigningKey(privateKeyHex: string): Promise<jose.KeyLike> {
-  const privateKeyBytes = Buffer.from(privateKeyHex, 'hex');
-  const pkcs8Pem = `-----BEGIN PRIVATE KEY-----\n${privateKeyBytes.toString('base64')}\n-----END PRIVATE KEY-----`;
+  const seed = Buffer.from(privateKeyHex, 'hex');
+  if (seed.length !== 32) {
+    throw new Error(`AUTH_PRIVATE_KEY must be 32-byte hex (got ${seed.length} bytes)`);
+  }
+  const pkcs8Der = Buffer.concat([PKCS8_ED25519_PREFIX, seed]);
+  const pkcs8Pem = `-----BEGIN PRIVATE KEY-----\n${pkcs8Der.toString('base64')}\n-----END PRIVATE KEY-----`;
   return jose.importPKCS8(pkcs8Pem, 'EdDSA');
 }
 
 /**
- * Derive the public verification key from a hex-encoded raw private key.
+ * Derive the public verification key from a 32-byte hex-encoded private seed.
  */
 export async function loadVerifyKey(privateKeyHex: string): Promise<jose.KeyLike> {
-  const privateKeyBytes = Buffer.from(privateKeyHex, 'hex');
-
-  // Import as extractable to derive public key
-  const privateKey = await crypto.subtle.importKey(
-    'pkcs8',
-    privateKeyBytes,
-    { name: 'Ed25519' },
-    true,
-    ['sign'],
-  );
-
-  const jwk = await crypto.subtle.exportKey('jwk', privateKey);
-  const publicKey = await crypto.subtle.importKey(
-    'jwk',
-    { kty: jwk.kty, crv: jwk.crv, x: jwk.x },
-    { name: 'Ed25519' },
-    true,
-    ['verify'],
-  );
-
-  const spkiBytes = await crypto.subtle.exportKey('spki', publicKey);
-  const spkiPem = `-----BEGIN PUBLIC KEY-----\n${Buffer.from(spkiBytes).toString('base64')}\n-----END PUBLIC KEY-----`;
+  const seed = Buffer.from(privateKeyHex, 'hex');
+  if (seed.length !== 32) {
+    throw new Error(`AUTH_PRIVATE_KEY must be 32-byte hex (got ${seed.length} bytes)`);
+  }
+  // Derive public key from seed using @noble/ed25519
+  const pubKey = await ed.getPublicKeyAsync(new Uint8Array(seed));
+  const spkiDer = Buffer.concat([SPKI_ED25519_PREFIX, Buffer.from(pubKey)]);
+  const spkiPem = `-----BEGIN PUBLIC KEY-----\n${spkiDer.toString('base64')}\n-----END PUBLIC KEY-----`;
   return jose.importSPKI(spkiPem, 'EdDSA');
 }

--- a/packages/fair/src/receipt.ts
+++ b/packages/fair/src/receipt.ts
@@ -1,0 +1,145 @@
+import * as jose from 'jose';
+
+export interface ReceiptPayload {
+  iss: 'node';
+  aud: string; // asset:{assetId}
+  sub: string; // settlementId
+  action: string;
+  amount: number;
+  currency: string;
+  manifestDigest: string;
+  iat: number;
+  exp: number;
+}
+
+/**
+ * Sign a receipt JWT with an Ed25519 private key.
+ *
+ * @param payload — receipt claims (iat/exp will be added if omitted)
+ * @param nodeKey — EdDSA CryptoKey or raw PKCS8 PEM
+ */
+export async function signReceipt(
+  payload: Omit<ReceiptPayload, 'iat' | 'exp'> & Partial<Pick<ReceiptPayload, 'iat' | 'exp'>>,
+  nodeKey: jose.KeyLike | Uint8Array,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = await new jose.SignJWT({
+    action: payload.action,
+    amount: payload.amount,
+    currency: payload.currency,
+    manifestDigest: payload.manifestDigest,
+  })
+    .setProtectedHeader({ alg: 'EdDSA' })
+    .setIssuer('node')
+    .setAudience(payload.aud)
+    .setSubject(payload.sub)
+    .setIssuedAt(payload.iat ?? now)
+    .setExpirationTime(payload.exp ?? now + 30 * 24 * 60 * 60)
+    .sign(nodeKey);
+
+  return jwt;
+}
+
+/**
+ * Verify a receipt JWT.
+ *
+ * @param token — the JWT string
+ * @param nodePublicKey — EdDSA public key for verification
+ * @returns the decoded payload or null if invalid
+ */
+export async function verifyReceipt(
+  token: string,
+  nodePublicKey: jose.KeyLike | Uint8Array,
+): Promise<ReceiptPayload | null> {
+  try {
+    const { payload } = await jose.jwtVerify(token, nodePublicKey, {
+      issuer: 'node',
+    });
+
+    // Validate required claims
+    const aud = payload.aud;
+    const audStr = Array.isArray(aud) ? aud[0] : aud;
+    if (typeof audStr !== 'string' || !audStr.startsWith('asset:')) {
+      return null;
+    }
+
+    const sub = payload.sub;
+    if (typeof sub !== 'string' || !sub) {
+      return null;
+    }
+
+    const action = payload.action as unknown;
+    if (typeof action !== 'string' || !action) {
+      return null;
+    }
+
+    const amount = payload.amount as unknown;
+    if (typeof amount !== 'number' || !Number.isInteger(amount)) {
+      return null;
+    }
+
+    const currency = payload.currency as unknown;
+    if (typeof currency !== 'string' || !currency) {
+      return null;
+    }
+
+    const manifestDigest = payload.manifestDigest as unknown;
+    if (typeof manifestDigest !== 'string' || !manifestDigest) {
+      return null;
+    }
+
+    return {
+      iss: 'node',
+      aud: audStr,
+      sub,
+      action,
+      amount,
+      currency,
+      manifestDigest,
+      iat: payload.iat ?? 0,
+      exp: payload.exp ?? 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load an EdDSA signing key from a hex-encoded raw private key.
+ *
+ * Expects AUTH_PRIVATE_KEY format: 64-byte hex string.
+ */
+export async function loadSigningKey(privateKeyHex: string): Promise<jose.KeyLike> {
+  const privateKeyBytes = Buffer.from(privateKeyHex, 'hex');
+  const pkcs8Pem = `-----BEGIN PRIVATE KEY-----\n${privateKeyBytes.toString('base64')}\n-----END PRIVATE KEY-----`;
+  return jose.importPKCS8(pkcs8Pem, 'EdDSA');
+}
+
+/**
+ * Derive the public verification key from a hex-encoded raw private key.
+ */
+export async function loadVerifyKey(privateKeyHex: string): Promise<jose.KeyLike> {
+  const privateKeyBytes = Buffer.from(privateKeyHex, 'hex');
+
+  // Import as extractable to derive public key
+  const privateKey = await crypto.subtle.importKey(
+    'pkcs8',
+    privateKeyBytes,
+    { name: 'Ed25519' },
+    true,
+    ['sign'],
+  );
+
+  const jwk = await crypto.subtle.exportKey('jwk', privateKey);
+  const publicKey = await crypto.subtle.importKey(
+    'jwk',
+    { kty: jwk.kty, crv: jwk.crv, x: jwk.x },
+    { name: 'Ed25519' },
+    true,
+    ['verify'],
+  );
+
+  const spkiBytes = await crypto.subtle.exportKey('spki', publicKey);
+  const spkiPem = `-----BEGIN PUBLIC KEY-----\n${Buffer.from(spkiBytes).toString('base64')}\n-----END PUBLIC KEY-----`;
+  return jose.importSPKI(spkiPem, 'EdDSA');
+}

--- a/packages/fair/src/receipt.ts
+++ b/packages/fair/src/receipt.ts
@@ -109,6 +109,21 @@ export async function verifyReceipt(
  *
  * Expects AUTH_PRIVATE_KEY format: 64-byte hex string.
  */
+/**
+ * Suggested expiration for a receipt based on action type.
+ * - reproduction: 30 days
+ * - streaming: 24 hours
+ * - derivative: 30 days
+ * - syndication: 30 days
+ */
+export function receiptExpiryForAction(action: string): number {
+  const now = Math.floor(Date.now() / 1000);
+  if (action === 'streaming') {
+    return now + 24 * 60 * 60;
+  }
+  return now + 30 * 24 * 60 * 60;
+}
+
 export async function loadSigningKey(privateKeyHex: string): Promise<jose.KeyLike> {
   const privateKeyBytes = Buffer.from(privateKeyHex, 'hex');
   const pkcs8Pem = `-----BEGIN PRIVATE KEY-----\n${privateKeyBytes.toString('base64')}\n-----END PRIVATE KEY-----`;

--- a/packages/fair/src/types.ts
+++ b/packages/fair/src/types.ts
@@ -146,6 +146,14 @@ export interface SignedFairManifest extends FairManifestV1_1 {
   signature: Signature;
 }
 
+export type SettlementScheme = 'x402' | 'stripe-link' | 'mjnx-direct' | 'solana-pay' | 'lightning';
+
+export interface SettlementConfig {
+  endpoint?: string;             // override convention
+  schemes?: SettlementScheme[];  // override server's default list
+  fallback?: SettlementScheme;   // preferred for human checkout
+}
+
 export interface FairManifestV1_1 {
   fair: string; // "1.1"
   version: '1.1';
@@ -171,6 +179,7 @@ export interface FairManifestV1_1 {
   intent?: FairIntent;
   signature?: Signature;
   tipping?: { enabled: boolean };
+  settlement?: SettlementConfig;
   // backward compat aliases
   distributions?: DidShareList;
   chain?: DidShareList;

--- a/packages/fair/src/upgrade.ts
+++ b/packages/fair/src/upgrade.ts
@@ -179,6 +179,7 @@ export function upgradeToV1_1(manifest: FairManifestV1_0 | FairManifestV1_1): Fa
     terms: v1_0.terms,
     intent: v1_0.intent,
     tipping: defaults.tipping,
+    // settlement is convention-driven; leave undefined on upgrade
   };
 
   // Apply type-aware overrides based on mimeType

--- a/packages/fair/src/validate.ts
+++ b/packages/fair/src/validate.ts
@@ -161,6 +161,36 @@ function validateV1_1(manifest: Record<string, unknown>): string[] {
     }
   }
 
+  // Settlement (optional)
+  if (manifest.settlement !== undefined) {
+    const settlement = manifest.settlement as Record<string, unknown>;
+    if (typeof settlement !== "object" || settlement === null) {
+      errors.push("settlement must be an object");
+    } else {
+      if (settlement.endpoint !== undefined && typeof settlement.endpoint !== "string") {
+        errors.push("settlement.endpoint must be a string when present");
+      }
+      if (settlement.schemes !== undefined) {
+        if (!Array.isArray(settlement.schemes)) {
+          errors.push("settlement.schemes must be an array when present");
+        } else {
+          const validSchemes = ["x402", "stripe-link", "mjnx-direct", "solana-pay", "lightning"];
+          for (const s of settlement.schemes) {
+            if (typeof s !== "string" || !validSchemes.includes(s)) {
+              errors.push(`settlement.schemes contains invalid scheme: ${s}`);
+            }
+          }
+        }
+      }
+      if (settlement.fallback !== undefined) {
+        const validSchemes = ["x402", "stripe-link", "mjnx-direct", "solana-pay", "lightning"];
+        if (typeof settlement.fallback !== "string" || !validSchemes.includes(settlement.fallback)) {
+          errors.push("settlement.fallback must be a valid settlement scheme");
+        }
+      }
+    }
+  }
+
   // Fees (optional)
   if (manifest.fees !== undefined) {
     if (!Array.isArray(manifest.fees)) {

--- a/packages/fair/tests/http-402.test.ts
+++ b/packages/fair/tests/http-402.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { build402Response } from '../src/http-402';
+import type { FairManifestV1_1, SettlementScheme } from '../src';
+
+function makeManifest(overrides?: Partial<FairManifestV1_1>): FairManifestV1_1 {
+  return {
+    fair: '1.1',
+    version: '1.1',
+    id: 'asset_test123',
+    type: 'image/png',
+    owner: 'did:imajin:owner123',
+    created: new Date().toISOString(),
+    access: { type: 'public' },
+    attribution: [
+      { did: 'did:imajin:owner123', role: 'creator', share: 0.99 },
+      { role: 'platform', name: 'Imajin', share: 0.01 },
+    ],
+    distribution: {
+      reproduction: { mode: 'allowed', price: { amount: 500, currency: 'USD' } },
+      streaming: { mode: 'allowed', price: { amount: 1, currency: 'USD' } },
+      derivative: { mode: 'allow-with-attribution' },
+      syndication: { mode: 'allow-with-attribution' },
+    },
+    transfer: { allowed: true, requiresAttribution: true, price: { amount: 100000, currency: 'USD' }, resaleRoyaltyBps: 500 },
+    fees: [
+      { role: 'protocol', name: 'MJN', rateBps: 100, fixedCents: 0 },
+    ],
+    training: { allowed: false },
+    commercial: { allowed: false, contactRequired: true },
+    tipping: { enabled: true },
+    ...overrides,
+  };
+}
+
+const ALL_SCHEMES: SettlementScheme[] = ['x402', 'stripe-link', 'mjnx-direct', 'solana-pay', 'lightning'];
+
+describe('build402Response', () => {
+  it('builds a 402 for reproduction with all schemes', () => {
+    const manifest = makeManifest();
+    const result = build402Response({
+      manifest,
+      assetId: 'asset_test123',
+      action: 'reproduction',
+      supportedSchemes: ALL_SCHEMES,
+      baseUrl: 'https://kernel.imajin.ai/media/api/assets',
+    });
+
+    expect(result.status).toBe(402);
+    expect(result.body.error).toBe('payment_required');
+    expect(result.body.price).toEqual({ amount: 500, currency: 'USD' });
+    expect(result.headers['Content-Type']).toBe('application/fair+json');
+    expect(result.headers['Link']).toBe('<https://kernel.imajin.ai/media/api/assets/asset_test123/fair>; rel="fair"');
+    expect(result.headers['X-Settle-Endpoint']).toBe('https://kernel.imajin.ai/media/api/assets/asset_test123/settle');
+    expect(result.body.settlement.schemes).toEqual(ALL_SCHEMES);
+  });
+
+  it('respects manifest settlement schemes override', () => {
+    const manifest = makeManifest({
+      settlement: { schemes: ['stripe-link', 'mjnx-direct'] },
+    });
+    const result = build402Response({
+      manifest,
+      assetId: 'asset_test123',
+      action: 'reproduction',
+      supportedSchemes: ALL_SCHEMES,
+      baseUrl: 'https://kernel.imajin.ai/media/api/assets',
+    });
+
+    expect(result.body.settlement.schemes).toEqual(['stripe-link', 'mjnx-direct']);
+    expect(result.headers['X-Settle-Stripe']).toBeDefined();
+    expect(result.headers['X-Settle-MjnxDirect']).toBeDefined();
+    expect(result.headers['X-Settle-X402']).toBeUndefined();
+  });
+
+  it('uses manifest endpoint override when present', () => {
+    const manifest = makeManifest({
+      settlement: { endpoint: 'https://custom.example.com/pay' },
+    });
+    const result = build402Response({
+      manifest,
+      assetId: 'asset_test123',
+      action: 'reproduction',
+      supportedSchemes: ['stripe-link'],
+      baseUrl: 'https://kernel.imajin.ai/media/api/assets',
+    });
+
+    expect(result.headers['X-Settle-Endpoint']).toBe('https://custom.example.com/pay');
+    expect(result.body.settlement.endpoint).toBe('https://custom.example.com/pay');
+  });
+
+  it('includes schemeUrls in headers when provided', () => {
+    const manifest = makeManifest();
+    const result = build402Response({
+      manifest,
+      assetId: 'asset_test123',
+      action: 'reproduction',
+      supportedSchemes: ['stripe-link', 'mjnx-direct'],
+      baseUrl: 'https://kernel.imajin.ai/media/api/assets',
+      schemeUrls: {
+        'stripe-link': 'https://pay.stripe.com/link/test_123',
+        'mjnx-direct': 'mjnx:pay?to=did:imajin:owner123&amount=500',
+      },
+    });
+
+    expect(result.headers['X-Settle-Stripe']).toBe('https://pay.stripe.com/link/test_123');
+    expect(result.headers['X-Settle-MjnxDirect']).toBe('mjnx:pay?to=did:imajin:owner123&amount=500');
+    expect(result.body.settlement.urls).toEqual({
+      'stripe-link': 'https://pay.stripe.com/link/test_123',
+      'mjnx-direct': 'mjnx:pay?to=did:imajin:owner123&amount=500',
+    });
+  });
+
+  it('throws when action has no price', () => {
+    const manifest = makeManifest();
+    expect(() =>
+      build402Response({
+        manifest,
+        assetId: 'asset_test123',
+        action: 'derivative',
+        supportedSchemes: ['stripe-link'],
+        baseUrl: 'https://kernel.imajin.ai/media/api/assets',
+      }),
+    ).toThrow('has no price');
+  });
+
+  it('throws when no schemes overlap', () => {
+    const manifest = makeManifest({
+      settlement: { schemes: ['solana-pay'] },
+    });
+    expect(() =>
+      build402Response({
+        manifest,
+        assetId: 'asset_test123',
+        action: 'reproduction',
+        supportedSchemes: ['stripe-link'],
+        baseUrl: 'https://kernel.imajin.ai/media/api/assets',
+      }),
+    ).toThrow('No supported settlement schemes');
+  });
+
+  it('includes splits in body when present', () => {
+    const manifest = makeManifest({
+      distribution: {
+        reproduction: {
+          mode: 'allowed',
+          price: { amount: 1000, currency: 'USD' },
+          splits: [
+            { did: 'did:imajin:owner123', role: 'creator', share: 0.8 },
+            { role: 'platform', name: 'Imajin', share: 0.2 },
+          ],
+        },
+      },
+    });
+    const result = build402Response({
+      manifest,
+      assetId: 'asset_test123',
+      action: 'reproduction',
+      supportedSchemes: ['stripe-link'],
+      baseUrl: 'https://kernel.imajin.ai/media/api/assets',
+    });
+
+    expect(result.body.splits).toHaveLength(2);
+    expect(result.body.splits?.[0].share).toBe(0.8);
+  });
+
+  it('works for streaming action', () => {
+    const manifest = makeManifest();
+    const result = build402Response({
+      manifest,
+      assetId: 'asset_test123',
+      action: 'streaming',
+      supportedSchemes: ['stripe-link'],
+      baseUrl: 'https://kernel.imajin.ai/media/api/assets',
+    });
+
+    expect(result.body.action).toBe('streaming');
+    expect(result.body.price).toEqual({ amount: 1, currency: 'USD' });
+  });
+});

--- a/packages/fair/tests/http-402.test.ts
+++ b/packages/fair/tests/http-402.test.ts
@@ -67,7 +67,7 @@ describe('build402Response', () => {
     });
 
     expect(result.body.settlement.schemes).toEqual(['stripe-link', 'mjnx-direct']);
-    expect(result.headers['X-Settle-Stripe']).toBeDefined();
+    expect(result.headers['X-Settle-StripeLink']).toBeDefined();
     expect(result.headers['X-Settle-MjnxDirect']).toBeDefined();
     expect(result.headers['X-Settle-X402']).toBeUndefined();
   });
@@ -102,7 +102,7 @@ describe('build402Response', () => {
       },
     });
 
-    expect(result.headers['X-Settle-Stripe']).toBe('https://pay.stripe.com/link/test_123');
+    expect(result.headers['X-Settle-StripeLink']).toBe('https://pay.stripe.com/link/test_123');
     expect(result.headers['X-Settle-MjnxDirect']).toBe('mjnx:pay?to=did:imajin:owner123&amount=500');
     expect(result.body.settlement.urls).toEqual({
       'stripe-link': 'https://pay.stripe.com/link/test_123',

--- a/packages/fair/tests/receipt.test.ts
+++ b/packages/fair/tests/receipt.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { signReceipt, verifyReceipt, loadSigningKey, loadVerifyKey } from '../src/receipt';
 
-// Deterministic test key — 64 bytes hex (ed25519 private key seed)
-const TEST_KEY_HEX = 'aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344';
+// Deterministic test key — 32-byte hex (ed25519 raw seed per RFC 8032)
+const TEST_KEY_HEX = 'aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344';
 
 describe('signReceipt / verifyReceipt', () => {
   it('round-trips a valid receipt', async () => {
@@ -13,6 +13,7 @@ describe('signReceipt / verifyReceipt', () => {
       {
         aud: 'asset:test123',
         sub: 'stl_abc123',
+        buyer: 'did:imajin:buyer1',
         action: 'reproduction',
         amount: 500,
         currency: 'USD',
@@ -25,6 +26,7 @@ describe('signReceipt / verifyReceipt', () => {
     expect(decoded).not.toBeNull();
     expect(decoded!.aud).toBe('asset:test123');
     expect(decoded!.sub).toBe('stl_abc123');
+    expect(decoded!.buyer).toBe('did:imajin:buyer1');
     expect(decoded!.action).toBe('reproduction');
     expect(decoded!.amount).toBe(500);
     expect(decoded!.currency).toBe('USD');
@@ -41,6 +43,7 @@ describe('signReceipt / verifyReceipt', () => {
       {
         aud: 'asset:test123',
         sub: 'stl_abc123',
+        buyer: 'did:imajin:buyer1',
         action: 'reproduction',
         amount: 500,
         currency: 'USD',
@@ -84,6 +87,7 @@ describe('signReceipt / verifyReceipt', () => {
       {
         aud: 'asset:test123',
         sub: 'stl_abc123',
+        buyer: 'did:imajin:buyer1',
         action: 'reproduction',
         amount: 500,
         currency: 'USD',
@@ -102,5 +106,44 @@ describe('signReceipt / verifyReceipt', () => {
     const verifyKey = await loadVerifyKey(TEST_KEY_HEX);
     const decoded = await verifyReceipt('not.a.jwt', verifyKey);
     expect(decoded).toBeNull();
+  });
+
+  it('rejects receipt with missing or non-DID buyer claim', async () => {
+    const signKey = await loadSigningKey(TEST_KEY_HEX);
+    const verifyKey = await loadVerifyKey(TEST_KEY_HEX);
+
+    // Manually craft a JWT without buyer claim
+    const { SignJWT } = await import('jose');
+    const noBuyer = await new SignJWT({
+      action: 'reproduction',
+      amount: 100,
+      currency: 'USD',
+      manifestDigest: 'sha256:x',
+    })
+      .setProtectedHeader({ alg: 'EdDSA' })
+      .setIssuer('node')
+      .setAudience('asset:test')
+      .setSubject('stl_x')
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(signKey);
+    expect(await verifyReceipt(noBuyer, verifyKey)).toBeNull();
+
+    // Non-DID buyer claim
+    const badBuyer = await new SignJWT({
+      buyer: 'not-a-did',
+      action: 'reproduction',
+      amount: 100,
+      currency: 'USD',
+      manifestDigest: 'sha256:x',
+    })
+      .setProtectedHeader({ alg: 'EdDSA' })
+      .setIssuer('node')
+      .setAudience('asset:test')
+      .setSubject('stl_x')
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(signKey);
+    expect(await verifyReceipt(badBuyer, verifyKey)).toBeNull();
   });
 });

--- a/packages/fair/tests/receipt.test.ts
+++ b/packages/fair/tests/receipt.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { signReceipt, verifyReceipt, loadSigningKey, loadVerifyKey } from '../src/receipt';
+
+// Deterministic test key — 64 bytes hex (ed25519 private key seed)
+const TEST_KEY_HEX = 'aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344';
+
+describe('signReceipt / verifyReceipt', () => {
+  it('round-trips a valid receipt', async () => {
+    const signKey = await loadSigningKey(TEST_KEY_HEX);
+    const verifyKey = await loadVerifyKey(TEST_KEY_HEX);
+
+    const token = await signReceipt(
+      {
+        aud: 'asset:test123',
+        sub: 'stl_abc123',
+        action: 'reproduction',
+        amount: 500,
+        currency: 'USD',
+        manifestDigest: 'sha256:deadbeef',
+      },
+      signKey,
+    );
+
+    const decoded = await verifyReceipt(token, verifyKey);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.aud).toBe('asset:test123');
+    expect(decoded!.sub).toBe('stl_abc123');
+    expect(decoded!.action).toBe('reproduction');
+    expect(decoded!.amount).toBe(500);
+    expect(decoded!.currency).toBe('USD');
+    expect(decoded!.manifestDigest).toBe('sha256:deadbeef');
+    expect(decoded!.iss).toBe('node');
+    expect(decoded!.exp).toBeGreaterThan(decoded!.iat);
+  });
+
+  it('rejects a tampered token', async () => {
+    const signKey = await loadSigningKey(TEST_KEY_HEX);
+    const verifyKey = await loadVerifyKey(TEST_KEY_HEX);
+
+    let token = await signReceipt(
+      {
+        aud: 'asset:test123',
+        sub: 'stl_abc123',
+        action: 'reproduction',
+        amount: 500,
+        currency: 'USD',
+        manifestDigest: 'sha256:deadbeef',
+      },
+      signKey,
+    );
+
+    // Tamper with the payload
+    token = token.slice(0, -5) + 'XXXXX';
+
+    const decoded = await verifyReceipt(token, verifyKey);
+    expect(decoded).toBeNull();
+  });
+
+  it('rejects token with wrong issuer', async () => {
+    const signKey = await loadSigningKey(TEST_KEY_HEX);
+    const verifyKey = await loadVerifyKey(TEST_KEY_HEX);
+
+    // Manually craft a JWT with wrong issuer via jose
+    const { SignJWT } = await import('jose');
+    const badToken = await new SignJWT({ action: 'reproduction', amount: 100, currency: 'USD', manifestDigest: 'sha256:x' })
+      .setProtectedHeader({ alg: 'EdDSA' })
+      .setIssuer('attacker')
+      .setAudience('asset:test')
+      .setSubject('stl_x')
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(signKey);
+
+    const decoded = await verifyReceipt(badToken, verifyKey);
+    expect(decoded).toBeNull();
+  });
+
+  it('rejects expired token', async () => {
+    const signKey = await loadSigningKey(TEST_KEY_HEX);
+    const verifyKey = await loadVerifyKey(TEST_KEY_HEX);
+
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signReceipt(
+      {
+        aud: 'asset:test123',
+        sub: 'stl_abc123',
+        action: 'reproduction',
+        amount: 500,
+        currency: 'USD',
+        manifestDigest: 'sha256:deadbeef',
+        iat: now - 3600,
+        exp: now - 1800,
+      },
+      signKey,
+    );
+
+    const decoded = await verifyReceipt(token, verifyKey);
+    expect(decoded).toBeNull();
+  });
+
+  it('returns null for malformed token', async () => {
+    const verifyKey = await loadVerifyKey(TEST_KEY_HEX);
+    const decoded = await verifyReceipt('not.a.jwt', verifyKey);
+    expect(decoded).toBeNull();
+  });
+});

--- a/packages/fair/tests/v1_1.test.ts
+++ b/packages/fair/tests/v1_1.test.ts
@@ -202,6 +202,56 @@ describe('validateManifest v1.1', () => {
     expect(result.ok).toBe(false);
     expect(result.errors.some((e) => e.includes('sum'))).toBe(true);
   });
+
+  it('accepts settlement when present and valid', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        settlement: {
+          endpoint: 'https://custom.example.com/settle',
+          schemes: ['stripe-link', 'mjnx-direct'],
+          fallback: 'stripe-link',
+        },
+      }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts manifest without settlement field', () => {
+    const manifest = makeValidV1_1();
+    delete (manifest as Record<string, unknown>).settlement;
+    const result = validateManifest(manifest);
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails when settlement.endpoint is not a string', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        settlement: { endpoint: 123 } as unknown as Record<string, unknown>,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('settlement.endpoint'))).toBe(true);
+  });
+
+  it('fails when settlement.schemes contains invalid scheme', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        settlement: { schemes: ['stripe-link', 'bogus'] } as unknown as Record<string, unknown>,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('invalid scheme'))).toBe(true);
+  });
+
+  it('fails when settlement.fallback is invalid', () => {
+    const result = validateManifest(
+      makeValidV1_1({
+        settlement: { fallback: 'bogus' } as unknown as Record<string, unknown>,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('settlement.fallback'))).toBe(true);
+  });
 });
 
 // ─── D1: upgradeToV1_1 ──────────────────────────────────────────────────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,119 @@ importers:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.19.17)
 
+  ../imajin-fixready:
+    dependencies:
+      '@imajin/db':
+        specifier: workspace:*
+        version: link:../pr-900-mjnx-only/packages/db
+      clsx:
+        specifier: ^2.1.0
+        version: 2.1.1
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.7
+      next:
+        specifier: ^14.2.0
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      qrcode:
+        specifier: ^1.5.3
+        version: 1.5.4
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
+      autoprefixer:
+        specifier: ^10
+        version: 10.4.27(postcss@8.5.9)
+      drizzle-kit:
+        specifier: ^0.31.9
+        version: 0.31.10
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.4(jiti@1.21.7)
+      eslint-config-next:
+        specifier: ^16.1.6
+        version: 16.2.6(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      postcss:
+        specifier: ^8
+        version: 8.5.9
+      tailwindcss:
+        specifier: ^3.4.0
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  ../imajin-karaoke:
+    dependencies:
+      '@imajin/db':
+        specifier: workspace:*
+        version: link:../pr-900-mjnx-only/packages/db
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
+      jose:
+        specifier: ^5.10.0
+        version: 5.10.0
+      next:
+        specifier: ^14.2.0
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18
+        version: 18.3.7(@types/react@18.3.28)
+      autoprefixer:
+        specifier: ^10
+        version: 10.4.27(postcss@8.5.9)
+      drizzle-kit:
+        specifier: ^0.31.9
+        version: 0.31.10
+      postcss:
+        specifier: ^8
+        version: 8.5.9
+      tailwindcss:
+        specifier: ^3.4.0
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   apps/coffee:
     dependencies:
       '@imajin/auth':
@@ -851,6 +964,9 @@ importers:
       '@noble/hashes':
         specifier: ^1.3.0
         version: 1.8.0
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1063,12 +1179,54 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.2':
@@ -1078,6 +1236,14 @@ packages:
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -1823,13 +1989,41 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1852,6 +2046,18 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -1864,6 +2070,10 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2020,6 +2230,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -2309,6 +2522,9 @@ packages:
 
   '@next/eslint-plugin-next@14.2.35':
     resolution: {integrity: sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==}
+
+  '@next/eslint-plugin-next@16.2.6':
+    resolution: {integrity: sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==}
 
   '@next/swc-darwin-arm64@14.2.33':
     resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
@@ -3095,6 +3311,12 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
@@ -3159,6 +3381,14 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/eslint-plugin@8.59.2':
+    resolution: {integrity: sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.2
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@7.18.0':
     resolution: {integrity: sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -3169,9 +3399,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.59.2':
+    resolution: {integrity: sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.2':
+    resolution: {integrity: sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@7.18.0':
     resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/scope-manager@8.59.2':
+    resolution: {integrity: sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.2':
+    resolution: {integrity: sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/type-utils@7.18.0':
     resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
@@ -3183,9 +3436,20 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/type-utils@8.59.2':
+    resolution: {integrity: sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@7.18.0':
     resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@8.59.2':
+    resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.18.0':
     resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
@@ -3196,15 +3460,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.59.2':
+    resolution: {integrity: sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/utils@7.18.0':
     resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@8.59.2':
+    resolution: {integrity: sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@7.18.0':
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.59.2':
+    resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -3729,6 +4010,10 @@ packages:
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   cm6-theme-basic-light@0.2.0:
     resolution: {integrity: sha512-1prg2gv44sYfpHscP26uLT/ePrh0mlmVwMSoSd3zYKQ92Ab3jPRLzyCnpyOCQLJbK+YdNs4HvMRqMNYdy4pMhA==}
     peerDependencies:
@@ -3777,6 +4062,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -4153,6 +4441,15 @@ packages:
       typescript:
         optional: true
 
+  eslint-config-next@16.2.6:
+    resolution: {integrity: sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==}
+    peerDependencies:
+      eslint: '>=9.0.0'
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   eslint-import-resolver-node@0.3.10:
     resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
 
@@ -4212,6 +4509,12 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
 
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
     engines: {node: '>=4'}
@@ -4222,9 +4525,21 @@ packages:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
@@ -4232,9 +4547,23 @@ packages:
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -4308,6 +4637,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -4343,6 +4676,10 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -4364,6 +4701,10 @@ packages:
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -4408,6 +4749,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -4471,6 +4816,14 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -4537,6 +4890,12 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
@@ -4581,6 +4940,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -4818,8 +5181,14 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -4836,6 +5205,11 @@ packages:
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -4951,6 +5325,9 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -6145,6 +6522,12 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -6189,6 +6572,13 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.59.2:
+    resolution: {integrity: sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -6558,6 +6948,9 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
@@ -6587,6 +6980,12 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -6646,15 +7045,102 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -7315,7 +7801,28 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
+    dependencies:
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -7331,7 +7838,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.57.1': {}
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -7358,6 +7888,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -7369,6 +7911,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.1.0': {}
 
@@ -7489,6 +8033,11 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -7975,6 +8524,10 @@ snapshots:
   '@next/eslint-plugin-next@14.2.35':
     dependencies:
       glob: 10.3.10
+
+  '@next/eslint-plugin-next@16.2.6':
+    dependencies:
+      fast-glob: 3.3.1
 
   '@next/swc-darwin-arm64@14.2.33':
     optional: true
@@ -8723,6 +9276,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/js-yaml@4.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
   '@types/json5@0.0.29': {}
 
   '@types/mdast@4.0.4':
@@ -8794,6 +9351,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      eslint: 9.39.4(jiti@1.21.7)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
@@ -8807,10 +9380,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
+
+  '@typescript-eslint/scope-manager@8.59.2':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -8824,7 +9427,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@1.21.7)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@7.18.0': {}
+
+  '@typescript-eslint/types@8.59.2': {}
 
   '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
     dependencies:
@@ -8841,6 +9458,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
@@ -8852,10 +9484,26 @@ snapshots:
       - supports-color
       - typescript
 
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@7.18.0':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.59.2':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -9413,6 +10061,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
+  clsx@2.1.1: {}
+
   cm6-theme-basic-light@0.2.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)(@lezer/highlight@1.2.3):
     dependencies:
       '@codemirror/language': 6.12.3
@@ -9453,6 +10103,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  convert-source-map@2.0.0: {}
 
   crelt@1.0.6: {}
 
@@ -9890,6 +10542,26 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
+  eslint-config-next@16.2.6(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.6
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
+      globals: 16.4.0
+      typescript-eslint: 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
@@ -9913,6 +10585,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@1.21.7)
+      get-tsconfig: 4.13.7
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -9921,6 +10608,17 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -9953,6 +10651,35 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
     dependencies:
       aria-query: 5.3.2
@@ -9972,9 +10699,39 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.11.2
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.4(jiti@1.21.7)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
   eslint-plugin-react-hooks@5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
+
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      eslint: 9.39.4(jiti@1.21.7)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
@@ -9998,12 +10755,43 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.3.2
+      eslint: 9.39.4(jiti@1.21.7)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.6
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
   eslint-scope@7.2.2:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@8.57.1:
     dependencies:
@@ -10048,12 +10836,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint@9.39.4(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
       es5-ext: 0.10.64
       event-emitter: 0.3.5
       type: 2.7.3
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -10125,6 +10960,14 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -10157,6 +11000,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
@@ -10182,6 +11029,11 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
       rimraf: 3.0.2
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
 
   flatted@3.4.2: {}
 
@@ -10223,6 +11075,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   generator-function@2.0.1: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -10301,6 +11155,10 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globals@14.0.0: {}
+
+  globals@16.4.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -10397,6 +11255,12 @@ snapshots:
 
   he@1.2.0: {}
 
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
+
   hono@4.12.12: {}
 
   html-escaper@2.0.2: {}
@@ -10431,6 +11295,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -10683,7 +11549,11 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@5.10.0: {}
+
   jose@6.2.2: {}
+
+  jose@6.2.3: {}
 
   js-tokens@10.0.0: {}
 
@@ -10699,6 +11569,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -10806,6 +11678,10 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lz-string@1.5.0: {}
 
@@ -11385,6 +12261,32 @@ snapshots:
   natural-compare@1.4.0: {}
 
   next-tick@1.1.0: {}
+
+  next@14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 14.2.35
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001787
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
 
   next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -12313,6 +13215,13 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+
   styled-jsx@5.1.1(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -12453,6 +13362,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
@@ -12513,6 +13426,17 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript-eslint@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 
@@ -12966,6 +13890,8 @@ snapshots:
 
   y18n@4.0.3: {}
 
+  yallist@3.1.1: {}
+
   yaml@2.8.3: {}
 
   yargs-parser@18.1.3:
@@ -12996,6 +13922,10 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## HTTP 402 native settlement — MJNx-direct only

Closes #883 (partial — MJNx-direct settlement; fiat rails deferred to #904)

### Architectural decision

After review, MJNx is the node's **local settlement currency**. Stripe (and other fiat rails) are deposit on-ramps **into** MJNx, not parallel settlement schemes. Stripe-as-settlement is broken at micro-attribution scale (30¢ flat fee makes <$2 settlements uneconomic) and requires significant activation energy (verified Stripe business, Stripe Connect, webhooks, country gating). On-ramp architecture is tracked in **#904**.

### In scope

- `POST /media/api/assets/[id]/settle` — MJNx-direct only; other schemes return 400 with a pointer to #904
- `POST /media/api/assets/[id]/settle/confirm` — owner-mediated receipt confirmation (auth-gated; full ledger debit in #904)
- `GET /media/api/assets/[id]/receipts` — settlement audit trail for asset owner
- `packages/fair` — `build402Response`, receipt JWT sign/verify, `SettlementConfig`, validate/upgrade utilities
- `media.settlements` + `media.access_log` schema (migration 0022 + new migration 0023 adds `status` column)
- `docs/audits/fair-http-402.md` — updated for MJNx-only scope

### Bug fixes in this PR

- **Brace mismatch** in priced asset GET route: extra `}` was closing `if (hasPrice)` before the access log block, leaving `settlement.id` / `settlement.buyerDid` out of scope
- **Double `requireAuth()` call** refactored into a single attempt in settle route
- **Manifest owner DID validation** before interpolating into `mjnx:pay?to=...` URI (rejects 500 if not a DID)
- **Canonicalize manifest digest**: replaced `sha256Text(JSON.stringify(manifest))` with `canonicalize()` from `@imajin/auth` for deterministic key-ordered JSON matching the codebase signing convention

### Deferred to #904

Stripe Link, x402, Solana Pay, Lightning, MJNx chain verification, multi-node interop, on-ramp flows, atomic ledger debit.