### PR TITLE
fix(events): drop double quantity prefix in order header

### DIFF
--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -196,9 +196,11 @@ function OrderCard({ order, eventId }: { order: UserOrder; eventId: string }) {
         }).format(order.totalAmount / 100)
     : 'N/A';
 
-  const headerLabel = order.quantity > 1
-    ? `${order.quantity}× ${order.ticketTypeName}`
-    : order.ticketTypeName;
+  // order.ticketTypeName already encodes per-type counts for mixed orders
+  // (e.g. "2× Things are great" or "1× Premium + 2× Bunkie"). Don't
+  // wrap it with another order.quantity× prefix or the label doubles up
+  // ("2× 2× Things are great").
+  const headerLabel = order.ticketTypeName;
 
   // Issue #10: optimistic local state so QR + done state appear immediately
   const [completedTickets, setCompletedTickets] = useState<Record<string, { status: string; qrCode?: string }>>({});


### PR DESCRIPTION
## Symptom

Order header showed `2× 2× Things are great` for a 2-ticket same-type order.

## Cause

Two layers both add a quantity prefix:

`apps/events/app/[eventId]/page.tsx` (line ~215) builds `order.ticketTypeName` with per-type counts already baked in:
- Same-type, qty > 1: `'2× Things are great'`
- Mixed singles: `'Bunkie + Premium'`
- Mixed multiples: `'1× Premium + 2× Bunkie'`

Then `apps/events/app/[eventId]/tickets-section.tsx` (line 199) wrapped that **again** with `${order.quantity}× ${order.ticketTypeName}` — producing `2× 2× Things are great` for the simple case and worse nonsense like `2× Bunkie + Premium` for mixed orders (where page.tsx had no prefix at all).

## Fix

Drop the tickets-section wrapper. `page.tsx`'s label is canonical and handles mixed orders correctly.