### PR TITLE
fix(events): validate Dykil iframe postMessage by source, not origin string

### DIFF
--- a/apps/events/app/[eventId]/survey-accordion.tsx
+++ b/apps/events/app/[eventId]/survey-accordion.tsx
@@ -72,8 +72,16 @@ export function SurveyAccordion({
   // Listen for postMessage from iframe
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      // Validate origin for security
-      if (!event.origin.includes('dykil')) return;
+      // Validate source: only accept messages from THIS accordion's iframe.
+      // We previously checked event.origin.includes('dykil'), but Dykil is
+      // deployed under a path (e.g. dev-jin.imajin.ai/dykil/...) not a
+      // dedicated subdomain, so the origin doesn't contain 'dykil' and every
+      // postMessage was getting silently dropped — which is why ticket
+      // registrations stayed 'pending' even after the user submitted the
+      // survey. Comparing event.source to the iframe's contentWindow is
+      // strictly more secure than origin-string-matching anyway.
+      const iframe = iframeRef.current;
+      if (!iframe || event.source !== iframe.contentWindow) return;
 
       if (event.data.type === 'survey-height') {
         setIframeHeight(event.data.height + 40); // Add some padding


### PR DESCRIPTION
## Symptom

Ryan bought 2 `Things are great` tickets, completed the Dykil survey on both (saw '✓ Response submitted'), and both tickets stayed `pending` with a 'Complete Registration' chip — even though `dykil.survey_responses` had ticket_id-linked rows for both.

## Root cause — long-latent bug, exposed by removing the SSR backstop in #916

`SurveyAccordion` validated incoming postMessage with:

```ts
if (!event.origin.includes('dykil')) return;
```

But Dykil isn't deployed on a `dykil.*` subdomain on dev or prod — it lives **under a path**: `NEXT_PUBLIC_DYKIL_URL=https://dev-jin.imajin.ai/dykil` on dev. The iframe's origin is therefore `dev-jin.imajin.ai`, which does **not** contain 'dykil'. Every `survey-completed` postMessage from the Dykil iframe got silently dropped → `onComplete` never fired → `/api/register/[ticketId]` POST never happened → registration_status stayed pending forever.

This bug has been latent for the entire path-based Dykil deployment. The SSR auto-complete backstop in `apps/events/app/[eventId]/page.tsx` was masking it by flipping status server-side. PR #916 removed the backstop because the canonical path was supposedly hardened — but it was actually broken at the very first hop.

## Fix

Validate event.source against the accordion's own iframe.contentWindow instead of checking origin substring:

```ts
const iframe = iframeRef.current;
if (!iframe || event.source !== iframe.contentWindow) return;
```

Strictly more secure (the browser guarantees `event.source` identity for the iframe element) and not coupled to whatever subdomain / path Dykil happens to be deployed under in the future.

## Cleanup

Ryan's two stuck dev tickets (`tkt_mp20t4im_4032b9_0` / `_8240b7_1`) manually flipped to `complete` via SQL since their Dykil responses were already in place — the fix prevents new tickets from getting stuck but doesn't retroactively replay missed postMessages.

## Refs

- #826 (parent registration source-of-truth work)
- #910 / #911 (hardening — should have caught this, missed it because the origin string-matching check looked plausible)
- #916 (removed the SSR backstop that was masking this bug)