### PR TITLE
feat(pay): self-service MJNx top-up — Stripe + EMT on-ramp (#948)

### DIFF
--- a/apps/kernel/app/pay/api/topup/emt/route.ts
+++ b/apps/kernel/app/pay/api/topup/emt/route.ts
@@ -1,0 +1,100 @@
+/**
+ * POST /pay/api/topup/emt
+ *
+ * Create a pending EMT top-up transaction.
+ * Admin will match the incoming EMT and credit the balance.
+ * Auth required.
+ *
+ * Request: { amount: number }
+ * Response: { success: boolean, transactionId: string, instructions: { email, amount, memo } }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@imajin/auth';
+import { db, transactions } from '@/src/db';
+import { generateId } from '@/src/lib/kernel/id';
+import { corsHeaders } from '@/src/lib/kernel/cors';
+import { rateLimit, getClientIP } from '@/src/lib/kernel/rate-limit';
+import { withLogger } from '@imajin/logger';
+
+const MIN_TOPUP = 20; // $20 CAD minimum
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 10, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  // Auth
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status || 401, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+  const handle = authResult.identity.handle || '';
+
+  let body: { amount?: number };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  const { amount } = body;
+
+  if (!amount || typeof amount !== 'number' || amount < MIN_TOPUP) {
+    return NextResponse.json(
+      { error: `Minimum top-up is $${MIN_TOPUP}` },
+      { status: 400, headers: cors }
+    );
+  }
+
+  // Create pending transaction — no balance change yet
+  const txId = generateId('tx');
+  await db.insert(transactions).values({
+    id: txId,
+    service: 'emt',
+    type: 'topup',
+    fromDid: null,
+    toDid: did,
+    amount: amount.toString(),
+    currency: 'CAD',
+    status: 'pending',
+    source: 'fiat',
+    metadata: {
+      method: 'emt',
+      handle,
+      email: 'pay@imajin.ai',
+      memo: handle ? `@${handle}` : did.slice(-12),
+    },
+  });
+
+  log.info({ service: 'pay', did, amount, transactionId: txId }, 'EMT top-up pending created');
+
+  return NextResponse.json(
+    {
+      success: true,
+      transactionId: txId,
+      instructions: {
+        email: 'pay@imajin.ai',
+        amount,
+        memo: handle ? `@${handle}` : did.slice(-12),
+      },
+    },
+    { headers: cors }
+  );
+});

--- a/apps/kernel/app/pay/api/topup/stripe/route.ts
+++ b/apps/kernel/app/pay/api/topup/stripe/route.ts
@@ -1,0 +1,142 @@
+/**
+ * POST /pay/api/topup/stripe
+ *
+ * Create a Stripe Checkout session for MJNx top-up.
+ * Auth required.
+ *
+ * Request: { amount: number, absorbFees: boolean }
+ * Response: { url: string, sessionId: string }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getPaymentService } from '@/src/lib/pay/pay';
+import { requireAuth } from '@imajin/auth';
+import { db, transactions } from '@/src/db';
+import { generateId } from '@/src/lib/kernel/id';
+import { corsHeaders } from '@/src/lib/kernel/cors';
+import { rateLimit, getClientIP } from '@/src/lib/kernel/rate-limit';
+import { STRIPE_RATE_BPS, STRIPE_FIXED_CENTS } from '@imajin/fair';
+import { withLogger } from '@imajin/logger';
+
+const MIN_TOPUP = 20; // $20 CAD minimum
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 10, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  // Auth
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status || 401, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+  const handle = authResult.identity.handle || '';
+
+  let body: { amount?: number; absorbFees?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  const { amount, absorbFees } = body;
+
+  if (!amount || typeof amount !== 'number' || amount < MIN_TOPUP) {
+    return NextResponse.json(
+      { error: `Minimum top-up is $${MIN_TOPUP}` },
+      { status: 400, headers: cors }
+    );
+  }
+
+  // Calculate charge amount in cents
+  const amountCents = Math.round(amount * 100);
+  let chargeAmountCents: number;
+
+  if (absorbFees === false) {
+    // User absorbs fees: they pay more, receive exact amount
+    // chargeAmount = (amount + 0.30) / (1 - 0.029)
+    chargeAmountCents = Math.ceil((amountCents + STRIPE_FIXED_CENTS) / (1 - STRIPE_RATE_BPS / 10000));
+  } else {
+    // Platform absorbs fees: charge = amount
+    chargeAmountCents = amountCents;
+  }
+
+  // Ensure Stripe minimum (50 cents)
+  if (chargeAmountCents < 50) {
+    chargeAmountCents = 50;
+  }
+
+  const pay = getPaymentService();
+
+  const baseUrl = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
+
+  const result = await pay.checkout({
+    items: [
+      {
+        name: 'MJNx Top-Up',
+        description: `$${amount.toFixed(2)} CAD → MJNx balance`,
+        amount: chargeAmountCents,
+        quantity: 1,
+      },
+    ],
+    currency: 'CAD',
+    successUrl: `${baseUrl}/topup/success?session_id={CHECKOUT_SESSION_ID}`,
+    cancelUrl: `${baseUrl}/topup`,
+    metadata: {
+      service: 'topup',
+      type: 'topup',
+      buyerDid: did,
+      topupAmount: amount.toString(),
+      absorbFees: absorbFees === false ? 'false' : 'true',
+      handle,
+    },
+  });
+
+  // Create pending transaction record
+  const txId = generateId('tx');
+  await db.insert(transactions).values({
+    id: txId,
+    service: 'topup',
+    type: 'topup',
+    fromDid: did,
+    toDid: did,
+    amount: amount.toString(),
+    currency: 'CAD',
+    status: 'pending',
+    stripeId: result.id,
+    source: 'fiat',
+    metadata: {
+      method: 'stripe',
+      topupAmount: amount.toString(),
+      chargeAmountCents: chargeAmountCents.toString(),
+      absorbFees: absorbFees === false ? 'false' : 'true',
+      handle,
+    },
+  });
+
+  log.info(
+    { service: 'pay', did, amount, chargeAmountCents, absorbFees, sessionId: result.id },
+    'Top-up Stripe checkout created'
+  );
+
+  return NextResponse.json(
+    { url: result.url, sessionId: result.id },
+    { headers: cors }
+  );
+});

--- a/apps/kernel/app/pay/api/webhook/route.ts
+++ b/apps/kernel/app/pay/api/webhook/route.ts
@@ -432,6 +432,61 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
     }
   }
 
+  // Handle top-up checkout sessions
+  if (session.metadata?.service === 'topup') {
+    const topupAmountStr = session.metadata?.topupAmount;
+    const buyerDid = session.metadata?.buyerDid;
+
+    if (topupAmountStr && buyerDid) {
+      const topupAmount = parseFloat(topupAmountStr);
+
+      // Atomic operation: insert transaction + update cash balance
+      const txId = generateId('tx');
+      await db.transaction(async (tx) => {
+        // Insert completed top-up transaction
+        await tx.insert(transactions).values({
+          id: txId,
+          service: 'topup',
+          type: 'topup',
+          fromDid: null,
+          toDid: buyerDid,
+          amount: topupAmount.toString(),
+          currency: (session.currency || 'cad').toUpperCase(),
+          status: 'completed',
+          stripeId: session.id,
+          source: 'fiat',
+          metadata: {
+            ...session.metadata,
+            checkoutSessionId: session.id,
+          },
+        });
+
+        // Credit cash balance
+        await tx
+          .insert(balances)
+          .values({
+            did: buyerDid,
+            cashAmount: topupAmount.toString(),
+            creditAmount: '0',
+            currency: (session.currency || 'cad').toUpperCase(),
+            updatedAt: new Date(),
+          })
+          .onConflictDoUpdate({
+            target: balances.did,
+            set: {
+              cashAmount: sql`${balances.cashAmount} + ${topupAmount}`,
+              updatedAt: new Date(),
+            },
+          });
+      });
+
+      log.info({ service: 'pay', transactionId: txId, buyerDid, amount: topupAmount }, 'Top-up credited via webhook');
+    }
+
+    // Skip further processing — topups don't need service notifications
+    return;
+  }
+
   // Notify the originating service based on metadata
   // Events service handles event tickets
   if (session.metadata?.eventId) {

--- a/apps/kernel/app/pay/components/BalanceCard.tsx
+++ b/apps/kernel/app/pay/components/BalanceCard.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 interface BalanceCardProps {
   cashAmount: number;
   creditAmount: number;
@@ -15,7 +17,15 @@ export function BalanceCard({ cashAmount, creditAmount, currency = 'CAD', update
 
   return (
     <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
-      <h2 className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-3">Your Balance</h2>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Your Balance</h2>
+        <Link
+          href="/pay/topup"
+          className="text-xs font-medium text-orange-500 hover:text-orange-400 transition-colors"
+        >
+          + Add Funds
+        </Link>
+      </div>
 
       <div className="text-4xl font-bold text-white mb-6">{fmtCash(cashAmount)}</div>
 

--- a/apps/kernel/app/pay/page.tsx
+++ b/apps/kernel/app/pay/page.tsx
@@ -63,10 +63,22 @@ export default async function Home() {
       />
 
       {/* Quick Navigation */}
-      <div className="flex gap-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+        <Link
+          href="/pay/topup"
+          className="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-xl p-4 text-center transition-colors group"
+        >
+          <div className="text-2xl mb-2">💳</div>
+          <div className="text-sm font-medium text-white group-hover:text-orange-400 transition-colors">
+            Add Funds
+          </div>
+          <div className="text-xs text-zinc-500 mt-1">
+            Top up your balance
+          </div>
+        </Link>
         <Link
           href="/pay/payouts"
-          className="flex-1 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-xl p-4 text-center transition-colors group"
+          className="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-xl p-4 text-center transition-colors group"
         >
           <div className="text-2xl mb-2">💰</div>
           <div className="text-sm font-medium text-white group-hover:text-orange-400 transition-colors">
@@ -78,7 +90,7 @@ export default async function Home() {
         </Link>
         <Link
           href="/pay/history"
-          className="flex-1 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-xl p-4 text-center transition-colors group"
+          className="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-xl p-4 text-center transition-colors group"
         >
           <div className="text-2xl mb-2">📊</div>
           <div className="text-sm font-medium text-white group-hover:text-orange-400 transition-colors">

--- a/apps/kernel/app/pay/topup/page.tsx
+++ b/apps/kernel/app/pay/topup/page.tsx
@@ -1,0 +1,476 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { STRIPE_RATE_BPS, STRIPE_FIXED_CENTS } from '@imajin/fair';
+
+const PRESET_AMOUNTS = [20, 50, 100, 250, 1000];
+const MIN_TOPUP = 20;
+
+function fmtCurrency(n: number) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'CAD',
+    minimumFractionDigits: 2,
+  }).format(n);
+}
+
+function calcStripeCharge(amount: number, userAbsorbs: boolean): number {
+  const amountCents = Math.round(amount * 100);
+  if (userAbsorbs) {
+    return Math.ceil((amountCents + STRIPE_FIXED_CENTS) / (1 - STRIPE_RATE_BPS / 10000)) / 100;
+  }
+  return amount;
+}
+
+function calcStripeFee(amount: number, userAbsorbs: boolean): number {
+  const charge = calcStripeCharge(amount, userAbsorbs);
+  return charge - amount;
+}
+
+type Step = 1 | 2 | 3;
+type Method = 'stripe' | 'emt';
+
+export default function TopupPage() {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>(1);
+  const [amount, setAmount] = useState<number>(50);
+  const [customAmount, setCustomAmount] = useState<string>('');
+  const [method, setMethod] = useState<Method>('stripe');
+  const [absorbFees, setAbsorbFees] = useState<boolean>(true); // true = platform absorbs
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionChecked, setSessionChecked] = useState(false);
+  const [emtInstructions, setEmtInstructions] = useState<{
+    email: string;
+    amount: number;
+    memo: string;
+  } | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Auth check on mount
+  useEffect(() => {
+    fetch('/api/session', { credentials: 'include' })
+      .then((res) => {
+        if (!res.ok) {
+          const authUrl = process.env.NEXT_PUBLIC_AUTH_URL || 'https://auth.imajin.ai';
+          const payUrl = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
+          window.location.href = `${authUrl}/login?next=${encodeURIComponent(`${payUrl}/topup`)}`;
+          return;
+        }
+        setSessionChecked(true);
+      })
+      .catch(() => {
+        setSessionChecked(true);
+      });
+  }, []);
+
+  const handlePresetClick = useCallback((val: number) => {
+    setAmount(val);
+    setCustomAmount('');
+    setError(null);
+  }, []);
+
+  const handleCustomChange = useCallback((val: string) => {
+    setCustomAmount(val);
+    const num = parseFloat(val);
+    if (!isNaN(num) && num > 0) {
+      setAmount(num);
+    }
+    setError(null);
+  }, []);
+
+  const canProceedStep1 = amount >= MIN_TOPUP;
+
+  const handleProceedToStep2 = useCallback(() => {
+    if (!canProceedStep1) {
+      setError(`Minimum top-up is $${MIN_TOPUP}`);
+      return;
+    }
+    setError(null);
+    setStep(2);
+  }, [canProceedStep1]);
+
+  const handleProceedToStep3 = useCallback(async () => {
+    setError(null);
+    setLoading(true);
+
+    try {
+      if (method === 'stripe') {
+        const res = await fetch('/pay/api/topup/stripe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            amount,
+            absorbFees,
+          }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          throw new Error(data.error || 'Failed to create checkout session');
+        }
+
+        // Redirect to Stripe Checkout
+        window.location.href = data.url;
+        return;
+      }
+
+      if (method === 'emt') {
+        const res = await fetch('/pay/api/topup/emt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ amount }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          throw new Error(data.error || 'Failed to create EMT request');
+        }
+
+        setEmtInstructions(data.instructions);
+        setStep(3);
+      }
+    } catch (err: any) {
+      setError(err.message || 'Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [amount, method, absorbFees]);
+
+  const handleCopyMemo = useCallback(() => {
+    if (emtInstructions?.memo) {
+      navigator.clipboard.writeText(emtInstructions.memo);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [emtInstructions]);
+
+  if (!sessionChecked) {
+    return (
+      <div className="max-w-xl mx-auto pt-12 text-center">
+        <div className="text-zinc-500">Checking session...</div>
+      </div>
+    );
+  }
+
+  const stripeCharge = calcStripeCharge(amount, !absorbFees);
+  const stripeFee = calcStripeFee(amount, !absorbFees);
+
+  return (
+    <div className="max-w-xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link href="/pay" className="text-zinc-500 hover:text-zinc-300 text-sm transition-colors">
+          ← Dashboard
+        </Link>
+        <h1 className="text-2xl font-bold text-white">Add Funds</h1>
+      </div>
+
+      {/* Step indicators */}
+      <div className="flex items-center gap-2">
+        <div className={`flex-1 h-1 rounded-full ${step >= 1 ? 'bg-orange-500' : 'bg-zinc-800'}`} />
+        <div className={`flex-1 h-1 rounded-full ${step >= 2 ? 'bg-orange-500' : 'bg-zinc-800'}`} />
+        <div className={`flex-1 h-1 rounded-full ${step >= 3 ? 'bg-orange-500' : 'bg-zinc-800'}`} />
+      </div>
+
+      {/* Step 1 — Amount */}
+      {step === 1 && (
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-white mb-1">How much?</h2>
+            <p className="text-sm text-zinc-500">Select an amount or enter your own (min $20)</p>
+          </div>
+
+          {/* Preset cards */}
+          <div className="grid grid-cols-3 sm:grid-cols-5 gap-3">
+            {PRESET_AMOUNTS.map((val) => (
+              <button
+                key={val}
+                onClick={() => handlePresetClick(val)}
+                className={`relative rounded-xl border px-3 py-4 text-center transition-all ${
+                  amount === val && !customAmount
+                    ? 'border-orange-500 bg-orange-500/10'
+                    : 'border-zinc-800 bg-zinc-900 hover:border-zinc-700'
+                }`}
+              >
+                <span className="text-sm font-semibold text-white">
+                  {val >= 1000 ? `$${(val / 1000).toFixed(0)}k` : `$${val}`}
+                </span>
+              </button>
+            ))}
+          </div>
+
+          {/* Custom amount */}
+          <div className="relative">
+            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 text-lg">$</span>
+            <input
+              type="number"
+              min={MIN_TOPUP}
+              step="0.01"
+              placeholder="Custom amount"
+              value={customAmount}
+              onChange={(e) => handleCustomChange(e.target.value)}
+              className="w-full bg-zinc-900 border border-zinc-800 rounded-xl pl-10 pr-4 py-4 text-white text-lg placeholder-zinc-600 focus:border-orange-500 focus:outline-none transition-colors"
+            />
+          </div>
+
+          {error && (
+            <div className="bg-red-900/20 border border-red-900/40 rounded-lg px-4 py-3 text-sm text-red-400">
+              {error}
+            </div>
+          )}
+
+          <button
+            onClick={handleProceedToStep2}
+            disabled={!canProceedStep1}
+            className="w-full px-4 py-3 bg-orange-500 hover:bg-orange-600 disabled:bg-zinc-800 disabled:text-zinc-600 text-white font-medium rounded-xl transition-colors"
+          >
+            Continue
+          </button>
+        </div>
+      )}
+
+      {/* Step 2 — Method + Fee Toggle */}
+      {step === 2 && (
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-white mb-1">Payment method</h2>
+            <p className="text-sm text-zinc-500">Choose how you want to add funds</p>
+          </div>
+
+          {/* Fee toggle */}
+          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-zinc-400">Who covers processing fees?</span>
+              <span className="text-xs text-zinc-500">
+                {absorbFees ? 'Platform' : 'Me'}
+              </span>
+            </div>
+            <div className="flex bg-black/40 rounded-lg p-1">
+              <button
+                onClick={() => setAbsorbFees(false)}
+                className={`flex-1 py-2 text-sm font-medium rounded-md transition-all ${
+                  !absorbFees
+                    ? 'bg-zinc-700 text-white'
+                    : 'text-zinc-500 hover:text-zinc-300'
+                }`}
+              >
+                Me
+              </button>
+              <button
+                onClick={() => setAbsorbFees(true)}
+                className={`flex-1 py-2 text-sm font-medium rounded-md transition-all ${
+                  absorbFees
+                    ? 'bg-zinc-700 text-white'
+                    : 'text-zinc-500 hover:text-zinc-300'
+                }`}
+              >
+                Platform
+              </button>
+            </div>
+          </div>
+
+          {/* Method cards */}
+          <div className="space-y-3">
+            {/* Stripe */}
+            <button
+              onClick={() => setMethod('stripe')}
+              className={`w-full text-left rounded-xl border p-4 transition-all ${
+                method === 'stripe'
+                  ? 'border-orange-500 bg-orange-500/5'
+                  : 'border-zinc-800 bg-zinc-900 hover:border-zinc-700'
+              }`}
+            >
+              <div className="flex items-start gap-4">
+                <div className="text-2xl shrink-0">💳</div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-white">Credit / Debit Card</span>
+                    <span className="text-xs text-green-400 bg-green-400/10 px-2 py-0.5 rounded-full">
+                      Instant
+                    </span>
+                  </div>
+                  <div className="text-xs text-zinc-500 mt-1">Powered by Stripe</div>
+
+                  {/* Breakdown */}
+                  <div className="mt-3 space-y-1.5 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-zinc-500">You receive</span>
+                      <span className="text-white font-medium">{fmtCurrency(amount)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-zinc-500">Processing fee</span>
+                      <span className={stripeFee > 0 ? 'text-zinc-400' : 'text-green-400'}>
+                        {stripeFee > 0 ? fmtCurrency(stripeFee) : 'Free'}
+                      </span>
+                    </div>
+                    <div className="flex justify-between border-t border-zinc-800 pt-1.5">
+                      <span className="text-zinc-400">You pay</span>
+                      <span className="text-white font-semibold">{fmtCurrency(stripeCharge)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-zinc-500">Credit to balance</span>
+                      <span className="text-amber-400 font-medium">人{Math.round(amount)}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+
+            {/* EMT */}
+            <button
+              onClick={() => setMethod('emt')}
+              className={`w-full text-left rounded-xl border p-4 transition-all ${
+                method === 'emt'
+                  ? 'border-orange-500 bg-orange-500/5'
+                  : 'border-zinc-800 bg-zinc-900 hover:border-zinc-700'
+              }`}
+            >
+              <div className="flex items-start gap-4">
+                <div className="text-2xl shrink-0">🏦</div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-white">Interac e-Transfer</span>
+                    <span className="text-xs text-amber-400 bg-amber-400/10 px-2 py-0.5 rounded-full">
+                      Zero fees
+                    </span>
+                  </div>
+                  <div className="text-xs text-zinc-500 mt-1">Manual — admin matched</div>
+
+                  {/* Breakdown */}
+                  <div className="mt-3 space-y-1.5 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-zinc-500">You receive</span>
+                      <span className="text-white font-medium">{fmtCurrency(amount)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-zinc-500">Processing fee</span>
+                      <span className="text-green-400 font-medium">$0.00</span>
+                    </div>
+                    <div className="flex justify-between border-t border-zinc-800 pt-1.5">
+                      <span className="text-zinc-400">You pay</span>
+                      <span className="text-white font-semibold">{fmtCurrency(amount)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-zinc-500">Credit to balance</span>
+                      <span className="text-amber-400 font-medium">人{Math.round(amount)}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+
+          {error && (
+            <div className="bg-red-900/20 border border-red-900/40 rounded-lg px-4 py-3 text-sm text-red-400">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <button
+              onClick={() => setStep(1)}
+              className="px-5 py-3 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 text-zinc-300 font-medium rounded-xl transition-colors"
+            >
+              Back
+            </button>
+            <button
+              onClick={handleProceedToStep3}
+              disabled={loading}
+              className="flex-1 px-4 py-3 bg-orange-500 hover:bg-orange-600 disabled:bg-zinc-800 disabled:text-zinc-600 text-white font-medium rounded-xl transition-colors"
+            >
+              {loading ? 'Processing...' : method === 'stripe' ? 'Pay with Stripe →' : 'Confirm e-Transfer →'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 3 — EMT Confirmation */}
+      {step === 3 && method === 'emt' && emtInstructions && (
+        <div className="space-y-6">
+          <div className="text-center">
+            <div className="text-4xl mb-3">🏦</div>
+            <h2 className="text-xl font-semibold text-white">Send your e-Transfer</h2>
+            <p className="text-sm text-zinc-500 mt-1">
+              Your balance will be credited once we receive and match your transfer.
+            </p>
+          </div>
+
+          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 space-y-4">
+            <div className="space-y-3">
+              <div>
+                <div className="text-xs text-zinc-500 mb-1">Send to</div>
+                <div className="flex items-center justify-between bg-black/40 rounded-lg px-4 py-3">
+                  <span className="text-white font-mono text-sm">{emtInstructions.email}</span>
+                  <button
+                    onClick={() => {
+                      navigator.clipboard.writeText(emtInstructions.email);
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 2000);
+                    }}
+                    className="text-xs text-orange-500 hover:text-orange-400 transition-colors"
+                  >
+                    {copied ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <div className="text-xs text-zinc-500 mb-1">Amount</div>
+                <div className="bg-black/40 rounded-lg px-4 py-3 text-white font-medium">
+                  {fmtCurrency(emtInstructions.amount)}
+                </div>
+              </div>
+
+              <div>
+                <div className="text-xs text-zinc-500 mb-1">Message / Memo</div>
+                <div className="flex items-center justify-between bg-black/40 rounded-lg px-4 py-3">
+                  <span className="text-white font-mono text-sm">{emtInstructions.memo}</span>
+                  <button
+                    onClick={handleCopyMemo}
+                    className="text-xs text-orange-500 hover:text-orange-400 transition-colors"
+                  >
+                    {copied ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+                <p className="text-xs text-zinc-600 mt-1.5">
+                  Include this exact memo so we can match your transfer to your account.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-amber-900/10 border border-amber-900/30 rounded-xl p-4">
+            <div className="text-sm text-amber-400 font-medium mb-1">What happens next?</div>
+            <ul className="text-sm text-zinc-400 space-y-1 list-disc list-inside">
+              <li>Send the e-Transfer from your bank app</li>
+              <li>We&apos;ll match it using the memo within 1 business day</li>
+              <li>Your MJNx balance will be credited automatically</li>
+            </ul>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <Link
+              href="/pay"
+              className="block w-full text-center px-4 py-3 bg-orange-500 hover:bg-orange-600 text-white font-medium rounded-xl transition-colors"
+            >
+              Back to Dashboard
+            </Link>
+            <Link
+              href="/pay/history"
+              className="block w-full text-center px-4 py-3 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 text-zinc-300 font-medium rounded-xl transition-colors"
+            >
+              View Transaction History
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/kernel/app/pay/topup/success/page.tsx
+++ b/apps/kernel/app/pay/topup/success/page.tsx
@@ -1,0 +1,81 @@
+import { redirect } from 'next/navigation';
+import { getSession } from '@imajin/auth';
+import { db, transactions } from '@/src/db';
+import { eq } from 'drizzle-orm';
+import Link from 'next/link';
+
+interface SuccessPageProps {
+  searchParams: { session_id?: string };
+}
+
+export default async function TopupSuccessPage({ searchParams }: SuccessPageProps) {
+  const session = await getSession();
+
+  if (!session) {
+    const authUrl = process.env.NEXT_PUBLIC_AUTH_URL || 'https://auth.imajin.ai';
+    const payUrl = process.env.NEXT_PUBLIC_PAY_URL || 'https://pay.imajin.ai';
+    redirect(`${authUrl}/login?next=${encodeURIComponent(`${payUrl}/topup/success`)}`);
+  }
+
+  const { session_id: stripeSessionId } = searchParams;
+  let amount: number | null = null;
+
+  if (stripeSessionId) {
+    const [tx] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.stripeId, stripeSessionId))
+      .limit(1);
+
+    if (tx) {
+      amount = parseFloat(tx.amount);
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto space-y-8 pt-8">
+      <div className="text-center space-y-4">
+        <div className="text-6xl mb-4">✅</div>
+        <h1 className="text-3xl font-bold text-white">Funds Added!</h1>
+        <p className="text-zinc-400">
+          {amount !== null
+            ? `$${amount.toFixed(2)} CAD has been credited to your MJNx balance.`
+            : 'Your top-up has been processed successfully.'}
+        </p>
+      </div>
+
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6 space-y-4">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-zinc-500">Status</span>
+          <span className="text-green-400 font-medium">Completed</span>
+        </div>
+        {amount !== null && (
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-zinc-500">Amount</span>
+            <span className="text-white font-medium">
+              {new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: 'CAD',
+              }).format(amount)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <Link
+          href="/pay"
+          className="block w-full text-center px-4 py-3 bg-orange-500 hover:bg-orange-600 text-white font-medium rounded-xl transition-colors"
+        >
+          Back to Dashboard
+        </Link>
+        <Link
+          href="/pay/history"
+          className="block w-full text-center px-4 py-3 bg-zinc-900 border border-zinc-800 hover:border-zinc-700 text-zinc-300 font-medium rounded-xl transition-colors"
+        >
+          View Transaction History
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Self-service "Add Funds" flow on the Pay page. Users can load MJNx via Stripe (instant, with fee transparency) or Interac e-Transfer (zero fees, admin-matched).

Closes #948

## Changes

### New
- `apps/kernel/app/pay/topup/page.tsx` — multi-step client component: amount selection → payment method + fee toggle → Stripe redirect or EMT instructions
- `apps/kernel/app/pay/api/topup/stripe/route.ts` — creates Stripe Checkout session with fee-adjusted charge amount
- `apps/kernel/app/pay/api/topup/emt/route.ts` — creates pending EMT transaction, returns copyable payment instructions
- `apps/kernel/app/pay/topup/success/page.tsx` — success page after Stripe checkout completes

### Modified
- `apps/kernel/app/pay/api/webhook/route.ts` — added topup handling in `handleCheckoutCompleted` (atomic tx + cash balance credit)
- `apps/kernel/app/pay/components/BalanceCard.tsx` — added "+ Add Funds" link
- `apps/kernel/app/pay/page.tsx` — added "Add Funds" card to Quick Navigation

## Key Design Decisions
- **Fee toggle**: user-selectable "Who covers processing fees?" with real-time breakdown. Makes it visually obvious EMT is the better deal.
- **EMT flow**: creates pending `pay.transactions` row (`service: 'emt'`, `status: 'pending'`). Admin matches via existing deposits flow — no new tables needed.
- **Webhook**: credits `cash_amount` (real money), not `credit_amount` (MJN earned).
- **No schema changes** — uses existing `pay.transactions` and `pay.balances` tables.

## Testing
- Type check clean (no new errors)
- Stripe flow: select amount → toggle fees → redirect to Checkout → webhook credits balance
- EMT flow: select amount → get instructions (email + memo) → admin matches when transfer arrives