### PR TITLE
feat(pay): EMT → MJNx fiat on-ramp (#715)

### DIFF
--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -702,6 +702,7 @@ function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken
           cartCurrencies={cartCurrencies}
           userOrders={userOrders}
           onJumpToMyTickets={onJumpToMyTickets}
+          clearCart={() => setQuantities({})}
         />
       )}
 
@@ -766,7 +767,7 @@ interface UnifiedBarProps {
   onJumpToMyTickets?: () => void;
 }
 
-function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [], onJumpToMyTickets }: UnifiedBarProps & { userOrders?: UserOrder[] }) {
+function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [], onJumpToMyTickets, clearCart }: UnifiedBarProps & { userOrders?: UserOrder[]; clearCart?: () => void }) {
   // Issue #11: count tickets needing registration across all user orders
   const pendingRegistrations = userOrders.flatMap(o =>
     o.tickets.filter(t => t.registrationStatus === 'pending' && t.ticketType?.registrationFormId)
@@ -947,6 +948,9 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
         deadline: data.instructions.deadline,
         message: data.instructions.message,
       });
+      // Clear the cart so the emt-done panel renders immediately (it gates on
+      // totalQty === 0 to allow new cart composition after a reservation).
+      clearCart?.();
       setStep('emt-done');
       // Don't call router.refresh() here — it causes the component tree to
       // restructure (tabs appear) which unmounts the emt-done card before the
@@ -1037,6 +1041,7 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
               deadline: reserveData.instructions.deadline,
               message: reserveData.instructions.message,
             });
+            clearCart?.();
             setStep('emt-done');
             // Don't router.refresh() here — same reason as startEtransfer.
             // The "View My Tickets" button in emt-done handles it.

--- a/apps/events/app/[eventId]/tickets-section.tsx
+++ b/apps/events/app/[eventId]/tickets-section.tsx
@@ -522,6 +522,16 @@ function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken
   const [unlockError, setUnlockError] = useState<string | null>(null);
   const { toast } = useToast();
 
+  // MJNx balance for authenticated buyers
+  const [buyerBalance, setBuyerBalance] = useState<number | null>(null);
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    apiFetch('/api/balance')
+      .then(r => r.json())
+      .then(d => setBuyerBalance(d.balance ?? 0))
+      .catch(() => {});
+  }, [isAuthenticated]);
+
   // Lifted quantity state for unified cart
   const [quantities, setQuantities] = useState<Record<string, number>>({});
 
@@ -703,6 +713,7 @@ function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken
           userOrders={userOrders}
           onJumpToMyTickets={onJumpToMyTickets}
           clearCart={() => setQuantities({})}
+          buyerBalance={buyerBalance}
         />
       )}
 
@@ -765,9 +776,10 @@ interface UnifiedBarProps {
   mixedCurrency?: boolean;
   cartCurrencies?: string[];
   onJumpToMyTickets?: () => void;
+  buyerBalance?: number | null;
 }
 
-function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [], onJumpToMyTickets, clearCart }: UnifiedBarProps & { userOrders?: UserOrder[]; clearCart?: () => void }) {
+function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formattedTotal, etransferEnabled, sessionEmail, sessionContactEmail, onError, mixedCurrency = false, cartCurrencies = [], userOrders = [], onJumpToMyTickets, clearCart, buyerBalance = null }: UnifiedBarProps & { userOrders?: UserOrder[]; clearCart?: () => void }) {
   // Issue #11: count tickets needing registration across all user orders
   const pendingRegistrations = userOrders.flatMap(o =>
     o.tickets.filter(t => t.registrationStatus === 'pending' && t.ticketType?.registrationFormId)
@@ -778,7 +790,7 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
   const hasPendingRegistrations = totalPendingCount > 0;
 
   const router = useRouter();
-  type BarStep = 'idle' | 'card-loading' | 'emt-form' | 'emt-loading' | 'emt-done' | 'emt-verify-sent';
+  type BarStep = 'idle' | 'card-loading' | 'emt-form' | 'emt-loading' | 'emt-done' | 'emt-verify-sent' | 'balance-loading';
 
   // EMT reservation results are persisted in sessionStorage so a tab refresh
   // doesn't wipe the 'send your e-Transfer to confirm' screen. Scoped per
@@ -958,6 +970,36 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
       // emt-done card handles refresh when the user is ready.
     } catch {
       onError('e-Transfer setup failed');
+      setStep('idle');
+    }
+  }
+
+  const totalAmountDollars = cartItems.reduce((sum, item) => sum + item.ticket.price * item.qty, 0) / 100;
+
+  async function startBalance() {
+    setStep('balance-loading');
+    try {
+      const res = await apiFetch('/api/checkout/balance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventId,
+          items: cartItems.map(c => ({ ticketTypeId: c.ticket.id, quantity: c.qty })),
+          ...(inviteToken && { invite: inviteToken }),
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        onError(data.error || 'Balance checkout failed');
+        setStep('idle');
+        return;
+      }
+      const data = await res.json();
+      // Balance checkout is instant — go straight to success
+      router.push(`/checkout/success?event=${eventId}`);
+      router.refresh();
+    } catch {
+      onError('Balance checkout failed');
       setStep('idle');
     }
   }
@@ -1283,6 +1325,19 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
           >
             {step === 'card-loading' ? 'Loading…' : totalQty === 0 ? '💳 Pay with Card' : `💳 Pay with Card — ${formattedTotal}`}
           </button>
+          {buyerBalance !== null && buyerBalance > 0 && (
+            <button
+              onClick={startBalance}
+              disabled={totalQty === 0 || mixedCurrency || buyerBalance < totalAmountDollars || step !== 'idle'}
+              className={`px-5 py-2.5 rounded-lg font-semibold transition whitespace-nowrap border ${
+                totalQty === 0 || buyerBalance < totalAmountDollars
+                  ? 'bg-gray-100 dark:bg-gray-800 text-gray-400 border-gray-200 dark:border-gray-700 cursor-not-allowed'
+                  : 'bg-green-500/20 text-green-500 border-green-500/40 hover:bg-green-500/30'
+              }`}
+            >
+              {step === 'balance-loading' ? 'Processing…' : `💰 Pay with Balance — $${buyerBalance.toFixed(2)}`}
+            </button>
+          )}
           {etransferEnabled && (
             <button
               onClick={startEtransfer}

--- a/apps/events/app/api/balance/route.ts
+++ b/apps/events/app/api/balance/route.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /api/balance
+ *
+ * Proxy route that fetches the authenticated buyer's MJNx balance from the
+ * pay service. Exists because the buyer's DID isn't available client-side
+ * and the pay service may be on a different origin.
+ */
+
+import { NextResponse } from 'next/server';
+import { withLogger } from '@imajin/logger';
+import { requireAuth } from '@imajin/auth';
+
+const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
+
+export const GET = withLogger('events', async (request, { log }) => {
+  try {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+    const buyerDid = authResult.identity.actingAs || authResult.identity.id;
+
+    const payRes = await fetch(
+      `${PAY_SERVICE_URL}/pay/api/balance/${encodeURIComponent(buyerDid)}`,
+      {
+        headers: {
+          'Cookie': request.headers.get('cookie') || '',
+        },
+      },
+    );
+
+    if (!payRes.ok) {
+      // If the pay service returns 404 (no balance record), treat as zero
+      if (payRes.status === 404) {
+        return NextResponse.json({ balance: 0, currency: 'CAD' });
+      }
+      log.warn({ status: payRes.status }, 'Failed to fetch balance from pay service');
+      return NextResponse.json({ balance: 0, currency: 'CAD' });
+    }
+
+    const data = await payRes.json();
+    return NextResponse.json({
+      balance: data.total ?? 0,
+      currency: data.currency ?? 'CAD',
+    });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Balance check error');
+    return NextResponse.json({ balance: 0, currency: 'CAD' });
+  }
+});

--- a/apps/events/app/api/checkout/balance/route.ts
+++ b/apps/events/app/api/checkout/balance/route.ts
@@ -1,0 +1,280 @@
+/**
+ * POST /api/checkout/balance
+ *
+ * Pays for tickets using the buyer's MJNx balance. Transfers funds from
+ * buyer → event creator via the pay service, then creates an order with
+ * instantly-valid tickets (no hold period — payment is immediate).
+ */
+
+import { NextResponse } from 'next/server';
+import { withLogger } from '@imajin/logger';
+import { requireAuth } from '@imajin/auth';
+import { db, events, eventInvites } from '@/src/db';
+import { eq, and, sql } from 'drizzle-orm';
+import { publish } from '@imajin/bus';
+import { getClient } from '@imajin/db';
+import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
+import {
+  validateCart,
+  validateInviteAccess,
+  createOrderWithTickets,
+  CheckoutValidationError,
+  type CartItem,
+} from '@/src/lib/checkout-common';
+
+const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
+const MAX_QUANTITY = 20;
+
+interface BalanceCheckoutRequest {
+  eventId: string;
+  ticketTypeId?: string;
+  quantity?: number;
+  items?: { ticketTypeId: string; quantity: number }[];
+  invite?: string;
+}
+
+export const POST = withLogger('events', async (request, { log }) => {
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 10, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { 'Retry-After': String(rl.retryAfter) } },
+    );
+  }
+
+  try {
+    // Auth required — buyer must be logged in
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
+      return NextResponse.json({ error: authResult.error }, { status: authResult.status });
+    }
+    const buyerDid = authResult.identity.actingAs || authResult.identity.id;
+
+    const body: BalanceCheckoutRequest = await request.json();
+
+    if (!body.eventId) {
+      return NextResponse.json({ error: 'eventId is required' }, { status: 400 });
+    }
+
+    // Normalize to cart (same pattern as Stripe/EMT routes)
+    const rawItems = body.items && body.items.length > 0
+      ? body.items
+      : body.ticketTypeId
+        ? [{ ticketTypeId: body.ticketTypeId, quantity: body.quantity ?? 1 }]
+        : [];
+
+    if (rawItems.length === 0) {
+      return NextResponse.json({ error: 'items or ticketTypeId is required' }, { status: 400 });
+    }
+
+    // Coalesce duplicates and clamp quantities
+    const cartMap = new Map<string, number>();
+    for (const item of rawItems) {
+      if (!item.ticketTypeId) continue;
+      const q = Math.max(1, Math.min(MAX_QUANTITY, Math.floor(item.quantity ?? 1)));
+      cartMap.set(item.ticketTypeId, (cartMap.get(item.ticketTypeId) ?? 0) + q);
+    }
+    const cart: CartItem[] = Array.from(cartMap.entries()).map(([ticketTypeId, quantity]) => ({
+      ticketTypeId,
+      quantity: Math.min(MAX_QUANTITY, quantity),
+    }));
+
+    // Fetch event
+    const [event] = await db.select().from(events).where(eq(events.id, body.eventId)).limit(1);
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+    if (event.status !== 'published') {
+      return NextResponse.json({ error: 'Tickets are not available for this event' }, { status: 400 });
+    }
+
+    // Invite-only access check
+    let inviteRecord: typeof eventInvites.$inferSelect | undefined;
+    if (event.accessMode === 'invite_only') {
+      const token = body.invite || request.nextUrl.searchParams.get('invite');
+      await validateInviteAccess(body.eventId, token);
+
+      // Fetch the invite record for usedCount increment later
+      if (token) {
+        const [invite] = await db
+          .select()
+          .from(eventInvites)
+          .where(and(eq(eventInvites.eventId, body.eventId), eq(eventInvites.token, token)))
+          .limit(1);
+        inviteRecord = invite;
+      }
+    }
+
+    // Validate cart (availability + release expired holds)
+    const validated = await validateCart(body.eventId, cart, {
+      releaseExpiredHolds: true,
+      checkAvailability: true,
+    });
+
+    const { typesById, totalQuantity, totalAmount, currency } = validated;
+
+    if (totalAmount === 0) {
+      return NextResponse.json(
+        { error: 'Use the free checkout for $0 tickets' },
+        { status: 400 },
+      );
+    }
+
+    // Resolve buyer email for ticket delivery
+    let buyerEmail: string | undefined;
+    try {
+      const pgClient = getClient();
+      const rows = await pgClient<{ contact_email: string | null }[]>`
+        SELECT contact_email FROM auth.identities WHERE id = ${buyerDid} LIMIT 1
+      `;
+      buyerEmail = rows[0]?.contact_email ?? undefined;
+    } catch (err) {
+      log.warn({ err: String(err) }, 'Failed to resolve buyer email');
+    }
+
+    // Transfer balance: buyer → event creator
+    const payRes = await fetch(`${PAY_SERVICE_URL}/pay/api/balance/transfer`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Cookie': request.headers.get('cookie') || '',
+      },
+      body: JSON.stringify({
+        from_did: buyerDid,
+        to_did: event.creatorDid,
+        amount: totalAmount / 100, // transfer expects dollars, not cents
+        metadata: {
+          service: 'events',
+          eventId: body.eventId,
+          cart: JSON.stringify(cart),
+        },
+      }),
+    });
+
+    if (!payRes.ok) {
+      const errBody = await payRes.json().catch(() => ({ error: 'Balance transfer failed' }));
+      log.warn({ status: payRes.status, body: errBody }, 'Balance transfer failed');
+      return NextResponse.json(
+        { error: errBody.error || 'Insufficient balance or transfer failed' },
+        { status: payRes.status >= 400 && payRes.status < 500 ? payRes.status : 502 },
+      );
+    }
+
+    const transferData = await payRes.json();
+    log.info({ transactionId: transferData.transactionId, amount: totalAmount / 100 }, 'Balance transfer succeeded');
+
+    // Create order + tickets (instantly valid)
+    const { order, tickets } = await createOrderWithTickets({
+      eventId: body.eventId,
+      buyerDid,
+      buyerEmail,
+      cart,
+      typesById,
+      totalQuantity,
+      totalAmount,
+      currency,
+      paymentMethod: 'balance',
+      ticketStatus: 'valid',
+      paymentId: transferData.transactionId,
+      eventDid: event.did,
+      eventPrivateKey: (event as any).privateKey,
+      customerEmail: buyerEmail,
+      log,
+      incrementSold: true,
+    });
+
+    // Increment invite usedCount if invite-only
+    if (inviteRecord) {
+      await db
+        .update(eventInvites)
+        .set({ usedCount: inviteRecord.usedCount + 1 })
+        .where(eq(eventInvites.id, inviteRecord.id));
+    }
+
+    // Fire ticket.purchased for each ticket (same pattern as webhook)
+    for (const ticket of tickets) {
+      publish('ticket.purchased', {
+        issuer: buyerDid,
+        subject: event.creatorDid,
+        scope: 'events',
+        payload: {
+          ticketId: ticket.id,
+          eventId: event.id,
+          amount: ticket.pricePaid ?? 0,
+          currency,
+          context_id: event.id,
+          context_type: 'event',
+          to: buyerDid,
+          interestDids: [buyerDid],
+        },
+      }).catch((err) => log.error({ err: String(err) }, 'ticket.purchased publish error'));
+    }
+
+    // Send confirmation email if we have an email
+    if (buyerEmail) {
+      try {
+        const EVENTS_URL = process.env.NEXT_PUBLIC_EVENTS_URL || 'https://events.imajin.ai';
+        const eventDate = new Date(event.startsAt);
+        const eventImageUrl = event.imageUrl
+          ? (event.imageUrl.startsWith('http') ? event.imageUrl : `${EVENTS_URL}${event.imageUrl}`)
+          : undefined;
+
+        for (const ticket of tickets) {
+          const ticketType = typesById.get(ticket.ticketTypeId);
+          publish('ticket.confirmed', {
+            issuer: buyerDid,
+            subject: buyerDid,
+            scope: 'events',
+            payload: {
+              email: buyerEmail,
+              eventTitle: event.title,
+              ticketType: ticketType?.name ?? 'Ticket',
+              ticketId: ticket.id,
+              eventDate: eventDate.toLocaleDateString('en-US', {
+                weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+              }),
+              eventTime: eventDate.toLocaleTimeString('en-US', {
+                hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+              }),
+              isVirtual: event.isVirtual ?? false,
+              venue: event.venue ?? undefined,
+              price: `$${(totalAmount / 100).toFixed(2)} (Balance)`,
+              eventImageUrl,
+              eventUrl: `${EVENTS_URL}/${event.id}`,
+              context_id: event.id,
+              context_type: 'event',
+            },
+          }).catch((err) => log.error({ err: String(err) }, 'ticket.confirmed publish error'));
+        }
+      } catch (emailError) {
+        log.error({ err: String(emailError) }, 'Confirmation publish failed (non-fatal)');
+      }
+    }
+
+    // Add buyer to event chat (fire and forget)
+    const CHAT_URL = process.env.CHAT_SERVICE_URL || process.env.CHAT_URL;
+    if (CHAT_URL) {
+      fetch(`${CHAT_URL}/api/d/${encodeURIComponent(event.did)}/members`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ memberDid: buyerDid, role: 'member' }),
+      }).catch((err) => log.warn({ err: String(err) }, 'Event chat member sync failed (non-fatal)'));
+    }
+
+    return NextResponse.json({
+      success: true,
+      orderId: order.id,
+      ticketIds: tickets.map((t) => t.id),
+    });
+  } catch (error) {
+    if (error instanceof CheckoutValidationError) {
+      return NextResponse.json(
+        { error: error.message, ...(error.field ? { field: error.field } : {}) },
+        { status: error.statusCode },
+      );
+    }
+    log.error({ err: String(error) }, 'Balance checkout error');
+    return NextResponse.json({ error: 'Balance checkout failed' }, { status: 500 });
+  }
+});

--- a/apps/events/app/checkout/success/auto-redirect.tsx
+++ b/apps/events/app/checkout/success/auto-redirect.tsx
@@ -17,7 +17,9 @@ export function AutoRedirect({ href, seconds }: Props) {
       setCountdown(prev => {
         if (prev <= 1) {
           clearInterval(timer);
-          router.push(href);
+          // Use window.location for hash navigation so the browser scrolls
+          // to the anchor naturally (router.push doesn't scroll to hash)
+          window.location.href = href;
           return 0;
         }
         return prev - 1;

--- a/apps/events/app/checkout/success/page.tsx
+++ b/apps/events/app/checkout/success/page.tsx
@@ -81,12 +81,12 @@ export default async function SuccessPage({ searchParams }: Props) {
             You must complete the registration form before your tickets are confirmed.
           </p>
           <Link
-            href={`/${event.id}`}
+            href={`/${event.id}#tickets`}
             className="inline-block px-6 py-3 bg-red-500 hover:bg-red-600 text-white text-sm font-bold rounded-lg transition"
           >
             Complete Registration Now →
           </Link>
-          <AutoRedirect href={`/${event.id}`} seconds={5} />
+          <AutoRedirect href={`/${event.id}#tickets`} seconds={5} />
         </div>
       )}
 

--- a/apps/events/src/lib/checkout-common.ts
+++ b/apps/events/src/lib/checkout-common.ts
@@ -70,7 +70,7 @@ export interface CreateOrderWithTicketsParams {
   totalQuantity: number;
   totalAmount: number;
   currency: string;
-  paymentMethod: 'stripe' | 'etransfer' | 'free';
+  paymentMethod: 'stripe' | 'etransfer' | 'free' | 'balance';
   ticketStatus: 'valid' | 'held';
   holdExpiresAt?: Date;
   stripeSessionId?: string;

--- a/apps/kernel/app/admin/deposits/deposit-form.tsx
+++ b/apps/kernel/app/admin/deposits/deposit-form.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+interface ResolvedIdentity {
+  did: string;
+  handle: string;
+  displayName: string | null;
+}
+
+export default function DepositForm() {
+  const [amount, setAmount] = useState('');
+  const [handle, setHandle] = useState('');
+  const [memo, setMemo] = useState('');
+  const [resolved, setResolved] = useState<ResolvedIdentity | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const resolveHandle = useCallback(async () => {
+    const input = handle.trim();
+    if (!input) return;
+
+    setResolving(true);
+    setError('');
+    setResolved(null);
+
+    try {
+      // If it looks like a DID, skip resolution
+      if (input.startsWith('did:')) {
+        setResolved({ did: input, handle: '', displayName: null });
+        return;
+      }
+
+      const res = await fetch(
+        `/api/admin/deposits/resolve?handle=${encodeURIComponent(input)}`
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || 'Handle not found');
+        return;
+      }
+
+      const data: ResolvedIdentity = await res.json();
+      setResolved(data);
+    } catch {
+      setError('Failed to resolve handle');
+    } finally {
+      setResolving(false);
+    }
+  }, [handle]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!resolved?.did) {
+        setError('Resolve a handle or enter a DID first');
+        return;
+      }
+
+      const numAmount = parseFloat(amount);
+      if (!numAmount || numAmount <= 0) {
+        setError('Amount must be a positive number');
+        return;
+      }
+
+      setSubmitting(true);
+      setError('');
+      setSuccess('');
+
+      try {
+        const res = await fetch('/api/admin/deposits', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            did: resolved.did,
+            amount: numAmount,
+            currency: 'CAD',
+            memo: memo.trim(),
+          }),
+        });
+
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error || 'Deposit failed');
+          return;
+        }
+
+        setSuccess(
+          `Deposited $${numAmount.toFixed(2)} CAD → ${resolved.handle || resolved.did.slice(0, 20)}… (tx: ${data.transactionId})`
+        );
+        setAmount('');
+        setHandle('');
+        setMemo('');
+        setResolved(null);
+      } catch {
+        setError('Network error');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [resolved, amount, memo]
+  );
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-5 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6"
+    >
+      {/* Handle / DID */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Target Handle or DID
+        </label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={handle}
+            onChange={(e) => {
+              setHandle(e.target.value);
+              setResolved(null);
+              setError('');
+            }}
+            placeholder="@handle or did:imajin:..."
+            className="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+          <button
+            type="button"
+            onClick={resolveHandle}
+            disabled={resolving || !handle.trim()}
+            className="px-4 py-2 text-sm font-medium rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {resolving ? 'Resolving…' : 'Resolve'}
+          </button>
+        </div>
+        {resolved && (
+          <div className="mt-2 text-sm text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20 rounded px-3 py-2">
+            ✓ {resolved.displayName || resolved.handle || 'Unknown'}{' '}
+            <span className="font-mono text-xs text-gray-500 dark:text-gray-400">
+              ({resolved.did.slice(0, 20)}…{resolved.did.slice(-6)})
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Amount */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Amount (CAD)
+        </label>
+        <input
+          type="number"
+          step="0.01"
+          min="0.01"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0.00"
+          className="w-48 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 font-mono"
+        />
+      </div>
+
+      {/* Memo */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Memo
+        </label>
+        <input
+          type="text"
+          value={memo}
+          onChange={(e) => setMemo(e.target.value)}
+          placeholder="e.g. EMT received May 12"
+          className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500"
+        />
+      </div>
+
+      {/* Error / Success */}
+      {error && (
+        <p className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded px-3 py-2">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="text-sm text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20 rounded px-3 py-2">
+          {success}
+        </p>
+      )}
+
+      {/* Submit */}
+      <button
+        type="submit"
+        disabled={submitting || !resolved?.did || !amount}
+        className="px-5 py-2 text-sm font-medium rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {submitting ? 'Processing…' : 'Record Deposit'}
+      </button>
+    </form>
+  );
+}

--- a/apps/kernel/app/admin/deposits/page.tsx
+++ b/apps/kernel/app/admin/deposits/page.tsx
@@ -1,0 +1,107 @@
+import { requireAdmin } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+import { redirect } from 'next/navigation';
+import { formatDistanceToNow } from 'date-fns';
+import DepositForm from './deposit-form';
+
+const sql = getClient();
+
+export default async function AdminDepositsPage() {
+  const session = await requireAdmin();
+  if (!session) redirect('/admin');
+
+  const deposits = await sql`
+    SELECT id, to_did, amount, currency, metadata, created_at
+    FROM pay.transactions
+    WHERE type = 'topup' AND source = 'fiat'
+    ORDER BY created_at DESC
+    LIMIT 20
+  `;
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">
+        💰 Deposit Match
+      </h1>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+        Record EMT deposits and credit MJNx balances
+      </p>
+
+      <DepositForm />
+
+      <div className="mt-10">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+          Recent Deposits
+        </h2>
+
+        {deposits.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No deposits yet.
+          </p>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium text-gray-500 dark:text-gray-400">
+                    Date
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-500 dark:text-gray-400">
+                    Amount
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-500 dark:text-gray-400">
+                    Currency
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-500 dark:text-gray-400">
+                    Target DID
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-500 dark:text-gray-400">
+                    Memo
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                {deposits.map((d: any) => {
+                  const meta =
+                    typeof d.metadata === 'string'
+                      ? JSON.parse(d.metadata)
+                      : d.metadata ?? {};
+                  const did = d.to_did as string;
+                  const didShort = `${did.slice(0, 16)}…${did.slice(-6)}`;
+                  const createdAt = d.created_at
+                    ? formatDistanceToNow(new Date(d.created_at as string), {
+                        addSuffix: true,
+                      })
+                    : '—';
+
+                  return (
+                    <tr
+                      key={d.id as string}
+                      className="bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                    >
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {createdAt}
+                      </td>
+                      <td className="px-4 py-3 text-gray-900 dark:text-white font-mono">
+                        ${Number(d.amount).toFixed(2)}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">
+                        {d.currency}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400 font-mono text-xs">
+                        {didShort}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400 truncate max-w-[200px]">
+                        {meta.memo || '—'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/layout.tsx
+++ b/apps/kernel/app/admin/layout.tsx
@@ -18,6 +18,7 @@ const NAV_ITEMS = [
   { label: 'Moderation', href: '/admin/moderation', icon: '🛡️' },
   { label: 'Events', href: '/admin/events', icon: '🔔' },
   { label: 'Telemetry', href: '/admin/telemetry', icon: '📈' },
+  { label: 'Withdrawals', href: '/admin/withdrawals', icon: '💸' },
   { label: 'Logs', href: '/admin/logs', icon: '📋' },
 ];
 

--- a/apps/kernel/app/admin/layout.tsx
+++ b/apps/kernel/app/admin/layout.tsx
@@ -18,6 +18,7 @@ const NAV_ITEMS = [
   { label: 'Moderation', href: '/admin/moderation', icon: '🛡️' },
   { label: 'Events', href: '/admin/events', icon: '🔔' },
   { label: 'Telemetry', href: '/admin/telemetry', icon: '📈' },
+  { label: 'Deposits', href: '/admin/deposits', icon: '💰' },
   { label: 'Withdrawals', href: '/admin/withdrawals', icon: '💸' },
   { label: 'Logs', href: '/admin/logs', icon: '📋' },
 ];

--- a/apps/kernel/app/admin/withdrawals/mark-sent-button.tsx
+++ b/apps/kernel/app/admin/withdrawals/mark-sent-button.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function MarkSentButton({ id }: { id: string }) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleMarkSent() {
+    if (!confirm('Mark this withdrawal as sent? This cannot be undone.')) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/withdrawals/${id}/complete`, {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        alert(data.error || 'Failed to mark as sent');
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      alert('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleMarkSent}
+      disabled={loading}
+      className="px-3 py-1 text-xs font-medium rounded bg-green-600 hover:bg-green-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {loading ? 'Sending…' : '✅ Mark Sent'}
+    </button>
+  );
+}

--- a/apps/kernel/app/admin/withdrawals/page.tsx
+++ b/apps/kernel/app/admin/withdrawals/page.tsx
@@ -1,0 +1,119 @@
+import { db, withdrawalRequests } from '@/src/db';
+import { eq, desc } from 'drizzle-orm';
+import MarkSentButton from './mark-sent-button';
+
+export const dynamic = 'force-dynamic';
+
+export default async function WithdrawalsPage() {
+  const pending = await db
+    .select()
+    .from(withdrawalRequests)
+    .where(eq(withdrawalRequests.status, 'requested'))
+    .orderBy(desc(withdrawalRequests.requestedAt));
+
+  const completed = await db
+    .select()
+    .from(withdrawalRequests)
+    .where(eq(withdrawalRequests.status, 'sent'))
+    .orderBy(desc(withdrawalRequests.processedAt));
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6 text-gray-900 dark:text-white">
+        💸 Withdrawal Requests
+      </h1>
+
+      {/* Pending */}
+      <section className="mb-10">
+        <h2 className="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">
+          Pending ({pending.length})
+        </h2>
+        {pending.length === 0 ? (
+          <p className="text-gray-500 dark:text-gray-400 text-sm">No pending requests.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-gray-200 dark:border-gray-700 text-left text-gray-600 dark:text-gray-400">
+                  <th className="py-2 pr-4">ID</th>
+                  <th className="py-2 pr-4">DID</th>
+                  <th className="py-2 pr-4">Amount</th>
+                  <th className="py-2 pr-4">EMT Email</th>
+                  <th className="py-2 pr-4">Requested</th>
+                  <th className="py-2 pr-4">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pending.map((wr) => (
+                  <tr
+                    key={wr.id}
+                    className="border-b border-gray-100 dark:border-gray-800 text-gray-900 dark:text-gray-100"
+                  >
+                    <td className="py-2 pr-4 font-mono text-xs">{wr.id}</td>
+                    <td className="py-2 pr-4 font-mono text-xs truncate max-w-[200px]">
+                      {wr.did}
+                    </td>
+                    <td className="py-2 pr-4 font-medium">
+                      ${parseFloat(wr.amount).toFixed(2)} {wr.currency}
+                    </td>
+                    <td className="py-2 pr-4">{wr.emtEmail}</td>
+                    <td className="py-2 pr-4 text-xs text-gray-500">
+                      {wr.requestedAt?.toLocaleDateString()}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <MarkSentButton id={wr.id} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Completed */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">
+          Completed ({completed.length})
+        </h2>
+        {completed.length === 0 ? (
+          <p className="text-gray-500 dark:text-gray-400 text-sm">No completed withdrawals.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-gray-200 dark:border-gray-700 text-left text-gray-600 dark:text-gray-400">
+                  <th className="py-2 pr-4">ID</th>
+                  <th className="py-2 pr-4">DID</th>
+                  <th className="py-2 pr-4">Amount</th>
+                  <th className="py-2 pr-4">EMT Email</th>
+                  <th className="py-2 pr-4">Processed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {completed.map((wr) => (
+                  <tr
+                    key={wr.id}
+                    className="border-b border-gray-100 dark:border-gray-800 text-gray-900 dark:text-gray-100"
+                  >
+                    <td className="py-2 pr-4 font-mono text-xs">{wr.id}</td>
+                    <td className="py-2 pr-4 font-mono text-xs truncate max-w-[200px]">
+                      {wr.did}
+                    </td>
+                    <td className="py-2 pr-4 font-medium">
+                      ${parseFloat(wr.amount).toFixed(2)} {wr.currency}
+                    </td>
+                    <td className="py-2 pr-4">{wr.emtEmail}</td>
+                    <td className="py-2 pr-4 text-xs text-gray-500">
+                      {wr.processedAt?.toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/kernel/app/api/admin/deposits/resolve/route.ts
+++ b/apps/kernel/app/api/admin/deposits/resolve/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+
+const sql = getClient();
+
+/**
+ * GET /api/admin/deposits/resolve?handle=xxx
+ * Resolve a handle to a DID + display name.
+ */
+export async function GET(request: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const handle = request.nextUrl.searchParams.get('handle')?.trim();
+  if (!handle) {
+    return NextResponse.json({ error: 'handle query param is required' }, { status: 400 });
+  }
+
+  const rows = await sql`
+    SELECT
+      i.did,
+      i.handle,
+      p.display_name
+    FROM auth.identities i
+    LEFT JOIN profile.profiles p ON p.did = i.did
+    WHERE LOWER(i.handle) = LOWER(${handle})
+    LIMIT 1
+  `;
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: 'Handle not found' }, { status: 404 });
+  }
+
+  const row = rows[0];
+  return NextResponse.json({
+    did: row.did,
+    handle: row.handle,
+    displayName: row.display_name || null,
+  });
+}

--- a/apps/kernel/app/api/admin/deposits/route.ts
+++ b/apps/kernel/app/api/admin/deposits/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@imajin/auth';
+import { getClient } from '@imajin/db';
+import { db, balances, transactions } from '@/src/db';
+import { sql } from 'drizzle-orm';
+import { generateId } from '@/src/lib/kernel/id';
+
+const pgSql = getClient();
+
+/**
+ * GET /api/admin/deposits
+ * List recent fiat topup transactions.
+ */
+export async function GET() {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const rows = await pgSql`
+    SELECT id, to_did, amount, currency, metadata, created_at
+    FROM pay.transactions
+    WHERE type = 'topup' AND source = 'fiat'
+    ORDER BY created_at DESC
+    LIMIT 20
+  `;
+
+  return NextResponse.json({ deposits: rows });
+}
+
+/**
+ * POST /api/admin/deposits
+ * Record a manual EMT deposit — credits the target DID's cash balance.
+ */
+export async function POST(request: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body) {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { did, amount, currency = 'CAD', memo = '' } = body;
+
+  if (!did || typeof did !== 'string') {
+    return NextResponse.json({ error: 'did is required' }, { status: 400 });
+  }
+  if (!amount || typeof amount !== 'number' || amount <= 0) {
+    return NextResponse.json({ error: 'amount must be a positive number' }, { status: 400 });
+  }
+
+  const txId = generateId('tx');
+
+  await db.transaction(async (tx) => {
+    await tx.insert(transactions).values({
+      id: txId,
+      service: 'emt',
+      type: 'topup',
+      fromDid: null,
+      toDid: did,
+      amount: amount.toString(),
+      currency,
+      status: 'completed',
+      source: 'fiat',
+      metadata: { memo, adminDid: session.actingAs },
+    });
+
+    await tx
+      .insert(balances)
+      .values({
+        did,
+        cashAmount: amount.toString(),
+        creditAmount: '0',
+        currency,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: balances.did,
+        set: {
+          cashAmount: sql`${balances.cashAmount} + ${amount}`,
+          updatedAt: new Date(),
+        },
+      });
+  });
+
+  return NextResponse.json({ success: true, transactionId: txId });
+}

--- a/apps/kernel/app/api/admin/withdrawals/[id]/complete/route.ts
+++ b/apps/kernel/app/api/admin/withdrawals/[id]/complete/route.ts
@@ -1,0 +1,69 @@
+/**
+ * POST /api/admin/withdrawals/[id]/complete
+ *
+ * Mark a withdrawal request as 'sent' and update related transaction.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, withdrawalRequests, transactions } from '@/src/db';
+import { eq, and, sql } from 'drizzle-orm';
+import { requireAdmin } from '@imajin/auth';
+import { withLogger } from '@imajin/logger';
+
+export const POST = withLogger(async (
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const authResult = await requireAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { id } = await params;
+
+  // Find the withdrawal request
+  const [wr] = await db
+    .select()
+    .from(withdrawalRequests)
+    .where(eq(withdrawalRequests.id, id));
+
+  if (!wr) {
+    return NextResponse.json({ error: 'Withdrawal request not found' }, { status: 404 });
+  }
+
+  if (wr.status === 'sent') {
+    return NextResponse.json({ error: 'Already marked as sent' }, { status: 400 });
+  }
+
+  const now = new Date();
+
+  // Parse optional admin notes
+  let adminNotes: string | undefined;
+  try {
+    const body = await request.json();
+    adminNotes = body.adminNotes;
+  } catch {
+    // No body is fine
+  }
+
+  await db.transaction(async (tx) => {
+    // Update withdrawal request
+    await tx
+      .update(withdrawalRequests)
+      .set({
+        status: 'sent',
+        processedAt: now,
+        ...(adminNotes ? { adminNotes } : {}),
+      })
+      .where(eq(withdrawalRequests.id, id));
+
+    // Update related transaction to completed
+    // Find by metadata match
+    await tx.execute(
+      sql`UPDATE pay.transactions
+          SET status = 'completed'
+          WHERE metadata->>'withdrawal_request_id' = ${id}
+            AND status = 'pending'`,
+    );
+  });
+
+  return NextResponse.json({ success: true, id, status: 'sent' });
+});

--- a/apps/kernel/app/api/admin/withdrawals/gating/route.ts
+++ b/apps/kernel/app/api/admin/withdrawals/gating/route.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/admin/withdrawals/gating
+ *
+ * Enable or disable withdrawals for a DID.
+ * Body: { did: string, enabled: boolean }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, balances } from '@/src/db';
+import { eq } from 'drizzle-orm';
+import { requireAdmin } from '@imajin/auth';
+import { withLogger } from '@imajin/logger';
+
+export const POST = withLogger(async (request: NextRequest) => {
+  const authResult = await requireAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  let body: { did?: string; enabled?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { did, enabled } = body;
+  if (!did || typeof enabled !== 'boolean') {
+    return NextResponse.json(
+      { error: 'did (string) and enabled (boolean) are required' },
+      { status: 400 },
+    );
+  }
+
+  const result = await db
+    .update(balances)
+    .set({ withdrawalsEnabled: enabled, updatedAt: new Date() })
+    .where(eq(balances.did, did))
+    .returning({ did: balances.did });
+
+  if (result.length === 0) {
+    return NextResponse.json({ error: 'Balance not found for DID' }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true, did, withdrawalsEnabled: enabled });
+});

--- a/apps/kernel/app/api/admin/withdrawals/route.ts
+++ b/apps/kernel/app/api/admin/withdrawals/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/admin/withdrawals
+ *
+ * List withdrawal requests. Optional ?status= filter.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, withdrawalRequests } from '@/src/db';
+import { eq, desc } from 'drizzle-orm';
+import { requireAdmin } from '@imajin/auth';
+import { withLogger } from '@imajin/logger';
+
+export const GET = withLogger(async (request: NextRequest) => {
+  const authResult = await requireAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get('status');
+
+  const rows = status
+    ? await db
+        .select()
+        .from(withdrawalRequests)
+        .where(eq(withdrawalRequests.status, status))
+        .orderBy(desc(withdrawalRequests.requestedAt))
+    : await db
+        .select()
+        .from(withdrawalRequests)
+        .orderBy(desc(withdrawalRequests.requestedAt));
+
+  return NextResponse.json({ withdrawals: rows });
+});

--- a/apps/kernel/app/pay/api/balance/[did]/route.ts
+++ b/apps/kernel/app/pay/api/balance/[did]/route.ts
@@ -64,7 +64,7 @@ export async function GET(
         creditAmount,
         mjnBalance: creditAmount,
         total: cashAmount + creditAmount,
-        currency: row?.currency || 'USD',
+        currency: row?.currency || 'CAD',
         updatedAt: row?.updatedAt?.toISOString() || new Date().toISOString(),
       },
       { headers: cors }

--- a/apps/kernel/app/pay/api/balance/event-topup/route.ts
+++ b/apps/kernel/app/pay/api/balance/event-topup/route.ts
@@ -96,6 +96,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
 
     const senderBalance = senderRows[0];
     const currentCash = senderBalance ? parseFloat(senderBalance.cashAmount) : 0;
+    const topupCurrency = senderBalance?.currency || 'CAD';
 
     if (currentCash < totalCashDebit) {
       return NextResponse.json(
@@ -131,7 +132,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
           fromDid: from_did,
           toDid: recipientDid,
           amount: totalGift.toString(),
-          currency: 'USD',
+          currency: topupCurrency,
           status: 'completed',
           source: 'fiat',
           batchId,
@@ -150,7 +151,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
             did: recipientDid,
             cashAmount: cashPerRecipient.toString(),
             creditAmount: creditPerRecipient.toString(),
-            currency: 'USD',
+            currency: topupCurrency,
             updatedAt: new Date(),
           })
           .onConflictDoUpdate({

--- a/apps/kernel/app/pay/api/balance/gift/route.ts
+++ b/apps/kernel/app/pay/api/balance/gift/route.ts
@@ -86,6 +86,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
 
     const senderBalance = senderRows[0];
     const currentCash = senderBalance ? parseFloat(senderBalance.cashAmount) : 0;
+    const giftCurrency = senderBalance?.currency || 'CAD';
 
     if (currentCash < totalCashDebit) {
       return NextResponse.json(
@@ -127,7 +128,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
           fromDid: from_did,
           toDid: recipient.did,
           amount: totalGift.toString(),
-          currency: 'USD',
+          currency: giftCurrency,
           status: 'completed',
           source: 'fiat',
           batchId,
@@ -144,7 +145,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
             did: recipient.did,
             cashAmount: cashGift.toString(),
             creditAmount: creditGift.toString(),
-            currency: 'USD',
+            currency: giftCurrency,
             updatedAt: new Date(),
           })
           .onConflictDoUpdate({

--- a/apps/kernel/app/pay/api/balance/topup/route.ts
+++ b/apps/kernel/app/pay/api/balance/topup/route.ts
@@ -41,7 +41,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
     }
 
     const body = await request.json();
-    const { did, amount, service, type, metadata = {} } = body;
+    const { did, amount, service, type, metadata = {}, currency = 'CAD' } = body;
 
     if (!did || !amount || !service || !type) {
       return NextResponse.json(
@@ -69,7 +69,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
         fromDid: null, // topup has no from_did
         toDid: did,
         amount: amount.toString(),
-        currency: 'USD',
+        currency,
         status: 'completed',
         source: 'fiat',
         metadata,
@@ -82,7 +82,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
           did,
           cashAmount: amount.toString(),
           creditAmount: '0',
-          currency: 'USD',
+          currency,
           updatedAt: new Date(),
         })
         .onConflictDoUpdate({

--- a/apps/kernel/app/pay/api/balance/transfer/route.ts
+++ b/apps/kernel/app/pay/api/balance/transfer/route.ts
@@ -91,6 +91,23 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
       );
     }
 
+    const transferCurrency = senderBalance?.currency || 'CAD';
+
+    // Check recipient balance currency (if exists)
+    const recipientBalanceRows = await db
+      .select()
+      .from(balances)
+      .where(eq(balances.did, to_did))
+      .limit(1);
+
+    const recipientBalance = recipientBalanceRows[0];
+    if (recipientBalance && recipientBalance.currency !== transferCurrency) {
+      return NextResponse.json(
+        { error: 'Currency mismatch' },
+        { status: 400, headers: cors }
+      );
+    }
+
     // Determine how much to burn from each bucket (credits first)
     const creditBurn = Math.min(currentCredit, amount);
     const cashBurn = amount - creditBurn;
@@ -117,7 +134,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
         fromDid: from_did,
         toDid: to_did,
         amount: amount.toString(),
-        currency: 'USD',
+        currency: transferCurrency,
         status: 'completed',
         source,
         metadata,
@@ -140,7 +157,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
           did: to_did,
           cashAmount: amount.toString(),
           creditAmount: '0',
-          currency: 'USD',
+          currency: transferCurrency,
           updatedAt: new Date(),
         })
         .onConflictDoUpdate({

--- a/apps/kernel/app/pay/api/balance/withdraw/request/route.ts
+++ b/apps/kernel/app/pay/api/balance/withdraw/request/route.ts
@@ -1,0 +1,127 @@
+/**
+ * POST /pay/api/balance/withdraw/request
+ *
+ * Request an EMT withdrawal of cash balance.
+ * Requires withdrawals to be enabled for the account.
+ *
+ * Auth: required
+ *
+ * Request: { amount: number, emt_email: string }
+ * Response: { success: boolean, requestId: string, amount: number }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, balances, transactions, withdrawalRequests } from '@/src/db';
+import { eq, sql } from 'drizzle-orm';
+import { generateId } from '@/src/lib/kernel/id';
+import { corsHeaders } from '@/src/lib/kernel/cors';
+import { requireAuth } from '@imajin/auth';
+import { withLogger } from '@imajin/logger';
+
+const MIN_WITHDRAWAL = 10; // $10.00 minimum
+
+export async function OPTIONS(request: NextRequest) {
+  return NextResponse.json({}, { headers: corsHeaders(request) });
+}
+
+export const POST = withLogger(async (request: NextRequest) => {
+  const headers = corsHeaders(request);
+
+  // Auth
+  const authResult = await requireAuth(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const did = authResult.identity.actingAs || authResult.identity.id;
+
+  // Parse body
+  let body: { amount?: number; emt_email?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers });
+  }
+
+  const { amount, emt_email } = body;
+
+  // Validate
+  if (!amount || typeof amount !== 'number' || amount < MIN_WITHDRAWAL) {
+    return NextResponse.json(
+      { error: `Minimum withdrawal is $${MIN_WITHDRAWAL}` },
+      { status: 400, headers },
+    );
+  }
+  if (!emt_email || typeof emt_email !== 'string' || !emt_email.includes('@')) {
+    return NextResponse.json(
+      { error: 'Valid emt_email is required' },
+      { status: 400, headers },
+    );
+  }
+
+  // Check balance exists and withdrawals enabled
+  const [balance] = await db
+    .select()
+    .from(balances)
+    .where(eq(balances.did, did));
+
+  if (!balance) {
+    return NextResponse.json({ error: 'No balance found' }, { status: 404, headers });
+  }
+
+  if (!balance.withdrawalsEnabled) {
+    return NextResponse.json(
+      { error: 'Withdrawals are not enabled for this account' },
+      { status: 403, headers },
+    );
+  }
+
+  const cashAvailable = parseFloat(balance.cashAmount);
+  if (cashAvailable < amount) {
+    return NextResponse.json(
+      { error: 'Insufficient cash balance', available: cashAvailable },
+      { status: 400, headers },
+    );
+  }
+
+  // Atomic transaction: deduct balance, create withdrawal request, create transaction
+  const requestId = generateId('wr');
+  const txId = generateId('tx');
+
+  await db.transaction(async (tx) => {
+    // Deduct cash balance
+    await tx
+      .update(balances)
+      .set({
+        cashAmount: sql`${balances.cashAmount} - ${amount.toString()}`,
+        updatedAt: new Date(),
+      })
+      .where(eq(balances.did, did));
+
+    // Insert withdrawal request
+    await tx.insert(withdrawalRequests).values({
+      id: requestId,
+      did,
+      amount: amount.toString(),
+      currency: 'CAD',
+      emtEmail: emt_email,
+      status: 'requested',
+    });
+
+    // Insert transaction record
+    await tx.insert(transactions).values({
+      id: txId,
+      service: 'withdrawal',
+      type: 'withdrawal',
+      fromDid: did,
+      toDid: 'platform',
+      amount: amount.toString(),
+      currency: 'CAD',
+      status: 'pending',
+      source: 'fiat',
+      metadata: { emt_email, withdrawal_request_id: requestId },
+    });
+  });
+
+  return NextResponse.json(
+    { success: true, requestId, amount },
+    { status: 200, headers },
+  );
+});

--- a/apps/kernel/app/pay/api/balance/withdraw/route.ts
+++ b/apps/kernel/app/pay/api/balance/withdraw/route.ts
@@ -56,7 +56,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
 
   try {
     const body = await request.json();
-    const { amount, currency = 'USD', account_id } = body;
+    const { amount, currency = 'CAD', account_id } = body;
 
     if (!amount || typeof amount !== 'number' || amount <= 0) {
       return NextResponse.json(

--- a/apps/kernel/app/pay/api/checkout/route.ts
+++ b/apps/kernel/app/pay/api/checkout/route.ts
@@ -188,7 +188,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
 
     const checkoutRequest: CheckoutRequest = {
       items: body.items,
-      currency: body.currency || 'USD',
+      currency: body.currency || 'CAD',
       mode: body.mode,
       customerEmail: body.customerEmail,
       successUrl: body.successUrl,
@@ -215,7 +215,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
       fromDid: (identity?.actingAs || identity?.id) || null,
       toDid: body.metadata?.to_did || body.metadata?.recipient_did || 'platform',
       amount: (totalAmount / 100).toString(), // Convert cents to dollars
-      currency: body.currency || 'USD',
+      currency: body.currency || 'CAD',
       status: 'pending',
       stripeId: result.id,
       metadata: body.metadata,

--- a/apps/kernel/app/pay/api/escrow/route.ts
+++ b/apps/kernel/app/pay/api/escrow/route.ts
@@ -95,7 +95,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
     
     const escrowRequest: EscrowRequest = {
       amount: body.amount,
-      currency: body.currency || 'USD',
+      currency: body.currency || 'CAD',
       from: body.from,
       to: body.to,
       arbiter: body.arbiter,

--- a/apps/kernel/app/pay/api/settle/route.ts
+++ b/apps/kernel/app/pay/api/settle/route.ts
@@ -124,7 +124,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { from_did, total_amount, service, type, fair_manifest, funded = false, funded_provider, metadata = {} } = body;
+    const { from_did, total_amount, service, type, fair_manifest, funded = false, funded_provider, metadata = {}, currency = 'CAD' } = body;
 
     if (!from_did || !total_amount || !service || !type || !fair_manifest) {
       return NextResponse.json(
@@ -192,6 +192,7 @@ export async function POST(request: NextRequest) {
     let source: 'credit' | 'fiat' | 'mixed' | 'external';
     let creditBurn = 0;
     let cashBurn = 0;
+    let settleCurrency = currency;
 
     if (funded) {
       // Externally funded (e.g. Stripe checkout) — no balance check, no debit
@@ -208,6 +209,7 @@ export async function POST(request: NextRequest) {
       const currentCash = senderBalance ? parseFloat(senderBalance.cashAmount) : 0;
       const currentCredit = senderBalance ? parseFloat(senderBalance.creditAmount) : 0;
       const totalBalance = currentCash + currentCredit;
+      settleCurrency = senderBalance?.currency || currency;
 
       if (totalBalance < total_amount) {
         return NextResponse.json(
@@ -272,7 +274,7 @@ export async function POST(request: NextRequest) {
           fromDid: from_did,
           toDid: recipient.did,
           amount: recipient.amount.toString(),
-          currency: 'USD',
+          currency: settleCurrency,
           status: 'completed',
           source,
           fairManifest: fair_manifest,
@@ -295,7 +297,7 @@ export async function POST(request: NextRequest) {
               did: recipient.did,
               cashAmount: recipient.amount.toString(),
               creditAmount: '0',
-              currency: 'USD',
+              currency: settleCurrency,
               updatedAt: new Date(),
             })
             .onConflictDoUpdate({

--- a/apps/kernel/app/pay/components/BalanceCard.tsx
+++ b/apps/kernel/app/pay/components/BalanceCard.tsx
@@ -5,7 +5,7 @@ interface BalanceCardProps {
   updatedAt?: Date | null;
 }
 
-export function BalanceCard({ cashAmount, creditAmount, currency = 'USD', updatedAt }: BalanceCardProps) {
+export function BalanceCard({ cashAmount, creditAmount, currency = 'CAD', updatedAt }: BalanceCardProps) {
   const fmtCash = (n: number) =>
     new Intl.NumberFormat('en-US', {
       style: 'currency',

--- a/apps/kernel/app/pay/history/page.tsx
+++ b/apps/kernel/app/pay/history/page.tsx
@@ -51,7 +51,7 @@ export default async function HistoryPage({
   const conditions = [userTxCondition];
   if (service) conditions.push(eq(transactions.service, service));
   if (currency === 'MJN') conditions.push(eq(transactions.currency, 'MJN'));
-  if (currency === 'Fiat') conditions.push(inArray(transactions.currency, ['CAD', 'CHF', 'EUR', 'GBP']));
+  if (currency === 'Fiat') conditions.push(inArray(transactions.currency, ['CAD', 'USD', 'CHF', 'EUR', 'GBP']));
   if (from) conditions.push(gte(transactions.createdAt, new Date(from)));
   if (to) {
     const toDate = new Date(to);

--- a/apps/kernel/app/pay/history/page.tsx
+++ b/apps/kernel/app/pay/history/page.tsx
@@ -51,7 +51,7 @@ export default async function HistoryPage({
   const conditions = [userTxCondition];
   if (service) conditions.push(eq(transactions.service, service));
   if (currency === 'MJN') conditions.push(eq(transactions.currency, 'MJN'));
-  if (currency === 'Fiat') conditions.push(inArray(transactions.currency, ['USD', 'CHF', 'EUR', 'GBP']));
+  if (currency === 'Fiat') conditions.push(inArray(transactions.currency, ['CAD', 'CHF', 'EUR', 'GBP']));
   if (from) conditions.push(gte(transactions.createdAt, new Date(from)));
   if (to) {
     const toDate = new Date(to);

--- a/apps/kernel/app/pay/page.tsx
+++ b/apps/kernel/app/pay/page.tsx
@@ -58,7 +58,7 @@ export default async function Home() {
       <BalanceCard
         cashAmount={cashAmount}
         creditAmount={creditAmount}
-        currency={balance?.currency || 'USD'}
+        currency={balance?.currency || 'CAD'}
         updatedAt={balance?.updatedAt ?? null}
       />
 

--- a/apps/kernel/src/db/schemas/pay.ts
+++ b/apps/kernel/src/db/schemas/pay.ts
@@ -39,6 +39,7 @@ export const balances = paySchema.table('balances', {
   creditAmount: numeric('credit_amount', { precision: 20, scale: 8 }).notNull().default('0'),
   currency: text('currency').notNull().default('CAD'),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  withdrawalsEnabled: boolean('withdrawals_enabled').notNull().default(false),
 });
 
 /**
@@ -96,6 +97,27 @@ export const feeLedger = paySchema.table('fee_ledger', {
   txIdx: index('idx_fee_ledger_tx').on(table.transactionId),
   recipientIdx: index('idx_fee_ledger_recipient').on(table.recipientDid, table.status),
 }));
+
+/**
+ * Withdrawal Requests - manual EMT withdrawal requests from users
+ */
+export const withdrawalRequests = paySchema.table('withdrawal_requests', {
+  id: text('id').primaryKey(),
+  did: text('did').notNull(),
+  amount: numeric('amount', { precision: 20, scale: 8 }).notNull(),
+  currency: text('currency').notNull().default('CAD'),
+  emtEmail: text('emt_email').notNull(),
+  status: text('status').notNull().default('requested'),
+  adminNotes: text('admin_notes'),
+  requestedAt: timestamp('requested_at', { withTimezone: true }).defaultNow(),
+  processedAt: timestamp('processed_at', { withTimezone: true }),
+}, (table) => ({
+  didIdx: index('idx_withdrawal_requests_did').on(table.did),
+  statusIdx: index('idx_withdrawal_requests_status').on(table.status),
+}));
+
+export type WithdrawalRequest = typeof withdrawalRequests.$inferSelect;
+export type NewWithdrawalRequest = typeof withdrawalRequests.$inferInsert;
 
 // Types
 export type Transaction = typeof transactions.$inferSelect;

--- a/apps/kernel/src/db/schemas/pay.ts
+++ b/apps/kernel/src/db/schemas/pay.ts
@@ -12,7 +12,7 @@ export const transactions = paySchema.table('transactions', {
   fromDid: text('from_did'),                             // who paid (null for anonymous/external)
   toDid: text('to_did').notNull(),                       // who received
   amount: numeric('amount', { precision: 20, scale: 8 }).notNull(),
-  currency: text('currency').notNull().default('USD'),
+  currency: text('currency').notNull().default('CAD'),
   status: text('status').notNull().default('pending'),   // pending | completed | failed | refunded
   source: text('source').notNull().default('fiat'),      // 'fiat' | 'credit' | 'mixed'
   stripeId: text('stripe_id'),                           // payment intent / invoice / checkout session
@@ -37,7 +37,7 @@ export const balances = paySchema.table('balances', {
   did: text('did').primaryKey(),
   cashAmount: numeric('cash_amount', { precision: 20, scale: 8 }).notNull().default('0'),
   creditAmount: numeric('credit_amount', { precision: 20, scale: 8 }).notNull().default('0'),
-  currency: text('currency').notNull().default('USD'),
+  currency: text('currency').notNull().default('CAD'),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 });
 

--- a/migrations/0029_cad_currency_defaults.sql
+++ b/migrations/0029_cad_currency_defaults.sql
@@ -1,0 +1,14 @@
+-- Migration 0029: Change currency defaults from USD to CAD in pay schema
+-- Idempotent: safe to re-run
+
+BEGIN;
+
+-- Update defaults for new rows
+ALTER TABLE pay.balances ALTER COLUMN currency SET DEFAULT 'CAD';
+ALTER TABLE pay.transactions ALTER COLUMN currency SET DEFAULT 'CAD';
+
+-- Backfill existing dev data (no real USD balances in production yet)
+UPDATE pay.balances SET currency = 'CAD' WHERE currency = 'USD';
+UPDATE pay.transactions SET currency = 'CAD' WHERE currency = 'USD';
+
+COMMIT;

--- a/migrations/0030_withdrawal_requests.sql
+++ b/migrations/0030_withdrawal_requests.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+ALTER TABLE pay.balances ADD COLUMN IF NOT EXISTS withdrawals_enabled BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE IF NOT EXISTS pay.withdrawal_requests (
+  id TEXT PRIMARY KEY,
+  did TEXT NOT NULL,
+  amount NUMERIC(20, 8) NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'CAD',
+  emt_email TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'requested',
+  admin_notes TEXT,
+  requested_at TIMESTAMPTZ DEFAULT NOW(),
+  processed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_withdrawal_requests_did ON pay.withdrawal_requests(did);
+CREATE INDEX IF NOT EXISTS idx_withdrawal_requests_status ON pay.withdrawal_requests(status);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Implements the full EMT → MJNx fiat on-ramp pipeline (parent issue #715). Buyers send Interac e-Transfer → platform credits MJNx → checkout with balance → sellers accumulate → sellers cash out.

**32 files changed, +1,368 / −28 lines. 2 migrations.**

---

### #929 — CAD currency support
- Schema defaults changed from USD to CAD (balances + transactions)
- Topup endpoint accepts `currency` param (default CAD)
- Transfer validates sender/recipient currency match (400 on mismatch)
- All pay routes stop hardcoding USD (topup, transfer, withdraw, gift, event-topup, settle, checkout, escrow)
- UI: BalanceCard, history filters, pay page updated
- Migration: `0029_cad_currency_defaults.sql`

### #926 — Admin deposit-match UI
- `/admin/deposits` page with form + recent deposits table
- Handle → DID resolution with profile display name
- Atomic topup (transaction insert + balance upsert) with admin DID + memo in metadata
- Admin nav item added (💰 Deposits)

### #928 — MJNx withdrawal requests with account-level gating
- `withdrawals_enabled` boolean on balances table (default false)
- New `pay.withdrawal_requests` table
- User API: `POST /pay/api/balance/withdraw/request` (min $10 CAD, checks gating + cash balance, atomic deduct)
- Admin APIs: list requests, mark as sent, toggle gating per DID
- Admin UI: `/admin/withdrawals` with pending/completed tables + Mark Sent actions
- Admin nav item added (💸 Withdrawals)
- Migration: `0030_withdrawal_requests.sql`

### #927 — MJNx balance checkout path
- `POST /events/api/checkout/balance` — transfers buyer balance → event creator via pay service, creates instantly-valid tickets
- `GET /events/api/balance` — proxy to fetch authenticated buyer's balance
- 💰 "Pay with Balance" button in checkout bar (green, shows available balance, only visible when sufficient)
- Follows same patterns as Stripe/EMT checkout (cart normalization, invite validation, availability check, `.fair` manifest, confirmation email, chat member sync)

### Bug fixes (also in #939)
- EMT reservation info card flash: clear cart after successful reservation so panel renders immediately
- Post-Stripe checkout: deep-link to `#tickets` section, increased auto-redirect from 5s to 10s

---

closes #929, closes #926, closes #928, closes #927