### PR TITLE
feat(events): campaign events — goal-based crowdfunding with Stripe SetupIntent (#749)

### DIFF
--- a/apps/events/app/[eventId]/campaign-section.tsx
+++ b/apps/events/app/[eventId]/campaign-section.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { loadStripe } from '@stripe/stripe-js';
+import { apiFetch } from '@imajin/config';
+import { Countdown } from './countdown';
+import { useToast } from '@imajin/ui';
+
+const STRIPE_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+
+interface CampaignStatus {
+  targetAmount: number;
+  currentAmount: number;
+  pledgeCount: number;
+  deadline: string | null;
+  percentFunded: number;
+  isFullyFunded: boolean;
+}
+
+interface Props {
+  eventId: string;
+  eventTitle: string;
+  isAuthenticated: boolean;
+}
+
+const PRESET_AMOUNTS = [10, 25, 50, 100, 250];
+
+export function CampaignSection({ eventId, eventTitle, isAuthenticated }: Props) {
+  const [status, setStatus] = useState<CampaignStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pledging, setPledging] = useState(false);
+  const [selectedAmount, setSelectedAmount] = useState<number | null>(null);
+  const [customAmount, setCustomAmount] = useState('');
+  const [userPledge, setUserPledge] = useState<{ id: string; amount: number; status: string } | null>(null);
+  const { toast } = useToast();
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await apiFetch(`/api/campaign/${eventId}/status`);
+      if (res.ok) {
+        const data = await res.json();
+        setStatus(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch campaign status:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  // Fetch user's pledge if authenticated
+  const fetchUserPledge = useCallback(async () => {
+    if (!isAuthenticated) return;
+    try {
+      const res = await apiFetch(`/api/campaign/${eventId}/my-pledge`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.pledge) {
+          setUserPledge(data.pledge);
+        }
+      }
+    } catch {
+      // Non-fatal — user may not have a pledge
+    }
+  }, [eventId, isAuthenticated]);
+
+  useEffect(() => {
+    fetchStatus();
+    fetchUserPledge();
+  }, [fetchStatus, fetchUserPledge]);
+
+  async function handlePledge() {
+    const amountCents = selectedAmount
+      ? selectedAmount * 100
+      : Math.round(parseFloat(customAmount) * 100);
+
+    if (!amountCents || amountCents < 100) {
+      toast.error('Minimum pledge is $1.00');
+      return;
+    }
+
+    if (!isAuthenticated) {
+      toast.error('Please sign in to pledge');
+      return;
+    }
+
+    setPledging(true);
+
+    try {
+      // Create pledge + SetupIntent
+      const pledgeRes = await apiFetch('/api/campaign/pledge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventId, amount: amountCents }),
+      });
+
+      if (!pledgeRes.ok) {
+        const data = await pledgeRes.json().catch(() => ({}));
+        toast.error(data.error || 'Failed to create pledge');
+        setPledging(false);
+        return;
+      }
+
+      const { pledgeId, clientSecret } = await pledgeRes.json();
+
+      // Load Stripe and confirm SetupIntent
+      if (!STRIPE_PUBLISHABLE_KEY) {
+        toast.error('Stripe not configured');
+        setPledging(false);
+        return;
+      }
+
+      const stripe = await loadStripe(STRIPE_PUBLISHABLE_KEY);
+      if (!stripe) {
+        toast.error('Failed to load Stripe');
+        setPledging(false);
+        return;
+      }
+
+      const result = await stripe.confirmSetup({
+        clientSecret,
+        confirmParams: {
+          return_url: `${window.location.origin}/${eventId}?pledge=confirmed`,
+        },
+      });
+
+      if ('error' in result && result.error) {
+        toast.error(result.error.message || 'Payment setup failed');
+        setPledging(false);
+        return;
+      }
+
+      // Confirm pledge on server
+      const setupIntent = 'setupIntent' in result ? (result as any).setupIntent : null;
+      if (setupIntent?.status === 'succeeded') {
+        const confirmRes = await apiFetch('/api/campaign/pledge/confirm', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            pledgeId,
+            setupIntentId: setupIntent.id as string,
+            paymentMethodId: setupIntent.payment_method as string,
+          }),
+        });
+
+        if (!confirmRes.ok) {
+          const data = await confirmRes.json().catch(() => ({}));
+          toast.error(data.error || 'Failed to confirm pledge');
+          setPledging(false);
+          return;
+        }
+
+        toast.success('Pledge confirmed! You will be charged when the goal is reached.');
+        setUserPledge({ id: pledgeId, amount: amountCents, status: 'confirmed' });
+        fetchStatus();
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Pledge failed');
+    } finally {
+      setPledging(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="bg-white dark:bg-gray-800/50 rounded-2xl shadow-lg p-6 md:p-8 mb-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+          <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-2/3" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!status) return null;
+
+  const formattedTarget = new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  }).format(status.targetAmount / 100);
+
+  const formattedCurrent = new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  }).format(status.currentAmount / 100);
+
+  return (
+    <div className="bg-white dark:bg-gray-800/50 rounded-2xl shadow-lg p-6 md:p-8 mb-6">
+      <div className="flex items-baseline justify-between mb-4">
+        <h2 className="text-2xl md:text-3xl font-bold">Campaign</h2>
+        {status.isFullyFunded && (
+          <span className="px-3 py-1 bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 text-sm font-semibold rounded-full">
+            🎉 Goal Reached!
+          </span>
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div className="mb-6">
+        <div className="flex justify-between text-sm mb-2">
+          <span className="text-gray-500 dark:text-gray-400">
+            {status.pledgeCount} backer{status.pledgeCount !== 1 ? 's' : ''}
+          </span>
+          <span className="font-semibold">
+            {formattedCurrent} of {formattedTarget}
+          </span>
+        </div>
+        <div className="w-full h-4 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-green-500 transition-all duration-500"
+            style={{ width: `${status.percentFunded}%` }}
+          />
+        </div>
+        <div className="text-right text-sm text-gray-500 dark:text-gray-400 mt-1">
+          {status.percentFunded}% funded
+        </div>
+      </div>
+
+      {/* Deadline countdown */}
+      {status.deadline && !status.isFullyFunded && (
+        <div className="mb-6">
+          <Countdown targetDate={status.deadline} label="Campaign ends in" />
+        </div>
+      )}
+
+      {/* User's pledge */}
+      {userPledge && (
+        <div className="mb-6 p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl">
+          <p className="text-sm text-green-800 dark:text-green-300">
+            ✅ Your pledge:{' '}
+            <strong>
+              {new Intl.NumberFormat('en-CA', {
+                style: 'currency',
+                currency: 'CAD',
+              }).format(userPledge.amount / 100)}
+            </strong>{' '}
+            — will be charged when the goal is reached
+          </p>
+        </div>
+      )}
+
+      {/* Pledge form */}
+      {!userPledge && !status.isFullyFunded && (
+        <div className="space-y-4">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Select an amount to pledge. You won&apos;t be charged until the campaign reaches its goal.
+          </p>
+
+          {/* Preset amounts */}
+          <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
+            {PRESET_AMOUNTS.map((amt) => (
+              <button
+                key={amt}
+                type="button"
+                onClick={() => {
+                  setSelectedAmount(amt);
+                  setCustomAmount('');
+                }}
+                className={`py-2.5 rounded-lg font-semibold text-sm transition ${
+                  selectedAmount === amt
+                    ? 'bg-orange-500 text-white'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                }`}
+              >
+                ${amt}
+              </button>
+            ))}
+          </div>
+
+          {/* Custom amount */}
+          <div className="flex items-center gap-2">
+            <span className="text-gray-500 dark:text-gray-400">$</span>
+            <input
+              type="number"
+              min="1"
+              step="0.01"
+              placeholder="Custom amount"
+              value={customAmount}
+              onChange={(e) => {
+                setCustomAmount(e.target.value);
+                setSelectedAmount(null);
+              }}
+              className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+
+          {/* Pledge button */}
+          <button
+            onClick={handlePledge}
+            disabled={pledging || (!selectedAmount && !customAmount)}
+            className="w-full py-3 bg-orange-500 hover:bg-orange-600 disabled:bg-orange-300 text-white font-semibold rounded-lg transition"
+          >
+            {pledging
+              ? 'Processing...'
+              : selectedAmount || customAmount
+              ? `Pledge $${selectedAmount || customAmount}`
+              : 'Back this Campaign'}
+          </button>
+
+          {!isAuthenticated && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+              Sign in to pledge
+            </p>
+          )}
+        </div>
+      )}
+
+      {status.isFullyFunded && !userPledge && (
+        <div className="text-center py-4">
+          <p className="text-lg font-semibold text-green-600 dark:text-green-400">
+            🎉 This campaign has reached its goal!
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/events/app/[eventId]/countdown.tsx
+++ b/apps/events/app/[eventId]/countdown.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 
 interface CountdownProps {
   targetDate: string;
+  label?: string;
 }
 
 interface TimeLeft {
@@ -28,7 +29,7 @@ function calculateTimeLeft(targetDate: string): TimeLeft | null {
   };
 }
 
-export function Countdown({ targetDate }: CountdownProps) {
+export function Countdown({ targetDate, label = 'Event starts in' }: CountdownProps) {
   const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(null);
   const [mounted, setMounted] = useState(false);
 
@@ -48,12 +49,12 @@ export function Countdown({ targetDate }: CountdownProps) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 mb-8">
         <div className="text-center">
-          <p className="text-sm text-gray-500 uppercase tracking-wide mb-4">Event starts in</p>
+          <p className="text-sm text-gray-500 uppercase tracking-wide mb-4">{label}</p>
           <div className="flex justify-center gap-4">
-            {['Days', 'Hours', 'Minutes', 'Seconds'].map((label) => (
-              <div key={label} className="text-center">
+            {['Days', 'Hours', 'Minutes', 'Seconds'].map((unitLabel) => (
+              <div key={unitLabel} className="text-center">
                 <div className="text-4xl font-bold text-gray-300">--</div>
-                <div className="text-xs text-gray-500 uppercase">{label}</div>
+                <div className="text-xs text-gray-500 uppercase">{unitLabel}</div>
               </div>
             ))}
           </div>
@@ -80,10 +81,10 @@ export function Countdown({ targetDate }: CountdownProps) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 mb-8">
       <div className="text-center">
-        <p className="text-sm text-gray-500 uppercase tracking-wide mb-4">Event starts in</p>
+        <p className="text-sm text-gray-500 uppercase tracking-wide mb-4">{label}</p>
         <div className="flex justify-center gap-4 md:gap-8">
-          {units.map(({ value, label }) => (
-            <div key={label} className="text-center">
+          {units.map(({ value, label: unitLabel }) => (
+            <div key={unitLabel} className="text-center">
               <div className="text-3xl md:text-5xl font-bold bg-gradient-to-br from-orange-500 to-amber-600 bg-clip-text text-transparent">
                 {value.toString().padStart(2, '0')}
               </div>

--- a/apps/events/app/[eventId]/edit/campaign-dashboard.tsx
+++ b/apps/events/app/[eventId]/edit/campaign-dashboard.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { apiFetch } from '@imajin/config';
+import { useToast } from '@imajin/ui';
+
+interface Pledge {
+  id: string;
+  backerDid: string;
+  amount: number;
+  currency: string;
+  status: string;
+  createdAt: string;
+  chargedAt: string | null;
+  failureReason: string | null;
+}
+
+interface CampaignStatus {
+  targetAmount: number;
+  currentAmount: number;
+  pledgeCount: number;
+  deadline: string | null;
+  percentFunded: number;
+  isFullyFunded: boolean;
+}
+
+interface Props {
+  eventId: string;
+}
+
+export function CampaignDashboard({ eventId }: Props) {
+  const [status, setStatus] = useState<CampaignStatus | null>(null);
+  const [pledges, setPledges] = useState<Pledge[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [settling, setSettling] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const [settleResult, setSettleResult] = useState<any>(null);
+  const { toast } = useToast();
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [statusRes, pledgesRes] = await Promise.all([
+        apiFetch(`/api/campaign/${eventId}/status`),
+        apiFetch(`/api/campaign/${eventId}/pledges`),
+      ]);
+
+      if (statusRes.ok) {
+        const s = await statusRes.json();
+        setStatus(s);
+      }
+
+      if (pledgesRes.ok) {
+        const p = await pledgesRes.json();
+        setPledges(p.pledges || []);
+      }
+    } catch (err) {
+      console.error('Failed to fetch campaign data:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  async function handleSettle() {
+    if (!status?.isFullyFunded) {
+      toast.error('Campaign target has not been met');
+      return;
+    }
+
+    if (!confirm('This will charge all confirmed backers. Continue?')) {
+      return;
+    }
+
+    setSettling(true);
+    setSettleResult(null);
+
+    try {
+      const res = await apiFetch(`/api/campaign/${eventId}/settle`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        toast.error(data.error || 'Settlement failed');
+        setSettling(false);
+        return;
+      }
+
+      setSettleResult(data);
+      toast.success(`Charged ${data.charged} of ${data.total} pledges`);
+      fetchData();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Settlement failed');
+    } finally {
+      setSettling(false);
+    }
+  }
+
+  async function handleCancel() {
+    if (!confirm('This will cancel the campaign and all pledges. This cannot be undone. Continue?')) {
+      return;
+    }
+
+    setCancelling(true);
+
+    try {
+      const res = await apiFetch(`/api/campaign/${eventId}/cancel`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        toast.error(data.error || 'Cancel failed');
+        setCancelling(false);
+        return;
+      }
+
+      toast.success(`Cancelled ${data.cancelled} pledges`);
+      fetchData();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Cancel failed');
+    } finally {
+      setCancelling(false);
+    }
+  }
+
+  const currencyFmt = new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+  });
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <div className="animate-pulse h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/3" />
+        <div className="animate-pulse h-32 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Status card */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
+        <h2 className="text-xl font-semibold mb-4">Campaign Status</h2>
+        {status && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+              <div className="text-sm text-gray-500 dark:text-gray-400">Goal</div>
+              <div className="text-xl font-bold">{currencyFmt.format(status.targetAmount / 100)}</div>
+            </div>
+            <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+              <div className="text-sm text-gray-500 dark:text-gray-400">Raised</div>
+              <div className="text-xl font-bold text-green-600">{currencyFmt.format(status.currentAmount / 100)}</div>
+            </div>
+            <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+              <div className="text-sm text-gray-500 dark:text-gray-400">Backers</div>
+              <div className="text-xl font-bold">{status.pledgeCount}</div>
+            </div>
+            <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+              <div className="text-sm text-gray-500 dark:text-gray-400">Progress</div>
+              <div className="text-xl font-bold">{status.percentFunded}%</div>
+            </div>
+          </div>
+        )}
+
+        {/* Progress bar */}
+        {status && (
+          <div className="mt-4">
+            <div className="w-full h-3 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-green-500 transition-all"
+                style={{ width: `${status.percentFunded}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <button
+          onClick={handleSettle}
+          disabled={settling || !status?.isFullyFunded}
+          className={`px-6 py-3 rounded-lg font-semibold transition ${
+            status?.isFullyFunded
+              ? 'bg-green-500 hover:bg-green-600 text-white'
+              : 'bg-gray-300 dark:bg-gray-700 text-gray-500 cursor-not-allowed'
+          }`}
+        >
+          {settling ? 'Charging...' : '💰 Charge All Backers'}
+        </button>
+        <button
+          onClick={handleCancel}
+          disabled={cancelling}
+          className="px-6 py-3 rounded-lg font-semibold bg-red-500 hover:bg-red-600 disabled:bg-red-300 text-white transition"
+        >
+          {cancelling ? 'Cancelling...' : '🚫 Cancel Campaign'}
+        </button>
+      </div>
+
+      {!status?.isFullyFunded && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Charging is only available when the campaign reaches its funding goal.
+        </p>
+      )}
+
+      {/* Settlement results */}
+      {settleResult && (
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
+          <h3 className="text-lg font-semibold mb-3">Settlement Results</h3>
+          <div className="grid grid-cols-3 gap-4 mb-4">
+            <div className="text-center p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
+              <div className="text-2xl font-bold text-green-600">{settleResult.charged}</div>
+              <div className="text-xs text-gray-500">Charged</div>
+            </div>
+            <div className="text-center p-3 bg-red-50 dark:bg-red-900/20 rounded-lg">
+              <div className="text-2xl font-bold text-red-600">{settleResult.failed}</div>
+              <div className="text-xs text-gray-500">Failed</div>
+            </div>
+            <div className="text-center p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+              <div className="text-2xl font-bold">{settleResult.total}</div>
+              <div className="text-xs text-gray-500">Total</div>
+            </div>
+          </div>
+          {settleResult.results?.length > 0 && (
+            <div className="space-y-1 max-h-60 overflow-y-auto">
+              {settleResult.results.map((r: any) => (
+                <div
+                  key={r.pledgeId}
+                  className={`flex items-center justify-between px-3 py-2 rounded text-sm ${
+                    r.status === 'charged'
+                      ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300'
+                      : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300'
+                  }`}
+                >
+                  <span className="font-mono text-xs">{r.pledgeId.slice(0, 16)}...</span>
+                  <span className="text-xs">{r.status === 'charged' ? '✅ Charged' : `❌ ${r.error || 'Failed'}`}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Pledges table */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
+        <h3 className="text-lg font-semibold mb-4">Pledges ({pledges.length})</h3>
+        {pledges.length === 0 ? (
+          <p className="text-gray-500 dark:text-gray-400 text-center py-8">No pledges yet</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 dark:border-gray-700">
+                  <th className="text-left py-2 px-3 font-medium text-gray-500 dark:text-gray-400">Backer</th>
+                  <th className="text-right py-2 px-3 font-medium text-gray-500 dark:text-gray-400">Amount</th>
+                  <th className="text-left py-2 px-3 font-medium text-gray-500 dark:text-gray-400">Status</th>
+                  <th className="text-left py-2 px-3 font-medium text-gray-500 dark:text-gray-400">Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pledges.map((p) => (
+                  <tr key={p.id} className="border-b border-gray-100 dark:border-gray-800">
+                    <td className="py-2 px-3 font-mono text-xs">{p.backerDid.slice(0, 16)}...</td>
+                    <td className="py-2 px-3 text-right font-semibold">
+                      {currencyFmt.format(p.amount / 100)}
+                    </td>
+                    <td className="py-2 px-3">
+                      <StatusBadge status={p.status} />
+                    </td>
+                    <td className="py-2 px-3 text-gray-500 dark:text-gray-400">
+                      {new Date(p.createdAt).toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    pending: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300',
+    confirmed: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+    charged: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300',
+    failed: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300',
+    cancelled: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+  };
+
+  return (
+    <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium ${styles[status] || styles.pending}`}>
+      {status}
+    </span>
+  );
+}

--- a/apps/events/app/[eventId]/edit/form.tsx
+++ b/apps/events/app/[eventId]/edit/form.tsx
@@ -8,6 +8,7 @@ import { FairEditor } from '@imajin/fair';
 import { apiFetch } from '@imajin/config';
 import type { FairManifest } from '@imajin/fair';
 import type { Event, TicketType } from '@/src/db/schema';
+import { CampaignDashboard } from './campaign-dashboard';
 
 interface Props {
   event: Event;
@@ -39,7 +40,7 @@ interface Survey {
   responseCount?: number;
 }
 
-type ActiveTab = 'details' | 'fair';
+type ActiveTab = 'details' | 'fair' | 'campaign';
 
 export default function EventEditForm({ event, existingTickets, creatorEmail, organizerDids, viewerDid, creatorHandle, creatorName }: Props) {
   const router = useRouter();
@@ -355,6 +356,19 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         >
           ⚖️ .fair Attribution
         </button>
+        {(event as any).eventType === 'campaign' && (
+          <button
+            type="button"
+            onClick={() => setActiveTab('campaign')}
+            className={`flex-1 px-4 py-2 rounded-md text-sm font-medium transition ${
+              activeTab === 'campaign'
+                ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-900 dark:text-white'
+                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+          >
+            💰 Campaign
+          </button>
+        )}
       </div>
 
       {/* .fair Editor */}
@@ -403,6 +417,11 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             </div>
           )}
         </div>
+      )}
+
+      {/* Campaign Dashboard */}
+      {activeTab === 'campaign' && (
+        <CampaignDashboard eventId={event.id} />
       )}
 
     {activeTab === 'details' && (

--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -6,6 +6,7 @@ const log = createLogger('events');
 import { db, events, ticketTypes, tickets, orders, eventInvites } from '@/src/db';
 import { eq, and } from 'drizzle-orm';
 import { TicketsSection } from './tickets-section';
+import { CampaignSection } from './campaign-section';
 import { generateQRCode } from '@/src/lib/email';
 import { getClient } from '@imajin/db';
 import { getContactEmail } from '@/src/lib/contact-email';
@@ -755,50 +756,61 @@ export default async function EventPage({ params, searchParams }: Props) {
           />
         </div>
 
-        {/* Tickets Section */}
-        <div className="bg-white dark:bg-gray-800/50 backdrop-blur-sm rounded-2xl shadow-lg p-6 md:p-8" id="tickets">
-          <div className="flex items-baseline justify-between mb-6">
-            <h2 className="text-2xl md:text-3xl font-bold">Tickets</h2>
-            {!session && <MagicLinkButton eventId={event.id} />}
-          </div>
+        {/* Campaign Section (for campaign events) */}
+        {event.eventType === 'campaign' && status !== 'cancelled' && (
+          <CampaignSection
+            eventId={event.id}
+            eventTitle={event.title}
+            isAuthenticated={!!session}
+          />
+        )}
 
-          {!canSeeTickets ? (
-            <div className="text-center py-12">
-              <div className="text-5xl mb-4">🔒</div>
-              <p className="text-lg font-semibold mb-2">This event is invite-only</p>
-              <p className="text-gray-500 dark:text-gray-400 text-sm">
-                You need a valid invite link to purchase tickets.
-              </p>
+        {/* Tickets Section (for regular events) */}
+        {event.eventType !== 'campaign' && (
+          <div className="bg-white dark:bg-gray-800/50 backdrop-blur-sm rounded-2xl shadow-lg p-6 md:p-8" id="tickets">
+            <div className="flex items-baseline justify-between mb-6">
+              <h2 className="text-2xl md:text-3xl font-bold">Tickets</h2>
+              {!session && <MagicLinkButton eventId={event.id} />}
             </div>
-          ) : canPurchaseTickets ? (
-            <TicketsGate
-              surveysRequired={requiredSurveyIds.length > 0}
-              initialCompleted={surveysCompleted}
-              requiredSurveyIds={requiredSurveyIds}
-            >
-              <TicketsSection
-                eventId={event.id}
-                eventTitle={event.title}
-                tickets={ticketTypesList}
-                userOrders={userOrders}
-                hasTicket={hasTicket}
-                inviteToken={inviteToken}
-                etransferEnabled={etransferEnabled}
-                isAuthenticated={!!session}
-                sessionEmail={session?.email ?? undefined}
-                sessionContactEmail={sessionContactEmail}
-                sellerConnected={sellerConnected}
-                hasHiddenTiers={hasHiddenTiers}
-              />
-            </TicketsGate>
-          ) : (
-            <p className="text-gray-500 dark:text-gray-400 text-center py-8">
-              {status === 'cancelled' ? 'Ticket sales are closed — this event was cancelled.' :
-               status === 'completed' ? 'This event has ended. Ticket sales are closed.' :
-               'Ticket sales are not currently available.'}
-            </p>
-          )}
-        </div>
+
+            {!canSeeTickets ? (
+              <div className="text-center py-12">
+                <div className="text-5xl mb-4">🔒</div>
+                <p className="text-lg font-semibold mb-2">This event is invite-only</p>
+                <p className="text-gray-500 dark:text-gray-400 text-sm">
+                  You need a valid invite link to purchase tickets.
+                </p>
+              </div>
+            ) : canPurchaseTickets ? (
+              <TicketsGate
+                surveysRequired={requiredSurveyIds.length > 0}
+                initialCompleted={surveysCompleted}
+                requiredSurveyIds={requiredSurveyIds}
+              >
+                <TicketsSection
+                  eventId={event.id}
+                  eventTitle={event.title}
+                  tickets={ticketTypesList}
+                  userOrders={userOrders}
+                  hasTicket={hasTicket}
+                  inviteToken={inviteToken}
+                  etransferEnabled={etransferEnabled}
+                  isAuthenticated={!!session}
+                  sessionEmail={session?.email ?? undefined}
+                  sessionContactEmail={sessionContactEmail}
+                  sellerConnected={sellerConnected}
+                  hasHiddenTiers={hasHiddenTiers}
+                />
+              </TicketsGate>
+            ) : (
+              <p className="text-gray-500 dark:text-gray-400 text-center py-8">
+                {status === 'cancelled' ? 'Ticket sales are closed — this event was cancelled.' :
+                 status === 'completed' ? 'This event has ended. Ticket sales are closed.' :
+                 'Ticket sales are not currently available.'}
+              </p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Mobile Sticky Bottom Bar — only for purchasable events */}

--- a/apps/events/app/api/campaign/[eventId]/cancel/route.ts
+++ b/apps/events/app/api/campaign/[eventId]/cancel/route.ts
@@ -1,0 +1,112 @@
+/**
+ * POST /api/campaign/{eventId}/cancel
+ *
+ * Cancel a campaign and all pending/confirmed pledges.
+ * Requires campaign creator auth.
+ *
+ * Response:
+ * {
+ *   cancelled: number
+ * }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@imajin/auth';
+import { db, events, pledges } from '@/src/db';
+import { eq, and, sql } from 'drizzle-orm';
+import { corsHeaders } from '@imajin/config';
+import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
+import { withLogger } from '@imajin/logger';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const POST = withLogger('events', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 10, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+
+  try {
+    const url = new URL(request.url);
+    const pathParts = url.pathname.split('/');
+    const eventId = pathParts[pathParts.length - 2]; // /api/campaign/{eventId}/cancel
+
+    if (!eventId) {
+      return NextResponse.json({ error: 'eventId is required' }, { status: 400, headers: cors });
+    }
+
+    // Fetch event
+    const [event] = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, eventId))
+      .limit(1);
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404, headers: cors });
+    }
+
+    if (event.eventType !== 'campaign') {
+      return NextResponse.json({ error: 'Not a campaign event' }, { status: 400, headers: cors });
+    }
+
+    if (event.creatorDid !== did) {
+      return NextResponse.json(
+        { error: 'Only the campaign creator can cancel' },
+        { status: 403, headers: cors }
+      );
+    }
+
+    // Cancel all pending and confirmed pledges
+    const cancelledPledges = await db
+      .select({ id: pledges.id })
+      .from(pledges)
+      .where(
+        and(
+          eq(pledges.eventId, eventId),
+          sql`${pledges.status} IN ('pending', 'confirmed')`
+        )
+      );
+
+    for (const p of cancelledPledges) {
+      await db
+        .update(pledges)
+        .set({ status: 'cancelled' })
+        .where(eq(pledges.id, p.id));
+    }
+
+    // Also mark the event as cancelled
+    await db
+      .update(events)
+      .set({ status: 'cancelled' })
+      .where(eq(events.id, eventId));
+
+    const cancelledCount = cancelledPledges.length;
+
+    return NextResponse.json({ cancelled: cancelledCount }, { headers: cors });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Campaign cancel error');
+    return NextResponse.json(
+      { error: 'Failed to cancel campaign' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/apps/events/app/api/campaign/[eventId]/my-pledge/route.ts
+++ b/apps/events/app/api/campaign/[eventId]/my-pledge/route.ts
@@ -1,0 +1,64 @@
+/**
+ * GET /api/campaign/{eventId}/my-pledge
+ *
+ * Returns the current user's pledge for a campaign, if any.
+ * Requires auth.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@imajin/auth';
+import { db, pledges } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+import { corsHeaders } from '@imajin/config';
+import { withLogger } from '@imajin/logger';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const GET = withLogger('events', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+
+  try {
+    const url = new URL(request.url);
+    const pathParts = url.pathname.split('/');
+    const eventId = pathParts[pathParts.length - 2]; // /api/campaign/{eventId}/my-pledge
+
+    if (!eventId) {
+      return NextResponse.json({ error: 'eventId is required' }, { status: 400, headers: cors });
+    }
+
+    const [pledge] = await db
+      .select({
+        id: pledges.id,
+        amount: pledges.amount,
+        status: pledges.status,
+      })
+      .from(pledges)
+      .where(
+        and(
+          eq(pledges.eventId, eventId),
+          eq(pledges.backerDid, did)
+        )
+      )
+      .limit(1);
+
+    return NextResponse.json({ pledge: pledge || null }, { headers: cors });
+  } catch (error) {
+    log.error({ err: String(error) }, 'My pledge error');
+    return NextResponse.json(
+      { error: 'Failed to get pledge' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/apps/events/app/api/campaign/[eventId]/pledges/route.ts
+++ b/apps/events/app/api/campaign/[eventId]/pledges/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /api/campaign/{eventId}/pledges
+ *
+ * Returns all pledges for a campaign event.
+ * Requires campaign creator auth.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@imajin/auth';
+import { db, events, pledges } from '@/src/db';
+import { eq } from 'drizzle-orm';
+import { corsHeaders } from '@imajin/config';
+import { withLogger } from '@imajin/logger';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const GET = withLogger('events', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+
+  try {
+    const url = new URL(request.url);
+    const pathParts = url.pathname.split('/');
+    const eventId = pathParts[pathParts.length - 2]; // /api/campaign/{eventId}/pledges
+
+    if (!eventId) {
+      return NextResponse.json({ error: 'eventId is required' }, { status: 400, headers: cors });
+    }
+
+    // Fetch event and verify creator
+    const [event] = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, eventId))
+      .limit(1);
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404, headers: cors });
+    }
+
+    if (event.creatorDid !== did) {
+      return NextResponse.json(
+        { error: 'Only the campaign creator can view pledges' },
+        { status: 403, headers: cors }
+      );
+    }
+
+    const pledgeList = await db
+      .select()
+      .from(pledges)
+      .where(eq(pledges.eventId, eventId))
+      .orderBy(pledges.createdAt);
+
+    return NextResponse.json({ pledges: pledgeList }, { headers: cors });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Campaign pledges error');
+    return NextResponse.json(
+      { error: 'Failed to get pledges' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/apps/events/app/api/campaign/[eventId]/settle/route.ts
+++ b/apps/events/app/api/campaign/[eventId]/settle/route.ts
@@ -1,0 +1,167 @@
+/**
+ * POST /api/campaign/{eventId}/settle
+ *
+ * Charge all confirmed pledges for a campaign.
+ * Requires campaign creator auth.
+ *
+ * Request: { eventId: string } (from URL)
+ *
+ * Response:
+ * {
+ *   charged: number,
+ *   failed: number,
+ *   total: number,
+ *   results: Array<{ pledgeId: string, status: string, error?: string }>
+ * }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@imajin/auth';
+import { db, events, pledges } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+import { corsHeaders } from '@imajin/config';
+import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
+import { withLogger } from '@imajin/logger';
+
+const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
+const PAY_SERVICE_API_KEY = process.env.PAY_SERVICE_API_KEY!;
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const POST = withLogger('events', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  // Heavy rate limit — triggers real charges
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 5, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+
+  try {
+    const url = new URL(request.url);
+    const pathParts = url.pathname.split('/');
+    const eventId = pathParts[pathParts.length - 2]; // /api/campaign/{eventId}/settle
+
+    if (!eventId) {
+      return NextResponse.json({ error: 'eventId is required' }, { status: 400, headers: cors });
+    }
+
+    // Fetch event
+    const [event] = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, eventId))
+      .limit(1);
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404, headers: cors });
+    }
+
+    if (event.eventType !== 'campaign') {
+      return NextResponse.json({ error: 'Not a campaign event' }, { status: 400, headers: cors });
+    }
+
+    if (event.creatorDid !== did) {
+      return NextResponse.json(
+        { error: 'Only the campaign creator can settle' },
+        { status: 403, headers: cors }
+      );
+    }
+
+    // Get all confirmed pledges
+    const confirmedPledges = await db
+      .select()
+      .from(pledges)
+      .where(
+        and(
+          eq(pledges.eventId, eventId),
+          eq(pledges.status, 'confirmed')
+        )
+      );
+
+    if (confirmedPledges.length === 0) {
+      return NextResponse.json(
+        { charged: 0, failed: 0, total: 0, results: [] },
+        { headers: cors }
+      );
+    }
+
+    // Check if target is met
+    const totalPledged = confirmedPledges.reduce((sum, p) => sum + p.amount, 0);
+    if (event.targetAmount && totalPledged < event.targetAmount) {
+      return NextResponse.json(
+        { error: 'Campaign target has not been met' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    // Call pay service to charge pledges
+    const payRes = await fetch(`${PAY_SERVICE_URL}/api/charge-pledges`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${PAY_SERVICE_API_KEY}`,
+      },
+      body: JSON.stringify({
+        eventId,
+        pledges: confirmedPledges.map((p) => ({
+          pledgeId: p.id,
+          amount: p.amount,
+          currency: p.currency,
+          stripeCustomerId: p.stripeCustomerId,
+          stripePaymentMethodId: p.stripePaymentMethodId,
+        })),
+      }),
+    });
+
+    if (!payRes.ok) {
+      const err = await payRes.json().catch(() => ({}));
+      log.error({ err: err.error || payRes.statusText }, 'Pay service charge-pledges failed');
+      return NextResponse.json(
+        { error: err.error || 'Failed to charge pledges' },
+        { status: 500, headers: cors }
+      );
+    }
+
+    const chargeResult = await payRes.json();
+
+    // Update pledge statuses based on results
+    for (const result of chargeResult.results || []) {
+      if (result.status === 'charged') {
+        await db
+          .update(pledges)
+          .set({ status: 'charged', chargedAt: new Date() })
+          .where(eq(pledges.id, result.pledgeId));
+      } else {
+        await db
+          .update(pledges)
+          .set({ status: 'failed', failureReason: result.error || 'Charge failed' })
+          .where(eq(pledges.id, result.pledgeId));
+      }
+    }
+
+    return NextResponse.json(chargeResult, { headers: cors });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Campaign settle error');
+    return NextResponse.json(
+      { error: 'Failed to settle campaign' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/apps/events/app/api/campaign/[eventId]/status/route.ts
+++ b/apps/events/app/api/campaign/[eventId]/status/route.ts
@@ -1,0 +1,91 @@
+/**
+ * GET /api/campaign/{eventId}/status
+ *
+ * Public endpoint — returns campaign funding status.
+ *
+ * Response:
+ * {
+ *   targetAmount: number,
+ *   currentAmount: number,
+ *   pledgeCount: number,
+ *   deadline: string | null,
+ *   percentFunded: number,
+ *   isFullyFunded: boolean
+ * }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, events, pledges } from '@/src/db';
+import { eq, and, sql } from 'drizzle-orm';
+import { corsHeaders } from '@imajin/config';
+import { withLogger } from '@imajin/logger';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const GET = withLogger('events', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  try {
+    const url = new URL(request.url);
+    const pathParts = url.pathname.split('/');
+    const eventId = pathParts[pathParts.length - 2]; // /api/campaign/{eventId}/status
+
+    if (!eventId) {
+      return NextResponse.json({ error: 'eventId is required' }, { status: 400, headers: cors });
+    }
+
+    // Fetch event
+    const [event] = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, eventId))
+      .limit(1);
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404, headers: cors });
+    }
+
+    if (event.eventType !== 'campaign') {
+      return NextResponse.json({ error: 'Not a campaign event' }, { status: 400, headers: cors });
+    }
+
+    // Sum confirmed + charged pledges
+    const pledgeRows = await db
+      .select({
+        totalAmount: sql<number>`COALESCE(SUM(${pledges.amount}), 0)`,
+        count: sql<number>`COUNT(*)`,
+      })
+      .from(pledges)
+      .where(
+        and(
+          eq(pledges.eventId, eventId),
+          sql`${pledges.status} IN ('confirmed', 'charged')`
+        )
+      );
+
+    const currentAmount = pledgeRows[0]?.totalAmount ?? 0;
+    const pledgeCount = pledgeRows[0]?.count ?? 0;
+    const targetAmount = event.targetAmount ?? 0;
+
+    const percentFunded = targetAmount > 0
+      ? Math.min(100, Math.floor((currentAmount / targetAmount) * 100))
+      : 0;
+
+    return NextResponse.json({
+      targetAmount,
+      currentAmount,
+      pledgeCount,
+      deadline: event.deadline ? new Date(event.deadline).toISOString() : null,
+      percentFunded,
+      isFullyFunded: currentAmount >= targetAmount,
+    }, { headers: cors });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Campaign status error');
+    return NextResponse.json(
+      { error: 'Failed to get campaign status' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/apps/events/app/api/campaign/pledge/confirm/route.ts
+++ b/apps/events/app/api/campaign/pledge/confirm/route.ts
@@ -1,0 +1,121 @@
+/**
+ * POST /api/campaign/pledge/confirm
+ *
+ * Confirm a pledge after Stripe.js successfully confirms the SetupIntent.
+ * Verifies the SetupIntent status and updates the pledge record.
+ *
+ * Request:
+ * {
+ *   pledgeId: string,
+ *   setupIntentId: string
+ * }
+ *
+ * Response:
+ * {
+ *   success: true,
+ *   pledge: { id: string, amount: number, status: string }
+ * }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@imajin/auth';
+import { db, pledges } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+import { corsHeaders } from '@imajin/config';
+import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
+import { withLogger } from '@imajin/logger';
+
+const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const POST = withLogger('events', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 20, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+
+  try {
+    const body = await request.json();
+    const { pledgeId, setupIntentId, paymentMethodId } = body;
+
+    if (!pledgeId || typeof pledgeId !== 'string') {
+      return NextResponse.json({ error: 'pledgeId is required' }, { status: 400, headers: cors });
+    }
+
+    if (!setupIntentId || typeof setupIntentId !== 'string') {
+      return NextResponse.json({ error: 'setupIntentId is required' }, { status: 400, headers: cors });
+    }
+
+    if (!paymentMethodId || typeof paymentMethodId !== 'string') {
+      return NextResponse.json({ error: 'paymentMethodId is required' }, { status: 400, headers: cors });
+    }
+
+    // Find the pledge
+    const [pledge] = await db
+      .select()
+      .from(pledges)
+      .where(and(eq(pledges.id, pledgeId), eq(pledges.backerDid, did)))
+      .limit(1);
+
+    if (!pledge) {
+      return NextResponse.json({ error: 'Pledge not found' }, { status: 404, headers: cors });
+    }
+
+    if (pledge.stripeSetupIntentId !== setupIntentId) {
+      return NextResponse.json(
+        { error: 'SetupIntent ID mismatch' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    // Update pledge to confirmed
+    await db
+      .update(pledges)
+      .set({
+        status: 'confirmed',
+        stripePaymentMethodId: paymentMethodId,
+        metadata: {
+          ...((pledge.metadata as Record<string, any>) || {}),
+          confirmedAt: new Date().toISOString(),
+        },
+      })
+      .where(eq(pledges.id, pledgeId));
+
+    return NextResponse.json(
+      {
+        success: true,
+        pledge: {
+          id: pledge.id,
+          amount: pledge.amount,
+          status: 'confirmed',
+        },
+      },
+      { headers: cors }
+    );
+  } catch (error) {
+    log.error({ err: String(error) }, 'Campaign pledge confirm error');
+    return NextResponse.json(
+      { error: 'Failed to confirm pledge' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/apps/events/app/api/campaign/pledge/route.ts
+++ b/apps/events/app/api/campaign/pledge/route.ts
@@ -1,0 +1,179 @@
+/**
+ * POST /api/campaign/pledge
+ *
+ * Create a pledge for a campaign event.
+ * Calls the pay service to create a Stripe SetupIntent.
+ *
+ * Request:
+ * {
+ *   eventId: string,
+ *   amount: number          // cents, min 100 = $1
+ * }
+ *
+ * Response:
+ * {
+ *   pledgeId: string,
+ *   clientSecret: string
+ * }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@imajin/auth';
+import { db, events, pledges } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+import { corsHeaders } from '@imajin/config';
+import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
+import { withLogger } from '@imajin/logger';
+import { randomBytes } from 'crypto';
+
+const PAY_SERVICE_URL = process.env.PAY_SERVICE_URL!;
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const POST = withLogger('events', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 10, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+
+  try {
+    const body = await request.json();
+    const { eventId, amount } = body;
+
+    if (!eventId || typeof eventId !== 'string') {
+      return NextResponse.json({ error: 'eventId is required' }, { status: 400, headers: cors });
+    }
+
+    if (typeof amount !== 'number' || amount < 100 || !Number.isInteger(amount)) {
+      return NextResponse.json(
+        { error: 'amount must be an integer >= 100 (minimum $1.00)' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    // Fetch and validate event
+    const [event] = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, eventId))
+      .limit(1);
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404, headers: cors });
+    }
+
+    if (event.eventType !== 'campaign') {
+      return NextResponse.json({ error: 'Not a campaign event' }, { status: 400, headers: cors });
+    }
+
+    if (event.status !== 'published') {
+      return NextResponse.json(
+        { error: 'Campaign is not available for pledging' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    if (event.deadline && new Date(event.deadline) < new Date()) {
+      return NextResponse.json(
+        { error: 'Campaign deadline has passed' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    // Check for existing pledge from this backer
+    const [existingPledge] = await db
+      .select()
+      .from(pledges)
+      .where(and(eq(pledges.eventId, eventId), eq(pledges.backerDid, did)))
+      .limit(1);
+
+    if (existingPledge && ['confirmed', 'charged'].includes(existingPledge.status)) {
+      return NextResponse.json(
+        { error: 'You already have an active pledge for this campaign' },
+        { status: 409, headers: cors }
+      );
+    }
+
+    // Call pay service to create SetupIntent
+    const payRes = await fetch(`${PAY_SERVICE_URL}/api/setup-intent`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: request.headers.get('cookie') || '',
+      },
+      body: JSON.stringify({
+        amount,
+        currency: event.targetAmount ? 'CAD' : 'CAD',
+        metadata: { eventId, backerDid: did },
+      }),
+    });
+
+    if (!payRes.ok) {
+      const err = await payRes.json().catch(() => ({}));
+      log.error({ err: err.error || payRes.statusText }, 'Pay service SetupIntent failed');
+      return NextResponse.json(
+        { error: err.error || 'Failed to create payment setup' },
+        { status: 500, headers: cors }
+      );
+    }
+
+    const { clientSecret, setupIntentId, customerId } = await payRes.json();
+
+    // Create or update pledge record
+    const pledgeId = existingPledge?.id || `plg_${randomBytes(12).toString('hex')}`;
+
+    if (existingPledge) {
+      await db
+        .update(pledges)
+        .set({
+          amount,
+          stripeSetupIntentId: setupIntentId,
+          stripeCustomerId: customerId,
+          status: 'pending',
+          metadata: { ...((existingPledge.metadata as Record<string, any>) || {}), updatedAt: new Date().toISOString() },
+        })
+        .where(eq(pledges.id, existingPledge.id));
+    } else {
+      await db.insert(pledges).values({
+        id: pledgeId,
+        eventId,
+        backerDid: did,
+        amount,
+        currency: 'CAD',
+        stripeSetupIntentId: setupIntentId,
+        stripeCustomerId: customerId,
+        status: 'pending',
+        metadata: {},
+      });
+    }
+
+    return NextResponse.json(
+      { pledgeId, clientSecret },
+      { headers: cors }
+    );
+  } catch (error) {
+    log.error({ err: String(error) }, 'Campaign pledge error');
+    return NextResponse.json(
+      { error: 'Failed to create pledge' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/apps/events/app/api/events/route.ts
+++ b/apps/events/app/api/events/route.ts
@@ -58,6 +58,9 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       tickets: ticketTypesInput,
       courseSlug,
       emtEmail,
+      eventType,
+      targetAmount,
+      deadline,
     } = body;
 
     // Validate required fields
@@ -66,6 +69,11 @@ export const POST = withLogger('events', async (request, { log, correlationId })
     }
     if (!startsAt) {
       return NextResponse.json({ error: 'startsAt is required' }, { status: 400 });
+    }
+    if (eventType === 'campaign') {
+      if (typeof targetAmount !== 'number' || targetAmount <= 0 || !Number.isInteger(targetAmount)) {
+        return NextResponse.json({ error: 'targetAmount must be a positive integer (cents)' }, { status: 400 });
+      }
     }
 
     // Generate event ID and DID
@@ -160,6 +168,9 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       tags: tags || [],
       courseSlug: courseSlug || null,
       emtEmail: emtEmail || null,
+      eventType: eventType || 'event',
+      targetAmount: eventType === 'campaign' ? targetAmount : null,
+      deadline: eventType === 'campaign' && deadline ? new Date(deadline) : null,
       status: 'draft',
       metadata: { fair: fairManifest },
     }).returning();

--- a/apps/events/app/create/form.tsx
+++ b/apps/events/app/create/form.tsx
@@ -37,6 +37,11 @@ export default function EventCreateForm({ organizerDid }: Props) {
   const [coverImageUrl, setCoverImageUrl] = useState('');
   const [courseSlug, setCourseSlug] = useState('');
 
+  // Event type
+  const [eventType, setEventType] = useState<'event' | 'campaign'>('event');
+  const [targetAmount, setTargetAmount] = useState('');
+  const [campaignDeadline, setCampaignDeadline] = useState('');
+
   // Ticket tiers
   const [tiers, setTiers] = useState<TicketTier[]>([
     { name: 'General Admission', price: 0, quantity: null, description: '' }
@@ -82,13 +87,18 @@ export default function EventCreateForm({ organizerDid }: Props) {
           country: locationType !== 'virtual' ? country : null,
           imageUrl: coverImageUrl || null,
           courseSlug: courseSlug || null,
-          tickets: tiers.filter(t => t.name).map(t => ({
+          eventType,
+          ...(eventType === 'campaign' && {
+            targetAmount: Math.round(parseFloat(targetAmount) * 100),
+            deadline: campaignDeadline ? new Date(campaignDeadline).toISOString() : null,
+          }),
+          tickets: eventType === 'event' ? tiers.filter(t => t.name).map(t => ({
             name: t.name,
             description: t.description,
             price: Math.round(t.price * 100), // Convert to cents
             currency: 'CAD',
             quantity: t.quantity,
-          })),
+          })) : [],
         }),
       });
 
@@ -112,7 +122,63 @@ export default function EventCreateForm({ organizerDid }: Props) {
       {/* Basic Info */}
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 space-y-4">
         <h2 className="text-xl font-semibold">Basic Info</h2>
-        
+
+        {/* Event Type */}
+        <div>
+          <label className="block text-sm font-medium mb-2">Event Type</label>
+          <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden">
+            {(['event', 'campaign'] as const).map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => setEventType(type)}
+                className={`flex-1 py-2 text-sm font-medium transition ${
+                  eventType === type
+                    ? 'bg-orange-500 text-white'
+                    : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'
+                }`}
+              >
+                {type === 'event' ? '🎉 Event' : '💰 Campaign'}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            {eventType === 'campaign'
+              ? 'Campaigns collect pledges toward a funding goal. Money only moves when the goal is reached.'
+              : 'Standard event with ticket sales.'}
+          </p>
+        </div>
+
+        {/* Campaign fields */}
+        {eventType === 'campaign' && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-xl">
+            <div>
+              <label className="block text-sm font-medium mb-1">Funding Goal (CAD) *</label>
+              <input
+                type="number"
+                min="1"
+                step="0.01"
+                value={targetAmount}
+                onChange={(e) => setTargetAmount(e.target.value)}
+                required={eventType === 'campaign'}
+                placeholder="5000"
+                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-orange-500"
+              />
+              <p className="text-xs text-gray-500 mt-1">Minimum $1.00</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Deadline</label>
+              <input
+                type="datetime-local"
+                value={campaignDeadline}
+                onChange={(e) => setCampaignDeadline(e.target.value)}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-orange-500"
+              />
+              <p className="text-xs text-gray-500 mt-1">Optional — when pledging closes</p>
+            </div>
+          </div>
+        )}
+
         <div>
           <label className="block text-sm font-medium mb-1">Event Name *</label>
           <input
@@ -262,79 +328,81 @@ export default function EventCreateForm({ organizerDid }: Props) {
         </div>
       </div>
 
-      {/* Ticket Tiers */}
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 space-y-4">
-        <div className="flex justify-between items-center">
-          <h2 className="text-xl font-semibold">Tickets</h2>
-          <button
-            type="button"
-            onClick={addTier}
-            className="text-orange-500 hover:text-orange-600 text-sm font-medium"
-          >
-            + Add Tier
-          </button>
-        </div>
-
-        {tiers.map((tier, index) => (
-          <div key={index} className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3">
-            <div className="flex justify-between items-start">
-              <div className="flex-1 grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Tier Name</label>
-                  <input
-                    type="text"
-                    value={tier.name}
-                    onChange={(e) => updateTier(index, 'name', e.target.value)}
-                    placeholder="General Admission"
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-1">Price (CAD)</label>
-                  <input
-                    type="number"
-                    min="0"
-                    step="0.01"
-                    value={tier.price}
-                    onChange={(e) => updateTier(index, 'price', parseFloat(e.target.value) || 0)}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-1">Quantity (blank = unlimited)</label>
-                  <input
-                    type="number"
-                    min="1"
-                    value={tier.quantity || ''}
-                    onChange={(e) => updateTier(index, 'quantity', e.target.value ? parseInt(e.target.value) : null)}
-                    placeholder="Unlimited"
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-1">Description</label>
-                  <input
-                    type="text"
-                    value={tier.description}
-                    onChange={(e) => updateTier(index, 'description', e.target.value)}
-                    placeholder="What's included"
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm"
-                  />
-                </div>
-              </div>
-              {tiers.length > 1 && (
-                <button
-                  type="button"
-                  onClick={() => removeTier(index)}
-                  className="ml-3 text-red-500 hover:text-red-600 text-sm"
-                >
-                  Remove
-                </button>
-              )}
-            </div>
+      {/* Ticket Tiers — only for regular events */}
+      {eventType === 'event' && (
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 space-y-4">
+          <div className="flex justify-between items-center">
+            <h2 className="text-xl font-semibold">Tickets</h2>
+            <button
+              type="button"
+              onClick={addTier}
+              className="text-orange-500 hover:text-orange-600 text-sm font-medium"
+            >
+              + Add Tier
+            </button>
           </div>
-        ))}
-      </div>
+
+          {tiers.map((tier, index) => (
+            <div key={index} className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-3">
+              <div className="flex justify-between items-start">
+                <div className="flex-1 grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Tier Name</label>
+                    <input
+                      type="text"
+                      value={tier.name}
+                      onChange={(e) => updateTier(index, 'name', e.target.value)}
+                      placeholder="General Admission"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Price (CAD)</label>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={tier.price}
+                      onChange={(e) => updateTier(index, 'price', parseFloat(e.target.value) || 0)}
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Quantity (blank = unlimited)</label>
+                    <input
+                      type="number"
+                      min="1"
+                      value={tier.quantity || ''}
+                      onChange={(e) => updateTier(index, 'quantity', e.target.value ? parseInt(e.target.value) : null)}
+                      placeholder="Unlimited"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">Description</label>
+                    <input
+                      type="text"
+                      value={tier.description}
+                      onChange={(e) => updateTier(index, 'description', e.target.value)}
+                      placeholder="What's included"
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm"
+                    />
+                  </div>
+                </div>
+                {tiers.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => removeTier(index)}
+                    className="ml-3 text-red-500 hover:text-red-600 text-sm"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
 
       {error && (
         <div className="p-4 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 rounded-lg">
@@ -347,7 +415,7 @@ export default function EventCreateForm({ organizerDid }: Props) {
         disabled={loading}
         className="w-full py-3 bg-orange-500 hover:bg-orange-600 disabled:bg-orange-300 text-white font-semibold rounded-lg transition"
       >
-        {loading ? 'Creating...' : 'Create Event'}
+        {loading ? 'Creating...' : eventType === 'campaign' ? 'Create Campaign' : 'Create Event'}
       </button>
     </form>
   );

--- a/apps/events/package.json
+++ b/apps/events/package.json
@@ -15,19 +15,20 @@
   "dependencies": {
     "@imajin/auth": "workspace:*",
     "@imajin/bus": "workspace:*",
-    "@imajin/emit": "workspace:*",
-    "@imajin/logger": "workspace:*",
     "@imajin/chat": "workspace:*",
     "@imajin/config": "workspace:*",
     "@imajin/db": "workspace:*",
     "@imajin/email": "workspace:*",
+    "@imajin/emit": "workspace:*",
     "@imajin/fair": "workspace:*",
     "@imajin/input": "workspace:*",
+    "@imajin/logger": "workspace:*",
     "@imajin/notify": "workspace:*",
     "@imajin/onboard": "workspace:*",
     "@imajin/ui": "workspace:*",
     "@noble/ed25519": "^3.0.0",
     "@noble/hashes": "^2.0.1",
+    "@stripe/stripe-js": "^4.10.0",
     "drizzle-orm": "^0.45.1",
     "html5-qrcode": "^2.3.8",
     "marked": "^12.0.0",
@@ -36,6 +37,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^20",
     "@types/qrcode": "^1.5.5",
     "@types/react": "^18",
@@ -45,7 +47,6 @@
     "postcss": "^8",
     "qrcode": "^1.5.4",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5",
-    "@tailwindcss/typography": "^0.5.19"
+    "typescript": "^5"
   }
 }

--- a/apps/events/src/db/index.ts
+++ b/apps/events/src/db/index.ts
@@ -3,3 +3,6 @@ import * as schema from './schema';
 
 export const db = createDb(schema);
 export * from './schema';
+
+// Re-export pledges for convenience
+export { schema };

--- a/apps/events/src/db/schema.ts
+++ b/apps/events/src/db/schema.ts
@@ -32,6 +32,11 @@ export const events = eventsSchema.table('events', {
   // Status
   status: text('status').notNull().default('draft'),        // draft, published, cancelled, completed
 
+  // Campaign fields
+  eventType: text('event_type').notNull().default('event'),  // 'event' | 'campaign'
+  targetAmount: integer('target_amount'),                    // funding goal in cents (null for regular events)
+  deadline: timestamp('deadline', { withTimezone: true }),   // campaign deadline (null = no deadline)
+
   // Access control
   accessMode: text('access_mode').notNull().default('public'), // public, invite_only
   
@@ -275,6 +280,40 @@ export const eventInvites = eventsSchema.table('event_invites', {
 // ticket_registrations was dropped in migration 0027 (#826 Part 3).
 // Attendee identity lives in dykil.survey_responses; joins use ticket_id.
 
+/**
+ * Pledges — conditional commitments for campaign events.
+ * Uses Stripe SetupIntent to save payment method without charging.
+ * Charged only when campaign target is met.
+ */
+export const pledges = eventsSchema.table('pledges', {
+  id: text('id').primaryKey(),                                 // plg_xxx
+  eventId: text('event_id').references(() => events.id).notNull(),
+  backerDid: text('backer_did').notNull(),
+  amount: integer('amount').notNull(),                         // cents
+  currency: text('currency').notNull().default('CAD'),
+
+  // Stripe
+  stripeSetupIntentId: text('stripe_setup_intent_id'),         // si_xxx
+  stripePaymentMethodId: text('stripe_payment_method_id'),     // pm_xxx
+  stripeCustomerId: text('stripe_customer_id'),                // cus_xxx
+
+  // MJNx escrow (future V2)
+  mjnxEscrowId: text('mjnx_escrow_id'),
+
+  // Status: pending (setup in progress), confirmed (card saved), charged, failed, cancelled
+  status: text('status').notNull().default('pending'),
+
+  chargedAt: timestamp('charged_at', { withTimezone: true }),
+  failureReason: text('failure_reason'),
+
+  metadata: jsonb('metadata').default({}),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => ({
+  eventIdx: index('idx_pledges_event').on(table.eventId),
+  backerIdx: index('idx_pledges_backer').on(table.backerDid),
+  statusIdx: index('idx_pledges_status').on(table.status),
+}));
+
 // Types
 export type Event = typeof events.$inferSelect;
 export type NewEvent = typeof events.$inferInsert;
@@ -286,4 +325,6 @@ export type TicketTransfer = typeof ticketTransfers.$inferSelect;
 export type TicketQueueEntry = typeof ticketQueue.$inferSelect;
 export type EventInvite = typeof eventInvites.$inferSelect;
 export type NewEventInvite = typeof eventInvites.$inferInsert;
+export type Pledge = typeof pledges.$inferSelect;
+export type NewPledge = typeof pledges.$inferInsert;
 

--- a/apps/kernel/app/pay/api/charge-pledges/route.ts
+++ b/apps/kernel/app/pay/api/charge-pledges/route.ts
@@ -1,0 +1,177 @@
+/**
+ * POST /api/charge-pledges
+ *
+ * Charge all confirmed pledges for a campaign event.
+ * Service-to-service endpoint — requires PAY_SERVICE_API_KEY.
+ * Called by the events service when a campaign reaches its goal.
+ *
+ * Request:
+ * {
+ *   eventId: string,
+ *   pledges: Array<{
+ *     pledgeId: string,
+ *     amount: number,
+ *     currency: string,
+ *     stripeCustomerId: string,
+ *     stripePaymentMethodId: string
+ *   }>
+ * }
+ *
+ * Response:
+ * {
+ *   charged: number,
+ *   failed: number,
+ *   total: number,
+ *   results: Array<{ pledgeId: string, status: 'charged' | 'failed', error?: string }>
+ * }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { corsHeaders } from '@/src/lib/kernel/cors';
+import { rateLimit, getClientIP } from '@/src/lib/kernel/rate-limit';
+import { withLogger } from '@imajin/logger';
+
+let _stripe: Stripe | null = null;
+function getStripe(): Stripe {
+  if (!_stripe) {
+    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: '2024-11-20.acacia' as Stripe.LatestApiVersion,
+    });
+  }
+  return _stripe;
+}
+
+interface PledgeCharge {
+  pledgeId: string;
+  amount: number;
+  currency: string;
+  stripeCustomerId: string;
+  stripePaymentMethodId: string;
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  // Heavy rate limit — this triggers real charges
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 5, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  // Service-to-service auth via API key
+  const apiKey = request.headers.get('authorization')?.replace('Bearer ', '');
+  const expectedKey = process.env.PAY_SERVICE_API_KEY;
+
+  if (!expectedKey || apiKey !== expectedKey) {
+    return NextResponse.json(
+      { error: 'Unauthorized - invalid API key' },
+      { status: 401, headers: cors }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const { eventId, pledges }: { eventId: string; pledges: PledgeCharge[] } = body;
+
+    if (!eventId || typeof eventId !== 'string') {
+      return NextResponse.json(
+        { error: 'eventId is required' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    if (!Array.isArray(pledges) || pledges.length === 0) {
+      return NextResponse.json(
+        { charged: 0, failed: 0, total: 0, results: [] },
+        { headers: cors }
+      );
+    }
+
+    const stripe = getStripe();
+    const results: Array<{ pledgeId: string; status: 'charged' | 'failed'; error?: string }> = [];
+    let charged = 0;
+    let failed = 0;
+
+    for (const pledge of pledges) {
+      try {
+        if (!pledge.stripeCustomerId || !pledge.stripePaymentMethodId) {
+          results.push({
+            pledgeId: pledge.pledgeId,
+            status: 'failed',
+            error: 'Missing Stripe customer or payment method',
+          });
+          failed++;
+          continue;
+        }
+
+        const paymentIntent = await stripe.paymentIntents.create({
+          amount: pledge.amount,
+          currency: pledge.currency.toLowerCase(),
+          customer: pledge.stripeCustomerId,
+          payment_method: pledge.stripePaymentMethodId,
+          off_session: true,
+          confirm: true,
+          metadata: {
+            eventId,
+            pledgeId: pledge.pledgeId,
+            type: 'campaign_pledge_charge',
+          },
+        });
+
+        if (paymentIntent.status === 'succeeded' || paymentIntent.status === 'processing') {
+          results.push({
+            pledgeId: pledge.pledgeId,
+            status: 'charged',
+          });
+          charged++;
+        } else if (paymentIntent.status === 'requires_action') {
+          // 3D Secure or similar — mark as failed for off_session
+          results.push({
+            pledgeId: pledge.pledgeId,
+            status: 'failed',
+            error: 'Payment requires additional authentication (3D Secure)',
+          });
+          failed++;
+        } else {
+          results.push({
+            pledgeId: pledge.pledgeId,
+            status: 'failed',
+            error: `Payment status: ${paymentIntent.status}`,
+          });
+          failed++;
+        }
+      } catch (err: any) {
+        const errorMessage = err.message || 'Payment failed';
+        log.error({ err: errorMessage, pledgeId: pledge.pledgeId }, 'Pledge charge failed');
+        results.push({
+          pledgeId: pledge.pledgeId,
+          status: 'failed',
+          error: errorMessage,
+        });
+        failed++;
+      }
+    }
+
+    return NextResponse.json({
+      charged,
+      failed,
+      total: pledges.length,
+      results,
+    }, { headers: cors });
+  } catch (error) {
+    log.error({ err: String(error) }, 'Charge pledges error');
+    return NextResponse.json(
+      { error: 'Failed to charge pledges' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/apps/kernel/app/pay/api/setup-intent/route.ts
+++ b/apps/kernel/app/pay/api/setup-intent/route.ts
@@ -1,0 +1,133 @@
+/**
+ * POST /api/setup-intent
+ *
+ * Create a Stripe SetupIntent to save a payment method for later charging.
+ * Used by campaign pledges — no money moves until the campaign succeeds.
+ *
+ * Request:
+ * {
+ *   amount: number,          // informational, stored in metadata (cents)
+ *   currency: string,        // e.g. "CAD"
+ *   metadata?: Record<string, string>
+ * }
+ *
+ * Response:
+ * {
+ *   clientSecret: string,
+ *   setupIntentId: string,
+ *   customerId: string
+ * }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { requireAuth } from '@imajin/auth';
+import { corsHeaders } from '@/src/lib/kernel/cors';
+import { rateLimit, getClientIP } from '@/src/lib/kernel/rate-limit';
+import { withLogger } from '@imajin/logger';
+
+let _stripe: Stripe | null = null;
+function getStripe(): Stripe {
+  if (!_stripe) {
+    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: '2024-11-20.acacia' as Stripe.LatestApiVersion,
+    });
+  }
+  return _stripe;
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
+  const cors = corsHeaders(request);
+
+  const ip = getClientIP(request);
+  const rl = rateLimit(ip, 20, 60_000);
+  if (rl.limited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: rl.retryAfter },
+      { status: 429, headers: { ...cors, 'Retry-After': String(rl.retryAfter) } }
+    );
+  }
+
+  // Require auth
+  const authResult = await requireAuth(request);
+  if ('error' in authResult) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status, headers: cors }
+    );
+  }
+
+  const did = authResult.identity.actingAs || authResult.identity.id;
+
+  try {
+    const body = await request.json();
+    const { amount, currency, metadata = {} } = body;
+
+    if (typeof amount !== 'number' || amount <= 0) {
+      return NextResponse.json(
+        { error: 'amount must be a positive number' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    if (!currency || typeof currency !== 'string') {
+      return NextResponse.json(
+        { error: 'currency is required' },
+        { status: 400, headers: cors }
+      );
+    }
+
+    const stripe = getStripe();
+
+    // Find existing customer for this DID, or create one
+    let customerId: string;
+    try {
+      const customers = await stripe.customers.list({
+        limit: 1,
+        ...(did ? { ['metadata[did]' as any]: did } : {}),
+      } as any);
+      if (customers.data.length > 0) {
+        customerId = customers.data[0].id;
+      } else {
+        const newCustomer = await stripe.customers.create({
+          metadata: { did },
+        });
+        customerId = newCustomer.id;
+      }
+    } catch (err) {
+      log.error({ err: String(err) }, 'Stripe customer lookup/creation failed');
+      return NextResponse.json(
+        { error: 'Failed to set up payment customer' },
+        { status: 500, headers: cors }
+      );
+    }
+
+    // Create SetupIntent
+    const setupIntent = await stripe.setupIntents.create({
+      customer: customerId,
+      metadata: {
+        ...metadata,
+        amount: String(amount),
+        currency: currency.toUpperCase(),
+        did,
+      },
+      usage: 'off_session',
+    });
+
+    return NextResponse.json({
+      clientSecret: setupIntent.client_secret!,
+      setupIntentId: setupIntent.id,
+      customerId,
+    }, { headers: cors });
+  } catch (error) {
+    log.error({ err: String(error) }, 'SetupIntent error');
+    return NextResponse.json(
+      { error: 'Failed to create setup intent' },
+      { status: 500, headers: cors }
+    );
+  }
+});

--- a/migrations/0032_campaign_events.sql
+++ b/migrations/0032_campaign_events.sql
@@ -1,0 +1,29 @@
+-- Campaign events: goal-based crowdfunding
+-- Issue #749
+
+-- Add campaign fields to events
+ALTER TABLE events.events ADD COLUMN IF NOT EXISTS event_type TEXT NOT NULL DEFAULT 'event';
+ALTER TABLE events.events ADD COLUMN IF NOT EXISTS target_amount INTEGER;
+ALTER TABLE events.events ADD COLUMN IF NOT EXISTS deadline TIMESTAMPTZ;
+
+-- Pledges table
+CREATE TABLE IF NOT EXISTS events.pledges (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL REFERENCES events.events(id),
+  backer_did TEXT NOT NULL,
+  amount INTEGER NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'CAD',
+  stripe_setup_intent_id TEXT,
+  stripe_payment_method_id TEXT,
+  stripe_customer_id TEXT,
+  mjnx_escrow_id TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  charged_at TIMESTAMPTZ,
+  failure_reason TEXT,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pledges_event ON events.pledges(event_id);
+CREATE INDEX IF NOT EXISTS idx_pledges_backer ON events.pledges(backer_did);
+CREATE INDEX IF NOT EXISTS idx_pledges_status ON events.pledges(status);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 9.1.7
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -202,7 +202,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -257,7 +257,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -343,6 +343,9 @@ importers:
       '@noble/hashes':
         specifier: ^2.0.1
         version: 2.2.0
+      '@stripe/stripe-js':
+        specifier: ^4.10.0
+        version: 4.10.0
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
@@ -354,7 +357,7 @@ importers:
         version: 12.0.2
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -508,7 +511,7 @@ importers:
         version: 5.1.7
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       otplib:
         specifier: ^13.4.0
         version: 13.4.0
@@ -644,7 +647,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -705,7 +708,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -778,7 +781,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -830,7 +833,7 @@ importers:
         version: 1.8.0
       next:
         specifier: '>=14'
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       drizzle-orm:
         specifier: ^0.45.1
@@ -852,7 +855,7 @@ importers:
         version: link:../notify
       next:
         specifier: '>=14'
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/chat:
     dependencies:
@@ -895,7 +898,7 @@ importers:
         version: link:../tokens
       next:
         specifier: '>=14'
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/db:
     dependencies:
@@ -1026,7 +1029,7 @@ importers:
         version: 5.1.7
       next:
         specifier: '>=14'
-        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       pino:
         specifier: ^9
         version: 9.14.0
@@ -3273,6 +3276,10 @@ packages:
 
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
+
+  '@stripe/stripe-js@4.10.0':
+    resolution: {integrity: sha512-KrMOL+sH69htCIXCaZ4JluJ35bchuCCznyPyrbN8JXSGQfwBI1SuIEMZNwvy8L8ykj29t6sa5BAAiL7fNoLZ8A==}
+    engines: {node: '>=12.16'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -6691,6 +6698,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -9231,6 +9239,8 @@ snapshots:
       - utf-8-validate
 
   '@stitches/core@1.2.8': {}
+
+  '@stripe/stripe-js@4.10.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -12292,6 +12302,32 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 14.2.35
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001787
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -13199,6 +13235,11 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@babel/core': 7.29.0
+
+  styled-jsx@5.1.1(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
## What

Campaign events: a new event type where pledges accumulate toward a funding goal. Money doesn't move until the target is met and the creator triggers settlement. Uses Stripe SetupIntents to save payment methods without charging.

Closes #749

## Schema

- `events.events`: added `event_type` ('event' | 'campaign'), `target_amount` (cents), `deadline`
- New `events.pledges` table: backer DID, amount, Stripe SetupIntent/PaymentMethod/Customer IDs, status tracking
- Migration: `0032_campaign_events.sql` (idempotent)

## Pay Service (Kernel)

- `POST /pay/api/setup-intent` — creates Stripe SetupIntent, finds/creates customer by DID
- `POST /pay/api/charge-pledges` — charges saved payment methods off-session (service-to-service)

## Events API

- Event creation now accepts `eventType`, `targetAmount`, `deadline`
- `POST /api/campaign/pledge` — create pledge + get SetupIntent client secret
- `POST /api/campaign/pledge/confirm` — confirm after Stripe.js succeeds
- `GET /api/campaign/{eventId}/status` — public funding progress
- `GET /api/campaign/{eventId}/my-pledge` — current user's pledge
- `GET /api/campaign/{eventId}/pledges` — creator-only full list
- `POST /api/campaign/{eventId}/settle` — charge all confirmed pledges (creator only, validates goal met)
- `POST /api/campaign/{eventId}/cancel` — cancel campaign + all pledges

## UI

- **Create form**: event type selector (Event / Campaign), target amount + deadline fields
- **Event page**: CampaignSection with progress bar, backer count, deadline countdown, pledge flow via Stripe.js `confirmSetup`
- **Edit page**: Campaign dashboard tab — pledge table, settle/cancel buttons, charge results

## Design Decisions

- **Manual settlement only** — creator clicks "Charge All Backers" when goal is met. No auto-trigger for V1.
- **One pledge per backer** — prevents spam, amount updatable
- **SetupIntent pattern** — saves card without charging. ~5-10% failure rate expected on charge (expired cards, insufficient funds) — handled gracefully with per-pledge status
- **MJNx escrow** — schema field is a placeholder for V2

## Dependencies

- Added `@stripe/stripe-js@^4.0.0` to events app (client-side card confirmation)