### PR TITLE
fix(auth): require-app-auth was double-prefixing /auth in validate URL

### DIFF
--- a/packages/auth/src/require-app-auth.ts
+++ b/packages/auth/src/require-app-auth.ts
@@ -45,7 +45,9 @@ export async function requireAppAuth(
   }
 
   try {
-    const res = await fetch(`${authUrl}/auth/api/apps/validate`, {
+    // AUTH_SERVICE_URL already includes the `/auth` prefix (consistent with
+    // require-auth.ts and session.ts which use `${authUrl}/api/...`)
+    const res = await fetch(`${authUrl}/api/apps/validate`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Problem

External apps using `X-App-DID` + `X-App-Authorization` headers got 404 "Invalid app authorization" on every kernel call. Karaoke couldn't list any events even though the user had authorized it correctly with `events:read` scope.

## Root cause

`AUTH_SERVICE_URL` is configured with the `/auth` prefix (`http://localhost:7000/auth`). Other consumers (`require-auth.ts`, `session.ts`) build URLs like `\${authUrl}/api/session`.

`require-app-auth.ts` was doing `\${authUrl}/auth/api/apps/validate`, doubling the prefix and hitting a 404.

## Fix

One-line change: drop the redundant `/auth` segment in the fetch URL.