### PR TITLE
feat(.fair): v1.1 UI editors + manual upgrade flow (#893 #894)

### DIFF
--- a/apps/kernel/app/media/api/assets/[id]/upgrade-fair/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/upgrade-fair/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, assets } from "@/src/db";
+import { requireAuth } from "@imajin/auth";
+import { eq } from "drizzle-orm";
+import type { FairManifest, FairManifestV1_1 } from "@imajin/fair";
+import { upgradeToV1_1, signManifest } from "@imajin/fair";
+import { getNodeDid } from "@/src/lib/kernel/node-identity";
+import { createLogger } from "@imajin/logger";
+import * as bus from "@imajin/bus";
+
+const log = createLogger("kernel");
+
+/**
+ * POST /api/assets/[id]/upgrade-fair
+ * Manually upgrade a v1.0 .fair manifest to v1.1, sign with platform key,
+ * persist, and publish a bus event.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // 1. Auth
+  const authResult = await requireAuth(request);
+  if ("error" in authResult) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
+
+  // 2. Load asset
+  let asset;
+  try {
+    [asset] = await db
+      .select()
+      .from(assets)
+      .where(eq(assets.id, id))
+      .limit(1);
+  } catch (err) {
+    log.error({ err: String(err) }, "DB lookup failed");
+    return NextResponse.json({ error: "Database failure" }, { status: 500 });
+  }
+
+  if (!asset || asset.status !== "active") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (asset.ownerDid !== requesterDid) {
+    return NextResponse.json({ error: "Forbidden — owner only" }, { status: 403 });
+  }
+
+  // 3. Load current manifest
+  let manifest: FairManifest | null = null;
+  if (
+    asset.fairManifest &&
+    typeof asset.fairManifest === "object" &&
+    Object.keys(asset.fairManifest as object).length > 0
+  ) {
+    manifest = asset.fairManifest as FairManifest;
+  }
+
+  if (!manifest) {
+    return NextResponse.json(
+      { error: "No .fair manifest found for this asset" },
+      { status: 404 }
+    );
+  }
+
+  // 4. Upgrade to v1.1
+  const upgraded = upgradeToV1_1(manifest);
+  const oldVersion = (manifest as Record<string, unknown>).version ?? "1.0";
+
+  // 5. Sign with platform/node key
+  const privateKeyHex = process.env.AUTH_PRIVATE_KEY;
+  if (!privateKeyHex) {
+    log.error({}, "AUTH_PRIVATE_KEY not configured — cannot sign upgraded manifest");
+    return NextResponse.json(
+      { error: "Signing key not available" },
+      { status: 500 }
+    );
+  }
+
+  const nodeDid = await getNodeDid();
+  const privateKey = Buffer.from(privateKeyHex, "hex");
+
+  let signed: FairManifestV1_1;
+  try {
+    signed = await signManifest(upgraded, {
+      did: nodeDid,
+      privateKey: new Uint8Array(privateKey),
+    });
+  } catch (err) {
+    log.error({ err: String(err) }, "Failed to sign upgraded manifest");
+    return NextResponse.json(
+      { error: "Signing failed" },
+      { status: 500 }
+    );
+  }
+
+  // 6. Persist to DB
+  try {
+    await db
+      .update(assets)
+      .set({ fairManifest: signed as unknown as Record<string, unknown> })
+      .where(eq(assets.id, id));
+  } catch (err) {
+    log.error({ err: String(err) }, "Failed to persist upgraded manifest");
+    return NextResponse.json({ error: "Database update failed" }, { status: 500 });
+  }
+
+  // 7. Publish bus event
+  try {
+    await bus.publish("asset.fair.upgraded", {
+      issuer: nodeDid,
+      subject: asset.ownerDid,
+      scope: "media",
+      payload: {
+        assetId: id,
+        oldVersion: String(oldVersion),
+        newVersion: "1.1",
+        signer: nodeDid,
+      },
+    });
+  } catch (err) {
+    log.error({ err: String(err) }, "Bus event publish failed (non-fatal)");
+  }
+
+  // 8. Return upgraded manifest
+  return NextResponse.json({ ok: true, manifest: signed });
+}

--- a/apps/kernel/src/components/media/AssetDetail.tsx
+++ b/apps/kernel/src/components/media/AssetDetail.tsx
@@ -142,6 +142,8 @@ export function AssetDetail({ asset, folders, currentDid, onClose, onDeleted, on
   const [transcript, setTranscript] = useState<Record<string, unknown> | null>(
     () => (asset.metadata as Record<string, unknown> | null)?.transcript as Record<string, unknown> | null ?? null
   );
+  const [upgradingFair, setUpgradingFair] = useState(false);
+  const [upgradeError, setUpgradeError] = useState<string | null>(null);
 
   const isImage = asset.mimeType.startsWith("image/");
   const isAudio = asset.mimeType.startsWith("audio/");
@@ -219,6 +221,34 @@ export function AssetDetail({ asset, folders, currentDid, onClose, onDeleted, on
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(manifest),
     }).catch(() => {});
+  };
+
+  const handleUpgradeFair = async () => {
+    if (!confirm(
+      "Upgrade this asset's `.fair` manifest? Existing values preserved; new primitives added with defaults including AI training opt-out."
+    )) {
+      return;
+    }
+    setUpgradingFair(true);
+    setUpgradeError(null);
+    try {
+      const res = await fetch(`/media/api/assets/${asset.id}/upgrade-fair`, {
+        method: "POST",
+        credentials: "include",
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setUpgradeError(data.error || "Upgrade failed");
+        return;
+      }
+      if (data.manifest) {
+        setFairManifest(data.manifest as FairManifest);
+      }
+    } catch {
+      setUpgradeError("Network error");
+    } finally {
+      setUpgradingFair(false);
+    }
   };
 
   const handleMove = async (folderId: string) => {
@@ -511,15 +541,19 @@ export function AssetDetail({ asset, folders, currentDid, onClose, onDeleted, on
             </div>
           )}
 
-          {/* v1.0 → v1.1 upgrade placeholder (Commit 5/6 will wire the actual button) */}
+          {/* v1.0 → v1.1 upgrade button */}
           {fairManifest && !isV1_1 && isOwner && (
-            <div className="mt-2">
+            <div className="mt-2 space-y-2">
               <button
-                disabled
-                className="w-full py-1.5 text-xs bg-orange-500/10 border border-orange-500/30 text-orange-400 rounded-lg opacity-50 cursor-not-allowed"
+                onClick={handleUpgradeFair}
+                disabled={upgradingFair}
+                className="w-full py-1.5 text-xs bg-orange-500/10 border border-orange-500/30 text-orange-400 rounded-lg hover:bg-orange-500/20 transition-colors disabled:opacity-50"
               >
-                Upgrade to v1.1 (coming soon)
+                {upgradingFair ? "Upgrading…" : "Upgrade to v1.1"}
               </button>
+              {upgradeError && (
+                <p className="text-xs text-red-400">{upgradeError}</p>
+              )}
             </div>
           )}
         </div>

--- a/apps/kernel/src/components/media/AssetDetail.tsx
+++ b/apps/kernel/src/components/media/AssetDetail.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import type { Asset } from "@/src/db/schema";
-import { FairEditor } from "@imajin/fair";
-import type { FairManifest } from "@imajin/fair";
+import { FairEditor, isFairManifestV1_1 } from "@imajin/fair";
+import type { FairManifest, FairManifestV1_1 } from "@imajin/fair";
+import { FairManifestEditor } from "./FairManifestEditor";
 
 const PROFILE_URL = process.env.NEXT_PUBLIC_SERVICE_PREFIX
   ? `${process.env.NEXT_PUBLIC_SERVICE_PREFIX}profile.${process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai'}`
@@ -45,7 +46,7 @@ function FairEditModal({
       onKeyDown={(e) => { if (e.key === 'Escape') onCancel(); }}
     >
       <div
-        className="bg-[#2a2a2a] border border-white/10 rounded-xl shadow-2xl p-4 w-[480px] max-h-[80vh] overflow-y-auto"
+        className="bg-[#2a2a2a] border border-white/10 rounded-xl shadow-2xl p-4 w-[520px] max-h-[85vh] overflow-y-auto"
         role="dialog"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
@@ -59,33 +60,45 @@ function FairEditModal({
             ✕
           </button>
         </div>
-        <FairEditor
-          resolveProfile={resolveProfile}
-          manifest={draft}
-          readOnly={false}
-          onChange={setDraft}
-          sections={["attribution", "access", "transfer"]}
-        />
-        <div className="flex justify-end gap-2 mt-3">
-          <button
-            onClick={onCancel}
-            className="px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-md transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            disabled={saving}
-            onClick={async () => {
-              setSaving(true);
-              await onSave(draft);
-              setSaving(false);
-              onCancel();
-            }}
-            className="px-4 py-1.5 text-sm bg-orange-500 text-white rounded-md hover:bg-orange-600 transition-colors disabled:opacity-50"
-          >
-            {saving ? 'Saving…' : 'Save'}
-          </button>
-        </div>
+        {isFairManifestV1_1(draft) ? (
+          <FairManifestEditor
+            manifest={draft}
+            mimeType={(draft as FairManifestV1_1).type}
+            onChange={(m) => setDraft(m)}
+            onSave={() => { setSaving(true); onSave(draft); setSaving(false); onCancel(); }}
+            readOnly={false}
+          />
+        ) : (
+          <FairEditor
+            resolveProfile={resolveProfile}
+            manifest={draft}
+            readOnly={false}
+            onChange={setDraft}
+            sections={["attribution", "access", "transfer"]}
+          />
+        )}
+        {!isFairManifestV1_1(draft) && (
+          <div className="flex justify-end gap-2 mt-3">
+            <button
+              onClick={onCancel}
+              className="px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-md transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              disabled={saving}
+              onClick={async () => {
+                setSaving(true);
+                await onSave(draft);
+                setSaving(false);
+                onCancel();
+              }}
+              className="px-4 py-1.5 text-sm bg-orange-500 text-white rounded-md hover:bg-orange-600 transition-colors disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -222,6 +235,12 @@ export function AssetDetail({ asset, folders, currentDid, onClose, onDeleted, on
   const currentFolder = folders.find((f) => f.id === asset.folderId);
   const metadata = asset.metadata as Record<string, unknown> | null;
   const exif = metadata?.exif as Record<string, unknown> | undefined;
+
+  // Determine manifest version and signing state
+  const isV1_1 = fairManifest ? isFairManifestV1_1(fairManifest) : false;
+  const isSigned = !!fairManifest && 'signature' in fairManifest && !!fairManifest.signature;
+  const isSigner = isSigned && currentDid === (fairManifest as FairManifestV1_1).signature?.signer;
+  const readOnlyEditor = isSigned && !isSigner;
 
   return (
     <div className="flex flex-1 overflow-hidden">
@@ -404,7 +423,7 @@ export function AssetDetail({ asset, folders, currentDid, onClose, onDeleted, on
       </div>
 
       {/* Metadata sidebar */}
-      <div className="w-72 shrink-0 overflow-y-auto bg-[#1a1a1a] border-l border-gray-800 p-4 space-y-4">
+      <div className="w-80 shrink-0 overflow-y-auto bg-[#1a1a1a] border-l border-gray-800 p-4 space-y-4">
         {/* Classification */}
         {asset.classification && (
           <div className="bg-[#252525] rounded-xl p-3">
@@ -450,8 +469,15 @@ export function AssetDetail({ asset, folders, currentDid, onClose, onDeleted, on
         {/* .fair manifest */}
         <div>
           <div className="flex items-center justify-between mb-2">
-            <p className="text-xs text-gray-500 uppercase tracking-widest">.fair</p>
-            {fairManifest && (
+            <div className="flex items-center gap-2">
+              <p className="text-xs text-gray-500 uppercase tracking-widest">.fair</p>
+              {fairManifest && !isV1_1 && (
+                <span className="text-[10px] px-1.5 py-0.5 bg-yellow-900/30 border border-yellow-700/50 rounded-full text-yellow-400">
+                  v1.0 legacy
+                </span>
+              )}
+            </div>
+            {fairManifest && isOwner && (
               <button
                 onClick={() => setEditingFair(true)}
                 className="text-xs text-orange-400 hover:text-orange-300 transition-colors"
@@ -462,21 +488,45 @@ export function AssetDetail({ asset, folders, currentDid, onClose, onDeleted, on
           </div>
 
           {fairManifest ? (
-            <FairEditor resolveProfile={resolveProfile}
-              manifest={fairManifest}
-              readOnly={true}
-              sections={["attribution", "access", "transfer"]}
-            />
+            isV1_1 ? (
+              <FairManifestEditor
+                manifest={fairManifest as FairManifestV1_1}
+                mimeType={asset.mimeType}
+                onChange={(m) => setFairManifest(m)}
+                onSave={() => handleSaveFair(fairManifest)}
+                readOnly={readOnlyEditor}
+                currentUserDid={currentDid}
+              />
+            ) : (
+              <FairEditor
+                resolveProfile={resolveProfile}
+                manifest={fairManifest}
+                readOnly={true}
+                sections={["attribution", "access", "transfer"]}
+              />
+            )
           ) : (
             <div className="bg-[#252525] rounded-xl p-3 text-xs text-gray-500 italic">
               No .fair manifest.
             </div>
           )}
+
+          {/* v1.0 → v1.1 upgrade placeholder (Commit 5/6 will wire the actual button) */}
+          {fairManifest && !isV1_1 && isOwner && (
+            <div className="mt-2">
+              <button
+                disabled
+                className="w-full py-1.5 text-xs bg-orange-500/10 border border-orange-500/30 text-orange-400 rounded-lg opacity-50 cursor-not-allowed"
+              >
+                Upgrade to v1.1 (coming soon)
+              </button>
+            </div>
+          )}
         </div>
       </div>
 
-      {/* .fair edit modal */}
-      {editingFair && fairManifest && (
+      {/* .fair edit modal (for v1.0 or when opening full editor) */}
+      {editingFair && fairManifest && !isV1_1 && (
         <FairEditModal
           manifest={fairManifest}
           onSave={handleSaveFair}

--- a/apps/kernel/src/components/media/FairManifestEditor.tsx
+++ b/apps/kernel/src/components/media/FairManifestEditor.tsx
@@ -1,0 +1,627 @@
+'use client';
+
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import type {
+  FairManifestV1_1,
+  DidShareList,
+  Money,
+  FairDistributionRight,
+  FairTraining,
+  FairCommercial,
+  FairTransferV1_1,
+  FairAccessV1_1,
+} from '@imajin/fair';
+import { validateManifest } from '@imajin/fair';
+import { DidShareListEditor, MoneyInput } from '@imajin/ui';
+
+interface SectionProps {
+  title: string;
+  error?: boolean;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+function Section({ title, error, children, defaultOpen = false }: SectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="bg-[#252525] rounded-xl overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        type="button"
+        className="w-full px-4 py-3 flex items-center justify-between hover:bg-[#2a2a2a] transition"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-gray-400 uppercase tracking-widest">
+            {title}
+          </span>
+          {error && (
+            <span className="w-2 h-2 rounded-full bg-red-500" title="Has errors" />
+          )}
+        </div>
+        <span className={`text-gray-500 text-xs transition-transform ${open ? 'rotate-180' : ''}`}>
+          ▾
+        </span>
+      </button>
+      {open && <div className="px-4 pb-4 space-y-3">{children}</div>}
+    </div>
+  );
+}
+
+function Toggle({
+  label,
+  checked,
+  onChange,
+  readOnly,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  readOnly?: boolean;
+}) {
+  return (
+    <label className="flex items-center gap-2 cursor-pointer">
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={readOnly}
+        onChange={(e) => onChange(e.target.checked)}
+        className="accent-orange-500 disabled:opacity-60"
+      />
+      <span className="text-xs text-gray-300">{label}</span>
+    </label>
+  );
+}
+
+const DIST_MODES = [
+  { value: 'allowed', label: 'Allowed' },
+  { value: 'allow-with-attribution', label: 'With attribution' },
+  { value: 'allow-with-share', label: 'With revenue share' },
+  { value: 'quote-with-attribution', label: 'Quote only' },
+  { value: 'reserved', label: 'Reserved' },
+];
+
+function DistributionRightEditor({
+  right,
+  onChange,
+  readOnly,
+}: {
+  right?: FairDistributionRight;
+  onChange: (r: FairDistributionRight | undefined) => void;
+  readOnly?: boolean;
+}) {
+  const mode = right?.mode ?? 'reserved';
+  const showPrice = mode === 'allowed' || mode === 'allow-with-share' || mode === 'allow-with-attribution';
+  const showSplits = mode === 'allow-with-share';
+  const showQuote = mode === 'quote-with-attribution';
+  const showSampling = showQuote; // for audio
+
+  return (
+    <div className="space-y-2">
+      <select
+        value={mode}
+        onChange={(e) => {
+          const newMode = e.target.value;
+          onChange({ ...right, mode: newMode });
+        }}
+        disabled={readOnly}
+        className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 focus:outline-none focus:border-orange-500 disabled:opacity-60"
+      >
+        {DIST_MODES.map((m) => (
+          <option key={m.value} value={m.value}>
+            {m.label}
+          </option>
+        ))}
+      </select>
+
+      {showPrice && (
+        <MoneyInput
+          value={right?.price}
+          onChange={(price) => onChange({ ...right, price: price ?? undefined })}
+          readOnly={readOnly}
+        />
+      )}
+
+      {showSplits && (
+        <DidShareListEditor
+          value={right?.splits ?? [{ role: 'creator', share: 1 }]}
+          onChange={(splits) => onChange({ ...right, splits })}
+          readOnly={readOnly}
+        />
+      )}
+
+      {showQuote && (
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <span className="text-[10px] text-gray-500">Max %</span>
+            <input
+              type="number"
+              value={right?.quote?.maxPercent ?? ''}
+              onChange={(e) => {
+                const val = e.target.value ? parseFloat(e.target.value) : undefined;
+                onChange({ ...right, quote: { ...right?.quote, maxPercent: val } });
+              }}
+              readOnly={readOnly}
+              className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 read-only:opacity-60"
+            />
+          </div>
+          <div className="flex-1">
+            <span className="text-[10px] text-gray-500">Max words</span>
+            <input
+              type="number"
+              value={right?.quote?.maxWords ?? ''}
+              onChange={(e) => {
+                const val = e.target.value ? parseInt(e.target.value) : undefined;
+                onChange({ ...right, quote: { ...right?.quote, maxWords: val } });
+              }}
+              readOnly={readOnly}
+              className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 read-only:opacity-60"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function mimeBucket(mimeType: string): 'text' | 'image' | 'audio' | 'video' | 'other' {
+  if (mimeType.startsWith('text/')) return 'text';
+  if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith('audio/')) return 'audio';
+  if (mimeType.startsWith('video/')) return 'video';
+  return 'other';
+}
+
+// ─── Debounce hook ─────────────────────────────────────────────────────────
+
+function useDebouncedCallback<T extends (...args: unknown[]) => void>(
+  fn: T,
+  delay: number
+) {
+  const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  return useCallback(
+    (...args: Parameters<T>) => {
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => fn(...args), delay);
+    },
+    [fn, delay]
+  );
+}
+
+// ─── FairManifestEditor ────────────────────────────────────────────────────
+
+export interface FairManifestEditorProps {
+  manifest: FairManifestV1_1;
+  mimeType?: string;
+  onChange: (manifest: FairManifestV1_1) => void;
+  onSave?: () => void;
+  readOnly?: boolean;
+  currentUserDid?: string;
+}
+
+export function FairManifestEditor({
+  manifest,
+  mimeType = 'application/octet-stream',
+  onChange,
+  onSave,
+  readOnly = false,
+  currentUserDid,
+}: FairManifestEditorProps) {
+  const [local, setLocal] = useState<FairManifestV1_1>(manifest);
+  const [validation, setValidation] = useState<{ ok: boolean; errors: string[] }>({
+    ok: true,
+    errors: [],
+  });
+  const [sectionErrors, setSectionErrors] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setLocal(manifest);
+  }, [manifest]);
+
+  const update = useCallback(
+    (patch: Partial<FairManifestV1_1>) => {
+      const next = { ...local, ...patch };
+      setLocal(next);
+      onChange(next);
+    },
+    [local, onChange]
+  );
+
+  const debouncedValidate = useDebouncedCallback((m: FairManifestV1_1) => {
+    const result = validateManifest(m);
+    setValidation(result);
+
+    // Map errors to sections
+    const errors: Record<string, boolean> = {};
+    for (const err of result.errors) {
+      if (err.startsWith('attribution')) errors.attribution = true;
+      if (err.startsWith('training')) errors.training = true;
+      if (err.startsWith('commercial')) errors.commercial = true;
+      if (err.startsWith('distribution')) errors.distribution = true;
+      if (err.startsWith('transfer')) errors.transfer = true;
+      if (err.startsWith('access')) errors.access = true;
+    }
+    setSectionErrors(errors);
+  }, 300);
+
+  useEffect(() => {
+    debouncedValidate(local);
+  }, [local, debouncedValidate]);
+
+  const bucket = useMemo(() => mimeBucket(mimeType), [mimeType]);
+
+  const attribution = local.attribution ?? [];
+  const training = local.training ?? { allowed: false };
+  const commercial = local.commercial ?? { allowed: false };
+  const distribution = local.distribution ?? {};
+  const transfer = local.transfer ?? { allowed: false };
+  const access =
+    typeof local.access === 'string'
+      ? ({ type: local.access } as FairAccessV1_1)
+      : local.access ?? ({ type: 'private' } as FairAccessV1_1);
+
+  // Signed manifest display
+  const isSigned = !!local.signature;
+  const isSigner = isSigned && currentUserDid === local.signature?.signer;
+
+  return (
+    <div className="bg-[#1a1a1a] text-gray-200 rounded-2xl shadow-xl p-4 space-y-4 w-full">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-gray-800 pb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-orange-500 font-bold text-sm">.fair</span>
+          <span className="text-gray-600 text-xs">v{local.version || local.fair || '1.0'}</span>
+          {isSigned && (
+            <span className="text-[10px] px-1.5 py-0.5 bg-emerald-900/30 border border-emerald-700/50 rounded-full text-emerald-400">
+              {isSigner ? 'Signed by you' : `Signed by ${local.signature!.signer.slice(0, 12)}…`}
+            </span>
+          )}
+        </div>
+        {isSigned && isSigner && (
+          <span className="text-[10px] text-gray-500">(re-signing on save)</span>
+        )}
+      </div>
+
+      {/* Validation summary */}
+      {!validation.ok && (
+        <div className="bg-red-900/20 border border-red-700/50 rounded-lg p-2">
+          <p className="text-xs text-red-400 font-medium">
+            {validation.errors.length} validation error{validation.errors.length > 1 ? 's' : ''}
+          </p>
+        </div>
+      )}
+
+      {/* Attribution */}
+      <Section title="Attribution split" error={sectionErrors.attribution} defaultOpen>
+        <DidShareListEditor
+          value={attribution}
+          onChange={(entries) => update({ attribution: entries })}
+          readOnly={readOnly}
+          defaultDid={currentUserDid}
+        />
+      </Section>
+
+      {/* AI Training opt-out — visually prominent */}
+      <div className="bg-[#1e1e2e] border border-orange-500/30 rounded-xl p-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="text-lg">🤖</span>
+          <span className="text-xs font-semibold text-orange-400 uppercase tracking-widest">
+            AI Training
+          </span>
+        </div>
+        <p className="text-xs text-gray-400">
+          Allow this asset to be used in AI training datasets. Disabling this opts your work out
+          of being used to train machine learning models.
+        </p>
+        <Toggle
+          label="Allow AI training"
+          checked={training.allowed}
+          onChange={(allowed) => update({ training: { ...training, allowed } })}
+          readOnly={readOnly}
+        />
+      </div>
+
+      {/* Commercial use */}
+      <Section title="Commercial use" error={sectionErrors.commercial}>
+        <Toggle
+          label="Allow commercial use"
+          checked={commercial.allowed}
+          onChange={(allowed) => update({ commercial: { ...commercial, allowed } })}
+          readOnly={readOnly}
+        />
+        {commercial.allowed && (
+          <Toggle
+            label="Contact required for commercial licensing"
+            checked={commercial.contactRequired ?? false}
+            onChange={(contactRequired) =>
+              update({ commercial: { ...commercial, contactRequired } })
+            }
+            readOnly={readOnly}
+          />
+        )}
+      </Section>
+
+      {/* Distribution actions */}
+      <Section title="Distribution" error={sectionErrors.distribution}>
+        <div className="space-y-3">
+          {(['reproduction', 'streaming', 'derivative', 'syndication'] as const).map((key) => (
+            <div key={key} className="bg-[#1a1a1a] rounded-lg p-3 space-y-2">
+              <p className="text-xs font-medium text-gray-400 capitalize">{key}</p>
+              <DistributionRightEditor
+                right={distribution[key]}
+                onChange={(r) => update({ distribution: { ...distribution, [key]: r } })}
+                readOnly={readOnly}
+              />
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      {/* Transfer */}
+      <Section title="Transfer" error={sectionErrors.transfer}>
+        <div className="space-y-3">
+          <Toggle
+            label="Transfers allowed"
+            checked={transfer.allowed}
+            onChange={(allowed) =>
+              update({ transfer: { ...transfer, allowed } as FairTransferV1_1 })
+            }
+            readOnly={readOnly}
+          />
+          {transfer.allowed && (
+            <>
+              <Toggle
+                label="Requires attribution on transfer"
+                checked={transfer.requiresAttribution ?? false}
+                onChange={(requiresAttribution) =>
+                  update({
+                    transfer: { ...transfer, requiresAttribution } as FairTransferV1_1,
+                  })
+                }
+                readOnly={readOnly}
+              />
+              <div>
+                <p className="text-xs text-gray-500 mb-1">Transfer price</p>
+                <MoneyInput
+                  value={transfer.price}
+                  onChange={(price) =>
+                    update({ transfer: { ...transfer, price } as FairTransferV1_1 })
+                  }
+                  readOnly={readOnly}
+                />
+              </div>
+              {transfer.price && (
+                <div>
+                  <p className="text-xs text-gray-500 mb-1">Revenue split on transfer</p>
+                  <DidShareListEditor
+                    value={transfer.splits ?? [{ role: 'creator', share: 1 }]}
+                    onChange={(splits) =>
+                      update({ transfer: { ...transfer, splits } as FairTransferV1_1 })
+                    }
+                    readOnly={readOnly}
+                    defaultDid={currentUserDid}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </Section>
+
+      {/* Access */}
+      <Section title="Access" error={sectionErrors.access}>
+        <div className="flex gap-2 flex-wrap">
+          {(['public', 'private', 'trust-graph', 'conversation'] as const).map((t) => (
+            <button
+              key={t}
+              disabled={readOnly}
+              onClick={() => update({ access: { ...access, type: t } })}
+              className={`px-3 py-1 rounded text-xs font-medium transition ${
+                access.type === t
+                  ? 'bg-orange-500 text-white'
+                  : 'bg-[#252525] text-gray-400 hover:bg-[#333]'
+              } disabled:cursor-default`}
+              type="button"
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        {access.type === 'conversation' && (
+          <input
+            type="text"
+            value={access.conversationDid ?? ''}
+            onChange={(e) => update({ access: { ...access, conversationDid: e.target.value } })}
+            placeholder="did:key:... (conversation)"
+            readOnly={readOnly}
+            className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 placeholder-gray-600 focus:outline-none focus:border-orange-500 read-only:opacity-60"
+          />
+        )}
+        {(access.type === 'private' || access.type === 'trust-graph') && (
+          <div className="space-y-2">
+            <p className="text-xs text-gray-500">Allowed DIDs</p>
+            {(access.allowedDids ?? []).map((did, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <span className="flex-1 text-xs text-gray-400 truncate">{did}</span>
+                {!readOnly && (
+                  <button
+                    onClick={() => {
+                      const next = [...(access.allowedDids ?? [])];
+                      next.splice(i, 1);
+                      update({ access: { ...access, allowedDids: next } });
+                    }}
+                    className="text-gray-600 hover:text-red-400 transition text-xs"
+                    type="button"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+            ))}
+            {!readOnly && (
+              <input
+                type="text"
+                placeholder="did:key:... (press Enter)"
+                className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 placeholder-gray-600 focus:outline-none focus:border-orange-500"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    const val = (e.target as HTMLInputElement).value.trim();
+                    if (val) {
+                      update({
+                        access: {
+                          ...access,
+                          allowedDids: [...(access.allowedDids ?? []), val],
+                        },
+                      });
+                      (e.target as HTMLInputElement).value = '';
+                    }
+                  }
+                }}
+              />
+            )}
+          </div>
+        )}
+      </Section>
+
+      {/* Type-specific */}
+      {bucket !== 'other' && (
+        <Section title={`Type-specific (${bucket})`}>
+          {bucket === 'text' && (
+            <div className="space-y-2">
+              <p className="text-xs text-gray-500">Quote limits for reproduction</p>
+              <div className="flex gap-2">
+                <div className="flex-1">
+                  <span className="text-[10px] text-gray-500">Max %</span>
+                  <input
+                    type="number"
+                    value={distribution.reproduction?.quote?.maxPercent ?? ''}
+                    onChange={(e) => {
+                      const val = e.target.value ? parseFloat(e.target.value) : undefined;
+                      update({
+                        distribution: {
+                          ...distribution,
+                          reproduction: {
+                            ...distribution.reproduction,
+                            quote: { ...distribution.reproduction?.quote, maxPercent: val },
+                          },
+                        },
+                      });
+                    }}
+                    readOnly={readOnly}
+                    className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 read-only:opacity-60"
+                  />
+                </div>
+                <div className="flex-1">
+                  <span className="text-[10px] text-gray-500">Max words</span>
+                  <input
+                    type="number"
+                    value={distribution.reproduction?.quote?.maxWords ?? ''}
+                    onChange={(e) => {
+                      const val = e.target.value ? parseInt(e.target.value) : undefined;
+                      update({
+                        distribution: {
+                          ...distribution,
+                          reproduction: {
+                            ...distribution.reproduction,
+                            quote: { ...distribution.reproduction?.quote, maxWords: val },
+                          },
+                        },
+                      });
+                    }}
+                    readOnly={readOnly}
+                    className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 read-only:opacity-60"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+          {bucket === 'audio' && (
+            <div className="space-y-2">
+              <Toggle
+                label="Allow sampling (with share)"
+                checked={(distribution.derivative?.sampling?.allowed ?? '') === 'allow-with-share'}
+                onChange={(checked) =>
+                  update({
+                    distribution: {
+                      ...distribution,
+                      derivative: {
+                        ...distribution.derivative,
+                        sampling: {
+                          allowed: checked ? 'allow-with-share' : 'reserved',
+                          share: distribution.derivative?.sampling?.share ?? 0.05,
+                        },
+                      },
+                    },
+                  })
+                }
+                readOnly={readOnly}
+              />
+              <Toggle
+                label="Allow sync licensing"
+                checked={(distribution.derivative?.sync?.allowed ?? '') === 'allowed'}
+                onChange={(checked) =>
+                  update({
+                    distribution: {
+                      ...distribution,
+                      derivative: {
+                        ...distribution.derivative,
+                        sync: {
+                          allowed: checked ? 'allowed' : 'reserved',
+                        },
+                      },
+                    },
+                  })
+                }
+                readOnly={readOnly}
+              />
+            </div>
+          )}
+          {bucket === 'video' && (
+            <Toggle
+              label="Allow sync licensing"
+              checked={(distribution.derivative?.sync?.allowed ?? '') === 'allowed'}
+              onChange={(checked) =>
+                update({
+                  distribution: {
+                    ...distribution,
+                    derivative: {
+                      ...distribution.derivative,
+                      sync: {
+                        allowed: checked ? 'allowed' : 'reserved',
+                      },
+                    },
+                  },
+                })
+              }
+              readOnly={readOnly}
+            />
+          )}
+        </Section>
+      )}
+
+      {/* Footer */}
+      <div className="flex items-center justify-between pt-2 border-t border-gray-800">
+        <div className="text-[10px] text-gray-700">
+          <a
+            href="https://github.com/ima-jin/.fair"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-orange-500 transition"
+          >
+            .fair spec
+          </a>
+          {' '}— transparent attribution
+        </div>
+        {!readOnly && onSave && (
+          <button
+            onClick={onSave}
+            disabled={!validation.ok}
+            className="px-4 py-1.5 text-xs bg-orange-500 text-white rounded-md hover:bg-orange-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            type="button"
+          >
+            Save
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/src/components/media/FairManifestEditor.tsx
+++ b/apps/kernel/src/components/media/FairManifestEditor.tsx
@@ -272,7 +272,9 @@ export function FairManifestEditor({
           <span className="text-gray-600 text-xs">v{local.version || local.fair || '1.0'}</span>
           {isSigned && (
             <span className="text-[10px] px-1.5 py-0.5 bg-emerald-900/30 border border-emerald-700/50 rounded-full text-emerald-400">
-              {isSigner ? 'Signed by you' : `Signed by ${local.signature!.signer.slice(0, 12)}…`}
+              {isSigner
+                ? 'Signed by you'
+                : `Signed by ${local.signature!.signer.slice(0, 16)}…`}
             </span>
           )}
         </div>
@@ -280,6 +282,29 @@ export function FairManifestEditor({
           <span className="text-[10px] text-gray-500">(re-signing on save)</span>
         )}
       </div>
+
+      {/* Signature details */}
+      {isSigned && (
+        <div className="bg-[#1a1a1a] rounded-lg p-2 space-y-1">
+          <p className="text-[10px] text-gray-500">
+            Signed by{' '}
+            <code className="text-gray-400">{local.signature!.signer}</code>
+            {' '}on{' '}
+            {local.signature!.signedAt
+              ? new Date(local.signature!.signedAt).toLocaleDateString()
+              : 'unknown date'}
+          </p>
+          {/* DFOS anchoring — from #897 / #882 */}
+          {'fair_dfos_event_id' in local && (local as Record<string, unknown>).fair_dfos_event_id && (
+            <p className="text-[10px] text-gray-500">
+              Anchored on DFOS:{" "}
+              <code className="text-gray-400">
+                {(local as Record<string, unknown>).fair_dfos_event_id as string}
+              </code>
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Validation summary */}
       {!validation.ok && (

--- a/docs/audits/fair-v1.1-ui.md
+++ b/docs/audits/fair-v1.1-ui.md
@@ -1,0 +1,81 @@
+# .fair v1.1 UI Audit
+
+## Current State of `AssetDetail.tsx`
+
+`apps/kernel/src/components/media/AssetDetail.tsx` currently handles `.fair` manifest display/editing as follows:
+
+- **Display (sidebar):** Uses `<FairEditor>` from `@imajin/fair` in `readOnly={true}` mode, showing `attribution`, `access`, `transfer` sections.
+- **Edit (modal):** Clicking "Edit ✏️" opens `FairEditModal`, which wraps `<FairEditor>` in `readOnly={false}` mode inside a fixed overlay modal. Save POSTs to `/media/api/assets/{id}/fair`.
+- **No v1.1 awareness:** The editor only shows v1.0 primitives (attribution, access, transfer, integrity). It does not display or edit v1.1 fields like `training`, `commercial`, `distribution`, or `tipping`.
+- **No signing flow:** The fair PUT endpoint does not sign manifests. The client sends the manifest as JSON and it's stored directly.
+
+## `FairAccordion` vs `FairManifestEditor`
+
+- **`FairAccordion`** (exists in `@imajin/fair`) is a **read-only** display component for attribution splits, fees, and distributions. It is used in consumer-facing contexts (e.g., event tickets). It is NOT an editor.
+- **`FairEditor`** (exists in `@imajin/fair`) is the current editable component, but it only handles v1.0 fields and its UI is a single flat panel.
+- **Decision:** For the v1.1 UI in `AssetDetail`, we need a NEW editor component — `FairManifestEditor` — that:
+  - Consumes a v1.1 manifest and emits changes
+  - Has collapsible accordion-style sections for each v1.1 primitive
+  - Lives in `apps/kernel/src/components/media/` (app-specific, not shared)
+  - Uses shared primitives (`DidShareListEditor`, `MoneyInput`) from `@imajin/ui`
+  - `FairAccordion` remains as the read-only consumer component; we do NOT modify it.
+
+## `<DidShareListEditor>` API Decisions
+
+- **Location:** `packages/ui/src/DidShareListEditor.tsx` (shared component library)
+- **Props:**
+  ```ts
+  interface DidShareListEditorProps {
+    value: DidShareList;
+    onChange: (value: DidShareList) => void;
+    readOnly?: boolean;
+    className?: string;
+    defaultDid?: string; // pre-fill for new rows
+  }
+  ```
+- **Behavior:**
+  - Array editor for `{ did?, role, share, name?, note? }`
+  - Live sum display; error state (red text) when sum ≠ 1.0
+  - Slider (0–100, 0.5 step) + number input for share
+  - Deletable rows, "+ Add" button
+  - Validates against D1 rules (share 0–1, sum = 1.0)
+  - Does NOT include `fixed` Money input by default — that is added by the consumer (`FairManifestEditor`) when a row has `fixed` set
+
+## `<MoneyInput>` API Decisions
+
+- **Location:** `packages/ui/src/MoneyInput.tsx`
+- **Props:**
+  ```ts
+  interface MoneyInputProps {
+    value?: Money;
+    onChange: (value: Money | undefined) => void;
+    readOnly?: boolean;
+    className?: string;
+    currencies?: string[]; // default: ['USD', 'EUR', 'GBP', 'CAD', 'MJNX']
+  }
+  ```
+- **Behavior:**
+  - Amount field: stores cents internally, displays as decimal (e.g., 100 → "1.00")
+  - Currency selector: ISO 4217 short list + MJNX
+  - Shows formatted preview (e.g., "$1.00 USD")
+  - Forward ref, className passthrough
+
+## "Upgrade to v1.1" Endpoint Location + Auth Pattern
+
+- **Location:** `apps/kernel/app/media/api/assets/[id]/upgrade-fair/route.ts`
+- **Auth:** `requireAuth(request)` → owner DID must equal `asset.ownerDid`
+- **Signing limitation:** The server does not have access to user private keys. The existing "owner-signed action" pattern in this codebase is:
+  1. Client signs with browser-stored keypair (for chat messages, attestations via auth service)
+  2. Server verifies the session but does not sign on behalf of users
+- **Decision for the upgrade endpoint:**
+  - Server upgrades the manifest structure using `upgradeToV1_1()`
+  - Server does NOT cryptographically sign with the owner's key (impossible server-side)
+  - Instead, the server signs with the **node's platform key** (`AUTH_PRIVATE_KEY`) and sets `signature.signer` to the **node DID** (`getNodeDid()`). This is a **platform attestation** pattern, consistent with `emitSessionAttestation`.
+  - The client can re-sign with the owner's key on the next save via the existing PUT `/fair` flow.
+  - Documented as transitional — true owner signing may be added when the auth service supports delegated signing.
+- **Bus event:** Publish `asset.fair.upgraded` with `{ assetId, oldVersion, newVersion, signer }`. Register in `packages/bus/src/config.ts` with attestation reactor.
+
+## Open Questions
+
+1. Should the upgrade endpoint also publish `fair.manifest.published` for DFOS? — **Deferred to #897/#882**. We'll add a conditional check: if `publishContentEvent` is available, call it; otherwise skip.
+2. Should `DidShareListEditor` live in `@imajin/fair` instead of `@imajin/ui`? — **No.** It's a generic array editor primitive that could be reused outside .fair contexts (e.g., revenue splits in other apps). `@imajin/ui` is the right home.

--- a/packages/bus/src/config.ts
+++ b/packages/bus/src/config.ts
@@ -224,6 +224,9 @@ const DEFAULTS: Record<string, ReactorConfig[]> = {
     { type: 'attestation', config: { attestationType: 'listing.created' }, enabled: true },
     { type: 'notify', config: {}, enabled: true },
   ],
+  'asset.fair.upgraded': [
+    { type: 'attestation', config: { attestationType: 'asset.fair.upgraded' }, enabled: true },
+  ],
 };
 
 export function getChainConfig(eventType: string, _scope: string): ChainConfig {

--- a/packages/bus/src/types.ts
+++ b/packages/bus/src/types.ts
@@ -485,6 +485,12 @@ export interface BusEventMap {
     context_id: string;
     context_type: string;
   };
+  'asset.fair.upgraded': {
+    assetId: string;
+    oldVersion: string;
+    newVersion: string;
+    signer: string;
+  };
 }
 
 export type BusEventType = keyof BusEventMap;

--- a/packages/ui/src/DidShareListEditor.tsx
+++ b/packages/ui/src/DidShareListEditor.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import type { DidShareList, DidShareEntry } from '@imajin/fair';
+
+interface DidShareListEditorProps {
+  value: DidShareList;
+  onChange: (value: DidShareList) => void;
+  readOnly?: boolean;
+  className?: string;
+  defaultDid?: string;
+  showFixed?: boolean;
+}
+
+const ROLE_OPTIONS = [
+  'creator', 'collaborator', 'producer', 'performer',
+  'platform', 'venue', 'distributor', 'label', 'other',
+];
+
+const SUM_TOLERANCE = 1e-6;
+
+export function DidShareListEditor({
+  value,
+  onChange,
+  readOnly = false,
+  className = '',
+  defaultDid,
+  showFixed = false,
+}: DidShareListEditorProps) {
+  const totalShare = useMemo(
+    () => value.reduce((sum, e) => sum + e.share, 0),
+    [value],
+  );
+
+  const isValid = Math.abs(totalShare - 1.0) <= SUM_TOLERANCE;
+  const isOver = totalShare > 1.0 + SUM_TOLERANCE;
+
+  const update = (i: number, patch: Partial<DidShareEntry>) => {
+    const next = value.map((e, idx) => (idx === i ? { ...e, ...patch } : e));
+    onChange(next);
+  };
+
+  const remove = (i: number) => {
+    onChange(value.filter((_, idx) => idx !== i));
+  };
+
+  const add = () => {
+    onChange([
+      ...value,
+      {
+        did: defaultDid ?? '',
+        role: 'collaborator',
+        share: 0,
+      },
+    ]);
+  };
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      {value.map((entry, i) => (
+        <div key={i} className="bg-[#252525] rounded-lg p-3 space-y-2">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={entry.did ?? ''}
+              onChange={(e) => update(i, { did: e.target.value })}
+              placeholder="did:key:..."
+              readOnly={readOnly}
+              className="flex-1 bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 placeholder-gray-600 focus:outline-none focus:border-orange-500 read-only:opacity-60"
+            />
+            <select
+              value={entry.role}
+              onChange={(e) => update(i, { role: e.target.value })}
+              disabled={readOnly}
+              className="bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 focus:outline-none focus:border-orange-500 disabled:opacity-60"
+            >
+              {ROLE_OPTIONS.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+            {!readOnly && (
+              <button
+                onClick={() => remove(i)}
+                className="text-gray-600 hover:text-red-400 transition text-sm px-1"
+                title="Remove"
+                type="button"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={0.5}
+              value={Math.round(entry.share * 1000) / 10}
+              onChange={(e) => update(i, { share: parseFloat(e.target.value) / 100 })}
+              disabled={readOnly}
+              className="flex-1 accent-orange-500 disabled:opacity-60"
+            />
+            <input
+              type="number"
+              min={0}
+              max={100}
+              step={0.5}
+              value={(entry.share * 100).toFixed(1)}
+              onChange={(e) => update(i, { share: parseFloat(e.target.value) / 100 })}
+              readOnly={readOnly}
+              className="w-16 bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 focus:outline-none focus:border-orange-500 text-right read-only:opacity-60"
+            />
+            <span className="text-xs text-gray-500">%</span>
+          </div>
+          <input
+            type="text"
+            value={entry.name ?? ''}
+            onChange={(e) => update(i, { name: e.target.value || undefined })}
+            placeholder="Name (optional)"
+            readOnly={readOnly}
+            className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-500 placeholder-gray-700 focus:outline-none focus:border-orange-500 read-only:opacity-60"
+          />
+        </div>
+      ))}
+
+      {!readOnly && (
+        <button
+          onClick={add}
+          type="button"
+          className="w-full py-1.5 rounded border border-dashed border-gray-700 text-xs text-gray-500 hover:border-orange-500 hover:text-orange-400 transition"
+        >
+          + Add contributor
+        </button>
+      )}
+
+      <div className="flex items-center justify-between text-xs">
+        <span
+          className={
+            isValid
+              ? 'text-gray-500'
+              : isOver
+                ? 'text-red-400 font-medium'
+                : 'text-orange-400 font-medium'
+          }
+        >
+          Total: {(totalShare * 100).toFixed(1)}%
+          {!isValid && (
+            <span className="ml-1">
+              {isOver ? '(must be ≤ 100%)' : '(must equal 100%)'}
+            </span>
+          )}
+        </span>
+        <span className="text-gray-600">
+          {value.length} {value.length === 1 ? 'entry' : 'entries'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/MoneyInput.tsx
+++ b/packages/ui/src/MoneyInput.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import type { Money } from '@imajin/fair';
+
+interface MoneyInputProps {
+  value?: Money;
+  onChange: (value: Money | undefined) => void;
+  readOnly?: boolean;
+  className?: string;
+  currencies?: string[];
+}
+
+const DEFAULT_CURRENCIES = ['USD', 'EUR', 'GBP', 'CAD', 'MJNX'];
+
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: '$',
+  EUR: '€',
+  GBP: '£',
+  CAD: 'C$',
+  MJNX: 'Ⓜ',
+};
+
+function formatCents(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+function parseDecimalInput(raw: string): number | null {
+  const cleaned = raw.replace(/,/g, '');
+  const parsed = parseFloat(cleaned);
+  if (Number.isNaN(parsed) || parsed < 0) return null;
+  return Math.round(parsed * 100);
+}
+
+export function MoneyInput({
+  value,
+  onChange,
+  readOnly = false,
+  className = '',
+  currencies = DEFAULT_CURRENCIES,
+}: MoneyInputProps) {
+  const symbol = value ? (CURRENCY_SYMBOLS[value.currency] ?? value.currency) : '$';
+
+  const formattedPreview = useMemo(() => {
+    if (!value) return '';
+    const amt = (value.amount / 100).toFixed(2);
+    return `${symbol}${amt} ${value.currency}`;
+  }, [value, symbol]);
+
+  return (
+    <div className={`space-y-1 ${className}`}>
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <span className="absolute left-2 top-1/2 -translate-y-1/2 text-xs text-gray-500 pointer-events-none">
+            {symbol}
+          </span>
+          <input
+            type="text"
+            inputMode="decimal"
+            value={value ? formatCents(value.amount) : ''}
+            onChange={(e) => {
+              const cents = parseDecimalInput(e.target.value);
+              if (cents === null) {
+                onChange(undefined);
+                return;
+              }
+              onChange({
+                amount: cents,
+                currency: value?.currency ?? currencies[0],
+              });
+            }}
+            placeholder="0.00"
+            readOnly={readOnly}
+            className="w-full bg-[#1a1a1a] border border-gray-700 rounded pl-6 pr-2 py-1.5 text-xs text-gray-200 placeholder-gray-600 focus:outline-none focus:border-orange-500 read-only:opacity-60"
+          />
+        </div>
+        <select
+          value={value?.currency ?? currencies[0]}
+          onChange={(e) => {
+            const currency = e.target.value;
+            const amount = value?.amount ?? 0;
+            if (amount === 0 && !value) {
+              onChange(undefined);
+            } else {
+              onChange({ amount, currency });
+            }
+          }}
+          disabled={readOnly}
+          className="bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1.5 text-xs text-gray-200 focus:outline-none focus:border-orange-500 disabled:opacity-60"
+        >
+          {currencies.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+      {value && value.amount > 0 && (
+        <p className="text-[10px] text-gray-500">{formattedPreview}</p>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -26,6 +26,8 @@ export { NotificationBell } from './notification-bell';
 
 export { ActionSheet } from './action-sheet';
 export { AppShell } from './app-shell';
+export { DidShareListEditor } from './DidShareListEditor';
+export { MoneyInput } from './MoneyInput';
 export type {
   AppShellProps,
   AppShellHeaderProps,


### PR DESCRIPTION
Closes #893
Closes #894

Depends on #896 (rebase to main once that merges); also rebases past #897 if #897 merges first.

## Six-commit summary

1. `feat(ui): DidShareListEditor + MoneyInput + audit doc (#893)` — Two new shared UI primitives in `packages/ui/` for editing DID-share lists and money amounts (cents + currency). Includes the audit doc at `docs/audits/fair-v1.1-ui.md`.
2. `feat(kernel): FairManifestEditor with per-action panels (#893)` — New `FairManifestEditor` component with accordion sections for attribution, AI training opt-out, commercial use, distribution actions, transfer, and type-specific rules. Debounced validation against D1's `validateManifest()`.
3. `feat(kernel): integrate FairManifestEditor into AssetDetail (#893)` — Replaces the existing `.fair` UI in `AssetDetail.tsx`. v1.0 manifests show a "v1.0 legacy" badge.
4. `feat(kernel): read-only mode for signed manifests (#893)` — When a manifest is signed by another DID, the editor renders read-only with signature details and DFOS anchoring badge. Signers see "(re-signing on save)".
5. `feat(kernel): POST /api/media/assets/[id]/upgrade-fair endpoint (#894)` — New authenticated endpoint that upgrades a v1.0 manifest to v1.1 using `upgradeToV1_1()`, signs with the platform key, persists, and publishes `asset.fair.upgraded` bus event.
6. `feat(kernel): Upgrade to v1.1 button on AssetDetail (#894)` — Owner-visible upgrade button with confirm dialog, loading state, inline error handling, and automatic manifest refresh on success.

## Screenshots

*(Ryan will add manually if needed)*

## Verification steps

1. Load an existing v1.0 asset on dev
2. See "v1.0 legacy" badge and "Upgrade to v1.1" button
3. Click upgrade → confirm dialog
4. See v1.1 editor with `training.allowed` toggle visually prominent
5. Edit attribution splits, distribution rights, transfer settings
6. Save → manifest is persisted
