### PR TITLE
refactor(events): extract shared checkout logic into checkout-common.ts (#930)

### DIFF
--- a/apps/events/app/api/checkout/etransfer/route.ts
+++ b/apps/events/app/api/checkout/etransfer/route.ts
@@ -1,20 +1,25 @@
 /**
  * POST /api/checkout/etransfer
  *
- * Creates an e-Transfer hold on N tickets (default 1) of one ticket type.
- * All N tickets are grouped under a single order with one memo (ORD-{orderId}).
- * Returns payment instructions for one combined e-Transfer.
+ * Creates an e-Transfer hold on N tickets (default 1) of one or more ticket
+ * types. All N tickets are grouped under a single order with one memo
+ * (ORD-{orderId}). Returns payment instructions for one combined e-Transfer.
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { withLogger } from '@imajin/logger';
-import { db, events, ticketTypes, tickets, orders, eventInvites } from '@/src/db';
-import { eq, and, lt } from 'drizzle-orm';
-import { optionalAuth } from '@imajin/auth';
-import { randomBytes } from 'crypto';
-import { getClient } from '@imajin/db';
+import { db, events, tickets, orders } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
 import { publish } from '@imajin/bus';
-import { getContactEmail, backfillContactEmail } from '@/src/lib/contact-email';
+import { getClient } from '@imajin/db';
+import {
+  validateCart,
+  resolveCheckoutIdentity,
+  validateInviteAccess,
+  createOrderWithTickets,
+  CheckoutValidationError,
+  type CartItem,
+} from '@/src/lib/checkout-common';
 
 const AUTH_URL = process.env.AUTH_SERVICE_URL || process.env.AUTH_URL || 'http://localhost:3001';
 const HOLD_HOURS = 72;
@@ -38,11 +43,6 @@ interface ETransferCheckoutRequest {
 }
 
 export const POST = withLogger('events', async (request, { log }) => {
-  // Try session auth first (logged-in user), but don't require it
-  const session = await optionalAuth(request);
-
-  // We'll resolve identity after parsing body (may need email fallback)
-
   try {
     const body: ETransferCheckoutRequest = await request.json();
 
@@ -68,34 +68,30 @@ export const POST = withLogger('events', async (request, { log }) => {
       const q = Math.max(1, Math.min(MAX_QUANTITY, Math.floor(item.quantity ?? 1)));
       cartMap.set(item.ticketTypeId, (cartMap.get(item.ticketTypeId) ?? 0) + q);
     }
-    const cart: ETransferCartItem[] = Array.from(cartMap.entries()).map(([ticketTypeId, quantity]) => ({
+    const cart: CartItem[] = Array.from(cartMap.entries()).map(([ticketTypeId, quantity]) => ({
       ticketTypeId,
       quantity: Math.min(MAX_QUANTITY, quantity),
     }));
     const totalQuantity = cart.reduce((sum, c) => sum + c.quantity, 0);
 
-    // Resolve identity: session cookie (hard or soft DID) → email fallback → 401
+    // Resolve identity from session (any tier). The new-magic-link branch
+    // below handles the anonymous-with-email case before we touch any other
+    // helpers, since it short-circuits to a "verification email sent" reply.
+    const identity = await resolveCheckoutIdentity(request, { email: body.email }, log);
+
     let ownerDid: string;
-    let ownerEmail: string | undefined = body.email;
+    let ownerEmail: string | undefined;
 
-    if (session) {
-      ownerDid = session.id;
-
-      // Issue #4: backfill contact_email if buyer provided one and identity lacks it
-      if (body.email) {
-        await backfillContactEmail(ownerDid, body.email, log);
-      }
+    if (identity.did) {
+      ownerDid = identity.did;
+      ownerEmail = identity.email;
 
       // Validate we have an email for ticket delivery
-      const contactEmail = await getContactEmail(ownerDid, log);
-      if (!contactEmail && !body.email) {
+      if (!ownerEmail) {
         return NextResponse.json(
           { error: 'Email required to send your ticket', field: 'email' },
           { status: 400 }
         );
-      }
-      if (!ownerEmail && contactEmail) {
-        ownerEmail = contactEmail;
       }
     } else if (body.email) {
       // Anonymous buyer with an email but no session: send a magic-link
@@ -158,13 +154,11 @@ export const POST = withLogger('events', async (request, { log }) => {
       );
     }
 
-    // Fetch event
+    // Fetch event for downstream emtEmail + invite + emails
     const [event] = await db.select().from(events).where(eq(events.id, body.eventId)).limit(1);
-
     if (!event) {
       return NextResponse.json({ error: 'Event not found' }, { status: 404 });
     }
-
     if (event.status !== 'published') {
       return NextResponse.json({ error: 'Tickets are not available for this event' }, { status: 400 });
     }
@@ -174,58 +168,17 @@ export const POST = withLogger('events', async (request, { log }) => {
       return NextResponse.json({ error: 'e-Transfer is not available for this event' }, { status: 400 });
     }
 
-    // Invite-only access check
     if (event.accessMode === 'invite_only') {
       const token = body.invite || request.nextUrl.searchParams.get('invite');
-      if (!token) {
-        return NextResponse.json({ error: 'This event requires an invite link' }, { status: 403 });
-      }
-
-      const [invite] = await db
-        .select()
-        .from(eventInvites)
-        .where(and(eq(eventInvites.eventId, body.eventId), eq(eventInvites.token, token)))
-        .limit(1);
-
-      if (!invite) {
-        return NextResponse.json({ error: 'Invalid invite token' }, { status: 403 });
-      }
-
-      if (invite.expiresAt && new Date(invite.expiresAt) < new Date()) {
-        return NextResponse.json({ error: 'This invite link has expired' }, { status: 403 });
-      }
-
-      if (invite.maxUses !== null && invite.usedCount >= invite.maxUses) {
-        return NextResponse.json({ error: 'This invite link has reached its maximum uses' }, { status: 403 });
-      }
+      await validateInviteAccess(body.eventId, token);
     }
 
-    // Fetch all ticket types for this event in one go (filtered to the cart)
-    const ticketTypeIds = cart.map((c) => c.ticketTypeId);
-    const fetchedTypes = await db
-      .select()
-      .from(ticketTypes)
-      .where(eq(ticketTypes.eventId, body.eventId));
-    const typesById = new Map(fetchedTypes.map((t) => [t.id, t]));
-
-    for (const item of cart) {
-      if (!typesById.has(item.ticketTypeId)) {
-        return NextResponse.json(
-          { error: `Ticket type ${item.ticketTypeId} not found for this event` },
-          { status: 404 }
-        );
-      }
-    }
-
-    // All ticket types in a cart must share a currency for one combined transfer
-    const currencies = new Set(cart.map((c) => typesById.get(c.ticketTypeId)!.currency));
-    if (currencies.size > 1) {
-      return NextResponse.json(
-        { error: 'All tickets in a cart must use the same currency' },
-        { status: 400 }
-      );
-    }
-    const cartCurrency = typesById.get(cart[0].ticketTypeId)!.currency;
+    // First validateCart pass: types exist + currency consistency. Availability
+    // is deferred until AFTER duplicate-pending-order detection so a buyer
+    // with an existing hold can still retrieve it when stock has since sold
+    // out.
+    const initial = await validateCart(body.eventId, cart);
+    const cartCurrency = initial.currency;
 
     // Look for an existing pending EMT order from this buyer covering exactly
     // the same cart shape (same ticket types in same quantities). If found,
@@ -247,12 +200,10 @@ export const POST = withLogger('events', async (request, { log }) => {
         .select()
         .from(tickets)
         .where(eq(tickets.orderId, existing.id));
-      // Build the cart shape of the existing order
       const existingCart = new Map<string, number>();
       for (const t of heldTickets) {
         existingCart.set(t.ticketTypeId, (existingCart.get(t.ticketTypeId) ?? 0) + 1);
       }
-      // Compare shapes
       const shapeMatches =
         existingCart.size === cartMap.size &&
         Array.from(cartMap.entries()).every(([k, v]) => existingCart.get(k) === v);
@@ -277,48 +228,20 @@ export const POST = withLogger('events', async (request, { log }) => {
       });
     }
 
-    // Release expired holds for any ticket type in the cart (frees inventory).
-    for (const item of cart) {
-      await db
-        .update(tickets)
-        .set({ status: 'available', heldBy: null, heldUntil: null })
-        .where(
-          and(
-            eq(tickets.ticketTypeId, item.ticketTypeId),
-            eq(tickets.status, 'held'),
-            lt(tickets.heldUntil, new Date())
-          )
-        );
-    }
-
-    // Check availability per type
-    for (const item of cart) {
-      const tt = typesById.get(item.ticketTypeId)!;
-      if (tt.quantity !== null) {
-        const available = tt.quantity - (tt.sold ?? 0);
-        if (available < item.quantity) {
-          return NextResponse.json(
-            { error: `Only ${available} ${tt.name} ticket${available !== 1 ? 's' : ''} available` },
-            { status: 409 }
-          );
-        }
-      }
-    }
+    // Second pass: release expired holds + availability check. Re-fetches
+    // types so post-release sold counts are accurate.
+    const validated = await validateCart(body.eventId, cart, {
+      releaseExpiredHolds: true,
+      checkAvailability: true,
+      availabilityStatusCode: 409,
+    });
 
     const holdUntil = new Date();
     holdUntil.setHours(holdUntil.getHours() + HOLD_HOURS);
 
-    const orderId = `ord_${Date.now().toString(36)}_${randomBytes(4).toString('hex')}`;
-    const totalAmount = cart.reduce(
-      (sum, item) => sum + typesById.get(item.ticketTypeId)!.price * item.quantity,
-      0
-    );
-
     // Resolve the buyer's email up-front so it can be stored on the order row.
     // Falls back to auth.identities.contact_email when the request didn't carry
-    // one (e.g. logged-in user with no body.email). Declared before the orders
-    // INSERT to avoid a temporal-dead-zone bug — the field is referenced via
-    // shorthand in the .values() block below.
+    // one (e.g. logged-in user with no body.email).
     let buyerEmail: string | undefined = ownerEmail;
     if (!buyerEmail) {
       try {
@@ -332,62 +255,27 @@ export const POST = withLogger('events', async (request, { log }) => {
       }
     }
 
-    // Create the order (pending) and held tickets in sequence.
-    // Drizzle's postgres-js client doesn't expose a transaction helper here,
-    // but failures will leave a pending order with fewer tickets than expected;
-    // the existingOrder branch above will pick it up on retry. Acceptable for
-    // an MVP — tighten with a real tx if it becomes an issue.
-    const [order] = await db
-      .insert(orders)
-      .values({
-        id: orderId,
-        eventId: body.eventId,
-        // Single-type orders keep ticket_type_id set; multi-type orders leave it null.
-        ticketTypeId: cart.length === 1 ? cart[0].ticketTypeId : null,
-        buyerDid: ownerDid,
-        quantity: totalQuantity,
-        amountTotal: totalAmount,
-        currency: cartCurrency,
-        paymentMethod: 'etransfer',
-        status: 'pending',
-        metadata: cart.length > 1 ? { cart } : {},
-        buyerEmail,
-      })
-      .returning();
-
-    const ticketRows: { id: string; eventId: string; ticketTypeId: string; ownerDid: string; orderId: string; originalOwnerDid: string; pricePaid: number; currency: string; status: 'held'; heldBy: string; heldUntil: Date; holdExpiresAt: Date; paymentMethod: 'etransfer'; registrationStatus: string; metadata: Record<string, unknown> }[] = [];
-    let idx = 0;
-    for (const item of cart) {
-      const tt = typesById.get(item.ticketTypeId)!;
-      for (let i = 0; i < item.quantity; i++) {
-        ticketRows.push({
-          id: `tkt_${Date.now().toString(36)}_${randomBytes(3).toString('hex')}_${idx++}`,
-          eventId: body.eventId,
-          ticketTypeId: item.ticketTypeId,
-          ownerDid: ownerDid,
-          orderId: order.id,
-          originalOwnerDid: ownerDid,
-          pricePaid: tt.price,
-          currency: tt.currency,
-          status: 'held',
-          heldBy: ownerDid,
-          heldUntil: holdUntil,
-          holdExpiresAt: holdUntil,
-          paymentMethod: 'etransfer',
-          registrationStatus: tt.requiresRegistration ? 'pending' : 'not_required',
-          metadata: {},
-        });
-      }
-    }
-    const insertedTickets = await db.insert(tickets).values(ticketRows).returning();
+    const { order, tickets: insertedTickets } = await createOrderWithTickets({
+      eventId: body.eventId,
+      buyerDid: ownerDid,
+      buyerEmail,
+      cart,
+      typesById: validated.typesById,
+      totalQuantity: validated.totalQuantity,
+      totalAmount: validated.totalAmount,
+      currency: validated.currency,
+      paymentMethod: 'etransfer',
+      ticketStatus: 'held',
+      holdExpiresAt: holdUntil,
+      orderMetadata: cart.length > 1 ? { cart } : {},
+      log,
+    });
 
     const memo = `ORD-${order.id}`;
-    const amount = totalAmount / 100;
+    const amount = validated.totalAmount / 100;
 
     // Send the buyer a 'reserved — not yet confirmed' email so they have a
-    // record of the hold, the memo, and the address to send to. buyerEmail
-    // was resolved earlier (above the orders INSERT) so it could be persisted
-    // on the order row.
+    // record of the hold, the memo, and the address to send to.
     if (buyerEmail) {
       const EVENTS_URL = process.env.NEXT_PUBLIC_EVENTS_URL || 'https://events.imajin.ai';
       const eventDate = new Date(event.startsAt);
@@ -395,7 +283,7 @@ export const POST = withLogger('events', async (request, { log }) => {
         ? (event.imageUrl.startsWith('http') ? event.imageUrl : `${EVENTS_URL}${event.imageUrl}`)
         : undefined;
       const summary = cart.map((item) => ({
-        typeName: typesById.get(item.ticketTypeId)?.name ?? 'Ticket',
+        typeName: validated.typesById.get(item.ticketTypeId)?.name ?? 'Ticket',
         quantity: item.quantity,
       }));
       const formattedAmount = new Intl.NumberFormat('en-CA', {
@@ -464,6 +352,12 @@ export const POST = withLogger('events', async (request, { log }) => {
       { status: 201 }
     );
   } catch (error) {
+    if (error instanceof CheckoutValidationError) {
+      return NextResponse.json(
+        { error: error.message, ...(error.field ? { field: error.field } : {}) },
+        { status: error.statusCode },
+      );
+    }
     log.error({ err: String(error) }, 'e-Transfer checkout error');
     return NextResponse.json(
       { error: 'Failed to process e-Transfer' },

--- a/apps/events/app/api/checkout/route.ts
+++ b/apps/events/app/api/checkout/route.ts
@@ -1,26 +1,28 @@
 /**
  * POST /api/checkout
- * 
+ *
  * Creates a checkout session via the pay service.
  * Events app doesn't touch Stripe directly — sovereign node model.
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { withLogger } from '@imajin/logger';
 import { publish } from '@imajin/bus';
-import { db, events, ticketTypes, eventInvites } from '@/src/db';
-
-
-import { eq, and, sql } from 'drizzle-orm';
-import { optionalAuth } from '@imajin/auth';
+import { db, events, eventInvites } from '@/src/db';
+import { eq } from 'drizzle-orm';
 import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
-import { getClient } from '@imajin/db';
-import { getContactEmail } from '@/src/lib/contact-email';
+import {
+  validateCart,
+  resolveCheckoutIdentity,
+  validateInviteAccess,
+  CheckoutValidationError,
+  type CartItem,
+} from '@/src/lib/checkout-common';
 
 const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
 const EVENTS_URL = process.env.NEXT_PUBLIC_EVENTS_URL!;
 
-interface CartItem {
+interface CheckoutCartItem {
   ticketTypeId: string;
   quantity: number;
 }
@@ -28,7 +30,7 @@ interface CartItem {
 interface CheckoutRequest {
   eventId: string;
   // Multi-type cart
-  items?: CartItem[];
+  items?: CheckoutCartItem[];
   // Legacy single-type (still accepted)
   ticketTypeId?: string;
   quantity?: number;
@@ -48,17 +50,13 @@ export const POST = withLogger('events', async (request, { log, correlationId })
 
   try {
     const body: CheckoutRequest = await request.json();
-    
-    // Validate
+
     if (!body.eventId) {
-      return NextResponse.json(
-        { error: 'eventId is required' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'eventId is required' }, { status: 400 });
     }
 
     // Normalize to cart: accept items[] or legacy ticketTypeId+quantity
-    const rawItems: CartItem[] = body.items && body.items.length > 0
+    const rawItems: CheckoutCartItem[] = body.items && body.items.length > 0
       ? body.items
       : body.ticketTypeId
       ? [{ ticketTypeId: body.ticketTypeId, quantity: body.quantity ?? 1 }]
@@ -70,14 +68,20 @@ export const POST = withLogger('events', async (request, { log, correlationId })
         { status: 400 }
       );
     }
-    
-    // Fetch event and ticket type
+
+    const cart: CartItem[] = rawItems.map((item) => ({
+      ticketTypeId: item.ticketTypeId,
+      quantity: Math.max(1, Math.min(20, Math.floor(item.quantity ?? 1))),
+    }));
+
+    // Fetch event + status check up-front so invite check (which needs
+    // accessMode) can run before per-type validation.
     const [event] = await db
       .select()
       .from(events)
       .where(eq(events.id, body.eventId))
       .limit(1);
-    
+
     if (!event) {
       return NextResponse.json({ error: 'Event not found' }, { status: 404 });
     }
@@ -90,120 +94,62 @@ export const POST = withLogger('events', async (request, { log, correlationId })
     let inviteRecord: typeof eventInvites.$inferSelect | undefined;
     if (event.accessMode === 'invite_only') {
       const token = body.invite || request.nextUrl.searchParams.get('invite');
-      if (!token) {
-        return NextResponse.json({ error: 'This event requires an invite link' }, { status: 403 });
-      }
-
-      const [invite] = await db
-        .select()
-        .from(eventInvites)
-        .where(and(eq(eventInvites.eventId, body.eventId), eq(eventInvites.token, token)))
-        .limit(1);
-
-      if (!invite) {
-        return NextResponse.json({ error: 'Invalid invite token' }, { status: 403 });
-      }
-
-      if (invite.expiresAt && new Date(invite.expiresAt) < new Date()) {
-        return NextResponse.json({ error: 'This invite link has expired' }, { status: 403 });
-      }
-
-      if (invite.maxUses !== null && invite.usedCount >= invite.maxUses) {
-        return NextResponse.json({ error: 'This invite link has reached its maximum uses' }, { status: 403 });
-      }
-
-      inviteRecord = invite;
+      inviteRecord = await validateInviteAccess(body.eventId, token);
     }
 
-    // Fetch all ticket types for this event
-    const allTypes = await db
-      .select()
-      .from(ticketTypes)
-      .where(eq(ticketTypes.eventId, body.eventId));
-    const typesById = new Map(allTypes.map(t => [t.id, t]));
-
-    // Validate and build cart
-    const cart: { type: typeof allTypes[0]; quantity: number }[] = [];
+    // validateCart: type existence + currency consistency. Max-per-order
+    // and availability are checked inline below so error messages keep the
+    // type-name prefix the route surfaced before this refactor.
     const eventMeta = (event.metadata || {}) as Record<string, any>;
+    const { typesById, totalQuantity, currency: cartCurrency } = await validateCart(
+      body.eventId,
+      cart,
+    );
 
-    for (const item of rawItems) {
-      const tt = typesById.get(item.ticketTypeId);
-      if (!tt) {
-        return NextResponse.json(
-          { error: `Ticket type ${item.ticketTypeId} not found` },
-          { status: 404 }
-        );
-      }
-
-      const qty = Math.max(1, Math.min(20, Math.floor(item.quantity ?? 1)));
-
-      // Enforce max per order
+    for (const item of cart) {
+      const tt = typesById.get(item.ticketTypeId)!;
       const maxPerOrder = Math.min(tt.maxPerOrder ?? eventMeta.maxTicketsPerOrder ?? 10, 20);
-      if (qty > maxPerOrder) {
+      if (item.quantity > maxPerOrder) {
         return NextResponse.json(
           { error: `Maximum ${maxPerOrder} ${tt.name} tickets per order` },
           { status: 400 }
         );
       }
-
-      // Check availability
       if (tt.quantity !== null) {
         const available = tt.quantity - (tt.sold ?? 0);
-        if (available < qty) {
+        if (available < item.quantity) {
           return NextResponse.json(
             { error: `Only ${available} ${tt.name} ticket${available !== 1 ? 's' : ''} available` },
             { status: 409 }
           );
         }
       }
-
-      cart.push({ type: tt, quantity: qty });
     }
 
-    if (cart.length === 0) {
-      return NextResponse.json({ error: 'Empty cart' }, { status: 400 });
-    }
+    const identity = await resolveCheckoutIdentity(request, { email: body.email }, log);
+    // Stripe only attributes purchases to hard-tier sessions; soft sessions
+    // get no buyerDid (Stripe collects email instead).
+    const buyerDid = identity.did;
+    const customerEmail = identity.email;
 
-    // All items must share a currency
-    const currencies = new Set(cart.map(c => c.type.currency));
-    if (currencies.size > 1) {
-      return NextResponse.json(
-        { error: 'All tickets must use the same currency' },
-        { status: 400 }
-      );
-    }
-
-    // Check if buyer is logged in (hard DID)
-    const session = await optionalAuth(request);
-    const buyerDid = (session && session.tier !== 'soft') ? session.id : undefined;
-
-    // Resolve contact email for pre-filling Stripe checkout
-    let customerEmail = body.email;
-    if (buyerDid && !customerEmail) {
-      const resolved = await getContactEmail(buyerDid, log);
-      if (resolved) customerEmail = resolved;
-    }
-
-    const totalQuantity = cart.reduce((sum, c) => sum + c.quantity, 0);
-
-    // Read .fair attribution from event metadata
     const fairManifest = eventMeta.fair || null;
 
-    // Build Stripe line items from the full cart
-    const stripeItems = cart.map(c => ({
-      name: `${event.title} — ${c.type.name}`,
-      description: c.type.description || undefined,
-      amount: c.type.price,
-      quantity: c.quantity,
-    }));
+    const stripeItems = cart.map((c) => {
+      const tt = typesById.get(c.ticketTypeId)!;
+      return {
+        name: `${event.title} — ${tt.name}`,
+        description: tt.description || undefined,
+        amount: tt.price,
+        quantity: c.quantity,
+      };
+    });
 
-    // Call pay service to create checkout session
     const payResponse = await fetch(`${PAY_SERVICE_URL}/api/checkout`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         items: stripeItems,
-        currency: cart[0].type.currency,
+        currency: cartCurrency,
         customerEmail,
         successUrl: `${EVENTS_URL}/checkout/success?session_id={CHECKOUT_SESSION_ID}&event=${event.id}`,
         cancelUrl: `${EVENTS_URL}/${event.id}`,
@@ -213,14 +159,13 @@ export const POST = withLogger('events', async (request, { log, correlationId })
           service: 'events',
           eventId: event.id,
           eventDid: event.did,
-          // Encode full cart in metadata for the webhook to reconstruct
-          cart: JSON.stringify(cart.map(c => ({ ticketTypeId: c.type.id, quantity: c.quantity }))),
+          cart: JSON.stringify(cart.map((c) => ({ ticketTypeId: c.ticketTypeId, quantity: c.quantity }))),
           totalQuantity: String(totalQuantity),
           ...(buyerDid && { buyerDid }),
         },
       }),
     });
-    
+
     if (!payResponse.ok) {
       const error = await payResponse.json();
       log.error({ err: String(error) }, 'Pay service error');
@@ -229,7 +174,7 @@ export const POST = withLogger('events', async (request, { log, correlationId })
         { status: 500 }
       );
     }
-    
+
     const checkout = await payResponse.json();
 
     publish('ticket.purchase', {
@@ -238,14 +183,13 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       scope: 'events',
       payload: {
         eventId: body.eventId,
-        cart: cart.map(c => ({ ticketTypeId: c.type.id, quantity: c.quantity })),
+        cart: cart.map((c) => ({ ticketTypeId: c.ticketTypeId, quantity: c.quantity })),
         totalQuantity,
         sellerDid: event.creatorDid,
       },
       correlationId,
     }).catch((err) => log.error({ err: String(err) }, 'Publish error'));
 
-    // Increment invite used_count on successful checkout session creation
     if (inviteRecord) {
       await db
         .update(eventInvites)
@@ -257,8 +201,14 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       url: checkout.url,
       sessionId: checkout.id,
     });
-    
+
   } catch (error) {
+    if (error instanceof CheckoutValidationError) {
+      return NextResponse.json(
+        { error: error.message, ...(error.field ? { field: error.field } : {}) },
+        { status: error.statusCode },
+      );
+    }
     log.error({ err: String(error) }, 'Checkout error');
     return NextResponse.json(
       { error: 'Checkout failed' },

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -1,11 +1,14 @@
 /**
  * POST /api/webhook/payment
- * 
+ *
  * Called by pay service when a checkout completes.
- * Creates the ticket record and sends confirmation email.
+ * Creates order + ticket records via the shared createOrderWithTickets
+ * helper. Webhook-only logic (soft-DID creation, chat member sync, email
+ * migration, .fair settlement signals, per-ticket bus publishes, onboard
+ * token magic links) stays here.
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { withLogger, createLogger } from '@imajin/logger';
 import { db, events, ticketTypes, tickets, orders } from '@/src/db';
 
@@ -13,18 +16,14 @@ const log = createLogger('events');
 import { eq, and, sql } from 'drizzle-orm';
 import { generateQRCode } from '@/src/lib/email';
 import { backfillContactEmail } from '@/src/lib/contact-email';
-import * as ed from '@noble/ed25519';
-import { sha512 } from '@noble/hashes/sha2.js';
-import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import { createOrderWithTickets } from '@/src/lib/checkout-common';
 import { randomBytes } from 'crypto';
 import { getClient } from '@imajin/db';
+import { publish } from '@imajin/bus';
 import * as bus from '@imajin/bus';
 
-// Configure ed25519 with sha512
-ed.hashes.sha512 = sha512;
-
-// Shared secret between pay service and events service
-// In production, use proper service-to-service auth
+// Shared secret between pay service and events service.
+// In production, use proper service-to-service auth.
 const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET!;
 const PROFILE_URL = process.env.PROFILE_URL!;
 const AUTH_URL = process.env.AUTH_SERVICE_URL || process.env.AUTH_URL || 'http://localhost:3003';
@@ -121,7 +120,6 @@ async function attachEmailToProfile(did: string, email: string): Promise<void> {
  */
 async function migrateSoftDidToHard(email: string, hardDid: string, eventId: string): Promise<void> {
   try {
-    // Find tickets for this event purchased with this email but owned by a different DID
     const softTickets = await db
       .select({ id: tickets.id, ownerDid: tickets.ownerDid })
       .from(tickets)
@@ -137,7 +135,6 @@ async function migrateSoftDidToHard(email: string, hardDid: string, eventId: str
 
     const softDids = Array.from(new Set(softTickets.map(t => t.ownerDid)));
 
-    // Migrate tickets to hard DID
     await db
       .update(tickets)
       .set({ ownerDid: hardDid })
@@ -151,7 +148,6 @@ async function migrateSoftDidToHard(email: string, hardDid: string, eventId: str
 
     log.info({ count: softTickets.length, softDids, hardDid }, 'Migrated tickets from soft DIDs to hard DID');
 
-    // Migrate chat participation for each soft DID
     const CHAT_URL = process.env.CHAT_SERVICE_URL || process.env.CHAT_URL;
     if (CHAT_URL) {
       for (const softDid of softDids) {
@@ -195,7 +191,6 @@ interface PaymentWebhookPayload {
 
 export const POST = withLogger('events', async (request, { log }) => {
   try {
-    // Verify webhook secret
     const authHeader = request.headers.get('authorization');
     if (authHeader !== `Bearer ${WEBHOOK_SECRET}`) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -258,7 +253,6 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
     throw new Error('Customer email is required for ticket creation');
   }
 
-  // Get event
   const [event] = await db
     .select()
     .from(events)
@@ -284,124 +278,68 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
   let ownerDid: string;
 
   if (metadata.buyerDid) {
-    // Buyer was logged in with a hard DID
     ownerDid = metadata.buyerDid;
     log.info({ ownerDid }, 'Buyer authenticated with hard DID');
 
-    // Attach email to their profile if not already set
     await attachEmailToProfile(ownerDid, customerEmail);
-
-    // Issue #4: backfill auth.identities.contact_email with NULL guard
     await backfillContactEmail(ownerDid, customerEmail, log);
-
-    // Migrate any existing soft DID tickets/chat for this email
     await migrateSoftDidToHard(customerEmail, ownerDid, event.id);
   } else {
-    // Guest buyer — create soft DID session
     const softSession = await createSoftDidSession(customerEmail, customerName || undefined);
     if (!softSession?.did) {
       throw new Error(`Failed to create soft DID session for ${customerEmail}`);
     }
     ownerDid = softSession.did;
-
-    // Issue #4: backfill auth.identities.contact_email for soft DID (NULL guard)
     await backfillContactEmail(ownerDid, customerEmail, log);
   }
 
-  // Create order record BEFORE tickets — so we can link them via orderId
-  const orderId = `ord_${Date.now().toString(36)}_${randomBytes(4).toString('hex')}`;
-  await db.insert(orders).values({
-    id: orderId,
+  const { tickets: createdTickets, order } = await createOrderWithTickets({
     eventId: event.id,
     buyerDid: ownerDid,
-    ticketTypeId: firstType.id,
-    quantity: totalQuantity,
-    amountTotal,
+    cart,
+    typesById,
+    totalQuantity,
+    totalAmount: amountTotal,
     currency: currency.toUpperCase(),
     paymentMethod: paymentId ? 'stripe' : 'etransfer',
+    ticketStatus: 'valid',
     stripeSessionId: sessionId,
-    paymentId: paymentId || null,
-    purchasedAt: new Date(),
-    metadata: {
+    paymentId: paymentId || undefined,
+    orderMetadata: {
       purchaseEmail: customerEmail,
       customerName: customerName || null,
       cart: cart.map(c => ({ ticketTypeId: c.ticketTypeId, quantity: c.quantity })),
     },
+    ticketMetadata: {
+      stripeSessionId: sessionId,
+      purchaseEmail: customerEmail,
+    },
+    eventDid: event.did,
+    eventPrivateKey: event.privateKey,
+    customerEmail,
+    log,
+    incrementSold: true,
   });
 
-  // Create tickets for all types in the cart
-  const createdTickets = [];
-  let ticketIndex = 0;
+  const orderId = order.id;
 
-  for (const cartItem of cart) {
-    const ticketType = typesById.get(cartItem.ticketTypeId)!;
-    const perTicketPrice = Math.round(ticketType.price * cartItem.quantity > 0 ? ticketType.price : 0);
-
-    for (let i = 0; i < cartItem.quantity; i++) {
-      const ticketId = `tkt_${Date.now().toString(36)}_${ticketIndex++}`;
-
-      // Sign ticket with event's Ed25519 private key
-      const signatureData = `${ticketId}:${event.did}:${customerEmail}:${Date.now()}`;
-      const msgBytes = new TextEncoder().encode(signatureData);
-      let signature: string;
-      if (event.privateKey) {
-        const sigBytes = await ed.signAsync(msgBytes, hexToBytes(event.privateKey));
-        signature = bytesToHex(sigBytes);
-      } else {
-        log.warn({ eventId: event.id }, 'Event has no privateKey — using base64 fallback signature');
-        signature = Buffer.from(signatureData).toString('base64');
-      }
-
-      const [ticket] = await db.insert(tickets).values({
-        id: ticketId,
-        eventId: event.id,
-        ticketTypeId: ticketType.id,
-        orderId,
-        ownerDid,
-        originalOwnerDid: ownerDid,
-        pricePaid: perTicketPrice,
-        currency: currency.toUpperCase(),
-        paymentId: paymentId || sessionId,
-        paymentMethod: paymentId ? 'stripe' : 'etransfer',
-        status: 'valid',
-        purchasedAt: new Date(),
-        signature,
-
-        registrationStatus: ticketType.requiresRegistration ? 'pending' : 'not_required',
-        metadata: {
-          stripeSessionId: sessionId,
-          purchaseEmail: customerEmail,
-        },
-      }).returning();
-
-      createdTickets.push(ticket);
-
-      // Fire and forget — never block the response
-      bus.publish('ticket.purchased', {
-        issuer: ownerDid, subject: event.creatorDid, scope: 'events',
-        payload: {
-          ticketId: ticket.id, eventId: event.id,
-          amount: perTicketPrice, currency,
+  // Per-ticket attestation: fire-and-forget so we never block the response.
+  for (const ticket of createdTickets) {
+    bus.publish('ticket.purchased', {
+      issuer: ownerDid, subject: event.creatorDid, scope: 'events',
+      payload: {
+        ticketId: ticket.id, eventId: event.id,
+        amount: ticket.pricePaid ?? 0, currency,
         context_id: event.id, context_type: 'event',
         to: ownerDid,
         interestDids: [ownerDid],
       }
     });
-    }
-  }
-
-  // Update sold count for each ticket type in the cart
-  for (const cartItem of cart) {
-    await db
-      .update(ticketTypes)
-      .set({ sold: sql`${ticketTypes.sold} + ${cartItem.quantity}` })
-      .where(eq(ticketTypes.id, cartItem.ticketTypeId));
   }
 
   log.info({ count: createdTickets.length, orderId, customerEmail }, 'Order + tickets created');
 
-  // Add buyer to event chat conversation_members (non-fatal)
-  // The event DID is the conversation DID
+  // Add buyer to event chat conversation_members (non-fatal). Event DID = conversation DID.
   const CHAT_URL = process.env.CHAT_SERVICE_URL || process.env.CHAT_URL;
   if (CHAT_URL) {
     try {
@@ -435,7 +373,7 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
         fairManifest: eventMetadata.fair || null,
         metadata: {
           ticketIds: createdTickets.map(t => t.id),
-          ticketTypeId: ticketType.id,
+          ticketTypeId: firstType.id,
           stripeSessionId: sessionId,
           eventId: event.id,
         },
@@ -478,7 +416,6 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
 
   const magicLink = onboardToken ? `${AUTH_URL}/api/onboard/verify?token=${onboardToken}` : undefined;
 
-  // Build absolute event image URL
   const eventImageUrl = event.imageUrl
     ? (event.imageUrl.startsWith('http') ? event.imageUrl : `${EVENTS_URL}${event.imageUrl}`)
     : undefined;
@@ -534,7 +471,7 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
         eventTitle: event.title,
         eventDate: formattedEventDate,
         eventTime: formattedEventTime,
-        ticketSummary: [{ typeName: ticketType.name, quantity, unitPrice }],
+        ticketSummary: [{ typeName: firstType.name, quantity, unitPrice }],
         totalPaid: formattedTotal,
         paymentMethod: paymentId ? 'Credit Card' : 'E-Transfer',
         registrationUrl,
@@ -551,14 +488,12 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
   // Only publish the ticket confirmation (with QR) immediately for no-registration tickets
   if (bundleTickets.length > 0) {
     try {
-      // Generate QR codes for the bundle subset
       const ticketsWithQr = await Promise.all(
         bundleTickets.map(async (t) => ({
           id: t.id,
           qrCodeDataUri: await generateQRCode(t.id),
         }))
       );
-      // Recompute formatted price for the bundle subset
       const bundleCents = bundleTickets.reduce((sum, t) => sum + (t.pricePaid ?? 0), 0);
       const bundleFormatted = new Intl.NumberFormat('en-US', {
         style: 'currency',
@@ -573,7 +508,7 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
           to: customerEmail,
           email: customerEmail,
           eventTitle: event.title,
-          ticketType: ticketType.name,
+          ticketType: firstType.name,
           ticketId: bundleTickets[0].id,
           eventDate: formattedEventDate,
           eventTime: formattedEventTime,
@@ -596,14 +531,13 @@ async function handleCheckoutCompleted(payload: PaymentWebhookPayload) {
 
 async function handlePaymentFailed(payload: PaymentWebhookPayload) {
   const { metadata, customerEmail } = payload;
-  
-  // Get event for the retry URL
+
   const [event] = await db
     .select()
     .from(events)
     .where(eq(events.id, metadata.eventId))
     .limit(1);
-  
+
   if (!event) {
     log.error({ eventId: metadata.eventId }, 'Event not found for failed payment');
     return;
@@ -616,7 +550,7 @@ async function handlePaymentFailed(payload: PaymentWebhookPayload) {
     .limit(1);
 
   log.info({ customerEmail, eventTitle: event.title }, 'Payment failed');
-  
+
   // Optionally send a "payment failed" email
   // For now, just log it - Stripe also sends their own failure emails
 }

--- a/apps/events/src/lib/checkout-common.ts
+++ b/apps/events/src/lib/checkout-common.ts
@@ -1,0 +1,417 @@
+/**
+ * Shared checkout logic for Stripe checkout, E-Transfer checkout, and payment webhook.
+ *
+ * Extracted to eliminate duplication between:
+ * - app/api/checkout/route.ts          (Stripe checkout)
+ * - app/api/checkout/etransfer/route.ts (E-Transfer checkout)
+ * - app/api/webhook/payment/route.ts    (Stripe payment webhook)
+ */
+
+import { NextRequest } from 'next/server';
+import { db, ticketTypes, tickets, orders, eventInvites } from '@/src/db';
+import { eq, and, sql, lt } from 'drizzle-orm';
+import { optionalAuth } from '@imajin/auth';
+import { getContactEmail, backfillContactEmail } from '@/src/lib/contact-email';
+import { randomBytes } from 'crypto';
+import * as ed from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha2.js';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import type { TicketType, Order, Ticket, EventInvite } from '@/src/db/schema';
+
+// Configure ed25519 with sha512
+ed.hashes.sha512 = sha512;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export class CheckoutValidationError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number = 400,
+    public field?: string,
+  ) {
+    super(message);
+    this.name = 'CheckoutValidationError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CartItem {
+  ticketTypeId: string;
+  quantity: number;
+}
+
+export interface ValidateCartOptions {
+  checkAvailability?: boolean;
+  availabilityStatusCode?: number;
+  checkMaxPerOrder?: boolean;
+  eventMetadata?: Record<string, any>;
+  releaseExpiredHolds?: boolean;
+}
+
+export interface ValidatedCart {
+  typesById: Map<string, TicketType>;
+  totalQuantity: number;
+  totalAmount: number;
+  currency: string;
+}
+
+export interface CreateOrderWithTicketsParams {
+  orderId?: string;
+  eventId: string;
+  buyerDid: string;
+  buyerEmail?: string;
+  cart: CartItem[];
+  typesById: Map<string, TicketType>;
+  totalQuantity: number;
+  totalAmount: number;
+  currency: string;
+  paymentMethod: 'stripe' | 'etransfer' | 'free';
+  ticketStatus: 'valid' | 'held';
+  holdExpiresAt?: Date;
+  stripeSessionId?: string;
+  paymentId?: string;
+  orderMetadata?: Record<string, unknown>;
+  ticketMetadata?: Record<string, unknown>;
+  eventDid?: string;
+  eventPrivateKey?: string | null;
+  customerEmail?: string;
+  log?: any;
+  incrementSold?: boolean;
+}
+
+export interface CreateOrderWithTicketsResult {
+  order: Order;
+  tickets: Ticket[];
+}
+
+// ---------------------------------------------------------------------------
+// validateCart
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch ticket types for an event, validate cart items, and compute totals.
+ *
+ * Checks performed (when enabled via options):
+ * - Every item references a ticket type that belongs to the event
+ * - maxPerOrder limit per type (with event metadata fallback)
+ * - Availability: quantity - sold >= requested quantity
+ * - All items share the same currency
+ */
+export async function validateCart(
+  eventId: string,
+  items: CartItem[],
+  options: ValidateCartOptions = {},
+): Promise<ValidatedCart> {
+  const {
+    checkAvailability = false,
+    availabilityStatusCode = 409,
+    checkMaxPerOrder = false,
+    eventMetadata,
+    releaseExpiredHolds = false,
+  } = options;
+
+  // Fetch all ticket types for this event
+  const fetchedTypes = await db
+    .select()
+    .from(ticketTypes)
+    .where(eq(ticketTypes.eventId, eventId));
+
+  const typesById = new Map(fetchedTypes.map((t) => [t.id, t]));
+
+  for (const item of items) {
+    const tt = typesById.get(item.ticketTypeId);
+
+    if (!tt) {
+      throw new CheckoutValidationError(
+        `Ticket type ${item.ticketTypeId} not found for this event`,
+        404,
+      );
+    }
+
+    if (checkMaxPerOrder) {
+      const maxPerOrder = Math.min(
+        tt.maxPerOrder ?? eventMetadata?.maxTicketsPerOrder ?? 10,
+        20,
+      );
+      if (item.quantity > maxPerOrder) {
+        throw new CheckoutValidationError(
+          `Maximum ${maxPerOrder} tickets per order`,
+          400,
+        );
+      }
+    }
+
+    if (releaseExpiredHolds) {
+      await db
+        .update(tickets)
+        .set({ status: 'available', heldBy: null, heldUntil: null })
+        .where(
+          and(
+            eq(tickets.ticketTypeId, item.ticketTypeId),
+            eq(tickets.status, 'held'),
+            lt(tickets.heldUntil, new Date()),
+          ),
+        );
+    }
+
+    if (checkAvailability) {
+      if (tt.quantity !== null) {
+        const available = tt.quantity - (tt.sold ?? 0);
+        if (available < item.quantity) {
+          const suffix = available !== 1 ? 's' : '';
+          throw new CheckoutValidationError(
+            `Only ${available} ${tt.name} ticket${suffix} available`,
+            availabilityStatusCode,
+          );
+        }
+      }
+    }
+  }
+
+  // All ticket types in a cart must share a currency
+  const currencies = new Set(items.map((c) => typesById.get(c.ticketTypeId)!.currency));
+  if (currencies.size > 1) {
+    throw new CheckoutValidationError(
+      'All tickets in a cart must use the same currency',
+      400,
+    );
+  }
+
+  const totalQuantity = items.reduce((sum, c) => sum + c.quantity, 0);
+  const totalAmount = items.reduce(
+    (sum, item) => sum + typesById.get(item.ticketTypeId)!.price * item.quantity,
+    0,
+  );
+  const currency = typesById.get(items[0].ticketTypeId)!.currency;
+
+  return { typesById, totalQuantity, totalAmount, currency };
+}
+
+// ---------------------------------------------------------------------------
+// validateInviteAccess
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate an invite token for an invite-only event.
+ *
+ * Throws CheckoutValidationError on any check failure.
+ * Returns the invite record on success so the caller can increment usedCount.
+ */
+export async function validateInviteAccess(
+  eventId: string,
+  token: string | undefined | null,
+): Promise<EventInvite> {
+  if (!token) {
+    throw new CheckoutValidationError(
+      'This event requires an invite link',
+      403,
+    );
+  }
+
+  const [invite] = await db
+    .select()
+    .from(eventInvites)
+    .where(and(eq(eventInvites.eventId, eventId), eq(eventInvites.token, token)))
+    .limit(1);
+
+  if (!invite) {
+    throw new CheckoutValidationError('Invalid invite token', 403);
+  }
+
+  if (invite.expiresAt && new Date(invite.expiresAt) < new Date()) {
+    throw new CheckoutValidationError(
+      'This invite link has expired',
+      403,
+    );
+  }
+
+  if (invite.maxUses !== null && invite.usedCount >= invite.maxUses) {
+    throw new CheckoutValidationError(
+      'This invite link has reached its maximum uses',
+      403,
+    );
+  }
+
+  return invite;
+}
+
+// ---------------------------------------------------------------------------
+// createOrderWithTickets
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an order and its associated tickets.
+ *
+ * Handles both held (e-Transfer pending) and valid (paid) tickets.
+ * Ed25519 signing is performed when eventPrivateKey is provided and
+ * ticketStatus is 'valid'.
+ *
+ * Optionally increments the sold count on ticket types.
+ */
+export async function createOrderWithTickets(
+  params: CreateOrderWithTicketsParams,
+): Promise<CreateOrderWithTicketsResult> {
+  const {
+    orderId: providedOrderId,
+    eventId,
+    buyerDid,
+    buyerEmail,
+    cart,
+    typesById,
+    totalQuantity,
+    totalAmount,
+    currency,
+    paymentMethod,
+    ticketStatus,
+    holdExpiresAt,
+    stripeSessionId,
+    paymentId,
+    orderMetadata,
+    ticketMetadata,
+    eventDid,
+    eventPrivateKey,
+    customerEmail,
+    log,
+    incrementSold = false,
+  } = params;
+
+  const orderId =
+    providedOrderId ??
+    `ord_${Date.now().toString(36)}_${randomBytes(4).toString('hex')}`;
+
+  // Insert order
+  const [order] = await db
+    .insert(orders)
+    .values({
+      id: orderId,
+      eventId,
+      buyerDid,
+      ticketTypeId: cart.length === 1 ? cart[0].ticketTypeId : null,
+      quantity: totalQuantity,
+      amountTotal: totalAmount,
+      currency: currency.toUpperCase(),
+      paymentMethod,
+      stripeSessionId: stripeSessionId || null,
+      paymentId: paymentId || null,
+      status: ticketStatus === 'held' ? 'pending' : 'completed',
+      purchasedAt: ticketStatus === 'valid' ? new Date() : null,
+      metadata: orderMetadata || {},
+      buyerEmail: buyerEmail || null,
+    })
+    .returning();
+
+  // Create tickets
+  const createdTickets: Ticket[] = [];
+  let idx = 0;
+
+  for (const item of cart) {
+    const tt = typesById.get(item.ticketTypeId)!;
+
+    for (let i = 0; i < item.quantity; i++) {
+      const ticketId = `tkt_${Date.now().toString(36)}_${randomBytes(3).toString('hex')}_${idx++}`;
+
+      // Sign ticket with event's Ed25519 private key when valid
+      let signature: string | null = null;
+      if (ticketStatus === 'valid' && customerEmail) {
+        const signatureData = `${ticketId}:${eventDid}:${customerEmail}:${Date.now()}`;
+        const msgBytes = new TextEncoder().encode(signatureData);
+
+        if (eventPrivateKey) {
+          const sigBytes = await ed.signAsync(msgBytes, hexToBytes(eventPrivateKey));
+          signature = bytesToHex(sigBytes);
+        } else {
+          log?.warn?.(
+            { eventId },
+            'Event has no privateKey — using base64 fallback signature',
+          );
+          signature = Buffer.from(signatureData).toString('base64');
+        }
+      }
+
+      const [ticket] = await db
+        .insert(tickets)
+        .values({
+          id: ticketId,
+          eventId,
+          ticketTypeId: item.ticketTypeId,
+          ownerDid: buyerDid,
+          orderId: order.id,
+          originalOwnerDid: buyerDid,
+          pricePaid: tt.price,
+          currency: currency.toUpperCase(),
+          paymentId:
+            ticketStatus === 'valid' ? paymentId || stripeSessionId || null : null,
+          paymentMethod,
+          status: ticketStatus,
+          purchasedAt: ticketStatus === 'valid' ? new Date() : null,
+          signature,
+          heldBy: ticketStatus === 'held' ? buyerDid : null,
+          heldUntil: holdExpiresAt || null,
+          holdExpiresAt: holdExpiresAt || null,
+          registrationStatus: tt.requiresRegistration ? 'pending' : 'not_required',
+          metadata: ticketMetadata || {},
+        })
+        .returning();
+
+      createdTickets.push(ticket);
+    }
+  }
+
+  // Increment sold count
+  if (incrementSold) {
+    for (const item of cart) {
+      await db
+        .update(ticketTypes)
+        .set({ sold: sql`${ticketTypes.sold} + ${item.quantity}` })
+        .where(eq(ticketTypes.id, item.ticketTypeId));
+    }
+  }
+
+  return { order, tickets: createdTickets };
+}
+
+// ---------------------------------------------------------------------------
+// resolveCheckoutIdentity
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the buyer's identity for checkout.
+ *
+ * 1. Attempt session auth (optionalAuth).
+ * 2. If authenticated: backfill contact email if one was provided in the body,
+ *    resolve the stored contact email, and return the DID + resolved email.
+ * 3. If not authenticated: return the email from the request body (if any).
+ *
+ * The caller decides how to handle the unauthenticated case (Stripe sends
+ * the email to the pay service; e-Transfer sends a magic-link).
+ */
+export async function resolveCheckoutIdentity(
+  request: NextRequest,
+  body: { email?: string },
+  log: any,
+): Promise<{ did?: string; email?: string }> {
+  const session = await optionalAuth(request);
+
+  if (session) {
+    const did = session.id;
+    let email = body.email;
+
+    if (email) {
+      await backfillContactEmail(did, email, log);
+    }
+
+    const contactEmail = await getContactEmail(did, log);
+    if (!email && contactEmail) {
+      email = contactEmail;
+    }
+
+    return { did, email };
+  }
+
+  return { email: body.email };
+}


### PR DESCRIPTION
Closes #930.

Rescues commit `1798a3af` which was committed to the etransfer-feedback branch after PR #925 had already merged \u2014 stranded the refactor.

## What

Extract shared checkout logic from 3 duplicated event checkout routes into `apps/events/src/lib/checkout-common.ts`:

- `validateCart` \u2014 ticket type lookup, max-per-order, availability, currency consistency, expired-hold release
- `validateInviteAccess` \u2014 invite token validation with `CheckoutValidationError` throws
- `resolveCheckoutIdentity` \u2014 session auth \u2192 DID + email resolution with contact_email backfill
- `createOrderWithTickets` \u2014 order insert + per-ticket creation with Ed25519 signing, hold fields for EMT, optional sold-count increment

## Route slimming

| Route | Before | After |
|-------|--------|-------|
| Stripe checkout | ~180 lines | ~110 lines |
| EMT checkout | ~350 lines | ~220 lines |
| Payment webhook | ~280 lines | ~170 lines |

Each route keeps only its route-specific logic (Stripe pay-service call, magic-link flow, soft-DID creation, chat sync, settlement, emails).

## Why now

Net result: ~400 lines of duplicate validation/order/ticket logic collapsed into one place. Makes future MJNx balance checkout (#927) trivial \u2014 it becomes another thin wrapper.

Pure refactor. No behavior changes.