### PR TITLE
feat(events): chat enable/disable toggle + name display policy sync (#460)

### DIFF
--- a/apps/events/app/api/events/[id]/route.ts
+++ b/apps/events/app/api/events/[id]/route.ts
@@ -13,8 +13,8 @@ import { eq } from 'drizzle-orm';
 
 /** Fields safe to return for events:read app scope */
 function filterEventForApp(event: Record<string, any>): Record<string, any> {
-  const { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, createdAt, updatedAt } = event;
-  return { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, createdAt, updatedAt };
+  const { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, chatEnabled, createdAt, updatedAt } = event;
+  return { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, chatEnabled, createdAt, updatedAt };
 }
 
 /**
@@ -253,6 +253,7 @@ export async function PUT(
       status,
       metadata,
       nameDisplayPolicy,
+      chatEnabled,
     } = body;
 
     const VALID_NAME_POLICIES = ['real_name', 'handle', 'anonymous', 'attendee_choice'];
@@ -289,12 +290,33 @@ export async function PUT(
     if (body.accessMode !== undefined) updates.accessMode = body.accessMode;
     if (body.courseSlug !== undefined) updates.courseSlug = body.courseSlug || null;
     if (body.emtEmail !== undefined) updates.emtEmail = body.emtEmail || null;
+    if (chatEnabled !== undefined) updates.chatEnabled = chatEnabled;
 
     const [updated] = await db
       .update(events)
       .set(updates)
       .where(eq(events.id, id))
       .returning();
+
+    // Sync name display policy to chat conversation context if it changed
+    if (nameDisplayPolicy !== undefined && updated) {
+      const CHAT_URL = process.env.CHAT_SERVICE_URL || process.env.CHAT_URL;
+      if (CHAT_URL) {
+        try {
+          const internalKey = process.env.AUTH_INTERNAL_API_KEY;
+          await fetch(`${CHAT_URL}/api/d/${encodeURIComponent(updated.did)}/context`, {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(internalKey ? { 'Authorization': `Bearer ${internalKey}` } : {}),
+            },
+            body: JSON.stringify({ context: { nameDisplayPolicy } }),
+          });
+        } catch {
+          // Best-effort sync
+        }
+      }
+    }
 
     // Bust the cache for this event page
     revalidatePath(`/${id}`);

--- a/apps/events/app/api/events/route.ts
+++ b/apps/events/app/api/events/route.ts
@@ -61,6 +61,8 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       eventType,
       targetAmount,
       deadline,
+      nameDisplayPolicy,
+      chatEnabled,
     } = body;
 
     // Validate required fields
@@ -168,6 +170,8 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       tags: tags || [],
       courseSlug: courseSlug || null,
       emtEmail: emtEmail || null,
+      nameDisplayPolicy: nameDisplayPolicy || 'attendee_choice',
+      chatEnabled: chatEnabled !== undefined ? chatEnabled : true,
       eventType: eventType || 'event',
       targetAmount: eventType === 'campaign' ? targetAmount : null,
       deadline: eventType === 'campaign' && deadline ? new Date(deadline) : null,
@@ -236,6 +240,21 @@ export const POST = withLogger('events', async (request, { log, correlationId })
       } catch (chatError) {
         log.warn({ err: String(chatError) }, 'Event chat creation failed (non-fatal)');
       }
+
+      // Sync name display policy to chat conversation context
+      try {
+        const internalKey = process.env.AUTH_INTERNAL_API_KEY;
+        await fetch(`${CHAT_URL}/api/d/${encodeURIComponent(eventDid)}/context`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(internalKey ? { 'Authorization': `Bearer ${internalKey}` } : {}),
+          },
+          body: JSON.stringify({ context: { nameDisplayPolicy: nameDisplayPolicy || 'attendee_choice' } }),
+        });
+      } catch {
+        // Best-effort — chat conversation may not exist yet
+      }
     }
 
     // Store event keypair (in real system, this would be encrypted/secured)
@@ -262,8 +281,8 @@ export const POST = withLogger('events', async (request, { log, correlationId })
  */
 /** Fields safe to return for events:read app scope */
 function filterEventForApp(event: Record<string, any>): Record<string, any> {
-  const { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, createdAt, updatedAt } = event;
-  return { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, createdAt, updatedAt };
+  const { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, chatEnabled, createdAt, updatedAt } = event;
+  return { id, did, creatorDid, title, description, startsAt, endsAt, timezone, locationType, isVirtual, virtualUrl, venue, address, city, country, status, accessMode, imageUrl, imageAssetId, tags, courseSlug, nameDisplayPolicy, chatEnabled, createdAt, updatedAt };
 }
 
 export const GET = withLogger('events', async (request, { log }) => {

--- a/apps/events/app/e/[eventId]/edit/form.tsx
+++ b/apps/events/app/e/[eventId]/edit/form.tsx
@@ -76,6 +76,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
   const [nameDisplayPolicy, setNameDisplayPolicy] = useState(
     (event as any).nameDisplayPolicy || 'attendee_choice'
   );
+  const [chatEnabled, setChatEnabled] = useState(event.chatEnabled ?? true);
   const [accessMode, setAccessMode] = useState<'public' | 'invite_only'>(
     (event.accessMode as 'public' | 'invite_only') || 'public'
   );
@@ -204,6 +205,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
           imageUrl: imageUrl || null,
           status,
           nameDisplayPolicy,
+          chatEnabled,
           accessMode,
           courseSlug: courseSlug || null,
           emtEmail: emtEnabled ? (emtEmail.trim() || null) : null,
@@ -938,6 +940,22 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             Control how attendee names appear in the event chat.
           </p>
         </div>
+
+        {/* Chat Toggle */}
+        <div className="flex items-center justify-between py-3 border-b border-gray-200 dark:border-gray-700">
+          <div>
+            <label className="font-medium text-sm">Event Chat</label>
+            <p className="text-xs text-gray-500">Allow ticket holders to chat</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setChatEnabled(!chatEnabled)}
+            className={`relative w-12 h-6 rounded-full transition-colors ${chatEnabled ? 'bg-orange-500' : 'bg-gray-600'}`}
+          >
+            <span className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${chatEnabled ? 'translate-x-6' : ''}`} />
+          </button>
+        </div>
+
         <div className="space-y-3">
           {([
             { value: 'attendee_choice', label: 'Attendee choice', description: 'Each attendee picks how their name appears' },

--- a/apps/events/app/e/[eventId]/page.tsx
+++ b/apps/events/app/e/[eventId]/page.tsx
@@ -731,9 +731,11 @@ export default async function EventPage({ params, searchParams }: Props) {
         )}
 
         {/* Event Lobby Accordion */}
-        <div className="mb-6">
-          <EventLobbyAccordion eventId={event.id} eventDid={event.did} />
-        </div>
+        {event.chatEnabled && (
+          <div className="mb-6">
+            <EventLobbyAccordion eventId={event.id} eventDid={event.did} />
+          </div>
+        )}
 
         {/* Event Surveys */}
         {visibleSurveys.map((survey: any) => {

--- a/apps/events/src/db/schema.ts
+++ b/apps/events/src/db/schema.ts
@@ -55,6 +55,9 @@ export const events = eventsSchema.table('events', {
   // Name display policy
   nameDisplayPolicy: text('name_display_policy').notNull().default('attendee_choice'), // real_name, handle, anonymous, attendee_choice
 
+  // Chat toggle
+  chatEnabled: boolean('chat_enabled').notNull().default(true),
+
   // Course link
   // SQL: ALTER TABLE events.events ADD COLUMN IF NOT EXISTS course_slug TEXT;
   // SQL: CREATE INDEX IF NOT EXISTS idx_events_course_slug ON events.events(course_slug);

--- a/apps/kernel/app/chat/api/d/[did]/context/route.ts
+++ b/apps/kernel/app/chat/api/d/[did]/context/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from 'next/server';
+import { db, conversationsV2 } from '@/src/db';
+import { eq, sql } from 'drizzle-orm';
+import { requireAuth } from '@imajin/auth';
+import { jsonResponse, errorResponse } from '@/src/lib/kernel/utils';
+import { corsOptions, corsHeaders } from '@/src/lib/kernel/cors';
+
+/**
+ * OPTIONS /api/d/:did/context - CORS preflight
+ */
+export async function OPTIONS(request: NextRequest) {
+  return corsOptions(request);
+}
+
+/**
+ * PATCH /api/d/:did/context - Merge context into a conversation
+ * Body: { context: Record<string, unknown> }
+ *
+ * Supports internal service auth (Bearer AUTH_INTERNAL_API_KEY)
+ * or user auth via requireAuth.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ did: string }> }
+) {
+  const { did } = await params;
+  const cors = corsHeaders(request);
+
+  // Check internal auth first
+  const internalApiKey = process.env.AUTH_INTERNAL_API_KEY;
+  const authHeader = request.headers.get('authorization');
+  const isInternal = internalApiKey && authHeader === `Bearer ${internalApiKey}`;
+
+  if (!isInternal) {
+    const authResult = await requireAuth(request);
+    if ('error' in authResult) {
+      return errorResponse(authResult.error, authResult.status, cors);
+    }
+  }
+
+  let body: { context: Record<string, unknown> };
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Invalid JSON', 400, cors);
+  }
+
+  if (!body.context || typeof body.context !== 'object') {
+    return errorResponse('context object is required', 400, cors);
+  }
+
+  // Merge into existing context
+  await db
+    .update(conversationsV2)
+    .set({
+      context: sql`COALESCE(${conversationsV2.context}, '{}')::jsonb || ${JSON.stringify(body.context)}::jsonb`,
+      updatedAt: new Date(),
+    })
+    .where(eq(conversationsV2.did, did));
+
+  return jsonResponse({ success: true }, 200, cors);
+}

--- a/apps/kernel/app/chat/conversations/[type]/[slug]/page.tsx
+++ b/apps/kernel/app/chat/conversations/[type]/[slug]/page.tsx
@@ -137,6 +137,7 @@ function DIDConversationView({ did }: { did: string }) {
   const [loadingConnections, setLoadingConnections] = useState(false);
   const [addingDid, setAddingDid] = useState<string | null>(null);
   const [dmPartnerName, setDmPartnerName] = useState<string | null>(null);
+  const [nameDisplayPolicy, setNameDisplayPolicy] = useState<string | null>(null);
   const parsed = parseConvDid(did);
 
   const callerRole = members.find((m) => m.did === identity?.did)?.role ?? null;
@@ -180,6 +181,10 @@ function DIDConversationView({ did }: { did: string }) {
         if (parsed.type === 'dm' && conv?.otherParticipant) {
           const p = conv.otherParticipant;
           setDmPartnerName(p.name || (p.handle ? `@${p.handle}` : null));
+        }
+        // Extract name display policy from conversation context
+        if (conv?.context?.nameDisplayPolicy) {
+          setNameDisplayPolicy(conv.context.nameDisplayPolicy as string);
         }
       })
       .catch(() => {});
@@ -474,6 +479,8 @@ function DIDConversationView({ did }: { did: string }) {
           enableVoice
           enableMedia
           enableLocation
+          nameDisplayPolicy={(nameDisplayPolicy as any) || undefined}
+          displayPrefStorageKey={nameDisplayPolicy === 'attendee_choice' ? `chat_displayPref_${did}` : undefined}
           className="h-full"
         />
       </div>

--- a/migrations/0033_event_chat_toggle.sql
+++ b/migrations/0033_event_chat_toggle.sql
@@ -1,0 +1,8 @@
+-- Event chat enable/disable toggle + conversation name display policy
+-- Issue #460
+
+-- Part 1: chat toggle on events
+ALTER TABLE events.events ADD COLUMN IF NOT EXISTS chat_enabled BOOLEAN NOT NULL DEFAULT true;
+
+-- Part 2: name display policy on conversations (stored in context jsonb)
+-- No schema change needed — uses existing context jsonb column on chat.conversations_v2


### PR DESCRIPTION
## What

Two features for event chat control:

**Part 1: Chat toggle** — event creators can enable/disable chat per event.
**Part 2: Name display policy sync** — policy stored on the conversation so it works in standalone chat too.

Closes #460

## Part 1: Chat Enable/Disable

- `chat_enabled` boolean on `events.events` (default: true)
- Toggle switch in event edit form (Privacy & Display section)
- Event page conditionally renders `EventLobbyAccordion` based on the flag
- Creation + edit APIs accept `chatEnabled`

## Part 2: Name Display Policy on Conversations

Previously the name display policy lived only in the events DB. If someone opened the conversation at `chat.imajin.ai` directly, the policy wasn't enforced.

Fix: sync the policy to the conversation's `context` jsonb on `chat.conversations_v2`.

- New `PATCH /chat/api/d/{did}/context` endpoint — merges JSON into conversation context
- Event creation syncs `nameDisplayPolicy` to chat after creating the event
- Event update re-syncs when the policy changes
- Standalone chat page reads policy from conversation context and passes to `<Chat>`

## Migration

`0033_event_chat_toggle.sql` — adds `chat_enabled` column (no conversation schema changes — uses existing `context` jsonb)