### PR TITLE
fix(events): Reserved-EMT panel no longer blocks new-order CTAs

### DIFF
--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -1118,7 +1118,16 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
     );
   }
 
-  if (step === 'emt-done' && emtResult) {
+  // The 'Reserved — send your e-Transfer' panel takes over the entire
+  // checkout bar while a user has an outstanding EMT reservation. That's
+  // the right thing when their cart is empty (their last action *was* the
+  // reservation), but the moment they start composing a NEW cart on the
+  // same page (e.g. 'Buy more tickets' tab) it blocks the pay-by-card /
+  // pay-by-EMT CTAs at the bottom of the ticket list. Fall through to the
+  // normal checkout UI as soon as the user has anything in the new cart;
+  // the reservation is still visible on the My Tickets tab, and this panel
+  // returns automatically when the cart is empty again.
+  if (step === 'emt-done' && emtResult && totalQty === 0) {
     return (
       <div className="sticky bottom-0 -mx-4 px-4 py-4 bg-gray-50/95 dark:bg-gray-900/95 backdrop-blur border-t border-gray-200 dark:border-gray-700 rounded-b-xl space-y-3">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Symptom

Logging in as a user who already has a pending EMT reservation shows the 'Reserved — send your e-Transfer to confirm' panel pinned to the bottom of the page. Correct behaviour when the user is just reading. But when the user goes to the 'Buy more tickets' tab and increments quantities, the panel keeps hijacking the entire `UnifiedCheckoutBar` — there's no Pay-with-Card or Pay-with-e-Transfer button visible for the new order.

## Cause

`UnifiedCheckoutBar` early-returns the Reserved panel whenever `step === 'emt-done'`:

```tsx
if (step === 'emt-done' && emtResult) {
  return <ReservedPanel … />;
}
// … new-order pay buttons further down
```

`step` is rehydrated from sessionStorage on mount (see #918), so the Reserved view persists across navigations and tab switches. Adding a new cart item doesn't change `step` — only an explicit checkout action does — so the early return wins forever.

## Fix

Gate the Reserved panel on `totalQty === 0`:

```tsx
if (step === 'emt-done' && emtResult && totalQty === 0) {
  return <ReservedPanel … />;
}
```

As soon as the user has anything in the new cart, the bar falls through to the normal pay-buttons render so the new order can be checked out. Reservation info is still visible on the My Tickets tab and the panel returns automatically when the cart is empty again.

Each order is independent — the in-flight reservation isn't touched, and the etransfer route's existing 'same buyer + same cart = return existing order' guard prevents accidental duplicates if the user re-reserves the same configuration.