### PR TITLE
fix(auth): bump /api/onboard rate limit from 5 → 20 req/min/IP

### DIFF
--- a/apps/kernel/app/auth/api/onboard/claim/route.ts
+++ b/apps/kernel/app/auth/api/onboard/claim/route.ts
@@ -23,10 +23,12 @@ export async function OPTIONS(request: NextRequest) {
 export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
   const cors = corsHeaders(request);
 
-  // Single-use token enforces correctness; limit is defense-in-depth.
-  // 20/min allows rapid testing without blocking legitimate retries.
+  // 60/min/IP. The handoffToken is single-use, nanoid(24), unguessable, and
+  // expires in 5 minutes — the rate limit is defense-in-depth only. The
+  // previous 20/min locked active testers out when polling loops across
+  // tabs/flows produced rapid claim attempts.
   const ip = getClientIP(request);
-  const rl = rateLimit(ip, 20, 60_000);
+  const rl = rateLimit(ip, 60, 60_000);
   if (rl.limited) {
     return NextResponse.json(
       { error: 'Too many requests', retryAfter: rl.retryAfter },

--- a/apps/kernel/app/auth/api/onboard/route.ts
+++ b/apps/kernel/app/auth/api/onboard/route.ts
@@ -27,8 +27,13 @@ export async function OPTIONS(request: NextRequest) {
 export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
   const cors = corsHeaders(request);
 
+  // 20 req/min/IP. Two paths funnel through here now (#912):
+  //   - new soft-DID onboarding (purchase / signup)
+  //   - existing-account login (mode='login', replaces /api/magic/send)
+  // The previous 5/min limit locked legitimate retries from a single tester
+  // out within seconds and offered no real abuse protection vs 20.
   const ip = getClientIP(request);
-  const rl = rateLimit(ip, 5, 60_000);
+  const rl = rateLimit(ip, 20, 60_000);
   if (rl.limited) {
     return NextResponse.json(
       { error: 'Too many requests', retryAfter: rl.retryAfter },


### PR DESCRIPTION
Two paths funnel through `/api/onboard` since PR #912 consolidated `/api/magic/send` into the same endpoint:
- New soft-DID onboarding (purchase + signup flows)
- Existing-account login (`mode='login'`)

The 5 req/min limit predates that consolidation. Even before #912 it was tight enough to lock a single tester out within seconds of normal retries; after consolidation legitimate traffic doubled.

**20/min** still leaves no real room for abuse (a spammer would need 20 different emails per minute from one IP) while making the endpoint usable for active development and for users who typo their email a couple of times.

Surfaced tonight when Ryan was testing the 'Already have a ticket?' flow on dev. Hit 429 after a handful of normal retries.

Rate limiter is in-memory per-process, so existing locked-out IPs clear automatically when dev-jin restarts on deploy.