### PR TITLE
fix(media): multi-select bugs — selection mode + performance

### DIFF
--- a/apps/kernel/src/components/media/AssetCard.tsx
+++ b/apps/kernel/src/components/media/AssetCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import type { Asset } from "@/src/db/schema";
 
 interface AssetCardProps {
@@ -7,6 +8,7 @@ interface AssetCardProps {
   selected: boolean;
   checked: boolean;
   compact?: boolean;
+  selectionActive?: boolean;
   onSelect: (e: React.MouseEvent) => void;
   onCheck: (e: React.MouseEvent) => void;
 }
@@ -62,7 +64,7 @@ export function FairBadge({ access }: { access: string }) {
   );
 }
 
-export function AssetCard({ asset, selected, checked, compact, onSelect, onCheck }: AssetCardProps) {
+function AssetCard({ asset, selected, checked, compact, selectionActive, onSelect, onCheck }: AssetCardProps) {
   const isImage = asset.mimeType.startsWith("image/");
   const fairAccess = getFairAccess(asset.fairManifest);
 
@@ -77,19 +79,21 @@ export function AssetCard({ asset, selected, checked, compact, onSelect, onCheck
     >
       {/* Checkbox overlay */}
       <div
-        className={`absolute top-1.5 left-1.5 z-10 transition-opacity ${
-          checked ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+        className={`absolute top-0.5 left-0.5 z-10 transition-opacity ${
+          checked || selectionActive ? "opacity-100" : "opacity-0 group-hover:opacity-100"
         }`}
         onClick={onCheck}
       >
-        <div
-          className={`w-5 h-5 rounded border-2 flex items-center justify-center text-[10px] font-bold transition-colors ${
-            checked
-              ? "bg-orange-500 border-orange-500 text-white"
-              : "bg-black/60 border-gray-400 text-transparent"
-          }`}
-        >
-          ✓
+        <div className="flex items-center justify-center min-w-[44px] min-h-[44px]">
+          <div
+            className={`w-5 h-5 rounded border-2 flex items-center justify-center text-[10px] font-bold transition-colors ${
+              checked
+                ? "bg-orange-500 border-orange-500 text-white"
+                : "bg-black/60 border-gray-400 text-transparent"
+            }`}
+          >
+            ✓
+          </div>
         </div>
       </div>
 
@@ -132,3 +136,14 @@ export function AssetCard({ asset, selected, checked, compact, onSelect, onCheck
     </div>
   );
 }
+
+const MemoAssetCard = React.memo(AssetCard, (prev, next) => {
+  return prev.asset.id === next.asset.id
+    && prev.selected === next.selected
+    && prev.checked === next.checked
+    && prev.selectionActive === next.selectionActive
+    && prev.compact === next.compact;
+});
+
+export { MemoAssetCard as AssetCard };
+export default MemoAssetCard;

--- a/apps/kernel/src/components/media/AssetGrid.tsx
+++ b/apps/kernel/src/components/media/AssetGrid.tsx
@@ -17,6 +17,9 @@ interface AssetGridProps {
   folders?: Folder[];
   selectedAssetIds?: Set<string>;
   moveFolderId?: string;
+  selectionMode?: boolean;
+  lastClickIdx?: number | null;
+  onLastClickIdxChange?: (idx: number | null) => void;
   onSortChange: (sort: string) => void;
   onOrderChange: (order: string) => void;
   onTypeFilterChange: (type: string) => void;
@@ -36,6 +39,9 @@ export function AssetGrid({
   folders = [],
   selectedAssetIds: externalSelectedAssetIds,
   moveFolderId: externalMoveFolderId,
+  selectionMode = false,
+  lastClickIdx: lastClickIdxValue,
+  onLastClickIdxChange,
   onSortChange,
   onOrderChange,
   onTypeFilterChange,
@@ -73,7 +79,7 @@ export function AssetGrid({
       else setInternalMoveFolderId(value);
     }
   }, [onMoveFolderIdChange, moveFolderId]);
-  const lastClickIdx = useRef<number | null>(null);
+  const selectionActive = selectedAssetIds.size > 0 || selectionMode;
   const uploadRef = useRef<UploadZoneHandle>(null);
   const dragCounter = useRef(0);
 
@@ -176,31 +182,36 @@ export function AssetGrid({
           else next.add(asset.id);
           return next;
         });
-        lastClickIdx.current = idx;
-      } else if (e.shiftKey && lastClickIdx.current !== null) {
+        onLastClickIdxChange?.(idx);
+      } else if (e.shiftKey && lastClickIdxValue != null) {
         e.preventDefault();
-        const start = Math.min(lastClickIdx.current, idx);
-        const end = Math.max(lastClickIdx.current, idx);
-        setSelectedAssetIds(() => {
-          const next = new Set<string>();
+        const start = Math.min(lastClickIdxValue, idx);
+        const end = Math.max(lastClickIdxValue, idx);
+        setSelectedAssetIds((prev) => {
+          const next = new Set(prev);
           for (let i = start; i <= end; i++) {
             next.add(assets[i].id);
           }
           return next;
         });
       } else {
-        // Normal click: toggle this asset in the selection AND open detail
-        setSelectedAssetIds((prev) => {
-          const next = new Set(prev);
-          if (next.has(asset.id)) next.delete(asset.id);
-          else next.add(asset.id);
-          return next;
-        });
-        lastClickIdx.current = idx;
-        onSelectAsset(asset.id);
+        if (selectionMode) {
+          // In selection mode: toggle selection only
+          setSelectedAssetIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(asset.id)) next.delete(asset.id);
+            else next.add(asset.id);
+            return next;
+          });
+          onLastClickIdxChange?.(idx);
+        } else {
+          // Not in selection mode: open detail
+          onLastClickIdxChange?.(idx);
+          onSelectAsset(asset.id);
+        }
       }
     },
-    [assets, onSelectAsset]
+    [assets, onSelectAsset, selectionMode, lastClickIdxValue, onLastClickIdxChange]
   );
 
   const handleCheckClick = useCallback((e: React.MouseEvent, assetId: string, idx: number) => {
@@ -211,8 +222,8 @@ export function AssetGrid({
       else next.add(assetId);
       return next;
     });
-    lastClickIdx.current = idx;
-  }, []);
+    onLastClickIdxChange?.(idx);
+  }, [setSelectedAssetIds, onLastClickIdxChange]);
 
   const handleBatchDelete = useCallback(async () => {
     if (!window.confirm(`Delete ${selectedAssetIds.size} file(s)? This cannot be undone.`)) return;
@@ -433,7 +444,10 @@ export function AssetGrid({
             Delete
           </button>
           <button
-            onClick={() => setSelectedAssetIds(new Set())}
+            onClick={() => {
+              setSelectedAssetIds(new Set());
+              onLastClickIdxChange?.(null);
+            }}
             className="text-xs px-2 py-1 rounded text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
           >
             ✕
@@ -475,6 +489,7 @@ export function AssetGrid({
                 asset={asset}
                 selected={asset.id === selectedAssetId}
                 checked={selectedAssetIds.has(asset.id)}
+                selectionActive={selectionActive}
                 onSelect={(e) => handleCardClick(e, asset, idx)}
                 onCheck={(e) => handleCheckClick(e, asset.id, idx)}
               />
@@ -489,6 +504,7 @@ export function AssetGrid({
                 selected={asset.id === selectedAssetId}
                 checked={selectedAssetIds.has(asset.id)}
                 compact
+                selectionActive={selectionActive}
                 onSelect={(e) => handleCardClick(e, asset, idx)}
                 onCheck={(e) => handleCheckClick(e, asset.id, idx)}
               />
@@ -522,17 +538,19 @@ export function AssetGrid({
                 >
                   {/* Checkbox */}
                   <div
-                    className={`shrink-0 transition-opacity ${isChecked ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
+                    className={`shrink-0 transition-opacity ${isChecked || selectionActive ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
                     onClick={(e) => handleCheckClick(e, asset.id, idx)}
                   >
-                    <div
-                      className={`w-4 h-4 rounded border-2 flex items-center justify-center text-[9px] font-bold transition-colors ${
-                        isChecked
-                          ? "bg-orange-500 border-orange-500 text-white"
-                          : "bg-black/60 border-gray-400 text-transparent"
-                      }`}
-                    >
-                      ✓
+                    <div className="flex items-center justify-center min-w-[44px] min-h-[44px]">
+                      <div
+                        className={`w-4 h-4 rounded border-2 flex items-center justify-center text-[9px] font-bold transition-colors ${
+                          isChecked
+                            ? "bg-orange-500 border-orange-500 text-white"
+                            : "bg-black/60 border-gray-400 text-transparent"
+                        }`}
+                      >
+                        ✓
+                      </div>
                     </div>
                   </div>
                   <span className="text-lg shrink-0">{getMimeIcon(asset.mimeType)}</span>

--- a/apps/kernel/src/components/media/MediaManager.tsx
+++ b/apps/kernel/src/components/media/MediaManager.tsx
@@ -42,6 +42,17 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
   const [order, setOrder] = useState<"asc" | "desc">("desc");
   const [selectedAssetIds, setSelectedAssetIds] = useState<Set<string>>(new Set());
   const [moveFolderId, setMoveFolderId] = useState<string>("");
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [lastClickIdx, setLastClickIdx] = useState<number | null>(null);
+
+  // Auto-enter/exit selection mode based on selectedAssetIds
+  useEffect(() => {
+    if (selectedAssetIds.size > 0 && !selectionMode) {
+      setSelectionMode(true);
+    } else if (selectedAssetIds.size === 0 && selectionMode) {
+      setSelectionMode(false);
+    }
+  }, [selectedAssetIds, selectionMode]);
 
   // Persist sort/order to localStorage after mount
   useEffect(() => {
@@ -115,6 +126,7 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
     setSelectedFolderId(id);
     setSelectedAssetId(null);
     setSelectedAssetIds(new Set());
+    setLastClickIdx(null);
     setMobileSidebarOpen(false);
   }, []);
 
@@ -221,9 +233,13 @@ export function MediaManager({ session, search = '' }: MediaManagerProps) {
                 loadAssets();
                 loadFolders();
                 setSelectedAssetIds(new Set());
+                setLastClickIdx(null);
               }}
               onSelectedAssetIdsChange={setSelectedAssetIds}
               onMoveFolderIdChange={setMoveFolderId}
+              selectionMode={selectionMode}
+              lastClickIdx={lastClickIdx}
+              onLastClickIdxChange={setLastClickIdx}
             />
           )}
         </AppShell.Split.Pane>


### PR DESCRIPTION
Fixes #973, #974

- Introduce selectionMode to separate selection clicks from detail-open clicks
- React.memo on AssetCard with custom comparator
- Checkboxes always visible during selection mode (mobile fix)
- Shift-click unions with existing selection
- lastClickIdx hoisted to MediaManager for persistence across grid/detail transitions