### PR TITLE
fix(events): don't auto-collapse SurveyAccordion on Dykil 'already done' load notification

### DIFF
--- a/apps/events/app/[eventId]/survey-accordion.tsx
+++ b/apps/events/app/[eventId]/survey-accordion.tsx
@@ -86,6 +86,24 @@ export function SurveyAccordion({
       if (event.data.type === 'survey-height') {
         setIframeHeight(event.data.height + 40); // Add some padding
       } else if (event.data.type === 'survey-completed') {
+        // Dykil sends two distinct 'survey-completed' shapes:
+        //   1. Fresh submit:    { type, surveyId, answers: {...} }  — user just
+        //      finished. Run onComplete (registers + flips status) and collapse.
+        //   2. On-load FYI:    { type, surveyId }                  — the iframe
+        //      loaded with a ticketId that already has a response. The accordion
+        //      is already 'complete'; the user expanded it to review/edit and
+        //      we must NOT collapse it or run onComplete again. Without this
+        //      branch the box would expand and immediately re-collapse the moment
+        //      Dykil finished its initial fetch.
+        const isFreshSubmit =
+          event.data.answers !== undefined && event.data.answers !== null;
+        if (!isFreshSubmit) {
+          // Sync local state in case parent hadn't told us yet, but stay open.
+          setIsCompleted(true);
+          try { localStorage.setItem(storageKey, 'true'); } catch {}
+          return;
+        }
+
         // Guard against double-fire from iframe or React strict mode
         if (isCompletingRef.current) return;
 


### PR DESCRIPTION
## Symptom

Clicking a completed registration accordion (✓ Completed badge) to review/edit answers didn't open — looked like a flash of expand then instant collapse. From the user's POV the box just wouldn't open.

## Cause

PR #919 (iframe source check) made every `survey-completed` postMessage from the Dykil iframe actually fire on the parent. That correctly unblocked **fresh** submissions. But it also surfaced an existing 'on-load FYI' postMessage that Dykil sends when the iframe loads against a `ticketId` that already has a response.

Dykil's embed sends two distinct shapes:

| Shape | When | Has `answers`? |
|---|---|---|
| `{ type, surveyId, answers: {...} }` | User just finished the form | yes |
| `{ type, surveyId }` | Iframe loaded; ticket already has a response | no |

The accordion's handler treated both the same: `onComplete()` → `finish()` → `setIsExpanded(false)`. For case (2) that means the box collapses immediately after opening.

## Fix

Distinguish the two by presence of `event.data.answers`. For the on-load FYI case:
- Sync `isCompleted` to true and persist the localStorage hint (still useful for optimistic UI elsewhere)
- **Don't** run `onComplete()`
- **Don't** `setIsExpanded(false)`

The user can now click into the completed accordion, review their answers, and dismiss when they want.

## Refs

- #919 (made postMessages actually flow)
- #911 (added the isCompletingRef guard + 409 handling)