### PR TITLE
fix(media): allow free streaming and fix 402 settlement URL

### DIFF
--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -218,7 +218,7 @@ export async function GET(
   // 4. Determine action and check for priced distribution
   const action = determineAction(request, asset.mimeType);
   const distRight = isFairManifestV1_1(manifest) ? manifest.distribution?.[action] : undefined;
-  const hasPrice = !!distRight?.price;
+  const hasPrice = !!distRight?.price && distRight.price.amount > 0;
 
   // 4a. Price-aware settlement flow
   if (hasPrice) {
@@ -227,7 +227,8 @@ export async function GET(
     if (!receiptHeader) {
       // No receipt → 402 with settlement options
       try {
-        const baseUrl = `${new URL(request.url).origin}/media/api/assets`;
+        const publicBase = process.env.NEXT_PUBLIC_BASE_URL || process.env.MEDIA_PUBLIC_URL || new URL(request.url).origin;
+        const baseUrl = `${publicBase}/media/api/assets`;
         const resp = build402Response({
           manifest: manifest as import("@imajin/fair").FairManifestV1_1,
           assetId: id,

--- a/apps/kernel/src/components/media/FairManifestEditor.tsx
+++ b/apps/kernel/src/components/media/FairManifestEditor.tsx
@@ -90,7 +90,8 @@ function DistributionRightEditor({
   readOnly?: boolean;
 }) {
   const mode = right?.mode ?? 'reserved';
-  const showPrice = mode === 'allowed' || mode === 'allow-with-share' || mode === 'allow-with-attribution';
+  const canHavePrice = mode === 'allowed' || mode === 'allow-with-share' || mode === 'allow-with-attribution';
+  const hasPrice = canHavePrice && !!right?.price && right.price.amount > 0;
   const showSplits = mode === 'allow-with-share';
   const showQuote = mode === 'quote-with-attribution';
   const showSampling = showQuote; // for audio
@@ -101,7 +102,10 @@ function DistributionRightEditor({
         value={mode}
         onChange={(e) => {
           const newMode = e.target.value;
-          onChange({ ...right, mode: newMode });
+          // When switching modes, strip the price if moving to a non-priceable mode
+          const isPriceable = newMode === 'allowed' || newMode === 'allow-with-share' || newMode === 'allow-with-attribution';
+          const { price: _price, ...rest } = right ?? {};
+          onChange(isPriceable ? { ...right, mode: newMode } : { ...rest, mode: newMode });
         }}
         disabled={readOnly}
         className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 focus:outline-none focus:border-orange-500 disabled:opacity-60"
@@ -113,12 +117,41 @@ function DistributionRightEditor({
         ))}
       </select>
 
-      {showPrice && (
-        <MoneyInput
-          value={right?.price}
-          onChange={(price) => onChange({ ...right, price: price ?? undefined })}
-          readOnly={readOnly}
-        />
+      {canHavePrice && (
+        <div className="space-y-2">
+          <Toggle
+            label="Set a price"
+            checked={hasPrice}
+            onChange={(checked) => {
+              if (checked) {
+                onChange({ ...right, price: { amount: 100, currency: 'USD' } });
+              } else {
+                // Remove price entirely — free access
+                const { price: _p, ...rest } = right ?? {};
+                onChange({ ...rest, mode: right?.mode ?? 'allowed' });
+              }
+            }}
+            readOnly={readOnly}
+          />
+          {hasPrice && (
+            <MoneyInput
+              value={right?.price}
+              onChange={(price) => {
+                if (!price || price.amount === 0) {
+                  // Clearing price or setting to 0 → remove price (free)
+                  const { price: _p, ...rest } = right ?? {};
+                  onChange({ ...rest, mode: right?.mode ?? 'allowed' });
+                } else {
+                  onChange({ ...right, price });
+                }
+              }}
+              readOnly={readOnly}
+            />
+          )}
+          {!hasPrice && (
+            <p className="text-[10px] text-gray-500">Free — no payment required</p>
+          )}
+        </div>
       )}
 
       {showSplits && (


### PR DESCRIPTION
## What

Two fixes for priced distribution on media assets:

1. **`price.amount === 0` now means free** — skip the 402 settlement flow entirely. Previously any truthy `price` object (even `{amount: 0}`) triggered payment required, so setting streaming to $0.00 still blocked the video.

2. **Settlement endpoint URL was wrong** — the 402 response used `request.url` origin which resolves to `localhost:3000` behind Caddy. Now uses `NEXT_PUBLIC_BASE_URL` / `MEDIA_PUBLIC_URL` first.

## Context

Reported on a video asset upgraded to .fair v1.1 — the browser video player sends Range requests, which triggers the streaming action check. With a 1-cent price, it returned 402 (correct behavior but the settlement URL was wrong). Setting to 0 cents still returned 402 (incorrect — 0 should mean free).