### PR TITLE
feat(profile): community page re-org — tabs, member chat, gated content (#954)

### DIFF
--- a/apps/kernel/app/profile/components/CommunityChat.tsx
+++ b/apps/kernel/app/profile/components/CommunityChat.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Chat, ChatProvider } from '@imajin/chat';
+
+const CHAT_URL = process.env.NEXT_PUBLIC_CHAT_URL || 'http://localhost:3007';
+const AUTH_URL = '';  // same-origin proxy
+const MEDIA_URL = process.env.NEXT_PUBLIC_MEDIA_URL || 'http://localhost:3009';
+
+interface CommunityChatProps {
+  communityDid: string;
+}
+
+export function CommunityChat({ communityDid }: CommunityChatProps) {
+  return (
+    <ChatProvider chatUrl={CHAT_URL} authUrl={AUTH_URL} mediaUrl={MEDIA_URL}>
+      <div className="h-[500px]">
+        <Chat
+          did={communityDid}
+          enableVoice
+          enableMedia
+          enableLocation
+          mediaUrl={MEDIA_URL}
+        />
+      </div>
+    </ChatProvider>
+  );
+}

--- a/apps/kernel/app/profile/components/CommunityTabs.tsx
+++ b/apps/kernel/app/profile/components/CommunityTabs.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export type CommunityTab = 'overview' | 'events' | 'chat' | 'members' | 'market';
+
+interface CommunityTabsProps {
+  tabs: { id: CommunityTab; label: string; icon: string; memberOnly?: boolean }[];
+  activeTab: CommunityTab;
+  onTabChange: (tab: CommunityTab) => void;
+  isMember: boolean;
+}
+
+export function CommunityTabs({ tabs, activeTab, onTabChange, isMember }: CommunityTabsProps) {
+  // Read initial tab from URL hash on mount
+  useEffect(() => {
+    const hash = window.location.hash.slice(1) as CommunityTab;
+    if (hash && tabs.some(t => t.id === hash)) {
+      if (tabs.find(t => t.id === hash)?.memberOnly && !isMember) return;
+      onTabChange(hash);
+    }
+  }, []);
+
+  // Update hash when tab changes
+  const handleTabChange = (tab: CommunityTab) => {
+    window.history.replaceState(null, '', `#${tab}`);
+    onTabChange(tab);
+  };
+
+  return (
+    <div className="flex gap-1 border-b border-zinc-800 mb-6 overflow-x-auto">
+      {tabs.map(tab => {
+        const disabled = tab.memberOnly && !isMember;
+        return (
+          <button
+            key={tab.id}
+            onClick={() => !disabled && handleTabChange(tab.id)}
+            disabled={disabled}
+            className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium whitespace-nowrap transition-colors border-b-2 ${
+              activeTab === tab.id
+                ? 'border-orange-500 text-orange-400'
+                : disabled
+                ? 'border-transparent text-zinc-600 cursor-not-allowed'
+                : 'border-transparent text-zinc-400 hover:text-zinc-200 hover:border-zinc-600'
+            }`}
+            title={disabled ? 'Join to access' : undefined}
+          >
+            <span>{tab.icon}</span>
+            <span>{tab.label}</span>
+            {disabled && <span className="text-xs">🔒</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/kernel/app/profile/components/profiles/CommunityPageClient.tsx
+++ b/apps/kernel/app/profile/components/profiles/CommunityPageClient.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+import { CommunityTabs, type CommunityTab } from '../CommunityTabs';
+import { CommunityChat } from '../CommunityChat';
+
+interface CommunityPageClientProps {
+  // Tab config
+  enabledTabs: CommunityTab[];
+  isMember: boolean;
+
+  // Content passed from server
+  overviewContent: React.ReactNode;
+  eventsContent: React.ReactNode;
+  membersContent: React.ReactNode;
+  marketContent: React.ReactNode | null;
+
+  // Chat
+  communityDid: string;
+}
+
+const TAB_CONFIG: Record<CommunityTab, { label: string; icon: string; memberOnly?: boolean }> = {
+  overview: { label: 'Overview', icon: '🏠' },
+  events: { label: 'Events', icon: '🎟' },
+  chat: { label: 'Chat', icon: '💬', memberOnly: true },
+  members: { label: 'Members', icon: '👥' },
+  market: { label: 'Market', icon: '🛍' },
+};
+
+export function CommunityPageClient({
+  enabledTabs,
+  isMember,
+  overviewContent,
+  eventsContent,
+  membersContent,
+  marketContent,
+  communityDid,
+}: CommunityPageClientProps) {
+  const [activeTab, setActiveTab] = useState<CommunityTab>('overview');
+
+  const tabs = enabledTabs.map(id => ({ id, ...TAB_CONFIG[id] }));
+
+  return (
+    <>
+      <CommunityTabs
+        tabs={tabs}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        isMember={isMember}
+      />
+
+      {activeTab === 'overview' && overviewContent}
+      {activeTab === 'events' && eventsContent}
+      {activeTab === 'chat' && isMember && <CommunityChat communityDid={communityDid} />}
+      {activeTab === 'members' && membersContent}
+      {activeTab === 'market' && marketContent}
+    </>
+  );
+}

--- a/apps/kernel/app/profile/components/profiles/CommunityProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/CommunityProfile.tsx
@@ -12,7 +12,9 @@ import { MemberList } from '../MemberList';
 import { Avatar } from '../Avatar';
 import { CopyDid } from '../CopyDid';
 import { MemberSection } from '../MemberSection';
+import { CommunityPageClient } from './CommunityPageClient';
 import type { ProfileViewProps } from '../../lib/types';
+import type { CommunityTab } from '../CommunityTabs';
 
 async function resolveCanJoin(
   profileDid: string,
@@ -43,12 +45,7 @@ async function resolveCanJoin(
   return { canJoin: true, joinVisibility };
 }
 
-export async function CommunityProfile({
-  profile,
-  identity,
-  viewer,
-  links,
-}: ProfileViewProps) {
+export async function CommunityProfile({ profile, identity, viewer, links }: ProfileViewProps) {
   const [forestConfig, viewerMemberRole] = await Promise.all([
     getForestConfig(profile.did),
     viewer.viewerDid && !viewer.isSelf
@@ -57,36 +54,103 @@ export async function CommunityProfile({
   ]);
 
   const { canJoin, joinVisibility } = await resolveCanJoin(
-    profile.did,
-    viewer,
-    viewerMemberRole,
-    forestConfig
+    profile.did, viewer, viewerMemberRole, forestConfig
   );
 
-  const isMaintainer =
-    viewerMemberRole === 'owner' ||
-    viewerMemberRole === 'admin' ||
-    viewerMemberRole === 'maintainer';
+  const isMember = !!viewerMemberRole;
+  const isMaintainer = ['owner', 'admin', 'maintainer'].includes(viewerMemberRole ?? '');
 
   const allMembers = await getMembersByRole(profile.did);
   const memberCount = allMembers.length;
-
   const topMembers = allMembers
-    .filter((m) => ['owner', 'admin', 'maintainer'].includes(m.role))
+    .filter(m => ['owner', 'admin', 'maintainer'].includes(m.role))
     .slice(0, 5);
 
-  const showEvents =
-    forestConfig?.enabledServices.includes('events') &&
-    profile.featureToggles?.show_events;
+  const enabledServices = forestConfig?.enabledServices ?? [];
 
-  const showMarket =
-    forestConfig?.enabledServices.includes('market') &&
-    profile.featureToggles?.show_market_items;
+  // Determine which tabs to show
+  const enabledTabs: CommunityTab[] = ['overview'];
+  if (enabledServices.includes('events') || profile.featureToggles?.show_events) {
+    enabledTabs.push('events');
+  }
+  if (enabledServices.includes('chat')) {
+    enabledTabs.push('chat');
+  }
+  enabledTabs.push('members'); // always show members
+  if (enabledServices.includes('market') && profile.featureToggles?.show_market_items) {
+    enabledTabs.push('market');
+  }
+
+  const showEvents = enabledServices.includes('events') && profile.featureToggles?.show_events;
+  const showMarket = enabledServices.includes('market') && profile.featureToggles?.show_market_items;
+
+  // --- Build tab content sections ---
+
+  const overviewContent = (
+    <div className="space-y-6">
+      {/* Gallery */}
+      <StubGallery identityDid={profile.did} isMaintainer={isMaintainer} />
+
+      {/* Links */}
+      {links.length > 0 && (
+        <div className="space-y-2">
+          {links.map((link, i) => (
+            <a
+              key={i}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg hover:bg-gray-800 transition"
+            >
+              <p className="text-white text-sm font-medium">{link.title}</p>
+              {link.description && (
+                <p className="text-gray-500 text-xs mt-0.5">{link.description}</p>
+              )}
+            </a>
+          ))}
+        </div>
+      )}
+
+      {/* Contact */}
+      <ContactCard contactEmail={profile.contactEmail} phone={profile.phone} />
+
+      <p className="text-xs text-gray-500 text-center">
+        Member since {formatMemberSince(profile.createdAt)}
+      </p>
+    </div>
+  );
+
+  const eventsContent = showEvents ? (
+    <UpcomingEvents
+      did={profile.did}
+      eventsBaseUrl={buildPublicUrl('events')}
+      viewerDid={viewer.viewerDid}
+    />
+  ) : (
+    <p className="text-sm text-zinc-500 text-center py-8">No events yet</p>
+  );
+
+  const membersContent = (
+    <MemberList
+      identityDid={profile.did}
+      grouped
+      showCount
+      title="Members"
+    />
+  );
+
+  const marketContent = showMarket ? (
+    <MarketItems
+      did={profile.did}
+      handle={profile.handle}
+      marketBaseUrl={buildPublicUrl('market')}
+    />
+  ) : null;
 
   return (
     <div className="max-w-lg mx-auto">
       <div className="bg-[#0a0a0a] border border-gray-800 rounded-2xl overflow-hidden">
-        {/* 1. Banner */}
+        {/* Banner */}
         {profile.banner && (
           <div
             className="w-full h-48 bg-cover bg-center"
@@ -94,118 +158,70 @@ export async function CommunityProfile({
           />
         )}
 
-        <div className="p-8 text-center">
-          {/* 2. Header */}
-          <ScopeHeader profile={profile} identity={identity} />
+        <div className="p-8">
+          {/* Header — always visible */}
+          <div className="text-center mb-6">
+            <ScopeHeader profile={profile} identity={identity} />
 
-          {profile.bio && (
-            <p className="text-gray-300 mb-6">{profile.bio}</p>
-          )}
+            {profile.bio && (
+              <p className="text-gray-300 mb-4">{profile.bio}</p>
+            )}
 
-          {/* 3. Action row */}
-          <div className="flex items-center justify-center gap-3">
-            <JoinButton
-              identityDid={profile.did}
-              viewerDid={viewer.viewerDid}
-              initialMemberRole={viewerMemberRole}
-              canJoin={canJoin}
-              joinVisibility={joinVisibility}
-            />
-            {viewer.viewerDid && !viewer.isSelf && (
-              <FollowButton
-                targetDid={profile.did}
-                initialFollowing={viewer.isFollowing}
+            {/* Actions */}
+            <div className="flex items-center justify-center gap-3 mb-4">
+              <JoinButton
+                identityDid={profile.did}
+                viewerDid={viewer.viewerDid}
+                initialMemberRole={viewerMemberRole}
+                canJoin={canJoin}
+                joinVisibility={joinVisibility}
               />
+              {viewer.viewerDid && !viewer.isSelf && (
+                <FollowButton
+                  targetDid={profile.did}
+                  initialFollowing={viewer.isFollowing}
+                />
+              )}
+            </div>
+
+            {/* Member count + avatars */}
+            {memberCount > 0 && (
+              <div className="flex items-center justify-center gap-3 mb-2">
+                <span className="text-sm text-gray-400">
+                  {memberCount} member{memberCount !== 1 ? 's' : ''}
+                </span>
+                {topMembers.length > 0 && (
+                  <div className="flex items-center -space-x-2">
+                    {topMembers.map(m => (
+                      <a
+                        key={m.did}
+                        href={`/profile/${m.handle ?? m.did}`}
+                        title={m.displayName}
+                        className="relative inline-block border-2 border-[#0a0a0a] rounded-full"
+                      >
+                        <Avatar avatar={m.avatar} displayName={m.displayName} size="sm" />
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
           </div>
 
-          {/* 4. Member summary */}
-          {memberCount > 0 && (
-            <div className="flex items-center justify-center gap-3 mb-6">
-              <span className="text-sm text-gray-400">
-                {memberCount} member{memberCount !== 1 ? 's' : ''}
-              </span>
-              {topMembers.length > 0 && (
-                <div className="flex items-center -space-x-2">
-                  {topMembers.map((m) => (
-                    <a
-                      key={m.did}
-                      href={`/profile/${m.handle ?? m.did}`}
-                      title={m.displayName}
-                      className="relative inline-block border-2 border-[#0a0a0a] rounded-full"
-                    >
-                      <Avatar avatar={m.avatar} displayName={m.displayName} size="sm" />
-                    </a>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* 5. Upcoming events */}
-          {showEvents && (
-            <UpcomingEvents
-              did={profile.did}
-              eventsBaseUrl={buildPublicUrl('events')}
-              viewerDid={viewer.viewerDid}
-            />
-          )}
-
-          {/* 6. Market items */}
-          {showMarket && (
-            <MarketItems
-              did={profile.did}
-              handle={profile.handle}
-              marketBaseUrl={buildPublicUrl('market')}
-            />
-          )}
-
-          {/* 7. Gallery */}
-          <StubGallery identityDid={profile.did} isMaintainer={isMaintainer} />
-
-          {/* 8. Links */}
-          {links.length > 0 && (
-            <div className="mb-6 space-y-2 text-left">
-              {links.map((link, i) => (
-                <a
-                  key={i}
-                  href={link.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg hover:bg-gray-800 transition"
-                >
-                  <p className="text-white text-sm font-medium">{link.title}</p>
-                  {link.description && (
-                    <p className="text-gray-500 text-xs mt-0.5">{link.description}</p>
-                  )}
-                </a>
-              ))}
-            </div>
-          )}
-
-          {/* 9. Members section */}
-          {memberCount > 0 && (
-            <MemberSection memberCount={memberCount} topMembers={topMembers}>
-              <MemberList
-                identityDid={profile.did}
-                grouped
-                showCount
-                title="Members"
-              />
-            </MemberSection>
-          )}
-
-          {/* 10. Contact */}
-          <ContactCard contactEmail={profile.contactEmail} phone={profile.phone} />
-
-          {/* Member since */}
-          <p className="text-xs text-gray-500 mt-4">
-            Member since {formatMemberSince(profile.createdAt)}
-          </p>
+          {/* Tabbed content */}
+          <CommunityPageClient
+            enabledTabs={enabledTabs}
+            isMember={isMember}
+            overviewContent={overviewContent}
+            eventsContent={eventsContent}
+            membersContent={membersContent}
+            marketContent={marketContent}
+            communityDid={profile.did}
+          />
         </div>
       </div>
 
-      {/* 11. Footer */}
+      {/* Footer */}
       <div className="text-center mt-4 space-y-1">
         <p className="text-xs text-gray-600">Powered by Imajin</p>
         <CopyDid did={profile.did} />


### PR DESCRIPTION
## What

Refactors the community profile page from a single vertical scroll into a tabbed layout with member-only chat.

Closes #954

## Before
Single stacked card: banner → header → events → market → gallery → links → members → contact. No structure, no gating, no chat.

## After

**Always-visible header:** banner, name, bio, join/follow buttons, member avatars

**Tabbed content:**
| Tab | Icon | Visibility |
|-----|------|-----------|
| Overview | 🏠 | Public |
| Events | 🎟 | Public (if enabled) |
| Chat | 💬 | Members only 🔒 |
| Members | 👥 | Public |
| Market | 🛍 | Public (if enabled) |

- Tabs enabled conditionally from `forestConfig.enabledServices`
- Non-members see Chat tab locked (🔒 icon, disabled)
- URL hash routing for deep links (`/@community#chat`)

## New Files
- `CommunityTabs.tsx` — client tab nav with hash sync + member gating
- `CommunityChat.tsx` — thin wrapper around `@imajin/chat` `Chat` component, uses community DID as conversation identifier
- `CommunityPageClient.tsx` — client component managing tab state, receives server-rendered content as props

## Modified
- `CommunityProfile.tsx` — refactored from 215 LOC single scroll to server component + tabbed client component. Header stays server-rendered, tab content passed as React nodes.

## Design Decisions
- **Community DID = conversation DID** — same pattern as event lobbies, no separate `lobbyConversationId` needed
- **Server + client split** — header and tab content are server-rendered for SSR; only tab switching and chat are client-side
- **No schema changes** — tabs derived from existing `forestConfig.enabledServices`
- **No migration needed**

## Dependencies
- Uses `@imajin/chat` (already in kernel's package.json) — the consolidated shared chat package from #953