### PR TITLE
feat(media): access/grants/article PATCH endpoints + X-Acting-As header (#933)

### DIFF
--- a/apps/kernel/app/media/api/assets/[id]/access/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/access/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { patchAccess } from "@/src/lib/media/routes/access";
+import { corsOptions } from "@/src/lib/kernel/cors";
+
+export const dynamic = "force-dynamic";
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return patchAccess(request, id);
+}

--- a/apps/kernel/app/media/api/assets/[id]/article/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/article/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { patchArticle } from "@/src/lib/media/routes/article";
+import { corsOptions } from "@/src/lib/kernel/cors";
+
+export const dynamic = "force-dynamic";
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return patchArticle(request, id);
+}

--- a/apps/kernel/app/media/api/assets/[id]/grants/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/grants/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { patchGrants } from "@/src/lib/media/routes/grants";
+import { corsOptions } from "@/src/lib/kernel/cors";
+
+export const dynamic = "force-dynamic";
+
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return patchGrants(request, id);
+}

--- a/apps/kernel/src/lib/media/__tests__/access-route.test.ts
+++ b/apps/kernel/src/lib/media/__tests__/access-route.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { patchAccess } from '../routes/access';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockUpdate = vi.fn();
+const mockSet = vi.fn();
+const mockDbWhere = vi.fn();
+
+vi.mock('@/src/db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: mockFrom })),
+    update: vi.fn(() => ({ set: mockSet })),
+  },
+  assets: { id: 'id', ownerDid: 'owner_did', status: 'status', fairManifest: 'fair_manifest', fairPath: 'fair_path', fairDfosEventId: 'fair_dfos_event_id', createdAt: 'created_at', mimeType: 'mime_type' },
+}));
+
+vi.mock('@imajin/auth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('@imajin/fair', () => ({
+  isFairManifestV1_1: vi.fn((m: unknown) => !!(m && typeof m === 'object' && 'version' in (m as object) && (m as { version: string }).version === '1.1')),
+}));
+
+vi.mock('@/src/lib/media/manifest-helpers', () => ({
+  updateManifestFlow: vi.fn(),
+}));
+
+vi.mock('@imajin/logger', () => ({
+  createLogger: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock('@/src/lib/kernel/cors', () => ({
+  corsHeaders: vi.fn(() => ({})),
+  corsOptions: vi.fn(() => new Response(null, { status: 204 })),
+}));
+
+import { requireAuth } from '@imajin/auth';
+import { db } from '@/src/db';
+import { updateManifestFlow } from '@/src/lib/media/manifest-helpers';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeRequest(body: unknown, url = 'https://test.imajin.ai/media/api/assets/asset_test/access') {
+  return new Request(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupAsset(overrides: Record<string, unknown> = {}) {
+  const asset = {
+    id: 'asset_test',
+    ownerDid: 'did:imajin:owner',
+    status: 'active',
+    mimeType: 'image/png',
+    fairManifest: {
+      fair: '1.1',
+      version: '1.1',
+      access: { type: 'private' },
+    },
+    fairPath: '/mnt/media/test.fair.json',
+    fairDfosEventId: 'evt_old',
+    createdAt: new Date('2026-05-12T10:00:00Z'),
+    metadata: {},
+    ...overrides,
+  };
+
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockLimit.mockResolvedValue([asset]);
+
+  mockSet.mockReturnValue({ where: mockDbWhere });
+  mockDbWhere.mockResolvedValue(undefined);
+
+  return asset;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('PATCH /media/api/assets/[id]/access', () => {
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ error: 'Not authenticated', status: 401 });
+
+    const res = await patchAccess(makeRequest({ access: 'public' }), 'asset_test');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when access is missing', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+
+    const res = await patchAccess(makeRequest({}), 'asset_test');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('access must be one of');
+  });
+
+  it('returns 400 when access is invalid', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+
+    const res = await patchAccess(makeRequest({ access: 'super-secret' }), 'asset_test');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when asset not found', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockResolvedValue([]);
+
+    const res = await patchAccess(makeRequest({ access: 'public' }), 'missing');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when user does not own the asset', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:intruder', actingAs: undefined } });
+    setupAsset();
+
+    const res = await patchAccess(makeRequest({ access: 'public' }), 'asset_test');
+    expect(res.status).toBe(403);
+  });
+
+  it('updates access to public and runs manifest flow', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset();
+    const updatedAsset = { ...asset, fairManifest: { ...asset.fairManifest, access: { type: 'public' } } };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    // Second db.select for returning updated asset
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    vi.mocked(updateManifestFlow).mockResolvedValueOnce({
+      signedManifest: updatedAsset.fairManifest as any,
+      dfosEventId: 'evt_new',
+    });
+
+    const res = await patchAccess(makeRequest({ access: 'public' }), 'asset_test');
+    expect(res.status).toBe(200);
+
+    expect(updateManifestFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'asset_test',
+        ownerDid: 'did:imajin:owner',
+      }),
+      expect.objectContaining({
+        access: { type: 'public' },
+      }),
+      expect.any(String)
+    );
+  });
+
+  it('updates access to conversation', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset();
+    const updatedAsset = { ...asset, fairManifest: { ...asset.fairManifest, access: { type: 'conversation' } } };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    vi.mocked(updateManifestFlow).mockResolvedValueOnce({
+      signedManifest: updatedAsset.fairManifest as any,
+      dfosEventId: null,
+    });
+
+    const res = await patchAccess(makeRequest({ access: 'conversation' }), 'asset_test');
+    expect(res.status).toBe(200);
+  });
+
+  it('handles missing manifest by creating a minimal v1.1 fallback', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset({ fairManifest: {} });
+    const updatedAsset = { ...asset };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    vi.mocked(updateManifestFlow).mockResolvedValueOnce({
+      signedManifest: {} as any,
+      dfosEventId: null,
+    });
+
+    const res = await patchAccess(makeRequest({ access: 'public' }), 'asset_test');
+    expect(res.status).toBe(200);
+    const callArgs = vi.mocked(updateManifestFlow).mock.calls[0];
+    expect(callArgs[1]).toMatchObject({
+      fair: '1.1',
+      version: '1.1',
+      access: { type: 'public' },
+    });
+  });
+
+  it('supports acting-as impersonation', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({
+      identity: { id: 'did:imajin:agent', actingAs: 'did:imajin:owner', actingAsRole: 'admin' },
+    });
+    const asset = setupAsset();
+    const updatedAsset = { ...asset, fairManifest: { ...asset.fairManifest, access: { type: 'public' } } };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    vi.mocked(updateManifestFlow).mockResolvedValueOnce({
+      signedManifest: updatedAsset.fairManifest as any,
+      dfosEventId: 'evt_new',
+    });
+
+    const res = await patchAccess(makeRequest({ access: 'public' }), 'asset_test');
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/kernel/src/lib/media/__tests__/article-route.test.ts
+++ b/apps/kernel/src/lib/media/__tests__/article-route.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { patchArticle } from '../routes/article';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockSet = vi.fn();
+const mockDbWhere = vi.fn();
+
+vi.mock('@/src/db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: mockFrom })),
+    update: vi.fn(() => ({ set: mockSet })),
+  },
+  assets: {},
+}));
+
+vi.mock('@imajin/auth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('@imajin/logger', () => ({
+  createLogger: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock('@imajin/bus', () => ({
+  publish: vi.fn(),
+}));
+
+vi.mock('@/src/lib/kernel/cors', () => ({
+  corsHeaders: vi.fn(() => ({})),
+  corsOptions: vi.fn(() => new Response(null, { status: 204 })),
+}));
+
+import { requireAuth } from '@imajin/auth';
+import { publish } from '@imajin/bus';
+import { db } from '@/src/db';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeRequest(body: unknown, url = 'https://test.imajin.ai/media/api/assets/asset_test/article') {
+  return new Request(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupAsset(overrides: Record<string, unknown> = {}) {
+  const asset = {
+    id: 'asset_test',
+    ownerDid: 'did:imajin:owner',
+    status: 'active',
+    mimeType: 'text/markdown',
+    fairManifest: {},
+    fairPath: null,
+    fairDfosEventId: null,
+    createdAt: new Date('2026-05-12T10:00:00Z'),
+    metadata: {},
+    ...overrides,
+  };
+
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockLimit.mockResolvedValue([asset]);
+
+  mockSet.mockReturnValue({ where: mockDbWhere });
+  mockDbWhere.mockResolvedValue(undefined);
+
+  return asset;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('PATCH /media/api/assets/[id]/article', () => {
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ error: 'Not authenticated', status: 401 });
+
+    const res = await patchArticle(makeRequest({ slug: 'hello', title: 'Hello' }), 'asset_test');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when slug is missing', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+
+    const res = await patchArticle(makeRequest({ title: 'Hello' }), 'asset_test');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('slug is required');
+  });
+
+  it('returns 400 when slug has underscores', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const res = await patchArticle(makeRequest({ slug: 'hello_world', title: 'Hello' }), 'asset_test');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when slug has uppercase', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const res = await patchArticle(makeRequest({ slug: 'Hello-World', title: 'Hello' }), 'asset_test');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when slug has spaces', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const res = await patchArticle(makeRequest({ slug: 'hello world', title: 'Hello' }), 'asset_test');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when title is missing', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+
+    const res = await patchArticle(makeRequest({ slug: 'hello' }), 'asset_test');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('title is required');
+  });
+
+  it('returns 404 when asset not found', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockResolvedValue([]);
+
+    const res = await patchArticle(makeRequest({ slug: 'hello', title: 'Hello' }), 'missing');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when user does not own the asset', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:intruder', actingAs: undefined } });
+    setupAsset();
+
+    const res = await patchArticle(makeRequest({ slug: 'hello', title: 'Hello' }), 'asset_test');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when mime type is not text/markdown', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    setupAsset({ mimeType: 'image/png' });
+
+    const res = await patchArticle(makeRequest({ slug: 'hello', title: 'Hello' }), 'asset_test');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('text/markdown');
+  });
+
+  it('publishes article with defaults and emits bus event', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset();
+    const updatedAsset = { ...asset, metadata: { article: { slug: 'hello-world', title: 'Hello World', status: 'POSTED', date: '2026-05-12' } } };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    const res = await patchArticle(
+      makeRequest({ slug: 'hello-world', title: 'Hello World' }),
+      'asset_test'
+    );
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.metadata).toEqual(updatedAsset.metadata);
+
+    expect(publish).toHaveBeenCalledWith(
+      'asset.article.published',
+      expect.objectContaining({
+        issuer: 'did:imajin:owner',
+        subject: 'did:imajin:owner',
+        scope: 'media',
+        payload: expect.objectContaining({
+          assetId: 'asset_test',
+          slug: 'hello-world',
+          title: 'Hello World',
+          status: 'POSTED',
+          date: expect.any(String),
+        }),
+      })
+    );
+  });
+
+  it('accepts all optional fields', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset();
+    const updatedAsset = {
+      ...asset,
+      metadata: {
+        article: {
+          slug: 'deep-dive',
+          title: 'A Deep Dive',
+          subtitle: 'Subtitle here',
+          description: 'Description here',
+          status: 'REVIEW',
+          date: '2026-06-01',
+          order: 5,
+        },
+      },
+    };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    const res = await patchArticle(
+      makeRequest({
+        slug: 'deep-dive',
+        title: 'A Deep Dive',
+        subtitle: 'Subtitle here',
+        description: 'Description here',
+        status: 'REVIEW',
+        date: '2026-06-01',
+        order: 5,
+      }),
+      'asset_test'
+    );
+    expect(res.status).toBe(200);
+
+    const setCall = vi.mocked(db.update).mock.calls;
+    expect(setCall.length).toBeGreaterThan(0);
+  });
+
+  it('merges article block into existing metadata', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset({ metadata: { source: 'editor', tags: ['tutorial'] } });
+    const updatedAsset = { ...asset };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    const res = await patchArticle(
+      makeRequest({ slug: 'merged', title: 'Merged' }),
+      'asset_test'
+    );
+    expect(res.status).toBe(200);
+
+    const setCall = vi.mocked(db.update).mock.calls;
+    expect(setCall.length).toBeGreaterThan(0);
+  });
+
+  it('supports acting-as impersonation', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({
+      identity: { id: 'did:imajin:agent', actingAs: 'did:imajin:owner', actingAsRole: 'admin' },
+    });
+    const asset = setupAsset();
+    const updatedAsset = { ...asset, metadata: { article: { slug: 'agent-post', title: 'Agent Post', status: 'POSTED', date: '2026-05-12' } } };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    const res = await patchArticle(
+      makeRequest({ slug: 'agent-post', title: 'Agent Post' }),
+      'asset_test'
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/kernel/src/lib/media/__tests__/grants-route.test.ts
+++ b/apps/kernel/src/lib/media/__tests__/grants-route.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { patchGrants } from '../routes/grants';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+const mockSet = vi.fn();
+const mockDbWhere = vi.fn();
+
+vi.mock('@/src/db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: mockFrom })),
+    update: vi.fn(() => ({ set: mockSet })),
+  },
+  assets: {},
+}));
+
+vi.mock('@imajin/auth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('@imajin/fair', () => ({
+  isFairManifestV1_1: vi.fn((m: unknown) => !!(m && typeof m === 'object' && 'version' in (m as object) && (m as { version: string }).version === '1.1')),
+}));
+
+vi.mock('@/src/lib/media/manifest-helpers', () => ({
+  updateManifestFlow: vi.fn(),
+}));
+
+vi.mock('@imajin/logger', () => ({
+  createLogger: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock('@/src/lib/kernel/cors', () => ({
+  corsHeaders: vi.fn(() => ({})),
+  corsOptions: vi.fn(() => new Response(null, { status: 204 })),
+}));
+
+import { requireAuth } from '@imajin/auth';
+import { updateManifestFlow } from '@/src/lib/media/manifest-helpers';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeRequest(body: unknown, url = 'https://test.imajin.ai/media/api/assets/asset_test/grants') {
+  return new Request(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupAsset(overrides: Record<string, unknown> = {}) {
+  const asset = {
+    id: 'asset_test',
+    ownerDid: 'did:imajin:owner',
+    status: 'active',
+    mimeType: 'image/png',
+    fairManifest: {
+      fair: '1.1',
+      version: '1.1',
+      access: { type: 'private' },
+    },
+    fairPath: '/mnt/media/test.fair.json',
+    fairDfosEventId: 'evt_old',
+    createdAt: new Date('2026-05-12T10:00:00Z'),
+    metadata: {},
+    ...overrides,
+  };
+
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockLimit.mockResolvedValue([asset]);
+
+  mockSet.mockReturnValue({ where: mockDbWhere });
+  mockDbWhere.mockResolvedValue(undefined);
+
+  return asset;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('PATCH /media/api/assets/[id]/grants', () => {
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ error: 'Not authenticated', status: 401 });
+
+    const res = await patchGrants(makeRequest({ add: ['did:imajin:friend'] }), 'asset_test');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when add and remove are both empty', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+
+    const res = await patchGrants(makeRequest({}), 'asset_test');
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('add or remove');
+  });
+
+  it('returns 404 when asset not found', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockResolvedValue([]);
+
+    const res = await patchGrants(makeRequest({ add: ['did:imajin:friend'] }), 'missing');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when user does not own the asset', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:intruder', actingAs: undefined } });
+    setupAsset();
+
+    const res = await patchGrants(makeRequest({ add: ['did:imajin:friend'] }), 'asset_test');
+    expect(res.status).toBe(403);
+  });
+
+  it('adds DIDs to allowedDids and switches to trust-graph', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset();
+    const updatedAsset = { ...asset };
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([updatedAsset]);
+
+    vi.mocked(updateManifestFlow).mockResolvedValueOnce({
+      signedManifest: {} as any,
+      dfosEventId: 'evt_new',
+    });
+
+    const res = await patchGrants(
+      makeRequest({ add: ['did:imajin:alice', 'did:imajin:bob'] }),
+      'asset_test'
+    );
+    expect(res.status).toBe(200);
+
+    const callArgs = vi.mocked(updateManifestFlow).mock.calls[0];
+    expect(callArgs[1].access).toEqual({
+      type: 'trust-graph',
+      allowedDids: ['did:imajin:alice', 'did:imajin:bob'],
+    });
+  });
+
+  it('merges add/remove with existing allowedDids, de-duping', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset({
+      fairManifest: {
+        fair: '1.1',
+        version: '1.1',
+        access: { type: 'trust-graph', allowedDids: ['did:imajin:alice', 'did:imajin:charlie'] },
+      },
+    });
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    vi.mocked(updateManifestFlow).mockResolvedValueOnce({
+      signedManifest: {} as any,
+      dfosEventId: 'evt_new',
+    });
+
+    const res = await patchGrants(
+      makeRequest({ add: ['did:imajin:bob', 'did:imajin:alice'], remove: ['did:imajin:charlie'] }),
+      'asset_test'
+    );
+    expect(res.status).toBe(200);
+
+    const callArgs = vi.mocked(updateManifestFlow).mock.calls[0];
+    expect(callArgs[1].access.allowedDids).toEqual(['did:imajin:alice', 'did:imajin:bob']);
+  });
+
+  it('removes all grants and keeps original access type when empty', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset({
+      fairManifest: {
+        fair: '1.1',
+        version: '1.1',
+        access: { type: 'trust-graph', allowedDids: ['did:imajin:alice'] },
+      },
+    });
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    vi.mocked(updateManifestFlow).mockResolvedValueOnce({
+      signedManifest: {} as any,
+      dfosEventId: 'evt_new',
+    });
+
+    const res = await patchGrants(
+      makeRequest({ remove: ['did:imajin:alice'] }),
+      'asset_test'
+    );
+    expect(res.status).toBe(200);
+
+    const callArgs = vi.mocked(updateManifestFlow).mock.calls[0];
+    expect(callArgs[1].access).toEqual({
+      type: 'trust-graph',
+      allowedDids: undefined,
+    });
+  });
+
+  it('filters non-string entries from add/remove arrays', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce({ identity: { id: 'did:imajin:owner', actingAs: undefined } });
+    const asset = setupAsset();
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    mockFrom.mockReturnValueOnce({ where: mockWhere });
+    mockWhere.mockReturnValueOnce({ limit: mockLimit });
+    mockLimit.mockResolvedValueOnce([asset]);
+
+    vi.mocked(updateManifestFlow).mockResolvedValueOnce({
+      signedManifest: {} as any,
+      dfosEventId: 'evt_new',
+    });
+
+    const res = await patchGrants(
+      makeRequest({ add: ['did:imajin:alice', 123, null, 'did:imajin:bob'] }),
+      'asset_test'
+    );
+    expect(res.status).toBe(200);
+
+    const callArgs = vi.mocked(updateManifestFlow).mock.calls[0];
+    expect(callArgs[1].access.allowedDids).toEqual(['did:imajin:alice', 'did:imajin:bob']);
+  });
+});

--- a/apps/kernel/src/lib/media/__tests__/manifest-helpers.test.ts
+++ b/apps/kernel/src/lib/media/__tests__/manifest-helpers.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+const mockWriteFile = vi.fn();
+const mockSignManifest = vi.fn();
+const mockCanonicalize = vi.fn((v: unknown) => JSON.stringify(v));
+const mockPublishContentEvent = vi.fn();
+const mockHexToBytes = vi.fn((hex: string) => new Uint8Array(hex.length / 2));
+const mockDbUpdate = vi.fn();
+const mockDbWhere = vi.fn();
+const mockSet = vi.fn();
+
+vi.mock('fs/promises', () => ({
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+}));
+
+vi.mock('@imajin/fair', () => ({
+  signManifest: (...args: unknown[]) => mockSignManifest(...args),
+  canonicalize: (v: unknown) => mockCanonicalize(v),
+  isFairManifestV1_1: vi.fn(),
+}));
+
+vi.mock('@imajin/dfos', () => ({
+  publishContentEvent: (...args: unknown[]) => mockPublishContentEvent(...args),
+}));
+
+vi.mock('@imajin/auth', () => ({
+  hexToBytes: (hex: string) => mockHexToBytes(hex),
+}));
+
+vi.mock('@imajin/logger', () => ({
+  createLogger: vi.fn(() => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  })),
+}));
+
+vi.mock('@/src/db', () => ({
+  db: {
+    update: vi.fn(() => ({ set: mockSet })),
+  },
+  assets: {},
+}));
+
+import {
+  getPlatformSigner,
+  signManifestWithPlatformKey,
+  writeManifestToDisk,
+  publishManifestDfosEvent,
+  updateManifestFlow,
+} from '../manifest-helpers';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.PLATFORM_DID = 'did:imajin:platform';
+  process.env.AUTH_PRIVATE_KEY = 'aabbccdd00112233';
+});
+
+afterEach(() => {
+  Object.assign(process.env, originalEnv);
+});
+
+function makeManifest(): import('@imajin/fair').FairManifestV1_1 {
+  return {
+    fair: '1.1',
+    version: '1.1',
+    id: 'asset_test123',
+    type: 'text/markdown',
+    owner: 'did:imajin:owner',
+    created: '2026-05-12T10:00:00.000Z',
+    access: { type: 'private' },
+    attribution: [{ did: 'did:imajin:owner', role: 'creator', share: 1 }],
+  };
+}
+
+// ─── getPlatformSigner ─────────────────────────────────────────────────────
+
+describe('getPlatformSigner', () => {
+  it('returns signer when env vars are set', () => {
+    const signer = getPlatformSigner();
+    expect(signer).not.toBeNull();
+    expect(signer?.did).toBe('did:imajin:platform');
+    expect(mockHexToBytes).toHaveBeenCalledWith('aabbccdd00112233');
+  });
+
+  it('returns null when PLATFORM_DID is missing', () => {
+    delete process.env.PLATFORM_DID;
+    expect(getPlatformSigner()).toBeNull();
+  });
+
+  it('returns null when AUTH_PRIVATE_KEY is missing', () => {
+    delete process.env.AUTH_PRIVATE_KEY;
+    expect(getPlatformSigner()).toBeNull();
+  });
+});
+
+// ─── signManifestWithPlatformKey ───────────────────────────────────────────
+
+describe('signManifestWithPlatformKey', () => {
+  it('signs manifest when signer is available', async () => {
+    const manifest = makeManifest();
+    const signed = { ...manifest, signature: { signer: 'did:imajin:platform', alg: 'ed25519' as const, value: 'sig', signedAt: 'now' } };
+    mockSignManifest.mockResolvedValueOnce(signed);
+
+    const result = await signManifestWithPlatformKey(manifest);
+    expect(mockSignManifest).toHaveBeenCalledWith(manifest, expect.objectContaining({ did: 'did:imajin:platform' }));
+    expect(result).toBe(signed);
+  });
+
+  it('returns unsigned manifest when signer is missing', async () => {
+    delete process.env.PLATFORM_DID;
+    const manifest = makeManifest();
+    const result = await signManifestWithPlatformKey(manifest);
+    expect(mockSignManifest).not.toHaveBeenCalled();
+    expect(result).toEqual(manifest);
+  });
+
+  it('falls back to unsigned manifest on signing error', async () => {
+    const manifest = makeManifest();
+    mockSignManifest.mockRejectedValueOnce(new Error('bad key'));
+
+    const result = await signManifestWithPlatformKey(manifest);
+    expect(result).toEqual(manifest);
+  });
+});
+
+// ─── writeManifestToDisk ───────────────────────────────────────────────────
+
+describe('writeManifestToDisk', () => {
+  it('writes JSON to the given path', async () => {
+    const manifest = makeManifest();
+    await writeManifestToDisk(manifest, '/tmp/test.fair.json');
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/tmp/test.fair.json',
+      JSON.stringify(manifest, null, 2)
+    );
+  });
+});
+
+// ─── publishManifestDfosEvent ──────────────────────────────────────────────
+
+describe('publishManifestDfosEvent', () => {
+  beforeEach(() => {
+    process.env.DFOS_RELAY_URL = 'https://relay.test.dfos';
+    process.env.DFOS_PRIVATE_KEY_HEX = '00112233aabbccdd';
+  });
+
+  it('publishes event and returns eventId', async () => {
+    mockPublishContentEvent.mockResolvedValueOnce({
+      eventId: 'evt_123',
+      anchoredAt: '2026-05-12T10:00:00.000Z',
+    });
+    mockCanonicalize.mockReturnValue('canonical');
+
+    const manifest = makeManifest();
+    const eventId = await publishManifestDfosEvent('asset_test', 'did:owner', manifest, 'https://media.imajin.ai');
+
+    expect(eventId).toBe('evt_123');
+    expect(mockPublishContentEvent).toHaveBeenCalledWith({
+      topic: 'fair.manifest.published',
+      payload: expect.objectContaining({
+        assetId: 'asset_test',
+        ownerDid: 'did:owner',
+        manifestDigest: expect.stringMatching(/^sha256:/),
+        manifestUrl: 'https://media.imajin.ai/media/api/assets/asset_test/fair',
+        fairVersion: '1.1',
+        signedAt: expect.any(String),
+      }),
+    });
+  });
+
+  it('returns null on publish error', async () => {
+    mockPublishContentEvent.mockRejectedValueOnce(new Error('relay down'));
+
+    const manifest = makeManifest();
+    const eventId = await publishManifestDfosEvent('asset_test', 'did:owner', manifest, 'https://media.imajin.ai');
+    expect(eventId).toBeNull();
+  });
+});
+
+// ─── updateManifestFlow ────────────────────────────────────────────────────
+
+describe('updateManifestFlow', () => {
+  beforeEach(() => {
+    process.env.DFOS_RELAY_URL = 'https://relay.test.dfos';
+    process.env.DFOS_PRIVATE_KEY_HEX = '00112233aabbccdd';
+
+    mockSet.mockReturnValue({ where: mockDbWhere });
+    mockDbWhere.mockResolvedValue(undefined);
+  });
+
+  it('runs full sign → write → publish → update flow', async () => {
+    const manifest = makeManifest();
+    const signed = { ...manifest, signature: { signer: 'did:imajin:platform', alg: 'ed25519' as const, value: 'sig', signedAt: 'now' } };
+    mockSignManifest.mockResolvedValueOnce(signed);
+    mockPublishContentEvent.mockResolvedValueOnce({
+      eventId: 'evt_flow',
+      anchoredAt: '2026-05-12T10:00:00.000Z',
+    });
+
+    const result = await updateManifestFlow(
+      {
+        id: 'asset_test',
+        ownerDid: 'did:owner',
+        fairPath: '/mnt/media/test.fair.json',
+        fairDfosEventId: null,
+      },
+      manifest,
+      'https://media.imajin.ai'
+    );
+
+    expect(result.signedManifest).toBe(signed);
+    expect(result.dfosEventId).toBe('evt_flow');
+    expect(mockWriteFile).toHaveBeenCalledWith('/mnt/media/test.fair.json', JSON.stringify(signed, null, 2));
+  });
+
+  it('skips disk write when fairPath is null', async () => {
+    const manifest = makeManifest();
+    mockSignManifest.mockResolvedValueOnce(manifest);
+    mockPublishContentEvent.mockResolvedValueOnce({
+      eventId: 'evt_nopath',
+      anchoredAt: '2026-05-12T10:00:00.000Z',
+    });
+
+    await updateManifestFlow(
+      {
+        id: 'asset_test',
+        ownerDid: 'did:owner',
+        fairPath: null,
+        fairDfosEventId: null,
+      },
+      manifest,
+      'https://media.imajin.ai'
+    );
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/kernel/src/lib/media/manifest-helpers.ts
+++ b/apps/kernel/src/lib/media/manifest-helpers.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared manifest helpers for media kernel endpoints.
+ *
+ * Extracts the common sign / write / publish / update flow so route
+ * handlers stay thin.
+ */
+
+import { writeFile } from "fs/promises";
+import { createHash } from "crypto";
+import { signManifest, canonicalize } from "@imajin/fair";
+import { publishContentEvent } from "@imajin/dfos";
+import { hexToBytes } from "@imajin/auth";
+import { createLogger } from "@imajin/logger";
+import type { FairManifest, FairManifestV1_1 } from "@imajin/fair";
+import { db, assets } from "@/src/db";
+import { eq } from "drizzle-orm";
+
+const log = createLogger("kernel");
+
+export interface PlatformSigner {
+  did: string;
+  privateKey: Uint8Array;
+}
+
+/**
+ * Resolve the platform signer from env vars.
+ * Returns null if either PLATFORM_DID or AUTH_PRIVATE_KEY is missing.
+ */
+export function getPlatformSigner(): PlatformSigner | null {
+  const platformDid = process.env.PLATFORM_DID;
+  const platformKeyHex = process.env.AUTH_PRIVATE_KEY;
+  if (!platformDid || !platformKeyHex) return null;
+  return { did: platformDid, privateKey: hexToBytes(platformKeyHex) };
+}
+
+/**
+ * Sign a manifest with the platform key.
+ * Falls back to the unsigned manifest if signing fails.
+ */
+export async function signManifestWithPlatformKey(
+  manifest: FairManifestV1_1
+): Promise<FairManifestV1_1> {
+  const signer = getPlatformSigner();
+  if (!signer) {
+    log.warn({}, "Platform signer not configured — manifest will be unsigned");
+    return manifest;
+  }
+  try {
+    return await signManifest(manifest, signer);
+  } catch (err) {
+    log.warn({ err: String(err) }, "Manifest signing failed, using unsigned manifest");
+    return manifest;
+  }
+}
+
+/**
+ * Write a manifest to disk as JSON.
+ */
+export async function writeManifestToDisk(
+  manifest: FairManifest,
+  fairPath: string
+): Promise<void> {
+  await writeFile(fairPath, JSON.stringify(manifest, null, 2));
+}
+
+/**
+ * Publish a fair.manifest.published DFOS event for the given manifest.
+ * Returns the eventId on success, null on failure (never throws).
+ */
+export async function publishManifestDfosEvent(
+  assetId: string,
+  ownerDid: string,
+  manifest: FairManifest,
+  baseUrl: string
+): Promise<string | null> {
+  const manifestUrl = `${baseUrl}/media/api/assets/${assetId}/fair`;
+  const manifestDigest = createHash("sha256")
+    .update(canonicalize(manifest))
+    .digest("hex");
+
+  try {
+    const result = await publishContentEvent({
+      topic: "fair.manifest.published",
+      payload: {
+        assetId,
+        ownerDid,
+        manifestDigest: `sha256:${manifestDigest}`,
+        manifestUrl,
+        fairVersion: (manifest as { fair?: string }).fair || "1.1",
+        signedAt: new Date().toISOString(),
+      },
+    });
+    return result.eventId;
+  } catch (err) {
+    log.error({ err: String(err), assetId }, "DFOS publish failed (non-fatal)");
+    return null;
+  }
+}
+
+/**
+ * Full manifest update flow: sign → write → publish → update DB.
+ *
+ * Returns the updated (signed) manifest and the DFOS event id (or null).
+ */
+export async function updateManifestFlow(
+  asset: {
+    id: string;
+    ownerDid: string;
+    fairPath: string | null;
+    fairDfosEventId: string | null;
+  },
+  manifest: FairManifestV1_1,
+  baseUrl: string
+): Promise<{ signedManifest: FairManifestV1_1; dfosEventId: string | null }> {
+  // 1. Sign
+  const signedManifest = await signManifestWithPlatformKey(manifest);
+
+  // 2. Write to disk (if we have a path)
+  if (asset.fairPath) {
+    await writeManifestToDisk(signedManifest, asset.fairPath);
+  }
+
+  // 3. Publish DFOS event
+  const dfosEventId = await publishManifestDfosEvent(
+    asset.id,
+    asset.ownerDid,
+    signedManifest,
+    baseUrl
+  );
+
+  // 4. Update DB
+  await db
+    .update(assets)
+    .set({
+      fairManifest: signedManifest,
+      fairDfosEventId: dfosEventId ?? asset.fairDfosEventId ?? null,
+      updatedAt: new Date(),
+    })
+    .where(eq(assets.id, asset.id));
+
+  return { signedManifest, dfosEventId };
+}

--- a/apps/kernel/src/lib/media/routes/access.ts
+++ b/apps/kernel/src/lib/media/routes/access.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, assets } from "@/src/db";
+import { requireAuth } from "@imajin/auth";
+import { eq } from "drizzle-orm";
+import { isFairManifestV1_1 } from "@imajin/fair";
+import type { FairManifestV1_1 } from "@imajin/fair";
+import { createLogger } from "@imajin/logger";
+import { updateManifestFlow } from "@/src/lib/media/manifest-helpers";
+import { corsHeaders } from "@/src/lib/kernel/cors";
+
+const log = createLogger("kernel");
+
+const ACCESS_TYPES = ["public", "private", "conversation"] as const;
+type AccessType = (typeof ACCESS_TYPES)[number];
+
+export async function patchAccess(
+  request: NextRequest,
+  id: string
+): Promise<NextResponse> {
+  const cors = corsHeaders(request);
+
+  // 1. Auth
+  const authResult = await requireAuth(request);
+  if ("error" in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
+
+  // 2. Parse body
+  let body: { access?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400, headers: cors }
+    );
+  }
+
+  const access = body.access;
+  if (!access || !ACCESS_TYPES.includes(access as AccessType)) {
+    return NextResponse.json(
+      { error: `access must be one of: ${ACCESS_TYPES.join(", ")}` },
+      { status: 400, headers: cors }
+    );
+  }
+
+  // 3. Load asset
+  let asset;
+  try {
+    [asset] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  } catch (err) {
+    log.error({ err: String(err) }, "DB lookup failed");
+    return NextResponse.json(
+      { error: "Database failure" },
+      { status: 500, headers: cors }
+    );
+  }
+
+  if (!asset || asset.status !== "active") {
+    return NextResponse.json({ error: "Not found" }, { status: 404, headers: cors });
+  }
+
+  if (asset.ownerDid !== requesterDid) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403, headers: cors });
+  }
+
+  // 4. Build updated manifest
+  let manifest: FairManifestV1_1;
+  if (
+    asset.fairManifest &&
+    typeof asset.fairManifest === "object" &&
+    Object.keys(asset.fairManifest as object).length > 0 &&
+    isFairManifestV1_1(asset.fairManifest as Record<string, unknown>)
+  ) {
+    manifest = { ...(asset.fairManifest as FairManifestV1_1) };
+  } else {
+    // Fallback: create a minimal v1.1 manifest from asset metadata
+    manifest = {
+      fair: "1.1",
+      version: "1.1",
+      id: asset.id,
+      type: asset.mimeType,
+      owner: asset.ownerDid,
+      created: (asset.createdAt ?? new Date()).toISOString(),
+      access: { type: "private" },
+      attribution: [{ did: asset.ownerDid, role: "creator", share: 1 }],
+    };
+  }
+
+  manifest.access = { type: access as AccessType };
+
+  // 5. Sign, write, publish, update DB
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.MEDIA_PUBLIC_URL ||
+    new URL(request.url).origin;
+
+  try {
+    await updateManifestFlow(
+      {
+        id: asset.id,
+        ownerDid: asset.ownerDid,
+        fairPath: asset.fairPath,
+        fairDfosEventId: asset.fairDfosEventId ?? null,
+      },
+      manifest,
+      baseUrl
+    );
+  } catch (err) {
+    log.error({ err: String(err), assetId: id }, "updateManifestFlow failed");
+    return NextResponse.json(
+      { error: "Failed to update manifest" },
+      { status: 500, headers: cors }
+    );
+  }
+
+  // 6. Return updated asset
+  const [updated] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  return NextResponse.json(updated, { status: 200, headers: cors });
+}

--- a/apps/kernel/src/lib/media/routes/article.ts
+++ b/apps/kernel/src/lib/media/routes/article.ts
@@ -1,0 +1,157 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, assets } from "@/src/db";
+import { requireAuth } from "@imajin/auth";
+import { eq } from "drizzle-orm";
+import { createLogger } from "@imajin/logger";
+import * as bus from "@imajin/bus";
+import { corsHeaders } from "@/src/lib/kernel/cors";
+
+const log = createLogger("kernel");
+
+const SLUG_REGEX = /^[a-z0-9-]+$/;
+const VALID_STATUSES = ["POSTED", "REVIEW", "DRAFT"] as const;
+type ArticleStatus = (typeof VALID_STATUSES)[number];
+
+export async function patchArticle(
+  request: NextRequest,
+  id: string
+): Promise<NextResponse> {
+  const cors = corsHeaders(request);
+
+  // 1. Auth
+  const authResult = await requireAuth(request);
+  if ("error" in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
+
+  // 2. Parse body
+  let body: {
+    slug?: unknown;
+    title?: unknown;
+    subtitle?: unknown;
+    description?: unknown;
+    status?: unknown;
+    date?: unknown;
+    order?: unknown;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400, headers: cors }
+    );
+  }
+
+  if (!body.slug || typeof body.slug !== "string" || !SLUG_REGEX.test(body.slug)) {
+    return NextResponse.json(
+      { error: "slug is required and must be URL-safe (a-z, 0-9, hyphens only)" },
+      { status: 400, headers: cors }
+    );
+  }
+  if (!body.title || typeof body.title !== "string" || !body.title.trim()) {
+    return NextResponse.json(
+      { error: "title is required" },
+      { status: 400, headers: cors }
+    );
+  }
+
+  const status: ArticleStatus =
+    body.status && VALID_STATUSES.includes(body.status as ArticleStatus)
+      ? (body.status as ArticleStatus)
+      : "POSTED";
+
+  const date =
+    body.date && typeof body.date === "string"
+      ? body.date
+      : new Date().toISOString().split("T")[0];
+
+  const order = typeof body.order === "number" ? body.order : undefined;
+
+  // 3. Load asset
+  let asset;
+  try {
+    [asset] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  } catch (err) {
+    log.error({ err: String(err) }, "DB lookup failed");
+    return NextResponse.json(
+      { error: "Database failure" },
+      { status: 500, headers: cors }
+    );
+  }
+
+  if (!asset || asset.status !== "active") {
+    return NextResponse.json({ error: "Not found" }, { status: 404, headers: cors });
+  }
+
+  if (asset.ownerDid !== requesterDid) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403, headers: cors });
+  }
+
+  // 4. Validate mime type
+  if (asset.mimeType !== "text/markdown") {
+    return NextResponse.json(
+      { error: "Asset must be text/markdown to publish as an article" },
+      { status: 400, headers: cors }
+    );
+  }
+
+  // 5. Merge article block into metadata
+  const existingMetadata =
+    asset.metadata && typeof asset.metadata === "object" ? (asset.metadata as Record<string, unknown>) : {};
+
+  const articleBlock = {
+    slug: body.slug,
+    title: body.title.trim(),
+    subtitle: typeof body.subtitle === "string" ? body.subtitle.trim() : undefined,
+    description: typeof body.description === "string" ? body.description.trim() : undefined,
+    status,
+    date,
+    ...(order !== undefined ? { order } : {}),
+  };
+
+  const metadata = {
+    ...existingMetadata,
+    article: articleBlock,
+  };
+
+  // 6. Update DB
+  try {
+    await db
+      .update(assets)
+      .set({ metadata, updatedAt: new Date() })
+      .where(eq(assets.id, id));
+  } catch (err) {
+    log.error({ err: String(err), assetId: id }, "DB update failed");
+    return NextResponse.json(
+      { error: "Database update failed" },
+      { status: 500, headers: cors }
+    );
+  }
+
+  // 7. Emit bus event (best-effort)
+  try {
+    await bus.publish("asset.article.published", {
+      issuer: requesterDid,
+      subject: asset.ownerDid,
+      scope: "media",
+      payload: {
+        assetId: id,
+        slug: body.slug,
+        title: body.title.trim(),
+        status,
+        date,
+      },
+    });
+  } catch (err) {
+    log.error({ err: String(err), assetId: id }, "Bus event publish failed (non-fatal)");
+  }
+
+  // 8. Return updated asset
+  const [updated] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  return NextResponse.json(updated, { status: 200, headers: cors });
+}

--- a/apps/kernel/src/lib/media/routes/grants.ts
+++ b/apps/kernel/src/lib/media/routes/grants.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db, assets } from "@/src/db";
+import { requireAuth } from "@imajin/auth";
+import { eq } from "drizzle-orm";
+import { isFairManifestV1_1 } from "@imajin/fair";
+import type { FairManifestV1_1 } from "@imajin/fair";
+import { createLogger } from "@imajin/logger";
+import { updateManifestFlow } from "@/src/lib/media/manifest-helpers";
+import { corsHeaders } from "@/src/lib/kernel/cors";
+
+const log = createLogger("kernel");
+
+export async function patchGrants(
+  request: NextRequest,
+  id: string
+): Promise<NextResponse> {
+  const cors = corsHeaders(request);
+
+  // 1. Auth
+  const authResult = await requireAuth(request);
+  if ("error" in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
+
+  // 2. Parse body
+  let body: { add?: unknown; remove?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400, headers: cors }
+    );
+  }
+
+  const add = Array.isArray(body.add) ? (body.add as unknown[]).filter((d): d is string => typeof d === "string") : [];
+  const remove = Array.isArray(body.remove) ? (body.remove as unknown[]).filter((d): d is string => typeof d === "string") : [];
+
+  if (add.length === 0 && remove.length === 0) {
+    return NextResponse.json(
+      { error: "add or remove must contain at least one DID string" },
+      { status: 400, headers: cors }
+    );
+  }
+
+  // 3. Load asset
+  let asset;
+  try {
+    [asset] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  } catch (err) {
+    log.error({ err: String(err) }, "DB lookup failed");
+    return NextResponse.json(
+      { error: "Database failure" },
+      { status: 500, headers: cors }
+    );
+  }
+
+  if (!asset || asset.status !== "active") {
+    return NextResponse.json({ error: "Not found" }, { status: 404, headers: cors });
+  }
+
+  if (asset.ownerDid !== requesterDid) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403, headers: cors });
+  }
+
+  // 4. Build updated manifest
+  let manifest: FairManifestV1_1;
+  if (
+    asset.fairManifest &&
+    typeof asset.fairManifest === "object" &&
+    Object.keys(asset.fairManifest as object).length > 0 &&
+    isFairManifestV1_1(asset.fairManifest as Record<string, unknown>)
+  ) {
+    manifest = { ...(asset.fairManifest as FairManifestV1_1) };
+  } else {
+    manifest = {
+      fair: "1.1",
+      version: "1.1",
+      id: asset.id,
+      type: asset.mimeType,
+      owner: asset.ownerDid,
+      created: (asset.createdAt ?? new Date()).toISOString(),
+      access: { type: "private" },
+      attribution: [{ did: asset.ownerDid, role: "creator", share: 1 }],
+    };
+  }
+
+  // Ensure access is an object
+  if (typeof manifest.access === "string") {
+    manifest.access = { type: manifest.access };
+  }
+
+  // Merge grants into allowedDids
+  const current = new Set(manifest.access.allowedDids ?? []);
+  for (const did of add) current.add(did);
+  for (const did of remove) current.delete(did);
+
+  // If grants exist, switch access type to trust-graph so allowedDids are honored
+  const hasGrants = current.size > 0;
+  manifest.access = {
+    type: hasGrants ? "trust-graph" : (manifest.access.type ?? "private"),
+    allowedDids: hasGrants ? Array.from(current) : undefined,
+  };
+
+  // 5. Sign, write, publish, update DB
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    process.env.MEDIA_PUBLIC_URL ||
+    new URL(request.url).origin;
+
+  try {
+    await updateManifestFlow(
+      {
+        id: asset.id,
+        ownerDid: asset.ownerDid,
+        fairPath: asset.fairPath,
+        fairDfosEventId: asset.fairDfosEventId ?? null,
+      },
+      manifest,
+      baseUrl
+    );
+  } catch (err) {
+    log.error({ err: String(err), assetId: id }, "updateManifestFlow failed");
+    return NextResponse.json(
+      { error: "Failed to update manifest" },
+      { status: 500, headers: cors }
+    );
+  }
+
+  // 6. Return updated asset
+  const [updated] = await db.select().from(assets).where(eq(assets.id, id)).limit(1);
+  return NextResponse.json(updated, { status: 200, headers: cors });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
   test: {
-    include: ['packages/*/tests/**/*.test.ts'],
+    include: ['packages/*/tests/**/*.test.ts', 'apps/**/__tests__/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@/': resolve(__dirname, 'apps/kernel/'),
+    },
   },
 });


### PR DESCRIPTION
Closes #933

## Summary

- Adds 3 new media kernel endpoints for asset control:
  - PATCH /media/api/assets/[id]/access - update access level (public/private/conversation)
  - PATCH /media/api/assets/[id]/grants - add/remove allowed DIDs (trust-graph access)
  - PATCH /media/api/assets/[id]/article - publish markdown assets as articles

- Extracts shared manifest logic (sign, write, DFOS publish, DB update) into `apps/kernel/src/lib/media/manifest-helpers.ts`

- Adds 41 unit/integration tests across all new routes and helpers

- Updates vitest.config.ts to include apps tests

## Notes
- X-Acting-As header support was already implemented in `packages/auth/src/require-auth.ts" (validates via auth service group controllers endpoint, sets `identity.actingAs` on success, returns 403 on failure)
- FairAccessV1_1 already has `allowedDids` field, so grants use that natively without schema changes