### PR TITLE
fix(media): UI quality sweep — limit, move, selection, duplicate folders (#931)

### DIFF
--- a/apps/kernel/app/media/api/assets/route.ts
+++ b/apps/kernel/app/media/api/assets/route.ts
@@ -313,7 +313,7 @@ export async function POST(request: NextRequest) {
     const folderConfig = CONTEXT_FOLDER_MAP[folderKey];
     if (folderConfig) {
       try {
-        // Find or create the system folder for this user
+        // Find or create the system folder for this user (idempotent under races)
         const existing = await db.select().from(folders).where(
           and(eq(folders.ownerDid, ownerDid), eq(folders.name, folderConfig.name), eq(folders.isSystem, true))
         ).limit(1);
@@ -323,13 +323,21 @@ export async function POST(request: NextRequest) {
           folderId = existing[0].id;
         } else {
           folderId = `folder_${nanoid(16)}`;
-          await db.insert(folders).values({
+          const [inserted] = await db.insert(folders).values({
             id: folderId,
             ownerDid,
             name: folderConfig.name,
             icon: folderConfig.icon,
             isSystem: true,
-          });
+          }).onConflictDoNothing().returning();
+
+          if (!inserted) {
+            // Another request created it concurrently; fetch the winner
+            const [retry] = await db.select().from(folders).where(
+              and(eq(folders.ownerDid, ownerDid), eq(folders.name, folderConfig.name), eq(folders.isSystem, true))
+            ).limit(1);
+            if (retry) folderId = retry.id;
+          }
         }
 
         // Link asset to folder

--- a/apps/kernel/app/media/api/folders/[id]/route.ts
+++ b/apps/kernel/app/media/api/folders/[id]/route.ts
@@ -4,6 +4,8 @@ import { requireAuth } from "@imajin/auth";
 import { eq, and } from "drizzle-orm";
 import { createLogger } from "@imajin/logger";
 
+export const dynamic = "force-dynamic";
+
 const log = createLogger("kernel");
 
 // ---------------------------------------------------------------------------

--- a/apps/kernel/app/media/api/folders/init/route.ts
+++ b/apps/kernel/app/media/api/folders/init/route.ts
@@ -5,6 +5,8 @@ import { requireAuth } from "@imajin/auth";
 import { eq } from "drizzle-orm";
 import { withLogger } from "@imajin/logger";
 
+export const dynamic = "force-dynamic";
+
 const DEFAULT_FOLDERS = [
   { name: "Photos", icon: "📷" },
   { name: "Audio", icon: "🎵" },
@@ -23,17 +25,6 @@ export const POST = withLogger('kernel', async (request, { log }) => {
   }
   const ownerDid = authResult.identity.actingAs || authResult.identity.id;
 
-  // Check if any folders already exist for this user
-  const existing = await db
-    .select({ id: folders.id })
-    .from(folders)
-    .where(eq(folders.ownerDid, ownerDid))
-    .limit(1);
-
-  if (existing.length > 0) {
-    return NextResponse.json({ message: "Already initialized", created: [] });
-  }
-
   try {
     const values = DEFAULT_FOLDERS.map((f, i) => ({
       id: `folder_${nanoid(16)}`,
@@ -45,8 +36,17 @@ export const POST = withLogger('kernel', async (request, { log }) => {
       parentId: null,
     }));
 
-    const created = await db.insert(folders).values(values).returning();
-    return NextResponse.json({ message: "Initialized", created }, { status: 201 });
+    // ON CONFLICT DO NOTHING makes this idempotent even under concurrent requests.
+    const created = await db
+      .insert(folders)
+      .values(values)
+      .onConflictDoNothing()
+      .returning();
+
+    return NextResponse.json(
+      { message: created.length > 0 ? "Initialized" : "Already initialized", created },
+      { status: created.length > 0 ? 201 : 200 }
+    );
   } catch (err) {
     log.error({ err: String(err) }, "DB insert failed");
     return NextResponse.json({ error: "Database failure", detail: String(err) }, { status: 500 });

--- a/apps/kernel/app/media/api/folders/route.ts
+++ b/apps/kernel/app/media/api/folders/route.ts
@@ -5,6 +5,8 @@ import { requireAuth } from "@imajin/auth";
 import { eq, sql } from "drizzle-orm";
 import { withLogger } from "@imajin/logger";
 
+export const dynamic = "force-dynamic";
+
 // ---------------------------------------------------------------------------
 // GET /api/folders — list all folders for authenticated user with asset counts
 // ---------------------------------------------------------------------------

--- a/apps/kernel/src/components/media/AssetGrid.tsx
+++ b/apps/kernel/src/components/media/AssetGrid.tsx
@@ -15,11 +15,15 @@ interface AssetGridProps {
   typeFilter: string;
   selectedAssetId: string | null;
   folders?: Folder[];
+  selectedAssetIds?: Set<string>;
+  moveFolderId?: string;
   onSortChange: (sort: string) => void;
   onOrderChange: (order: string) => void;
   onTypeFilterChange: (type: string) => void;
   onSelectAsset: (id: string) => void;
   onUploaded: () => void;
+  onSelectedAssetIdsChange?: (ids: Set<string>) => void;
+  onMoveFolderIdChange?: (id: string) => void;
 }
 
 export function AssetGrid({
@@ -30,16 +34,45 @@ export function AssetGrid({
   typeFilter,
   selectedAssetId,
   folders = [],
+  selectedAssetIds: externalSelectedAssetIds,
+  moveFolderId: externalMoveFolderId,
   onSortChange,
   onOrderChange,
   onTypeFilterChange,
   onSelectAsset,
   onUploaded,
+  onSelectedAssetIdsChange,
+  onMoveFolderIdChange,
 }: AssetGridProps) {
   const [dragging, setDragging] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("large-grid");
-  const [selectedAssetIds, setSelectedAssetIds] = useState<Set<string>>(new Set());
-  const [moveFolderId, setMoveFolderId] = useState<string>("");
+  const [internalSelectedAssetIds, setInternalSelectedAssetIds] = useState<Set<string>>(new Set());
+  const [internalMoveFolderId, setInternalMoveFolderId] = useState<string>("");
+
+  const selectedAssetIds = externalSelectedAssetIds ?? internalSelectedAssetIds;
+  const moveFolderId = externalMoveFolderId ?? internalMoveFolderId;
+
+  const setSelectedAssetIds = useCallback((value: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+    if (typeof value === 'function') {
+      const next = value(selectedAssetIds);
+      if (onSelectedAssetIdsChange) onSelectedAssetIdsChange(next);
+      else setInternalSelectedAssetIds(next);
+    } else {
+      if (onSelectedAssetIdsChange) onSelectedAssetIdsChange(value);
+      else setInternalSelectedAssetIds(value);
+    }
+  }, [onSelectedAssetIdsChange, selectedAssetIds]);
+
+  const setMoveFolderId = useCallback((value: string | ((prev: string) => string)) => {
+    if (typeof value === 'function') {
+      const next = value(moveFolderId);
+      if (onMoveFolderIdChange) onMoveFolderIdChange(next);
+      else setInternalMoveFolderId(next);
+    } else {
+      if (onMoveFolderIdChange) onMoveFolderIdChange(value);
+      else setInternalMoveFolderId(value);
+    }
+  }, [onMoveFolderIdChange, moveFolderId]);
   const lastClickIdx = useRef<number | null>(null);
   const uploadRef = useRef<UploadZoneHandle>(null);
   const dragCounter = useRef(0);
@@ -156,7 +189,7 @@ export function AssetGrid({
           return next;
         });
       } else {
-        setSelectedAssetIds(new Set());
+        // Don't clear multi-selection on normal click — it survives detail open/close
         lastClickIdx.current = idx;
         onSelectAsset(asset.id);
       }
@@ -211,20 +244,31 @@ export function AssetGrid({
 
   const handleBatchMove = useCallback(async () => {
     if (!moveFolderId) return;
-    await Promise.all(
-      Array.from(selectedAssetIds).map((id) =>
-        fetch(`/media/api/assets/${id}`, {
-          method: "PATCH",
+    const results = await Promise.allSettled(
+      Array.from(selectedAssetIds).map(async (id) => {
+        const res = await fetch(`/media/api/assets/${id}/folders`, {
+          method: "PUT",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ folderId: moveFolderId }),
-        })
-      )
+          body: JSON.stringify({ folderIds: [moveFolderId] }),
+        });
+        if (!res.ok) throw new Error(`${id}: ${res.status}`);
+        return id;
+      })
     );
-    setSelectedAssetIds(new Set());
+    const failed = results.filter((r) => r.status === "rejected");
+    const succeeded = results.filter((r) => r.status === "fulfilled").map((r) => (r as PromiseFulfilledResult<string>).value);
+    setSelectedAssetIds((prev) => {
+      const next = new Set(prev);
+      for (const id of succeeded) next.delete(id);
+      return next;
+    });
+    if (failed.length > 0) {
+      alert(`${failed.length} of ${results.length} file(s) failed to move. The rest were moved.`);
+    }
     setMoveFolderId("");
     onUploaded();
-  }, [selectedAssetIds, moveFolderId, onUploaded]);
+  }, [selectedAssetIds, moveFolderId, onUploaded, setSelectedAssetIds, setMoveFolderId]);
 
   return (
     <div

--- a/apps/kernel/src/components/media/MediaManager.tsx
+++ b/apps/kernel/src/components/media/MediaManager.tsx
@@ -40,6 +40,8 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
   const [typeFilter, setTypeFilter] = useState("");
   const [sort, setSort] = useState<SortKey>("created");
   const [order, setOrder] = useState<"asc" | "desc">("desc");
+  const [selectedAssetIds, setSelectedAssetIds] = useState<Set<string>>(new Set());
+  const [moveFolderId, setMoveFolderId] = useState<string>("");
 
   // Persist sort/order to localStorage after mount
   useEffect(() => {
@@ -60,7 +62,7 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
 
   const loadAssets = useCallback(async () => {
     setLoading(true);
-    const params = new URLSearchParams({ sort, order });
+    const params = new URLSearchParams({ sort, order, limit: "200" });
     if (typeFilter) params.set("type", typeFilter);
     const res = await fetch(`/media/api/assets?${params}`, { credentials: "include" });
     if (res.ok) {
@@ -142,7 +144,8 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
     await fetch(`/media/api/folders/${id}`, { method: "DELETE", credentials: "include" });
     if (selectedFolderId === id) setSelectedFolderId(null);
     loadFolders();
-  }, [loadFolders, selectedFolderId]);
+    loadAssets();
+  }, [loadFolders, loadAssets, selectedFolderId]);
 
   const sidebarContent = (
     <FolderTree
@@ -185,8 +188,12 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
               onDeleted={() => {
                 setSelectedAssetId(null);
                 loadAssets();
+                loadFolders();
               }}
-              onMoved={loadAssets}
+              onMoved={() => {
+                loadAssets();
+                loadFolders();
+              }}
             />
           ) : (
             <AssetGrid
@@ -197,6 +204,8 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
               typeFilter={typeFilter}
               selectedAssetId={selectedAssetId}
               folders={folders}
+              selectedAssetIds={selectedAssetIds}
+              moveFolderId={moveFolderId}
               onSortChange={(s) => {
                 setSort(s as SortKey);
                 localStorage.setItem("imajin-media-sort", s);
@@ -207,7 +216,12 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
               }}
               onTypeFilterChange={setTypeFilter}
               onSelectAsset={setSelectedAssetId}
-              onUploaded={loadAssets}
+              onUploaded={() => {
+                loadAssets();
+                loadFolders();
+              }}
+              onSelectedAssetIdsChange={setSelectedAssetIds}
+              onMoveFolderIdChange={setMoveFolderId}
             />
           )}
         </AppShell.Split.Pane>

--- a/migrations/0028_folders_unique_constraint.sql
+++ b/migrations/0028_folders_unique_constraint.sql
@@ -1,0 +1,40 @@
+-- Deduplicate folders: keep the oldest folder for each (owner_did, name, parent_id)
+-- and update asset references before deleting duplicates.
+-- Then add a unique index to prevent future races.
+
+CREATE TEMP TABLE folder_dedup_map AS
+WITH ranked AS (
+  SELECT
+    id,
+    owner_did,
+    name,
+    COALESCE(parent_id, '') as parent_key,
+    ROW_NUMBER() OVER (PARTITION BY owner_did, name, COALESCE(parent_id, '') ORDER BY created_at ASC, id ASC) as rn
+  FROM media.folders
+)
+SELECT r.id as dupe_id, k.id as keeper_id
+FROM ranked r
+JOIN ranked k ON r.owner_did = k.owner_did AND r.name = k.name AND r.parent_key = k.parent_key
+WHERE r.rn > 1 AND k.rn = 1;
+
+-- Update junction table references
+UPDATE media.asset_folders af
+SET folder_id = m.keeper_id
+FROM folder_dedup_map m
+WHERE af.folder_id = m.dupe_id;
+
+-- Update assets.folder_id references
+UPDATE media.assets a
+SET folder_id = m.keeper_id
+FROM folder_dedup_map m
+WHERE a.folder_id = m.dupe_id;
+
+-- Delete duplicate folders
+DELETE FROM media.folders f
+USING folder_dedup_map m
+WHERE f.id = m.dupe_id;
+
+DROP TABLE folder_dedup_map;
+
+-- Add unique index to prevent future duplicate folders
+CREATE UNIQUE INDEX idx_folders_unique_name ON media.folders (owner_did, name, (COALESCE(parent_id, '')));


### PR DESCRIPTION
Fixes #931

## Bug Fixes

**Bug 1: 50-item limit hides older assets**
-  now passes  to the API

**Bug 2: Bulk move action doesn't work**
-  now calls the correct endpoint:  with 
- Added  + partial failure handling

**Bug 3: Selection state lost when clicking asset for detail**
- Lifted  and  state from  up to 
- Normal click no longer clears multi-selection, so it survives detail panel open/close

**Bug 4: Duplicate folders from race in /media/api/folders/init**
- Added migration :
  - Deduplicates existing folders by 
  - Updates  and  references
  - Adds 
- : removed early-exit check, uses  for idempotency
-  auto-folder assignment: same  pattern with retry-fetch fallback

## Quality Sweep
- After upload: refresh both assets AND folders (counts update)
- After folder delete: refresh assets too (stale  references cleared)
- After asset move/delete in detail: refresh both assets and folders
- Added  to folder routes to prevent caching

## Files Changed
- 
- 
- 
- 
- 
- 
- 