### PR TITLE
fix: DID resolution + connection picker in DidShareListEditor, avatar URL fix

### DIFF
--- a/apps/kernel/app/auth/page.tsx
+++ b/apps/kernel/app/auth/page.tsx
@@ -65,11 +65,18 @@ export default async function AuthPage() {
 
   const mediaUrl = process.env.NEXT_PUBLIC_MEDIA_URL ?? '';
 
-  // Resolve avatar URL
+  // Resolve avatar URL — relative /api/media/ paths must go through the
+  // public URL because Caddy serves them via file_server; the Next.js image
+  // optimizer fetches internally from localhost where that route doesn't exist.
+  const publicBase = process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXT_PUBLIC_WWW_URL || '';
   let avatarSrc: string | null = null;
   if (profile.avatarAssetId && mediaUrl) {
     avatarSrc = `${mediaUrl}/api/media/${profile.avatarAssetId}`;
-  } else if (profile.avatar && (profile.avatar.startsWith('http') || profile.avatar.startsWith('/'))) {
+  } else if (profile.avatar && profile.avatar.startsWith('http')) {
+    avatarSrc = profile.avatar;
+  } else if (profile.avatar && profile.avatar.startsWith('/') && publicBase) {
+    avatarSrc = `${publicBase}${profile.avatar}`;
+  } else if (profile.avatar && profile.avatar.startsWith('/')) {
     avatarSrc = profile.avatar;
   }
 

--- a/apps/kernel/src/components/media/FairManifestEditor.tsx
+++ b/apps/kernel/src/components/media/FairManifestEditor.tsx
@@ -14,6 +14,28 @@ import type {
 import { validateManifest } from '@imajin/fair';
 import { DidShareListEditor, MoneyInput } from '@imajin/ui';
 
+const CONNECTIONS_URL_BASE = process.env.NEXT_PUBLIC_CONNECTIONS_URL || 'https://jin.imajin.ai/connections';
+const CONNECTIONS_API_URL = `${CONNECTIONS_URL_BASE}/api/connections`;
+
+const PROFILE_URL = process.env.NEXT_PUBLIC_SERVICE_PREFIX
+  ? `${process.env.NEXT_PUBLIC_SERVICE_PREFIX}profile.${process.env.NEXT_PUBLIC_DOMAIN || 'imajin.ai'}`
+  : 'https://profile.imajin.ai';
+
+async function resolveProfile(did: string): Promise<{ name: string; handle?: string; avatar?: string } | null> {
+  try {
+    const res = await fetch(`${PROFILE_URL}/api/profile/${encodeURIComponent(did)}`, { credentials: 'include' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      name: data.handle || data.name || did.slice(0, 16) + '…',
+      handle: data.handle,
+      avatar: data.avatar,
+    };
+  } catch {
+    return null;
+  }
+}
+
 interface SectionProps {
   title: string;
   error?: boolean;
@@ -84,10 +106,14 @@ function DistributionRightEditor({
   right,
   onChange,
   readOnly,
+  connectionsUrl,
+  resolveProfile,
 }: {
   right?: FairDistributionRight;
   onChange: (r: FairDistributionRight | undefined) => void;
   readOnly?: boolean;
+  connectionsUrl?: string;
+  resolveProfile?: (did: string) => Promise<{ name: string; handle?: string; avatar?: string } | null>;
 }) {
   const mode = right?.mode ?? 'reserved';
   const canHavePrice = mode === 'allowed' || mode === 'allow-with-share' || mode === 'allow-with-attribution';
@@ -159,6 +185,8 @@ function DistributionRightEditor({
           value={right?.splits ?? [{ role: 'creator', share: 1 }]}
           onChange={(splits) => onChange({ ...right, splits })}
           readOnly={readOnly}
+          connectionsUrl={connectionsUrl}
+          resolveProfile={resolveProfile}
         />
       )}
 
@@ -229,6 +257,8 @@ export interface FairManifestEditorProps {
   onSave?: () => void;
   readOnly?: boolean;
   currentUserDid?: string;
+  connectionsUrl?: string;
+  resolveProfile?: (did: string) => Promise<{ name: string; handle?: string; avatar?: string } | null>;
 }
 
 export function FairManifestEditor({
@@ -238,6 +268,8 @@ export function FairManifestEditor({
   onSave,
   readOnly = false,
   currentUserDid,
+  connectionsUrl = CONNECTIONS_API_URL,
+  resolveProfile: resolveProfileProp = resolveProfile,
 }: FairManifestEditorProps) {
   const [local, setLocal] = useState<FairManifestV1_1>(manifest);
   const [validation, setValidation] = useState<{ ok: boolean; errors: string[] }>({
@@ -355,6 +387,8 @@ export function FairManifestEditor({
           onChange={(entries) => update({ attribution: entries })}
           readOnly={readOnly}
           defaultDid={currentUserDid}
+          connectionsUrl={connectionsUrl}
+          resolveProfile={resolveProfileProp}
         />
       </Section>
 
@@ -408,6 +442,8 @@ export function FairManifestEditor({
                 right={distribution[key]}
                 onChange={(r) => update({ distribution: { ...distribution, [key]: r } })}
                 readOnly={readOnly}
+                connectionsUrl={connectionsUrl}
+                resolveProfile={resolveProfileProp}
               />
             </div>
           ))}
@@ -457,6 +493,8 @@ export function FairManifestEditor({
                     }
                     readOnly={readOnly}
                     defaultDid={currentUserDid}
+                    connectionsUrl={connectionsUrl}
+                    resolveProfile={resolveProfileProp}
                   />
                 </div>
               )}

--- a/packages/ui/src/DidShareListEditor.tsx
+++ b/packages/ui/src/DidShareListEditor.tsx
@@ -1,7 +1,20 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { DidShareList, DidShareEntry } from '@imajin/fair';
+
+interface ResolvedProfile {
+  name: string;
+  handle?: string;
+  avatar?: string;
+}
+
+interface Connection {
+  did: string;
+  name: string | null;
+  handle: string | null;
+  avatar?: string | null;
+}
 
 interface DidShareListEditorProps {
   value: DidShareList;
@@ -10,6 +23,8 @@ interface DidShareListEditorProps {
   className?: string;
   defaultDid?: string;
   showFixed?: boolean;
+  connectionsUrl?: string;
+  resolveProfile?: (did: string) => Promise<ResolvedProfile | null>;
 }
 
 const ROLE_OPTIONS = [
@@ -19,6 +34,225 @@ const ROLE_OPTIONS = [
 
 const SUM_TOLERANCE = 1e-6;
 
+// ─── ResolvedDidChip ───────────────────────────────────────────────────────
+
+function ResolvedDidChip({
+  did,
+  profile,
+  onClear,
+  readOnly,
+}: {
+  did: string;
+  profile: ResolvedProfile | null;
+  onClear: () => void;
+  readOnly?: boolean;
+}) {
+  const displayName = profile?.name || did.slice(0, 16) + '…';
+  const handle = profile?.handle;
+  const avatar = profile?.avatar;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(did).catch(() => {});
+  };
+
+  return (
+    <div
+      className="flex-1 flex items-center gap-2 bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 min-w-0 cursor-pointer hover:border-gray-600 transition"
+      title={did}
+      onClick={handleCopy}
+    >
+      {avatar ? (
+        <img
+          src={avatar}
+          alt=""
+          className="w-5 h-5 rounded-full object-cover flex-shrink-0"
+        />
+      ) : (
+        <div className="w-5 h-5 rounded-full bg-gray-700 flex items-center justify-center text-gray-400 text-[10px] font-semibold flex-shrink-0">
+          {(displayName).charAt(0).toUpperCase()}
+        </div>
+      )}
+      <span className="text-xs text-gray-200 truncate">{displayName}</span>
+      {handle && (
+        <span className="text-xs text-gray-500 truncate">@{handle}</span>
+      )}
+      {!readOnly && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClear();
+          }}
+          className="ml-auto text-gray-600 hover:text-red-400 transition text-xs px-1"
+          title="Clear"
+          type="button"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── InlineDidPicker ───────────────────────────────────────────────────────
+
+function InlineDidPicker({
+  connectionsUrl,
+  onSelect,
+  readOnly,
+}: {
+  connectionsUrl?: string;
+  onSelect: (did: string) => void;
+  readOnly?: boolean;
+}) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [loading, setLoading] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Fetch connections when picker opens and URL is available
+  useEffect(() => {
+    if (!connectionsUrl || connections.length > 0) return;
+    setLoading(true);
+    fetch(connectionsUrl)
+      .then((r) => r.json())
+      .then((data) => {
+        const list = (data.connections || []).map((c: Record<string, unknown>) => ({
+          did: String(c.did || ''),
+          name: c.name ? String(c.name) : null,
+          handle: c.handle ? String(c.handle) : null,
+          avatar: c.avatar ? String(c.avatar) : null,
+        })) as Connection[];
+        setConnections(list);
+      })
+      .catch(() => {
+        setConnections([]);
+      })
+      .finally(() => setLoading(false));
+  }, [connectionsUrl, connections.length]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const isRawDid = query.trim().startsWith('did:');
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return connections;
+    return connections.filter(
+      (c) =>
+        (c.handle || '').toLowerCase().includes(q) ||
+        (c.name || '').toLowerCase().includes(q) ||
+        c.did.toLowerCase().includes(q)
+    );
+  }, [query, connections]);
+
+  const handleSelect = (did: string) => {
+    onSelect(did);
+    setQuery('');
+    setOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const trimmed = query.trim();
+      if (isRawDid) {
+        handleSelect(trimmed);
+      } else if (filtered.length > 0) {
+        handleSelect(filtered[0].did);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  const showDropdown = open && (filtered.length > 0 || isRawDid || loading);
+
+  return (
+    <div ref={wrapperRef} className="flex-1 relative">
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        placeholder={connectionsUrl ? 'Search connections or paste DID…' : 'did:key:...'}
+        readOnly={readOnly}
+        className="w-full bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 placeholder-gray-600 focus:outline-none focus:border-orange-500 read-only:opacity-60"
+      />
+      {showDropdown && (
+        <div className="absolute z-10 top-full left-0 right-0 mt-1 bg-[#1a1a1a] border border-gray-700 rounded max-h-36 overflow-y-auto shadow-lg">
+          {loading ? (
+            <div className="px-3 py-2 text-xs text-gray-500">Loading…</div>
+          ) : (
+            <>
+              {isRawDid && (
+                <button
+                  onClick={() => handleSelect(query.trim())}
+                  className="w-full flex items-center gap-2 px-3 py-2 hover:bg-[#252525] transition text-left"
+                  type="button"
+                >
+                  <span className="text-xs text-orange-400">Use raw DID:</span>
+                  <span className="text-xs text-gray-300 truncate">{query.trim()}</span>
+                </button>
+              )}
+              {filtered.map((conn) => (
+                <button
+                  key={conn.did}
+                  onClick={() => handleSelect(conn.did)}
+                  className="w-full flex items-center gap-2 px-3 py-2 hover:bg-[#252525] transition text-left"
+                  type="button"
+                >
+                  {conn.avatar ? (
+                    <img
+                      src={conn.avatar}
+                      alt=""
+                      className="w-5 h-5 rounded-full object-cover flex-shrink-0"
+                    />
+                  ) : (
+                    <div className="w-5 h-5 rounded-full bg-gray-700 flex items-center justify-center text-gray-400 text-[10px] font-semibold flex-shrink-0">
+                      {(conn.name || conn.handle || conn.did).charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <span className="text-xs text-gray-200 truncate">
+                      {conn.name || (conn.handle ? `@${conn.handle}` : conn.did.slice(0, 20) + '…')}
+                    </span>
+                    {conn.handle && conn.name && (
+                      <span className="text-xs text-gray-500 ml-1">@{conn.handle}</span>
+                    )}
+                  </div>
+                </button>
+              ))}
+              {filtered.length === 0 && !isRawDid && (
+                <div className="px-3 py-2 text-xs text-gray-500">
+                  {connections.length === 0 ? 'No connections available.' : 'No matches.'}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── DidShareListEditor ────────────────────────────────────────────────────
+
 export function DidShareListEditor({
   value,
   onChange,
@@ -26,9 +260,13 @@ export function DidShareListEditor({
   className = '',
   defaultDid,
   showFixed = false,
+  connectionsUrl,
+  resolveProfile,
 }: DidShareListEditorProps) {
+  const [resolvedCache, setResolvedCache] = useState<Record<string, ResolvedProfile | null>>({});
+
   const totalShare = useMemo(
-    () => value.reduce((sum, e) => sum + e.share, 0),
+    () => value.reduce((sum: number, e: DidShareEntry) => sum + e.share, 0),
     [value],
   );
 
@@ -36,12 +274,12 @@ export function DidShareListEditor({
   const isOver = totalShare > 1.0 + SUM_TOLERANCE;
 
   const update = (i: number, patch: Partial<DidShareEntry>) => {
-    const next = value.map((e, idx) => (idx === i ? { ...e, ...patch } : e));
+    const next = value.map((e: DidShareEntry, idx: number) => (idx === i ? { ...e, ...patch } : e));
     onChange(next);
   };
 
   const remove = (i: number) => {
-    onChange(value.filter((_, idx) => idx !== i));
+    onChange(value.filter((_e: DidShareEntry, idx: number) => idx !== i));
   };
 
   const add = () => {
@@ -55,19 +293,53 @@ export function DidShareListEditor({
     ]);
   };
 
+  // Auto-resolve existing DIDs on mount / when resolveProfile changes
+  useEffect(() => {
+    if (!resolveProfile) return;
+    const dids = value.map((e) => e.did).filter(Boolean);
+    const uniqueDids = [...new Set(dids)].filter((did) => !(did in resolvedCache));
+    if (uniqueDids.length === 0) return;
+
+    Promise.all(
+      uniqueDids.map(async (did) => {
+        try {
+          const profile = await resolveProfile(did);
+          return { did, profile };
+        } catch {
+          return { did, profile: null };
+        }
+      })
+    ).then((results) => {
+      setResolvedCache((prev) => {
+        const next = { ...prev };
+        for (const { did, profile } of results) {
+          next[did] = profile;
+        }
+        return next;
+      });
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolveProfile, value.map((e) => e.did).join(',')]);
+
   return (
     <div className={`space-y-3 ${className}`}>
       {value.map((entry, i) => (
         <div key={i} className="bg-[#252525] rounded-lg p-3 space-y-2">
           <div className="flex items-center gap-2">
-            <input
-              type="text"
-              value={entry.did ?? ''}
-              onChange={(e) => update(i, { did: e.target.value })}
-              placeholder="did:key:..."
-              readOnly={readOnly}
-              className="flex-1 bg-[#1a1a1a] border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 placeholder-gray-600 focus:outline-none focus:border-orange-500 read-only:opacity-60"
-            />
+            {entry.did ? (
+              <ResolvedDidChip
+                did={entry.did}
+                profile={resolvedCache[entry.did] ?? null}
+                onClear={() => update(i, { did: '' })}
+                readOnly={readOnly}
+              />
+            ) : (
+              <InlineDidPicker
+                connectionsUrl={connectionsUrl}
+                onSelect={(did) => update(i, { did })}
+                readOnly={readOnly}
+              />
+            )}
             <select
               value={entry.role}
               onChange={(e) => update(i, { role: e.target.value })}


### PR DESCRIPTION
## Changes

### feat(ui): DID resolution + connection picker in DidShareListEditor
- DID resolution for share targets (lookup display names instead of raw DIDs)
- Connection picker integration for selecting share recipients
- Enhanced share list editing UX

### fix(auth): resolve relative avatar paths to public URL for next/image
- Fixes avatar rendering where relative paths weren't resolving correctly for next/image

---

*Two commits, rebased clean onto main.*