### PR TITLE
fix(fair): owner-editable v1.1 manifests + normalize migrated attribution

### DIFF
--- a/apps/kernel/app/media/api/assets/[id]/fair/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/fair/route.ts
@@ -3,7 +3,9 @@ import { readFile, writeFile } from "fs/promises";
 import { db, assets } from "@/src/db";
 import { requireAuth } from "@imajin/auth";
 import { eq } from "drizzle-orm";
-import type { FairManifest } from "@imajin/fair";
+import type { FairManifest, FairManifestV1_1 } from "@imajin/fair";
+import { isFairManifestV1_1 } from "@imajin/fair";
+import { signFairAsNode } from "@/src/lib/kernel/sign-fair-manifest";
 import { createLogger } from "@imajin/logger";
 
 const log = createLogger("kernel");
@@ -155,24 +157,36 @@ export async function PUT(
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
+  // v1.1 manifests are always node-signed. If the owner edited the content,
+  // the existing signature is over stale data — re-sign with the node key
+  // before persisting. v1.0 manifests are written through as-is for now.
+  let toPersist: FairManifest = manifest;
+  if (isFairManifestV1_1(manifest)) {
+    const result = await signFairAsNode(manifest as FairManifestV1_1);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+    toPersist = result.signed;
+  }
+
   // Update DB
   await db
     .update(assets)
-    .set({ fairManifest: manifest as unknown as Record<string, unknown> })
+    .set({ fairManifest: toPersist as unknown as Record<string, unknown> })
     .where(eq(assets.id, id));
 
-  // TODO(#894): On manual manifest upgrade, re-sign and re-publish to DFOS
-  // if the signature changes. Wire up publishContentEvent + update
+  // TODO(#894): On manual manifest upgrade, re-publish to DFOS so the
+  // updated signature propagates. Wire up publishContentEvent + update
   // assets.fair_dfos_event_id when D5 ships.
 
   // Update sidecar file if it exists
   if (asset.fairPath) {
     try {
-      await writeFile(asset.fairPath, JSON.stringify(manifest, null, 2));
+      await writeFile(asset.fairPath, JSON.stringify(toPersist, null, 2));
     } catch {
       // Non-fatal — DB is source of truth
     }
   }
 
-  return NextResponse.json({ ok: true, manifest });
+  return NextResponse.json({ ok: true, manifest: toPersist });
 }

--- a/apps/kernel/app/media/api/assets/[id]/upgrade-fair/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/upgrade-fair/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { db, assets } from "@/src/db";
 import { requireAuth } from "@imajin/auth";
 import { eq } from "drizzle-orm";
-import type { FairManifest, FairManifestV1_1 } from "@imajin/fair";
-import { upgradeToV1_1, signManifest } from "@imajin/fair";
+import type { FairManifest } from "@imajin/fair";
+import { upgradeToV1_1 } from "@imajin/fair";
 import { getNodeDid } from "@/src/lib/kernel/node-identity";
+import { signFairAsNode } from "@/src/lib/kernel/sign-fair-manifest";
 import { createLogger } from "@imajin/logger";
 import * as bus from "@imajin/bus";
 
@@ -86,48 +87,13 @@ export async function POST(
   // 5. Upgrade to v1.1
   const upgraded = upgradeToV1_1(normalized as unknown as FairManifest);
 
-  // 5. Sign with platform/node key
-  const privateKeyHex = process.env.AUTH_PRIVATE_KEY;
-  if (!privateKeyHex) {
-    log.error({}, "AUTH_PRIVATE_KEY not configured — cannot sign upgraded manifest");
-    return NextResponse.json(
-      { error: "Signing key not available" },
-      { status: 500 }
-    );
+  // 6. Sign with node key (shared helper — same path as PUT /fair).
+  const signResult = await signFairAsNode(upgraded);
+  if (!signResult.ok) {
+    return NextResponse.json({ error: signResult.error }, { status: signResult.status });
   }
-
+  const signed = signResult.signed;
   const nodeDid = await getNodeDid();
-
-  // AUTH_PRIVATE_KEY may be either:
-  //   - 32-byte raw Ed25519 seed (64 hex chars), or
-  //   - 48-byte PKCS8 DER (96 hex chars, with 16-byte algorithm-OID prefix).
-  // Noble wants the 32-byte raw seed.
-  const keyBuf = Buffer.from(privateKeyHex, "hex");
-  let seedBytes: Uint8Array;
-  if (keyBuf.length === 32) {
-    seedBytes = new Uint8Array(keyBuf);
-  } else if (keyBuf.length === 48) {
-    // PKCS8 DER: SEQUENCE { INTEGER 0, SEQUENCE { OID 1.3.101.112 }, OCTET STRING { OCTET STRING { <32 bytes> } } }
-    // Last 32 bytes are the seed.
-    seedBytes = new Uint8Array(keyBuf.subarray(16));
-  } else {
-    log.error({ len: keyBuf.length }, "AUTH_PRIVATE_KEY wrong length (expected 32 or 48 bytes)");
-    return NextResponse.json({ error: "Signing key has wrong length" }, { status: 500 });
-  }
-
-  let signed: FairManifestV1_1;
-  try {
-    signed = await signManifest(upgraded, {
-      did: nodeDid,
-      privateKey: seedBytes,
-    });
-  } catch (err) {
-    log.error({ err: String(err) }, "Failed to sign upgraded manifest");
-    return NextResponse.json(
-      { error: "Signing failed" },
-      { status: 500 }
-    );
-  }
 
   // 6. Persist to DB
   try {

--- a/apps/kernel/src/components/media/AssetDetail.tsx
+++ b/apps/kernel/src/components/media/AssetDetail.tsx
@@ -266,11 +266,13 @@ export function AssetDetail({ asset, folders, currentDid, onClose, onDeleted, on
   const metadata = asset.metadata as Record<string, unknown> | null;
   const exif = metadata?.exif as Record<string, unknown> | undefined;
 
-  // Determine manifest version and signing state
+  // Determine manifest version and signing state.
+  // The owner can always edit their own manifest (server re-signs on save with
+  // the node key). Non-owners get a read-only view whenever the manifest is
+  // signed — they have nothing to gain from local edits.
   const isV1_1 = fairManifest ? isFairManifestV1_1(fairManifest) : false;
   const isSigned = !!fairManifest && 'signature' in fairManifest && !!fairManifest.signature;
-  const isSigner = isSigned && currentDid === (fairManifest as FairManifestV1_1).signature?.signer;
-  const readOnlyEditor = isSigned && !isSigner;
+  const readOnlyEditor = isSigned && !isOwner;
 
   return (
     <div className="flex flex-1 overflow-hidden">

--- a/apps/kernel/src/lib/kernel/sign-fair-manifest.ts
+++ b/apps/kernel/src/lib/kernel/sign-fair-manifest.ts
@@ -1,0 +1,76 @@
+import type { FairManifestV1_1 } from "@imajin/fair";
+import { signManifest, isFairManifestV1_1 } from "@imajin/fair";
+import { getNodeDid } from "./node-identity";
+import { createLogger } from "@imajin/logger";
+
+const log = createLogger("kernel");
+
+/**
+ * Result of an attempted node-signing pass.
+ *   - ok=true   → manifest is signed (`signed` populated)
+ *   - ok=false  → caller decides whether to fall back, surface error, etc.
+ */
+export type SignFairResult =
+  | { ok: true; signed: FairManifestV1_1 }
+  | { ok: false; error: string; status: number };
+
+/**
+ * Sign a v1.1 .fair manifest with this node's key.
+ *
+ * Used by:
+ *   - upgrade-fair (v1.0 → v1.1 migration)
+ *   - PUT /fair    (owner edits to a v1.1 manifest)
+ *
+ * Both paths rely on AUTH_PRIVATE_KEY in env. The node holds the only key
+ * authorized to sign on behalf of the owner; the owner's edits are accepted
+ * because the PUT endpoint authenticates them as the asset owner first.
+ *
+ * Accepts either 32-byte raw Ed25519 seed (64 hex chars) or PKCS8 DER (96
+ * hex chars). Returns 500-shaped failures for missing/malformed keys so the
+ * caller can short-circuit with NextResponse.json.
+ */
+export async function signFairAsNode(
+  manifest: FairManifestV1_1,
+): Promise<SignFairResult> {
+  const privateKeyHex = process.env.AUTH_PRIVATE_KEY;
+  if (!privateKeyHex) {
+    log.error({}, "AUTH_PRIVATE_KEY not configured — cannot sign manifest");
+    return { ok: false, error: "Signing key not available", status: 500 };
+  }
+
+  const keyBuf = Buffer.from(privateKeyHex, "hex");
+  let seedBytes: Uint8Array;
+  if (keyBuf.length === 32) {
+    seedBytes = new Uint8Array(keyBuf);
+  } else if (keyBuf.length === 48) {
+    // PKCS8 DER: last 32 bytes are the seed.
+    seedBytes = new Uint8Array(keyBuf.subarray(16));
+  } else {
+    log.error(
+      { len: keyBuf.length },
+      "AUTH_PRIVATE_KEY wrong length (expected 32 or 48 bytes)",
+    );
+    return { ok: false, error: "Signing key has wrong length", status: 500 };
+  }
+
+  const nodeDid = await getNodeDid();
+
+  try {
+    // Strip any existing signature so we re-sign over current content.
+    const stripped = { ...manifest } as FairManifestV1_1 & {
+      signature?: unknown;
+    };
+    delete stripped.signature;
+    const signed = await signManifest(stripped, {
+      did: nodeDid,
+      privateKey: seedBytes,
+    });
+    return { ok: true, signed: signed as FairManifestV1_1 };
+  } catch (err) {
+    log.error({ err: String(err) }, "Failed to sign manifest");
+    return { ok: false, error: "Signing failed", status: 500 };
+  }
+}
+
+/** Re-export for callers that need to gate on v1.1-ness before signing. */
+export { isFairManifestV1_1 };

--- a/packages/fair/src/upgrade.ts
+++ b/packages/fair/src/upgrade.ts
@@ -77,37 +77,71 @@ function buildDefaults(mimeType: string): {
   };
 }
 
+const EPSILON = 0.001;
+
 /**
  * Convert a DidShareList from v1.0 attribution/chain format.
- * If the v1.0 attribution only has the owner, we apply the new 99/1 default.
- * Otherwise we preserve all entries and normalize shares if they sum > 1.
+ *
+ * Migration must produce a manifest that passes the totals=100% validator,
+ * otherwise the upgraded asset becomes uneditable garbage. We handle three
+ * cases:
+ *
+ *   1. Single creator entry — apply the new 99/1 default (owner + Imajin
+ *      platform). This covers both the canonical share=1.0 case and the
+ *      "share was bogus from v1.0" case (e.g. share=0.52 with no other
+ *      entries, which we saw in the wild on dev assets).
+ *
+ *   2. Multiple entries summing close to 1.0 — preserve as-is.
+ *
+ *   3. Multiple entries with shares interpreted as percentages (any single
+ *      share > 1, or total > 1.5) — divide by 100 first, then validate.
+ *
+ *   4. Multiple entries whose normalized shares still don't sum to 1.0 —
+ *      scale proportionally. Preserves the ratio the user intended while
+ *      ensuring the manifest validates.
  */
 function convertAttribution(
   v1_0: FairManifestV1_0,
 ): FairManifestV1_1['attribution'] {
   const entries = v1_0.attribution?.length ? v1_0.attribution : (v1_0.chain ?? []);
 
-  // If only a single creator entry with share=1.0, apply the new 99/1 default
-  if (
-    entries.length === 1 &&
-    entries[0].role === 'creator' &&
-    entries[0].share === 1.0
-  ) {
+  // Case 1: single creator entry — always apply the 99/1 default.
+  if (entries.length === 1 && entries[0].role === 'creator') {
     return [
       { did: v1_0.owner, role: 'creator', share: 0.99 },
       { role: 'platform', name: 'Imajin', share: 0.01 },
     ];
   }
 
-  // Otherwise preserve existing entries (they may not sum to 1.0, but that's user data)
-  return entries.map((e) => ({
+  if (entries.length === 0) {
+    return [
+      { did: v1_0.owner, role: 'creator', share: 0.99 },
+      { role: 'platform', name: 'Imajin', share: 0.01 },
+    ];
+  }
+
+  // Case 3: percentages-as-fractions — divide by 100.
+  const rawSum = entries.reduce((s, e) => s + (e.share ?? 0), 0);
+  const looksLikePercentages = entries.some((e) => (e.share ?? 0) > 1) || rawSum > 1.5;
+  const scale = looksLikePercentages ? 100 : 1;
+
+  const stage1 = entries.map((e) => ({
     did: e.did,
     role: e.role,
-    share: e.share,
+    share: (e.share ?? 0) / scale,
     name: e.name,
     note: e.note,
     chainProof: e.chainProof,
   }));
+
+  // Case 4: still not summing to 1.0 — scale proportionally.
+  const stage1Sum = stage1.reduce((s, e) => s + e.share, 0);
+  if (stage1Sum > 0 && Math.abs(stage1Sum - 1.0) > EPSILON) {
+    return stage1.map((e) => ({ ...e, share: e.share / stage1Sum }));
+  }
+
+  // Case 2: shares already sum to 1.0 within tolerance.
+  return stage1;
 }
 
 /**

--- a/packages/fair/tests/v1_1.test.ts
+++ b/packages/fair/tests/v1_1.test.ts
@@ -347,6 +347,85 @@ describe('upgradeToV1_1', () => {
     const result = upgradeToV1_1(v1_0 as any);
     expect(result.distribution?.derivative?.sync?.allowed).toBe('reserved');
   });
+
+  // Regression: a single-creator v1.0 manifest with a non-1.0 share
+  // (e.g. 0.52 from misuse of the share field) used to be migrated
+  // verbatim, producing a v1.1 manifest that failed the totals=100%
+  // validator and became uneditable in the UI.
+  it('normalizes a single-creator entry with a bogus share to the 99/1 default', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'image/png',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: 'public',
+      attribution: [{ did: 'did:imajin:owner', role: 'creator', share: 0.52 }],
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    expect(result.attribution).toHaveLength(2);
+    const total = result.attribution.reduce((s: number, e) => s + e.share, 0);
+    expect(Math.abs(total - 1.0)).toBeLessThan(0.001);
+    expect(result.attribution[0].did).toBe('did:imajin:owner');
+    expect(result.attribution[0].share).toBe(0.99);
+  });
+
+  it('treats percentage-style multi-entry attribution (sum 100) as fractions', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'image/png',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: 'public',
+      attribution: [
+        { did: 'did:imajin:a', role: 'creator', share: 70 },
+        { did: 'did:imajin:b', role: 'collaborator', share: 30 },
+      ],
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    const total = result.attribution.reduce((s: number, e) => s + e.share, 0);
+    expect(Math.abs(total - 1.0)).toBeLessThan(0.001);
+    expect(result.attribution[0].share).toBeCloseTo(0.7, 6);
+    expect(result.attribution[1].share).toBeCloseTo(0.3, 6);
+  });
+
+  it('proportionally scales multi-entry attribution that does not sum to 1', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'image/png',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: 'public',
+      attribution: [
+        { did: 'did:imajin:a', role: 'creator', share: 0.3 },
+        { did: 'did:imajin:b', role: 'collaborator', share: 0.2 },
+      ],
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    const total = result.attribution.reduce((s: number, e) => s + e.share, 0);
+    expect(Math.abs(total - 1.0)).toBeLessThan(0.001);
+    // Ratio preserved: 0.3:0.2 → 0.6:0.4
+    expect(result.attribution[0].share).toBeCloseTo(0.6, 6);
+    expect(result.attribution[1].share).toBeCloseTo(0.4, 6);
+  });
+
+  it('falls back to 99/1 default when v1.0 attribution is empty', () => {
+    const v1_0 = {
+      fair: '1.0',
+      id: 'asset_old',
+      type: 'image/png',
+      owner: 'did:imajin:owner',
+      created: '2024-01-01T00:00:00Z',
+      access: 'public',
+      attribution: [],
+    };
+    const result = upgradeToV1_1(v1_0 as any);
+    expect(result.attribution).toHaveLength(2);
+    expect(result.attribution[0].share).toBe(0.99);
+    expect(result.attribution[1].share).toBe(0.01);
+  });
 });
 
 // ─── D2: sign/verify ────────────────────────────────────────────────────────


### PR DESCRIPTION
Three related bugs in the v1.0 → v1.1 user-triggered migration path, surfaced when testing a migration on dev.

## Symptoms

After migrating a v1.0 asset to v1.1:
1. The .fair editor showed 2 validation errors and a 52% attribution total (must equal 100%)
2. **None of the fields were editable** — clicking edit did nothing
3. Native v1.1 assets created by the user worked fine

## Root causes & fixes

### 1. Editor locked for the owner (`apps/kernel/src/components/media/AssetDetail.tsx`)

The upgrade endpoint signs the migrated v1.1 manifest with the **node DID** (the node performs the migration; it doesn't have the owner's key). `AssetDetail` then gated edit access on:

```ts
const isSigner = isSigned && currentDid === manifest.signature?.signer;
const readOnlyEditor = isSigned && !isSigner;
```

For a migrated asset, `isSigner = false` (signer is the node, viewer is the owner), so the editor went read-only. Native v1.1 assets had `signer = viewer`, which is why they worked.

**Fix:** gate on owner, not signer. The owner can always edit their own manifest; the server re-signs on save.

```ts
const readOnlyEditor = isSigned && !isOwner;
```

### 2. Migrated attribution can sum to ≠100% (`packages/fair/src/upgrade.ts`)

`convertAttribution` only applied the 99/1 default when the single v1.0 entry had `share === 1.0` exactly. A real dev manifest with `share = 0.52` fell through to the 'preserve as-is' branch, producing a v1.1 attribution summing to 0.52 — invalid by the totals=100% validator.

**Fix:** `convertAttribution` now handles four cases:
- single-creator entry (any share) → 99/1 default
- empty attribution → 99/1 default
- percentages-as-fractions (any share > 1 or sum > 1.5) → divide by 100
- multi-entry that doesn't sum to 1 → scale proportionally

6 new unit tests cover each path.

### 3. PUT /fair didn't re-sign on owner edit (`apps/kernel/app/media/api/assets/[id]/fair/route.ts`)

The endpoint wrote the new manifest verbatim, leaving the (now stale) node signature attached to changed content. Any `verifyManifest` call afterwards would fail forever.

**Fix:** factored `signFairAsNode` helper into `apps/kernel/src/lib/kernel/sign-fair-manifest.ts` (shared with `upgrade-fair`). PUT now strips the stale signature and re-signs with the node key before persisting. `upgrade-fair` refactored to use the same helper.

## Files changed

- `apps/kernel/src/components/media/AssetDetail.tsx` — owner-aware read-only gating
- `packages/fair/src/upgrade.ts` — `convertAttribution` normalization
- `packages/fair/tests/v1_1.test.ts` — 6 new regression tests
- `apps/kernel/src/lib/kernel/sign-fair-manifest.ts` — new shared signing helper
- `apps/kernel/app/media/api/assets/[id]/fair/route.ts` — re-sign on PUT
- `apps/kernel/app/media/api/assets/[id]/upgrade-fair/route.ts` — use shared helper

## Test status

- `pnpm --filter @imajin/fair test`: **41/41 pass** (35 existing + 6 new)
- Kernel typecheck deferred to CI (local approval was timing out at end of session)

## Migrating existing bad-state assets

Any v1.1 assets already in the wild that were produced by the buggy migration will still have invalid attribution totals. Re-running upgrade-fair on them is now idempotent at the protocol level but won't re-normalize the attribution. If we have any such assets in prod they'll need a one-off SQL fix or a manual re-upgrade through the UI. I haven't checked prod yet — flagging here for follow-up.