### PR TITLE
feat(events): drop ticket_registrations table — #826 Part 3 (final)

### DIFF
--- a/apps/events/src/db/schema.ts
+++ b/apps/events/src/db/schema.ts
@@ -272,24 +272,8 @@ export const eventInvites = eventsSchema.table('event_invites', {
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 });
 
-/**
- * Ticket Registrations - attendee registration data per ticket
- */
-export const ticketRegistrations = eventsSchema.table('ticket_registrations', {
-  id: text('id').primaryKey(),                              // reg_xxx
-  ticketId: text('ticket_id').notNull().references(() => tickets.id, { onDelete: 'cascade' }),
-  eventId: text('event_id').notNull().references(() => events.id),
-  name: text('name'),
-  email: text('email'),
-  formId: text('form_id').notNull(),                        // Dykil form ID
-  responseId: text('response_id'),                          // Dykil response ID
-  registeredByDid: text('registered_by_did'),
-  registeredAt: timestamp('registered_at', { withTimezone: true }).defaultNow(),
-}, (table) => ({
-  ticketUniq: index('idx_ticket_registrations_ticket').on(table.ticketId),  // actually UNIQUE constraint
-  eventIdx: index('idx_ticket_registrations_event').on(table.eventId),
-  emailIdx: index('idx_ticket_registrations_email').on(table.email),
-}));
+// ticket_registrations was dropped in migration 0027 (#826 Part 3).
+// Attendee identity lives in dykil.survey_responses; joins use ticket_id.
 
 // Types
 export type Event = typeof events.$inferSelect;
@@ -302,5 +286,4 @@ export type TicketTransfer = typeof ticketTransfers.$inferSelect;
 export type TicketQueueEntry = typeof ticketQueue.$inferSelect;
 export type EventInvite = typeof eventInvites.$inferSelect;
 export type NewEventInvite = typeof eventInvites.$inferInsert;
-export type TicketRegistration = typeof ticketRegistrations.$inferSelect;
-export type NewTicketRegistration = typeof ticketRegistrations.$inferInsert;
+

--- a/migrations/0027_drop_ticket_registrations.sql
+++ b/migrations/0027_drop_ticket_registrations.sql
@@ -1,0 +1,25 @@
+-- 0027_drop_ticket_registrations.sql
+--
+-- Issue #826 — Part 3 (final).
+--
+-- Drop events.ticket_registrations. The table was a denormalized copy of
+-- attendee identity that drifted from the source of truth (dykil.survey_responses).
+-- After #906 (data migration: every registration now has a matching survey_response)
+-- and #907 (code refactor: all reads now join dykil.survey_responses directly),
+-- nothing in app code touches this table.
+--
+-- Pre-flight check (run before applying, results captured 2026-05-11 evening):
+--   SELECT COUNT(*) FROM events.ticket_registrations;
+--     prod: 69, dev: 11
+--   SELECT COUNT(*) FROM events.ticket_registrations tr
+--   WHERE NOT EXISTS (SELECT 1 FROM dykil.survey_responses sr WHERE sr.ticket_id = tr.ticket_id);
+--     prod: 0, dev: 0
+--
+-- Every registration row has a corresponding dykil.survey_responses row joined
+-- by ticket_id. App code reads attendee identity from survey_response.answers
+-- (full_name, email). Safe to drop.
+--
+-- CASCADE handles the FK from any stray references; in practice there should
+-- be none (only the table's own indexes and PK reference it).
+
+DROP TABLE IF EXISTS events.ticket_registrations CASCADE;


### PR DESCRIPTION
Final piece of #826. After #906 (data migration) and #907 (read-path refactor), `events.ticket_registrations` is dead code in the database.

## Verification

```
grep -rn 'ticket_registrations\\|ticketRegistrations' apps packages \\
  | grep -v node_modules | grep -v .next | grep -v migrations/
```

Returns only unrelated matches: `TicketRegistrationSurvey` (React component name), a documentation comment in page.tsx, and openapi.yaml `operationId`s for the `/api/register` endpoints (which stay — they refer to the *registration* concept, not the deprecated table).

## Preflight (run earlier today)

|  | prod | dev |
|---|---|---|
| ticket_registrations rows | 69 | 11 |
| rows with no matching dykil.survey_response by ticket_id | **0** | **0** |

Attendee identity lives entirely in `dykil.survey_responses` now, joined by `ticket_id`. All read paths go through that join after #907.

## Changes

- `migrations/0027_drop_ticket_registrations.sql` — `DROP TABLE … CASCADE`
- `apps/events/src/db/schema.ts` — remove `ticketRegistrations` table definition + `TicketRegistration`/`NewTicketRegistration` types

Schema entry and migration ship in the same PR per the schema-migration-sync rule.

## Applied state

- **Dev:** migration applied manually before opening this PR to validate; table is gone.
- **Prod:** deferred to manual run after merge, since DROP TABLE is one-way.

## schema-migration-sync

`bash scripts/check-schema-migration-sync.sh origin/main` → ✅ passes locally.

## Closes

Closes #826.