### PR TITLE
fix(events): don't render QR for held/available/refunded/cancelled tickets

### DIFF
--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -169,10 +169,19 @@ async function getUserOrders(eventId: string, userDid: string) {
       )
     );
 
-  // Generate QR codes in parallel
+  // Generate QR codes in parallel.
+  //
+  // Only mint a QR when the ticket is actually redeemable:
+  //   - ticket.status ∈ {'valid', 'used'} — 'held' means the EMT/payment hasn't
+  //     arrived yet, 'available' means no buyer, 'refunded'/'cancelled' are dead.
+  //   - registrationStatus !== 'pending' — attendee still needs to complete
+  //     their survey before they can scan in.
+  const QR_REDEEMABLE_STATUSES = new Set(['valid', 'used']);
   const rowsWithQr = await Promise.all(
     rows.map(async ({ ticket, ticketType, order }) => {
-      const qrCodeDataUri = ticket.registrationStatus !== 'pending'
+      const isRedeemable = QR_REDEEMABLE_STATUSES.has(ticket.status);
+      const regOk = ticket.registrationStatus !== 'pending';
+      const qrCodeDataUri = isRedeemable && regOk
         ? (await generateQRCode(ticket.id) || undefined)
         : undefined;
       return { ticket, ticketType, order, qrCodeDataUri };


### PR DESCRIPTION
## Symptom (caught while testing dev tonight)

A ticket in `status='held'` (EMT reserved but payment not yet confirmed) was rendering a QR code in the user's My Tickets section. QR shouldn't appear until the EMT lands and the ticket flips to `valid`.

## Cause

`apps/events/app/[eventId]/page.tsx` had:

```ts
const qrCodeDataUri = ticket.registrationStatus !== 'pending'
  ? (await generateQRCode(ticket.id) || undefined)
  : undefined;
```

Only checked `registrationStatus`, never `ticket.status`. A held ticket with `registration_status='not_required'` slipped through.

## Fix

Add a status allow-list. QR is only generated when:
- `ticket.status` is `valid` or `used` (redeemable / already scanned), **AND**
- `registrationStatus` is not `pending`

Held / available / refunded / cancelled all render with no QR.

## Not a security issue

The check-in route (`/api/events/[id]/tickets/[ticketId]/check-in`) already validates `status === 'valid'` before admitting a scan, so a held-ticket QR wouldn't have let anyone in. This was strictly UX — the page implied the ticket was good when it wasn't.