### PR TITLE
fix(dykil,events): eliminate race between Dykil INSERT and events register POST

### DIFF
--- a/apps/dykil/app/(bare)/embed/[surveyId]/page.tsx
+++ b/apps/dykil/app/(bare)/embed/[surveyId]/page.tsx
@@ -251,13 +251,17 @@ export default function SurveyEmbedPage() {
       surveyModelRef.current.data = data;
     }
     setSubmitted(true);
-    // Notify parent iframe immediately — include answers so host can extract name/email
-    window.parent.postMessage(
-      { type: 'survey-completed', surveyId, answers: data },
-      '*'
-    );
 
-    // POST in background — response is already shown to user
+    // POST first, THEN postMessage to parent. The old order was:
+    //   1) postMessage immediately, 2) POST in background
+    // which raced the parent's downstream /api/register call against our own
+    // INSERT into dykil.survey_responses. The events POST would frequently
+    // arrive before Dykil's row was committed and 404 with 'No survey response
+    // found for this ticket' — the user had to retry to make it stick.
+    //
+    // setSubmitted(true) above already shows the 'Response submitted' UI to the
+    // user immediately; the network round-trip happens 'invisibly' behind it.
+    // Only the postMessage that drives downstream state needs to wait.
     try {
       const res = await apiFetch(`/api/surveys/${surveyId}/respond`, {
         method: 'POST',
@@ -279,6 +283,14 @@ export default function SurveyEmbedPage() {
     } catch (error) {
       console.error('Failed to submit response:', error);
     }
+
+    // Now that the response is durable in dykil.survey_responses, tell the
+    // parent. The parent's onComplete → POST /api/register/[ticketId] will
+    // find the row and flip the ticket to 'complete' without racing.
+    window.parent.postMessage(
+      { type: 'survey-completed', surveyId, answers: data },
+      '*'
+    );
   };
 
   if (loading) {

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -342,7 +342,18 @@ function TicketRegistrationSurvey({ ticket, eventId, override, onComplete }: { t
         const data = await res.json().catch(() => ({}));
         const msg = data.error || `Registration failed (${res.status})`;
 
-        // Client errors (4xx) — don't retry
+        // 404 from /api/register typically means the Dykil survey_responses
+        // row hasn't been INSERTed yet — a transient race that resolves in
+        // milliseconds. Retry with backoff like a 5xx. Dykil now posts before
+        // postMessage so this should be rare; the retry is defense in depth.
+        if (res.status === 404 && attempt < maxRetries) {
+          const backoff = 500 * Math.pow(2, attempt - 1);
+          console.log('[events:registration]', { ticketId: ticket.id, attempt, backoff }, 'retrying 404 (likely Dykil race)');
+          await new Promise(r => setTimeout(r, backoff));
+          continue;
+        }
+
+        // Other client errors (4xx) — don't retry
         if (res.status >= 400 && res.status < 500) {
           setLastError(msg);
           toast.error(msg);


### PR DESCRIPTION
## Symptom

User fills out registration survey → 'No survey response found for this ticket' on first submission → retries → second attempt sticks.

Caught tonight on `tkt_moz2ormb_02631e_0`.

## Cause

`apps/dykil/app/(bare)/embed/[surveyId]/page.tsx` `submitResponse()` fired the parent `postMessage` BEFORE posting the response to its own API:

```ts
setSubmitted(true);
window.parent.postMessage({ type: 'survey-completed', surveyId, answers }, '*');  // 1️⃣
// ... then POST to dykil API
const res = await apiFetch('/api/surveys/{id}/respond', ...);  // 2️⃣
```

Parent `SurveyAccordion` received the postMessage → triggered `POST /api/register/[ticketId]` → which queries `dykil.survey_responses` for the ticket. That query frequently ran **before** Dykil's own INSERT had committed. The events route 404'd ('No survey response found for this ticket'), surfaced as an error toast, and the user had to retry.

Latent for as long as the Dykil/events split has existed. Worked previously because the SSR auto-complete backstop in page.tsx covered it asynchronously. After #916 removed the backstop and #919 made postMessages actually flow, the race became user-visible.

## Fix

### Primary: `apps/dykil/app/(bare)/embed/[surveyId]/page.tsx`

POST first, postMessage after. `setSubmitted(true)` still runs first so the iframe shows 'Response submitted' instantly — only the *parent notification* waits for durability. Added latency is one HTTP round-trip.

### Defense in depth: `apps/events/app/[eventId]/tickets-section.tsx`

Treat 404 from `/api/register/[ticketId]` as transient (same retry+backoff path as 5xx, max 3 attempts). The Dykil-side fix should make this unreachable in practice but the retry covers future regressions, browser network re-ordering, and any other 'response not yet visible' window.

## Refs

- #911 (hardening that added the retry loop in the first place)
- #919 (made postMessages actually flow)
- #921 (distinguished on-load FYI from fresh submit)