### PR TITLE
fix(events): unlock tiers must use apiFetch, not raw fetch

### DIFF
--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -548,7 +548,12 @@ function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken
     setUnlockLoading(true);
     setUnlockError(null);
     try {
-      const res = await fetch(`/api/events/${eventId}/tiers/unlock?code=${encodeURIComponent(unlockCode.trim())}`);
+      // Must use apiFetch so the request routes to the events service in
+      // production. Raw fetch resolves the relative URL against window.origin,
+      // which is the marketing site / kernel in prod (events lives on a
+      // separate origin). That returned HTML, res.json() threw, and the user
+      // saw 'Failed to unlock. Please try again.' for every valid code.
+      const res = await apiFetch(`/api/events/${eventId}/tiers/unlock?code=${encodeURIComponent(unlockCode.trim())}`);
       const data = await res.json();
       if (!res.ok) {
         setUnlockError(data.error || 'Invalid code');


### PR DESCRIPTION
## Symptom

Live testing the access codes `24HOURS` and `STAFF2026` on the event page: clicking 'Unlock' immediately fails with 'Failed to unlock. Please try again.' for any code.

## Cause

`apps/events/app/[eventId]/tickets-section.tsx` line 551 used raw `fetch` to hit a relative URL:

```ts
const res = await fetch(`/api/events/${eventId}/tiers/unlock?code=…`);
```

In production the event page is served from a different origin than the events service. Relative URLs resolve to the marketing / kernel host, which returns HTML for `/api/events/.../tiers/unlock`. `res.json()` throws on the HTML body → catch block fires → user sees the generic 'Failed to unlock' error.

Every other events-internal call in the same file already uses `apiFetch` from `@imajin/config` which routes to the right service. This one was an oversight.

## Fix

Swap `fetch` → `apiFetch`. One-line change.