### PR TITLE
fix(events): remove SSR registration auto-complete backstop (closes #910)

### DIFF
--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -352,39 +352,7 @@ export default async function EventPage({ params, searchParams }: Props) {
   }
 
   // Fetch user's orders (+ legacy tickets) if logged in
-  let userOrders = session?.id ? await getUserOrders(event.id, session.id) : [];
-
-  // Auto-complete pending tickets whose Dykil survey response already exists.
-  // The in-page SurveyAccordion fires POST /api/register/[ticketId] on submit,
-  // but if a user fills the survey via a direct Dykil URL, the events ticket
-  // stays 'pending' forever without this backstop. Status flip only — no
-  // cross-schema metadata writes, no ticket_registrations writes (#826).
-  if (session?.id && userOrders.length > 0) {
-    const pendingTicketIds = userOrders
-      .flatMap((o) => o.tickets)
-      .filter((t) => t.registrationStatus === 'pending' && t.ticketType?.registrationFormId)
-      .map((t) => t.id);
-    if (pendingTicketIds.length > 0) {
-      try {
-        const completed = await sql<{ id: string }[]>`
-          UPDATE events.tickets
-          SET registration_status = 'complete'
-          WHERE id = ANY(${pendingTicketIds}::text[])
-            AND registration_status = 'pending'
-            AND EXISTS (
-              SELECT 1 FROM dykil.survey_responses sr WHERE sr.ticket_id = events.tickets.id
-            )
-          RETURNING id
-        `;
-        if (completed.length > 0) {
-          // Regenerate userOrders so QR codes render for the freshly-completed tickets.
-          userOrders = await getUserOrders(event.id, session.id);
-        }
-      } catch (err) {
-        log.error({ err: String(err) }, 'Auto-complete pending tickets failed');
-      }
-    }
-  }
+  const userOrders = session?.id ? await getUserOrders(event.id, session.id) : [];
 
   const hasTicket = userOrders.length > 0;
 


### PR DESCRIPTION
Final step of #910. Drops the slim status-flip-only auto-complete block that #909 restored in `apps/events/app/[eventId]/page.tsx`.

That block was a belt-and-suspenders safety net while the canonical `SurveyAccordion → onComplete → POST /api/register/[ticketId]` path was unproven. Status-flip only — no emails — so any edge case it caught gave a *silent* activation with no QR.

After tonight's work the canonical path is now both reliable and complete:

- **#911**: 3-retry with backoff, dedupe via `isCompletingRef`, 409-as-success, iframe double-fire guard, structured `withLogger` logging on every branch
- **#915**: restored `event.registration` / `event.rsvp` / `ticket.registration.completed` publishes that #907 dropped, so registration completion now fires the 'you're in' email + QR

The backstop *never* sent emails — leaving it in is objectively worse UX for any edge case it would have caught (silent activation vs loudly-retried-then-emailed activation).

Closes #910.

## Diff

-33 lines, +1 line. Pure deletion.

## Refs

- #826 (parent epic)
- #909 (added the backstop as a hotfix)
- #911 (canonical path hardening)
- #915 (restored post-reg emails)