### PR TITLE
fix(events): checkout flow bug fixes

### DIFF
--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -702,6 +702,7 @@ function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken
           cartCurrencies={cartCurrencies}
           userOrders={userOrders}
           onJumpToMyTickets={onJumpToMyTickets}
+          clearCart={() => setQuantities({})}
         />
       )}
 
@@ -766,7 +767,7 @@ interface UnifiedBarProps {
   onJumpToMyTickets?: () => void;
 }
 
-function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [], onJumpToMyTickets }: UnifiedBarProps & { userOrders?: UserOrder[] }) {
+function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [], onJumpToMyTickets, clearCart }: UnifiedBarProps & { userOrders?: UserOrder[]; clearCart?: () => void }) {
   // Issue #11: count tickets needing registration across all user orders
   const pendingRegistrations = userOrders.flatMap(o =>
     o.tickets.filter(t => t.registrationStatus === 'pending' && t.ticketType?.registrationFormId)
@@ -947,6 +948,9 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
         deadline: data.instructions.deadline,
         message: data.instructions.message,
       });
+      // Clear the cart so the emt-done panel renders immediately (it gates on
+      // totalQty === 0 to allow new cart composition after a reservation).
+      clearCart?.();
       setStep('emt-done');
       // Don't call router.refresh() here — it causes the component tree to
       // restructure (tabs appear) which unmounts the emt-done card before the
@@ -1037,6 +1041,7 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
               deadline: reserveData.instructions.deadline,
               message: reserveData.instructions.message,
             });
+            clearCart?.();
             setStep('emt-done');
             // Don't router.refresh() here — same reason as startEtransfer.
             // The "View My Tickets" button in emt-done handles it.

--- a/apps/events/app/checkout/success/auto-redirect.tsx
+++ b/apps/events/app/checkout/success/auto-redirect.tsx
@@ -17,7 +17,9 @@ export function AutoRedirect({ href, seconds }: Props) {
       setCountdown(prev => {
         if (prev <= 1) {
           clearInterval(timer);
-          router.push(href);
+          // Use window.location for hash navigation so the browser scrolls
+          // to the anchor naturally (router.push doesn't scroll to hash)
+          window.location.href = href;
           return 0;
         }
         return prev - 1;

--- a/apps/events/app/checkout/success/page.tsx
+++ b/apps/events/app/checkout/success/page.tsx
@@ -81,12 +81,12 @@ export default async function SuccessPage({ searchParams }: Props) {
             You must complete the registration form before your tickets are confirmed.
           </p>
           <Link
-            href={`/${event.id}`}
+            href={`/${event.id}#tickets`}
             className="inline-block px-6 py-3 bg-red-500 hover:bg-red-600 text-white text-sm font-bold rounded-lg transition"
           >
             Complete Registration Now →
           </Link>
-          <AutoRedirect href={`/${event.id}`} seconds={5} />
+          <AutoRedirect href={`/${event.id}#tickets`} seconds={5} />
         </div>
       )}
 

--- a/apps/events/app/checkout/success/page.tsx
+++ b/apps/events/app/checkout/success/page.tsx
@@ -86,14 +86,14 @@ export default async function SuccessPage({ searchParams }: Props) {
           >
             Complete Registration Now →
           </Link>
-          <AutoRedirect href={`/${event.id}#tickets`} seconds={5} />
+          <AutoRedirect href={`/${event.id}#tickets`} seconds={10} />
         </div>
       )}
 
       <div className="flex flex-col sm:flex-row gap-4 justify-center">
         {event ? (
           <Link
-            href={`/${event.id}`}
+            href={`/${event.id}#tickets`}
             className="inline-block px-8 py-3 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition font-semibold text-lg"
           >
             Go to the Event →


### PR DESCRIPTION
Two bug fixes found during checkout testing:

### 1. EMT reservation info card flash
After clicking "Pay by e-Transfer" and the reservation succeeds, the EMT info card would flash briefly then disappear. Required a page refresh to see it.

**Cause:** The emt-done panel gates on `totalQty === 0` to allow new cart composition after a reservation. But cart quantities weren't cleared after a successful reservation, so totalQty was still >0 and the panel fell through to the regular checkout bar.

**Fix:** Call `clearCart()` after setting emtResult in both the direct EMT path and the post-verification polling path.

### 2. Post-Stripe checkout redirect doesn't scroll to tickets
After returning from Stripe, the success page shows a registration warning with a 5-second auto-redirect. The redirect went to the event page root — user had to manually scroll down to find their tickets.

**Fix:** Changed redirect target from `/{eventId}` to `/{eventId}#tickets`. The tickets section already has `id="tickets"`. Also switched AutoRedirect from `router.push` to `window.location.href` so the browser handles hash scrolling natively. Since `hasTicket` is true post-purchase, the "My Tickets" tab shows by default.