### PR TITLE
feat(migrations): backfill survey_responses for orphan registrations (#826)

### DIFF
--- a/migrations/0025_backfill_survey_responses_for_orphan_registrations.sql
+++ b/migrations/0025_backfill_survey_responses_for_orphan_registrations.sql
@@ -1,0 +1,62 @@
+-- 0025_backfill_survey_responses_for_orphan_registrations.sql
+--
+-- Issue #826 — prepare for dropping events.ticket_registrations by ensuring
+-- every registration is represented in dykil.survey_responses (the source of truth).
+--
+-- Three operations, all idempotent:
+--   1. Backfill ticket_id on existing survey_responses that we can match via
+--      ticket_registrations.response_id (~14 rows in prod at time of writing).
+--   2. Insert *partial* survey_responses ({email, full_name}) for ticket_registrations
+--      that have no matching survey_response anywhere (~24 rows in prod). These
+--      attendees have name+email only; remaining survey fields will be re-collected.
+--   3. Flip those orphan tickets back to registration_status='pending' so the
+--      organizer (and the registration UI) prompts them to complete the survey.
+--      Dykil's submit endpoint upserts by (survey_id, ticket_id) so the partial
+--      row is cleanly overwritten on re-submission.
+
+BEGIN;
+
+-- 1. Link existing survey_responses to their ticket via stored response_id.
+UPDATE dykil.survey_responses sr
+SET ticket_id = tr.ticket_id
+FROM events.ticket_registrations tr
+WHERE sr.id = tr.response_id
+  AND sr.ticket_id IS NULL
+  AND tr.ticket_id IS NOT NULL;
+
+-- 2. Seed partial responses for true orphans (no survey_response by ticket_id
+--    OR by response_id). Preserves whatever attendee identity we have.
+INSERT INTO dykil.survey_responses (id, survey_id, ticket_id, answers, created_at)
+SELECT
+  'response_backfill_' || substr(md5(tr.id || ':' || tr.ticket_id), 1, 16),
+  tr.form_id,
+  tr.ticket_id,
+  jsonb_strip_nulls(jsonb_build_object(
+    'email', NULLIF(trim(tr.email), ''),
+    'full_name', NULLIF(trim(tr.name), '')
+  )),
+  COALESCE(tr.registered_at, now())
+FROM events.ticket_registrations tr
+WHERE NOT EXISTS (
+        SELECT 1 FROM dykil.survey_responses sr
+        WHERE sr.ticket_id = tr.ticket_id
+           OR (tr.response_id IS NOT NULL AND sr.id = tr.response_id)
+      )
+  -- Only seed when the form exists in Dykil; skip non-Dykil legacy rows.
+  AND EXISTS (SELECT 1 FROM dykil.surveys s WHERE s.id = tr.form_id)
+ON CONFLICT (id) DO NOTHING;
+
+-- 3. Flip those orphans back to pending so the attendee gets re-prompted.
+--    Identifying them by sr.id prefix is sufficient — we just created them
+--    above with only {email, full_name}.
+UPDATE events.tickets t
+SET registration_status = 'pending'
+WHERE t.registration_status = 'complete'
+  AND EXISTS (
+    SELECT 1
+    FROM dykil.survey_responses sr
+    WHERE sr.ticket_id = t.id
+      AND sr.id LIKE 'response_backfill_%'
+  );
+
+COMMIT;

--- a/migrations/0026_clone_shared_survey_responses_per_ticket.sql
+++ b/migrations/0026_clone_shared_survey_responses_per_ticket.sql
@@ -1,0 +1,38 @@
+-- 0026_clone_shared_survey_responses_per_ticket.sql
+--
+-- Issue #826 followup to 0025.
+--
+-- A handful of bundle-buy tickets share a single dykil.survey_response with the
+-- order's "primary" ticket (the buyer filled the survey once for the whole order,
+-- but each ticket carries its own attendee identity in events.ticket_registrations).
+--
+-- Today the guest list reads from ticket_registrations so it shows the per-ticket
+-- attendee correctly. After ticket_registrations is dropped (#826), the read path
+-- will join dykil.survey_responses by ticket_id and lose these attendees.
+--
+-- Fix: clone the shared survey_response into a per-ticket copy, overlaying the
+-- registration row's name+email so the per-ticket attendee survives.
+--
+-- Idempotent: skips tickets that already have their own survey_response.
+
+INSERT INTO dykil.survey_responses (id, survey_id, ticket_id, respondent_did, answers, created_at)
+SELECT
+  'response_clone_' || substr(md5(tr.id || ':' || tr.ticket_id), 1, 16),
+  shared.survey_id,
+  tr.ticket_id,
+  shared.respondent_did,
+  shared.answers
+    || jsonb_strip_nulls(jsonb_build_object(
+         'email', NULLIF(trim(tr.email), ''),
+         'full_name', NULLIF(trim(tr.name), '')
+       )),
+  COALESCE(tr.registered_at, shared.created_at, now())
+FROM events.ticket_registrations tr
+JOIN dykil.survey_responses shared ON shared.id = tr.response_id
+WHERE shared.ticket_id IS NOT NULL
+  AND shared.ticket_id <> tr.ticket_id
+  AND NOT EXISTS (
+    SELECT 1 FROM dykil.survey_responses sr
+    WHERE sr.ticket_id = tr.ticket_id
+  )
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Part 1 of #826 — prepare for dropping `events.ticket_registrations` by making `dykil.survey_responses` the unambiguous source of truth.

## Migrations

**0025** — backfill survey_responses for orphan registrations
- UPDATE `ticket_id` on existing survey_responses linkable via `ticket_registrations.response_id`
- INSERT partial responses (`{email, full_name}`) for true orphans (registration row exists, no survey_response anywhere)
- Flip those orphan tickets back to `registration_status='pending'` so the attendee gets re-prompted

**0026** — clone shared survey_responses per ticket
- Bundle-buy tickets where one survey response was shared across multiple tickets in the order would lose their per-attendee identity when `ticket_registrations` is dropped. Clone the shared response into per-ticket copies, overlaying the registration row's name/email.

Both migrations are idempotent.

## Applied state (already run on prod + dev)

|  | prod | dev |
|---|---|---|
| ticket_registrations rows | 69 | 11 |
| ticket_id backfilled (0025 UPDATE) | 13 | 0 |
| partial responses seeded (0025 INSERT) | 24 | 4 |
| tickets flipped to pending (0025) | 24 | 4 |
| cloned per-ticket responses (0026) | 2 | 0 |
| **orphan registrations remaining** | **0** | **0** |

⚠️ The 24 prod tickets flipped to `pending` are all `SUMMER CAMP - THE MUSICAL!` attendees. They'll be re-prompted to complete the survey on next visit. Organizer (Debbie) should be aware they may need a chase email.

## Follow-up

- **PR 2 (next):** Code refactor — remove auto-sync hack in `apps/events/app/[eventId]/page.tsx`, swap all `ticket_registrations` reads to join `dykil.survey_responses`, simplify `/api/register/[ticketId]`, delete the `sync-registration` route.
- **PR 3 (after PR 2 stable in dev):** `DROP TABLE events.ticket_registrations` migration.

Refs #826