### PR TITLE
fix(events): bundle filter by registration state + restore post-reg emails

### DIFF
--- a/apps/events/app/api/register/[ticketId]/route.ts
+++ b/apps/events/app/api/register/[ticketId]/route.ts
@@ -3,15 +3,22 @@
  * GET  /api/register/[ticketId]
  *
  * Per-ticket registration API.
- * POST creates a registration for a pending ticket.
- * GET returns the existing registration for a ticket.
+ *   POST — verify the attendee's Dykil survey response exists, flip the ticket
+ *          to 'complete', and emit the bus events that drive the
+ *          "you're in" email + RSVP signal.
+ *   GET  — return a backwards-compatible registration shape from the Dykil
+ *          response.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { withLogger } from '@imajin/logger';
-import { db, tickets } from '@/src/db';
+import { db, tickets, events, ticketTypes } from '@/src/db';
 import { eq } from 'drizzle-orm';
 import { getClient } from '@imajin/db';
+import { publish } from '@imajin/bus';
+import { generateQRCode } from '@/src/lib/email';
+
+const EVENTS_URL = process.env.NEXT_PUBLIC_EVENTS_URL || 'https://events.imajin.ai';
 
 export const POST = withLogger('events', async (request, { log }) => {
   const ticketId = request.nextUrl.pathname.split('/').pop()!;
@@ -42,8 +49,10 @@ export const POST = withLogger('events', async (request, { log }) => {
 
   // Verify Dykil survey response exists for this ticket
   const sql = getClient();
-  const [surveyResponse] = await sql`
-    SELECT id FROM dykil.survey_responses WHERE ticket_id = ${ticketId} LIMIT 1
+  const [surveyResponse] = await sql<
+    { id: string; answers: Record<string, unknown> }[]
+  >`
+    SELECT id, answers FROM dykil.survey_responses WHERE ticket_id = ${ticketId} LIMIT 1
   `;
 
   if (!surveyResponse) {
@@ -61,7 +70,119 @@ export const POST = withLogger('events', async (request, { log }) => {
 
   log.info({ ticketId }, 'registration status updated to complete');
 
-  return NextResponse.json({ success: true });
+  // Fire the post-registration notifications. The 'you're in' email for
+  // reg-required tickets travels via ticket.registration.completed; the
+  // event.registration / event.rsvp pair are for the broadcast + interest
+  // signal pipeline. All publishes are fire-and-forget — a notification
+  // failure must not roll back a successful registration.
+  const answers = (surveyResponse.answers ?? {}) as Record<string, unknown>;
+  const attendeeEmail =
+    typeof answers.email === 'string' ? answers.email.trim().toLowerCase() : null;
+
+  let qrCodeDataUri: string | undefined;
+  try {
+    const [event] = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, ticket.eventId))
+      .limit(1);
+    const [ticketType] = await db
+      .select()
+      .from(ticketTypes)
+      .where(eq(ticketTypes.id, ticket.ticketTypeId))
+      .limit(1);
+
+    if (event && attendeeEmail) {
+      const eventDate = new Date(event.startsAt);
+      const eventImageUrl = event.imageUrl
+        ? event.imageUrl.startsWith('http')
+          ? event.imageUrl
+          : `${EVENTS_URL}${event.imageUrl}`
+        : undefined;
+
+      qrCodeDataUri = await generateQRCode(ticket.id);
+
+      publish('event.registration', {
+        issuer: ticket.ownerDid || '',
+        subject: ticket.ownerDid || '',
+        scope: 'events',
+        payload: {
+          eventTitle: event.title,
+          email: attendeeEmail,
+          context_id: event.id,
+          context_type: 'event',
+        },
+      }).catch((err) => log.error({ err: String(err) }, 'event.registration publish failed'));
+
+      if (ticket.ownerDid) {
+        publish('event.rsvp', {
+          issuer: ticket.ownerDid,
+          subject: '',
+          scope: 'events',
+          payload: {
+            context_id: event.id,
+            context_type: 'event',
+            interestDids: [ticket.ownerDid],
+          },
+        }).catch((err) => log.error({ err: String(err) }, 'event.rsvp publish failed'));
+      }
+
+      publish('ticket.registration.completed', {
+        issuer: ticket.ownerDid || '',
+        subject: ticket.ownerDid || '',
+        scope: 'events',
+        payload: {
+          email: attendeeEmail,
+          eventTitle: event.title,
+          ticketType: ticketType?.name ?? 'Ticket',
+          ticketId: ticket.id,
+          eventDate: eventDate.toLocaleDateString('en-US', {
+            weekday: 'long',
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          }),
+          eventTime: eventDate.toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZoneName: 'short',
+          }),
+          isVirtual: event.isVirtual ?? false,
+          venue: event.venue ?? undefined,
+          price:
+            ticket.pricePaid != null
+              ? new Intl.NumberFormat('en-US', {
+                  style: 'currency',
+                  currency: ticket.currency || 'USD',
+                }).format(ticket.pricePaid / 100)
+              : 'Included',
+          magicLink: `${EVENTS_URL}/${event.id}`,
+          eventImageUrl,
+          eventUrl: `${EVENTS_URL}/${event.id}`,
+          qrCodeDataUri,
+          context_id: event.id,
+          context_type: 'event',
+        },
+      }).catch((err) =>
+        log.error({ err: String(err) }, 'ticket.registration.completed publish failed'),
+      );
+
+      log.info(
+        { ticketId, hasQr: !!qrCodeDataUri },
+        'registration completion events published',
+      );
+    } else if (!attendeeEmail) {
+      log.info(
+        { ticketId },
+        'no attendee email in survey answers; skipping registration emails',
+      );
+    }
+  } catch (err) {
+    // Non-fatal: registration is already 'complete' in the DB.
+    log.error({ err: String(err) }, 'failed to publish registration completion events');
+  }
+
+  return NextResponse.json({ success: true, qrCodeDataUri });
 });
 
 export const GET = withLogger('events', async (request) => {

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -475,10 +475,16 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     currency: currency.toUpperCase(),
   }).format(amountTotal / 100 / quantity);
 
-  // Split tickets by whether their type requires registration
-  const bundleTickets = createdTickets.filter((t) => !ticketType.requiresRegistration);
+  // Split tickets by their actual registration state, not by ticket-type
+  // policy. A reg-required ticket that's already 'complete' is redeemable
+  // and belongs in the bundle email. The previous filter on
+  // ticketType.requiresRegistration excluded already-registered tickets from
+  // the "you're in" QR email entirely.
+  const bundleTickets = createdTickets.filter(
+    (t) => t.registrationStatus !== 'pending',
+  );
   const registrationPendingTickets = createdTickets.filter(
-    (t) => ticketType.requiresRegistration && t.registrationStatus !== 'complete'
+    (t) => t.registrationStatus === 'pending',
   );
 
   // CTA targets: the first pending-and-required ticket, falling back to my-tickets

--- a/apps/events/src/lib/confirm-payment.ts
+++ b/apps/events/src/lib/confirm-payment.ts
@@ -189,15 +189,18 @@ export async function confirmHeldTickets(
           ? `${AUTH_URL}/api/onboard/verify?token=${onboardToken}`
           : `${EVENTS_URL}/${event.id}/my-tickets`;
 
-        // Split tickets by whether their type requires registration
-        const bundleTickets = confirmedTickets.filter((t) => {
-          const tt = typesById.get(t.ticketTypeId);
-          return tt && !tt.requiresRegistration;
-        });
-        const registrationPendingTickets = confirmedTickets.filter((t) => {
-          const tt = typesById.get(t.ticketTypeId);
-          return tt?.requiresRegistration && t.registrationStatus !== 'complete';
-        });
+        // Split tickets by their actual registration state, not by ticket-type
+        // policy. A reg-required ticket that's already 'complete' is just as
+        // redeemable as a 'not_required' ticket and belongs in the bundle email.
+        //
+        // Previous logic gated on tt.requiresRegistration, which excluded
+        // already-registered tickets from the "you're in" QR email entirely.
+        const bundleTickets = confirmedTickets.filter(
+          (t) => t.registrationStatus !== 'pending',
+        );
+        const registrationPendingTickets = confirmedTickets.filter(
+          (t) => t.registrationStatus === 'pending',
+        );
 
         // CTA targets: the first pending-and-required ticket, falling back to my-tickets
         const ctaTicket = registrationPendingTickets[0] ?? null;


### PR DESCRIPTION
## Symptom (caught tonight on dev)

Admin clicked 'Confirm e-Transfer' on a 2-ticket order (Bunkie + Things are great admission).
- Bunkie: `requires_registration=false`, `registration_status=not_required`
- Admission: `requires_registration=true`, `registration_status=complete` (registered BEFORE the EMT was confirmed)

Buyer got the purchase receipt ✓ and a 'you're in' email — but **only for the Bunkie**. The admission ticket got no 'you're in' even though it was fully registered and redeemable.

## Bug 1 — bundle filter gates on type, not state

`apps/events/src/lib/confirm-payment.ts` (EMT) and `apps/events/app/api/webhook/payment/route.ts` (Stripe) both split confirmed tickets into:

```ts
bundleTickets = filter(t => !tt.requiresRegistration)
pending       = filter(t =>  tt.requiresRegistration && !=complete)
```

A reg-required ticket that was already `complete` at confirm time falls into **neither** bucket → no 'you're in' email.

**Fix:** split by actual state:

```ts
bundleTickets = filter(t => t.registrationStatus !== 'pending')
pending       = filter(t => t.registrationStatus === 'pending')
```

`not_required` → bundle ✓, `complete` → bundle ✓, `pending` → pending bucket ✓.

## Bug 2 — post-#907 regression: register POST stopped firing emails

PR #907 (#826 part 2) simplified `/api/register/[ticketId]` POST to just verify the Dykil response exists and flip status. It dropped three publishes the old handler did:

| Event | Purpose |
|---|---|
| `event.registration` | Attendee notification fan-out |
| `event.rsvp` | Interest signal for broadcast pipeline |
| `ticket.registration.completed` | The 'you're in' email + QR for the freshly-registered ticket |

Without them, completing a survey for a reg-required ticket flipped the status silently — no email, no RSVP signal, no QR.

**Fix:** restore the publishes. Attendee email now read from `dykil.survey_responses.answers.email` (was `ticket_registrations.email` in the old handler — gone after #826).

Side-effect: POST response now includes `qrCodeDataUri` so the in-page `SurveyAccordion → handleRegistrationComplete` callback can render the QR inline without a refresh. The client already reads `data.qrCodeDataUri` (line 322 of `tickets-section.tsx`); it was just always `undefined` between #907 and now.

All publishes are fire-and-forget — a bus hiccup won't roll back a successful registration.