### PR TITLE
fix(events): e-transfer checkout feedback for logged-in users

### DIFF
--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -945,7 +945,10 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
         message: data.instructions.message,
       });
       setStep('emt-done');
-      router.refresh();
+      // Don't call router.refresh() here — it causes the component tree to
+      // restructure (tabs appear) which unmounts the emt-done card before the
+      // user can read the instructions. The "View My Tickets" button in the
+      // emt-done card handles refresh when the user is ready.
     } catch {
       onError('e-Transfer setup failed');
       setStep('idle');
@@ -1032,8 +1035,8 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
               message: reserveData.instructions.message,
             });
             setStep('emt-done');
-            // Refresh server data so My Tickets tab sees the new order
-            router.refresh();
+            // Don't router.refresh() here — same reason as startEtransfer.
+            // The "View My Tickets" button in emt-done handles it.
           } catch {
             onError('e-Transfer setup failed');
             setStep('idle');
@@ -1177,6 +1180,23 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
         {emtResult.quantity > 1 && (
           <p className="text-xs text-gray-500">Reserved {emtResult.quantity} tickets in one order. Send a single e-Transfer for the full amount.</p>
         )}
+        <button
+          onClick={() => {
+            // Clear the emt-done state so it doesn't persist on return
+            setEmtResult(null);
+            setStep('idle');
+            router.refresh();
+            if (onJumpToMyTickets) {
+              onJumpToMyTickets();
+            } else {
+              window.location.hash = 'my-tickets';
+              window.location.reload();
+            }
+          }}
+          className="w-full px-4 py-2.5 rounded-lg font-semibold text-sm bg-orange-500 text-white hover:bg-orange-600 transition"
+        >
+          🎫 View My Tickets →
+        </button>
       </div>
     );
   }

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -874,6 +874,9 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           eventId,
+          // Send full cart for multi-type orders
+          items: cartItems.map(ci => ({ ticketTypeId: ci.ticket.id, quantity: ci.qty })),
+          // Legacy single-type fields for backward compat
           ticketTypeId: first.ticket.id,
           quantity: first.qty,
           ...(inviteToken && { invite: inviteToken }),
@@ -1296,14 +1299,7 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
           ⚠️ Your cart mixes currencies ({cartCurrencies.join(' + ')}). Pick tickets in one currency to check out together.
         </p>
       )}
-      {/* Multi-type hint: only relevant when card is the only path. With
-          e-Transfer enabled, EMT covers the whole cart in one go and the user
-          doesn't need this warning. */}
-      {!mixedCurrency && multiType && !etransferEnabled && (
-        <p className="text-xs text-amber-500 mt-2">
-          ⚠️ Card payment is single-type only — you'll check out {first?.ticket.name} first, then return for the rest.
-        </p>
-      )}
+
       {!mixedCurrency && etransferEnabled && totalQty > 0 && (
         <p className="text-xs text-gray-400 mt-1">
           e-Transfer pays the organizer directly. One transfer covers all reserved tickets.

--- a/apps/events/app/api/checkout/route.ts
+++ b/apps/events/app/api/checkout/route.ts
@@ -20,10 +20,18 @@ import { getContactEmail } from '@/src/lib/contact-email';
 const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
 const EVENTS_URL = process.env.NEXT_PUBLIC_EVENTS_URL!;
 
-interface CheckoutRequest {
-  eventId: string;
+interface CartItem {
   ticketTypeId: string;
   quantity: number;
+}
+
+interface CheckoutRequest {
+  eventId: string;
+  // Multi-type cart
+  items?: CartItem[];
+  // Legacy single-type (still accepted)
+  ticketTypeId?: string;
+  quantity?: number;
   email?: string;
   invite?: string;
 }
@@ -42,14 +50,26 @@ export const POST = withLogger('events', async (request, { log, correlationId })
     const body: CheckoutRequest = await request.json();
     
     // Validate
-    if (!body.eventId || !body.ticketTypeId) {
+    if (!body.eventId) {
       return NextResponse.json(
-        { error: 'eventId and ticketTypeId are required' },
+        { error: 'eventId is required' },
         { status: 400 }
       );
     }
-    
-    const quantity = body.quantity || 1;
+
+    // Normalize to cart: accept items[] or legacy ticketTypeId+quantity
+    const rawItems: CartItem[] = body.items && body.items.length > 0
+      ? body.items
+      : body.ticketTypeId
+      ? [{ ticketTypeId: body.ticketTypeId, quantity: body.quantity ?? 1 }]
+      : [];
+
+    if (rawItems.length === 0) {
+      return NextResponse.json(
+        { error: 'items or ticketTypeId is required' },
+        { status: 400 }
+      );
+    }
     
     // Fetch event and ticket type
     const [event] = await db
@@ -95,21 +115,64 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       inviteRecord = invite;
     }
 
-    const [ticketType] = await db
+    // Fetch all ticket types for this event
+    const allTypes = await db
       .select()
       .from(ticketTypes)
-      .where(
-        and(
-          eq(ticketTypes.id, body.ticketTypeId),
-          eq(ticketTypes.eventId, body.eventId)
-        )
-      )
-      .limit(1);
-    
-    if (!ticketType) {
-      return NextResponse.json({ error: 'Ticket type not found' }, { status: 404 });
+      .where(eq(ticketTypes.eventId, body.eventId));
+    const typesById = new Map(allTypes.map(t => [t.id, t]));
+
+    // Validate and build cart
+    const cart: { type: typeof allTypes[0]; quantity: number }[] = [];
+    const eventMeta = (event.metadata || {}) as Record<string, any>;
+
+    for (const item of rawItems) {
+      const tt = typesById.get(item.ticketTypeId);
+      if (!tt) {
+        return NextResponse.json(
+          { error: `Ticket type ${item.ticketTypeId} not found` },
+          { status: 404 }
+        );
+      }
+
+      const qty = Math.max(1, Math.min(20, Math.floor(item.quantity ?? 1)));
+
+      // Enforce max per order
+      const maxPerOrder = Math.min(tt.maxPerOrder ?? eventMeta.maxTicketsPerOrder ?? 10, 20);
+      if (qty > maxPerOrder) {
+        return NextResponse.json(
+          { error: `Maximum ${maxPerOrder} ${tt.name} tickets per order` },
+          { status: 400 }
+        );
+      }
+
+      // Check availability
+      if (tt.quantity !== null) {
+        const available = tt.quantity - (tt.sold ?? 0);
+        if (available < qty) {
+          return NextResponse.json(
+            { error: `Only ${available} ${tt.name} ticket${available !== 1 ? 's' : ''} available` },
+            { status: 409 }
+          );
+        }
+      }
+
+      cart.push({ type: tt, quantity: qty });
     }
-    
+
+    if (cart.length === 0) {
+      return NextResponse.json({ error: 'Empty cart' }, { status: 400 });
+    }
+
+    // All items must share a currency
+    const currencies = new Set(cart.map(c => c.type.currency));
+    if (currencies.size > 1) {
+      return NextResponse.json(
+        { error: 'All tickets must use the same currency' },
+        { status: 400 }
+      );
+    }
+
     // Check if buyer is logged in (hard DID)
     const session = await optionalAuth(request);
     const buyerDid = (session && session.tier !== 'soft') ? session.id : undefined;
@@ -121,46 +184,26 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       if (resolved) customerEmail = resolved;
     }
 
-    // Enforce max per order: per-type override > event metadata > default 10, hard cap 20
-    const eventMeta = (event.metadata || {}) as Record<string, any>;
-    const maxPerOrder = Math.min(
-      ticketType.maxPerOrder ?? eventMeta.maxTicketsPerOrder ?? 10,
-      20
-    );
-    if (quantity > maxPerOrder) {
-      return NextResponse.json(
-        { error: `Maximum ${maxPerOrder} tickets per order` },
-        { status: 400 }
-      );
-    }
+    const totalQuantity = cart.reduce((sum, c) => sum + c.quantity, 0);
 
-    // Check availability
-    if (ticketType.quantity !== null) {
-      const available = ticketType.quantity - (ticketType.sold ?? 0);
-      if (available < quantity) {
-        return NextResponse.json(
-          { error: `Only ${available} tickets available` },
-          { status: 400 }
-        );
-      }
-    }
-    
     // Read .fair attribution from event metadata
-    const eventMetadata = (event.metadata || {}) as Record<string, any>;
-    const fairManifest = eventMetadata.fair || null;
+    const fairManifest = eventMeta.fair || null;
+
+    // Build Stripe line items from the full cart
+    const stripeItems = cart.map(c => ({
+      name: `${event.title} — ${c.type.name}`,
+      description: c.type.description || undefined,
+      amount: c.type.price,
+      quantity: c.quantity,
+    }));
 
     // Call pay service to create checkout session
     const payResponse = await fetch(`${PAY_SERVICE_URL}/api/checkout`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        items: [{
-          name: `${event.title} — ${ticketType.name}`,
-          description: ticketType.description || undefined,
-          amount: ticketType.price,
-          quantity,
-        }],
-        currency: ticketType.currency,
+        items: stripeItems,
+        currency: cart[0].type.currency,
         customerEmail,
         successUrl: `${EVENTS_URL}/checkout/success?session_id={CHECKOUT_SESSION_ID}&event=${event.id}`,
         cancelUrl: `${EVENTS_URL}/${event.id}`,
@@ -170,8 +213,9 @@ export const POST = withLogger('events', async (request, { log, correlationId })
           service: 'events',
           eventId: event.id,
           eventDid: event.did,
-          ticketTypeId: ticketType.id,
-          quantity: String(quantity),
+          // Encode full cart in metadata for the webhook to reconstruct
+          cart: JSON.stringify(cart.map(c => ({ ticketTypeId: c.type.id, quantity: c.quantity }))),
+          totalQuantity: String(totalQuantity),
           ...(buyerDid && { buyerDid }),
         },
       }),
@@ -192,7 +236,12 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       issuer: buyerDid || '',
       subject: event.creatorDid,
       scope: 'events',
-      payload: { eventId: body.eventId, ticketTypeId: body.ticketTypeId, quantity, sellerDid: event.creatorDid },
+      payload: {
+        eventId: body.eventId,
+        cart: cart.map(c => ({ ticketTypeId: c.type.id, quantity: c.quantity })),
+        totalQuantity,
+        sellerDid: event.creatorDid,
+      },
       correlationId,
     }).catch((err) => log.error({ err: String(err) }, 'Publish error'));
 

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -183,8 +183,12 @@ interface PaymentWebhookPayload {
   metadata: {
     eventId: string;
     eventDid: string;
-    ticketTypeId: string;
-    quantity: string;
+    // Legacy single-type fields
+    ticketTypeId?: string;
+    quantity?: string;
+    // Multi-type cart (JSON string)
+    cart?: string;
+    totalQuantity?: string;
     buyerDid?: string;
   };
 }
@@ -221,7 +225,22 @@ export const POST = withLogger('events', async (request, { log }) => {
 async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
   const { metadata, customerName, amountTotal, currency, sessionId, paymentId } = payload;
   const customerEmail = payload.customerEmail || null;
-  const quantity = parseInt(metadata.quantity) || 1;
+
+  // Parse cart: multi-type (cart JSON) or legacy single-type
+  interface CartEntry { ticketTypeId: string; quantity: number }
+  let cart: CartEntry[];
+  if (metadata.cart) {
+    try {
+      cart = JSON.parse(metadata.cart);
+    } catch {
+      throw new Error(`Invalid cart metadata: ${metadata.cart}`);
+    }
+  } else if (metadata.ticketTypeId) {
+    cart = [{ ticketTypeId: metadata.ticketTypeId, quantity: parseInt(metadata.quantity || '1') }];
+  } else {
+    throw new Error('No cart or ticketTypeId in metadata');
+  }
+  const totalQuantity = cart.reduce((sum, c) => sum + c.quantity, 0);
 
   // Idempotency: check if an order for this Stripe session already exists
   const existingOrder = await db
@@ -239,7 +258,7 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     throw new Error('Customer email is required for ticket creation');
   }
 
-  // Get event and ticket type
+  // Get event
   const [event] = await db
     .select()
     .from(events)
@@ -250,15 +269,16 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     throw new Error(`Event not found: ${metadata.eventId}`);
   }
 
-  const [ticketType] = await db
-    .select()
-    .from(ticketTypes)
-    .where(eq(ticketTypes.id, metadata.ticketTypeId))
-    .limit(1);
-
-  if (!ticketType) {
-    throw new Error(`Ticket type not found: ${metadata.ticketTypeId}`);
+  // Fetch all ticket types referenced in cart
+  const allTypes = await db.select().from(ticketTypes).where(eq(ticketTypes.eventId, metadata.eventId));
+  const typesById = new Map(allTypes.map(t => [t.id, t]));
+  for (const item of cart) {
+    if (!typesById.has(item.ticketTypeId)) {
+      throw new Error(`Ticket type not found: ${item.ticketTypeId}`);
+    }
   }
+  // Use first type for backward-compat fields that need a single value
+  const firstType = typesById.get(cart[0].ticketTypeId)!;
 
   // Resolve owner DID: use hard DID if buyer was logged in, otherwise create soft DID
   let ownerDid: string;
@@ -294,8 +314,8 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     id: orderId,
     eventId: event.id,
     buyerDid: ownerDid,
-    ticketTypeId: ticketType.id,
-    quantity,
+    ticketTypeId: firstType.id,
+    quantity: totalQuantity,
     amountTotal,
     currency: currency.toUpperCase(),
     paymentMethod: paymentId ? 'stripe' : 'etransfer',
@@ -305,70 +325,78 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     metadata: {
       purchaseEmail: customerEmail,
       customerName: customerName || null,
+      cart: cart.map(c => ({ ticketTypeId: c.ticketTypeId, quantity: c.quantity })),
     },
   });
 
-  // Create ticket(s)
+  // Create tickets for all types in the cart
   const createdTickets = [];
+  let ticketIndex = 0;
 
-  for (let i = 0; i < quantity; i++) {
-    const ticketId = `tkt_${Date.now().toString(36)}_${i}`;
+  for (const cartItem of cart) {
+    const ticketType = typesById.get(cartItem.ticketTypeId)!;
+    const perTicketPrice = Math.round(ticketType.price * cartItem.quantity > 0 ? ticketType.price : 0);
 
-    // Sign ticket with event's Ed25519 private key
-    const signatureData = `${ticketId}:${event.did}:${customerEmail}:${Date.now()}`;
-    const msgBytes = new TextEncoder().encode(signatureData);
-    let signature: string;
-    if (event.privateKey) {
-      const sigBytes = await ed.signAsync(msgBytes, hexToBytes(event.privateKey));
-      signature = bytesToHex(sigBytes);
-    } else {
-      // Fallback for events created before privateKey was stored
-      log.warn({ eventId: event.id }, 'Event has no privateKey — using base64 fallback signature');
-      signature = Buffer.from(signatureData).toString('base64');
-    }
+    for (let i = 0; i < cartItem.quantity; i++) {
+      const ticketId = `tkt_${Date.now().toString(36)}_${ticketIndex++}`;
 
-    const [ticket] = await db.insert(tickets).values({
-      id: ticketId,
-      eventId: event.id,
-      ticketTypeId: ticketType.id,
-      orderId,
-      ownerDid,
-      originalOwnerDid: ownerDid,
-      pricePaid: amountTotal / quantity,
-      currency: currency.toUpperCase(),
-      paymentId: paymentId || sessionId,
-      paymentMethod: paymentId ? 'stripe' : 'etransfer',
-      status: 'valid',
-      purchasedAt: new Date(),
-      signature,
+      // Sign ticket with event's Ed25519 private key
+      const signatureData = `${ticketId}:${event.did}:${customerEmail}:${Date.now()}`;
+      const msgBytes = new TextEncoder().encode(signatureData);
+      let signature: string;
+      if (event.privateKey) {
+        const sigBytes = await ed.signAsync(msgBytes, hexToBytes(event.privateKey));
+        signature = bytesToHex(sigBytes);
+      } else {
+        log.warn({ eventId: event.id }, 'Event has no privateKey — using base64 fallback signature');
+        signature = Buffer.from(signatureData).toString('base64');
+      }
 
-      registrationStatus: ticketType.requiresRegistration ? 'pending' : 'not_required',
-      metadata: {
-        stripeSessionId: sessionId,
-        purchaseEmail: customerEmail,
-      },
-    }).returning();
+      const [ticket] = await db.insert(tickets).values({
+        id: ticketId,
+        eventId: event.id,
+        ticketTypeId: ticketType.id,
+        orderId,
+        ownerDid,
+        originalOwnerDid: ownerDid,
+        pricePaid: perTicketPrice,
+        currency: currency.toUpperCase(),
+        paymentId: paymentId || sessionId,
+        paymentMethod: paymentId ? 'stripe' : 'etransfer',
+        status: 'valid',
+        purchasedAt: new Date(),
+        signature,
 
-    createdTickets.push(ticket);
+        registrationStatus: ticketType.requiresRegistration ? 'pending' : 'not_required',
+        metadata: {
+          stripeSessionId: sessionId,
+          purchaseEmail: customerEmail,
+        },
+      }).returning();
 
-    // Fire and forget — never block the response
-    bus.publish('ticket.purchased', {
-      issuer: ownerDid, subject: event.creatorDid, scope: 'events',
-      payload: {
-        ticketId: ticket.id, eventId: event.id,
-        amount: amountTotal / quantity, currency,
+      createdTickets.push(ticket);
+
+      // Fire and forget — never block the response
+      bus.publish('ticket.purchased', {
+        issuer: ownerDid, subject: event.creatorDid, scope: 'events',
+        payload: {
+          ticketId: ticket.id, eventId: event.id,
+          amount: perTicketPrice, currency,
         context_id: event.id, context_type: 'event',
         to: ownerDid,
         interestDids: [ownerDid],
       }
     });
+    }
   }
 
-  // Update sold count
-  await db
-    .update(ticketTypes)
-    .set({ sold: sql`${ticketTypes.sold} + ${quantity}` })
-    .where(eq(ticketTypes.id, ticketType.id));
+  // Update sold count for each ticket type in the cart
+  for (const cartItem of cart) {
+    await db
+      .update(ticketTypes)
+      .set({ sold: sql`${ticketTypes.sold} + ${cartItem.quantity}` })
+      .where(eq(ticketTypes.id, cartItem.ticketTypeId));
+  }
 
   log.info({ count: createdTickets.length, orderId, customerEmail }, 'Order + tickets created');
 

--- a/apps/kernel/app/auth/authorize/page.tsx
+++ b/apps/kernel/app/auth/authorize/page.tsx
@@ -34,12 +34,25 @@ function AuthorizeForm() {
       return;
     }
 
-    fetch(`/api/registry/apps/${appId}`)
+    // Check if user is logged in before showing consent screen
+    fetch('/profile/api/auth/session', { credentials: 'include' })
+      .then(res => res.json())
+      .then(session => {
+        if (!session?.did) {
+          // Not logged in — redirect to login, then back here
+          const returnUrl = encodeURIComponent(window.location.href);
+          window.location.href = `/auth/login?redirect=${returnUrl}`;
+          return;
+        }
+        return fetch(`/api/registry/apps/${appId}`);
+      })
       .then(res => {
+        if (!res) return; // redirecting to login
         if (!res.ok) throw new Error('App not found');
         return res.json();
       })
-      .then((data: AppInfo) => {
+      .then((data?: AppInfo) => {
+        if (!data) return; // redirecting to login
         setApp(data);
 
         // Scopes from URL (what the app is requesting right now), filtered against what the app registered


### PR DESCRIPTION
## Problem

When a logged-in user with a verified email clicks **Pay by e-Transfer**, the API succeeds but there's no visible feedback. The quantity counter stays, and the user can keep re-submitting.

**Root cause:** `router.refresh()` fires immediately after `setStep('emt-done')`. The server re-renders with `hasTicket=true`, which restructures the component tree (direct `<PurchaseUI>` → tabbed interface). React unmounts the old PurchaseUI (with the emt-done card) before the user can read the instructions.

## Fix

- Remove `router.refresh()` from both EMT success paths (direct checkout + post-verification claim)
- The emt-done card now **persists** with full payment instructions (amount, email, memo, deadline)
- Added a **"🎫 View My Tickets →"** button that triggers refresh + tab switch when the user is ready
- Duplicate-order API protection still prevents actual double-charges

## Changes

`apps/events/app/[eventId]/tickets-section.tsx` — UnifiedCheckoutBar