### PR TITLE
feat(media): selection toolbar + long-press + keyboard shortcuts (#975) + fix(dykil): copy link

### DIFF
--- a/apps/dykil/app/(chrome)/dashboard/page.tsx
+++ b/apps/dykil/app/(chrome)/dashboard/page.tsx
@@ -177,7 +177,8 @@ export default function DashboardPage() {
                       <button
                         onClick={() => {
                           const handle = survey.handle || 'survey';
-                          const url = `${window.location.origin}/${handle}/${survey.id}`;
+                          const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '/dykil';
+                          const url = `${window.location.origin}${basePath}/${handle}/${survey.id}`;
                           navigator.clipboard.writeText(url);
                           toast.success('Survey link copied!');
                         }}

--- a/apps/kernel/src/components/media/AssetCard.tsx
+++ b/apps/kernel/src/components/media/AssetCard.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { Asset } from "@/src/db/schema";
+import { useLongPress } from "./useLongPress";
 
 interface AssetCardProps {
   asset: Asset;
@@ -11,6 +12,7 @@ interface AssetCardProps {
   selectionActive?: boolean;
   onSelect: (e: React.MouseEvent) => void;
   onCheck: (e: React.MouseEvent) => void;
+  onLongPress?: () => void;
 }
 
 export function formatSize(bytes: number): string {
@@ -64,18 +66,24 @@ export function FairBadge({ access }: { access: string }) {
   );
 }
 
-function AssetCard({ asset, selected, checked, compact, selectionActive, onSelect, onCheck }: AssetCardProps) {
+function AssetCard({ asset, selected, checked, compact, selectionActive, onSelect, onCheck, onLongPress }: AssetCardProps) {
   const isImage = asset.mimeType.startsWith("image/");
   const fairAccess = getFairAccess(asset.fairManifest);
+  const longPress = useLongPress(() => {
+    onLongPress?.();
+  }, 400);
 
   return (
     <div
       className={`group relative bg-[#252525] rounded-xl overflow-hidden cursor-pointer border-2 transition-all duration-150 ${
         selected || checked
           ? "border-orange-500 shadow-lg shadow-orange-500/20"
+          : selectionActive
+          ? "border-transparent hover:border-gray-500 opacity-90 hover:opacity-100"
           : "border-transparent hover:border-gray-600"
       }`}
       onClick={onSelect}
+      {...longPress}
     >
       {/* Checkbox overlay */}
       <div
@@ -142,7 +150,8 @@ const MemoAssetCard = React.memo(AssetCard, (prev, next) => {
     && prev.selected === next.selected
     && prev.checked === next.checked
     && prev.selectionActive === next.selectionActive
-    && prev.compact === next.compact;
+    && prev.compact === next.compact
+    && prev.onLongPress === next.onLongPress;
 });
 
 export { MemoAssetCard as AssetCard };

--- a/apps/kernel/src/components/media/AssetGrid.tsx
+++ b/apps/kernel/src/components/media/AssetGrid.tsx
@@ -4,6 +4,7 @@ import { useRef, useState, useCallback, useEffect } from "react";
 import type { Asset, Folder } from "@/src/db/schema";
 import { AssetCard, formatSize, getMimeIcon, getFairAccess, FairBadge } from "./AssetCard";
 import { UploadZone, type UploadZoneHandle } from "./UploadZone";
+import { SelectionToolbar } from "./SelectionToolbar";
 
 type ViewMode = "large-grid" | "small-grid" | "list";
 
@@ -82,6 +83,44 @@ export function AssetGrid({
   const selectionActive = selectedAssetIds.size > 0 || selectionMode;
   const uploadRef = useRef<UploadZoneHandle>(null);
   const dragCounter = useRef(0);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const batchDeleteRef = useRef<() => void>(() => {});
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Only handle when no input is focused
+      const active = document.activeElement;
+      const isTyping = active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA" || active.tagName === "SELECT");
+      if (isTyping) return;
+
+      // Ctrl/Cmd+A — select all visible
+      if ((e.ctrlKey || e.metaKey) && e.key === "a") {
+        e.preventDefault();
+        setSelectedAssetIds(new Set(assets.map((a) => a.id)));
+        onLastClickIdxChange?.(null);
+        return;
+      }
+
+      // Escape — exit selection mode
+      if (e.key === "Escape" && selectionActive) {
+        e.preventDefault();
+        setSelectedAssetIds(new Set());
+        onLastClickIdxChange?.(null);
+        return;
+      }
+
+      // Delete / Backspace — batch delete
+      if ((e.key === "Delete" || e.key === "Backspace") && selectedAssetIds.size > 0) {
+        e.preventDefault();
+        batchDeleteRef.current();
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [assets, selectionActive, selectedAssetIds.size, setSelectedAssetIds, onLastClickIdxChange]);
 
   // Init viewMode from localStorage after mount (avoids SSR mismatch)
   useEffect(() => {
@@ -225,6 +264,16 @@ export function AssetGrid({
     onLastClickIdxChange?.(idx);
   }, [setSelectedAssetIds, onLastClickIdxChange]);
 
+  const handleLongPress = useCallback((assetId: string, idx: number) => {
+    setSelectedAssetIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(assetId)) next.delete(assetId);
+      else next.add(assetId);
+      return next;
+    });
+    onLastClickIdxChange?.(idx);
+  }, [setSelectedAssetIds, onLastClickIdxChange]);
+
   const handleBatchDelete = useCallback(async () => {
     if (!window.confirm(`Delete ${selectedAssetIds.size} file(s)? This cannot be undone.`)) return;
     const results = await Promise.allSettled(
@@ -247,6 +296,11 @@ export function AssetGrid({
     }
     onUploaded();
   }, [selectedAssetIds, onUploaded]);
+
+  // Keep ref in sync so keyboard shortcut can call latest version
+  useEffect(() => {
+    batchDeleteRef.current = handleBatchDelete;
+  }, [handleBatchDelete]);
 
   const handleBatchDownload = useCallback(() => {
     Array.from(selectedAssetIds).forEach((id) => {
@@ -400,58 +454,56 @@ export function AssetGrid({
         </div>
       )}
 
-      {/* Batch action bar — visible when >1 selected */}
-      {selectedAssetIds.size > 1 && (
-        <div className="flex items-center gap-2 px-4 py-2 bg-orange-500/10 border-b border-orange-500/30 shrink-0 flex-wrap">
-          <span className="text-xs text-orange-400 font-medium">
-            {selectedAssetIds.size} selected
-          </span>
-          <div className="flex-1" />
-          <button
-            onClick={handleBatchDownload}
-            className="text-xs px-2.5 py-1 rounded bg-white/10 text-gray-300 hover:bg-white/20 transition-colors"
+      {/* Selection toolbar — visible when in selection mode */}
+      {selectionActive && selectedAssetIds.size > 0 && (
+        <SelectionToolbar
+          count={selectedAssetIds.size}
+          total={assets.length}
+          onSelectAll={() => {
+            setSelectedAssetIds(new Set(assets.map((a) => a.id)));
+            onLastClickIdxChange?.(null);
+          }}
+          onClearSelection={() => {
+            setSelectedAssetIds(new Set());
+            onLastClickIdxChange?.(null);
+          }}
+          onDelete={handleBatchDelete}
+          onMove={() => {
+            // Show move folder selector inline; if already visible, trigger move
+            if (!moveFolderId && folders.length > 0) {
+              setMoveFolderId(folders[0]?.id ?? "");
+            } else {
+              handleBatchMove();
+            }
+          }}
+          onDownload={handleBatchDownload}
+        />
+      )}
+
+      {/* Inline move folder selector when triggered from toolbar */}
+      {selectionActive && selectedAssetIds.size > 0 && folders.length > 0 && (
+        <div className="flex items-center gap-2 px-4 py-1.5 bg-[#1a1a1a] border-b border-gray-800 shrink-0">
+          <span className="text-xs text-gray-500">Move to:</span>
+          <select
+            value={moveFolderId}
+            onChange={(e) => setMoveFolderId(e.target.value)}
+            className="bg-[#252525] border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-orange-500"
           >
-            ↓ Download
-          </button>
-          {folders.length > 0 && (
-            <div className="flex items-center gap-1">
-              <select
-                value={moveFolderId}
-                onChange={(e) => setMoveFolderId(e.target.value)}
-                className="bg-[#252525] border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-orange-500"
-              >
-                <option value="">Move to folder…</option>
-                {folders.map((f) => (
-                  <option key={f.id} value={f.id}>
-                    {f.name}
-                  </option>
-                ))}
-              </select>
-              {moveFolderId && (
-                <button
-                  onClick={handleBatchMove}
-                  className="text-xs px-2.5 py-1 rounded bg-white/10 text-gray-300 hover:bg-white/20 transition-colors"
-                >
-                  Move
-                </button>
-              )}
-            </div>
+            <option value="">Select folder…</option>
+            {folders.map((f) => (
+              <option key={f.id} value={f.id}>
+                {f.name}
+              </option>
+            ))}
+          </select>
+          {moveFolderId && (
+            <button
+              onClick={handleBatchMove}
+              className="text-xs px-2.5 py-1 rounded bg-white/10 text-gray-300 hover:bg-white/20 transition-colors"
+            >
+              Move
+            </button>
           )}
-          <button
-            onClick={handleBatchDelete}
-            className="text-xs px-2.5 py-1 rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
-          >
-            Delete
-          </button>
-          <button
-            onClick={() => {
-              setSelectedAssetIds(new Set());
-              onLastClickIdxChange?.(null);
-            }}
-            className="text-xs px-2 py-1 rounded text-gray-500 hover:text-gray-300 hover:bg-white/10 transition-colors"
-          >
-            ✕
-          </button>
         </div>
       )}
 
@@ -482,7 +534,7 @@ export function AssetGrid({
             </button>
           </div>
         ) : viewMode === "large-grid" ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+          <div ref={gridRef} className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
             {assets.map((asset, idx) => (
               <AssetCard
                 key={asset.id}
@@ -492,11 +544,12 @@ export function AssetGrid({
                 selectionActive={selectionActive}
                 onSelect={(e) => handleCardClick(e, asset, idx)}
                 onCheck={(e) => handleCheckClick(e, asset.id, idx)}
+                onLongPress={() => handleLongPress(asset.id, idx)}
               />
             ))}
           </div>
         ) : viewMode === "small-grid" ? (
-          <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 gap-1.5">
+          <div ref={gridRef} className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 gap-1.5">
             {assets.map((asset, idx) => (
               <AssetCard
                 key={asset.id}
@@ -507,6 +560,7 @@ export function AssetGrid({
                 selectionActive={selectionActive}
                 onSelect={(e) => handleCardClick(e, asset, idx)}
                 onCheck={(e) => handleCheckClick(e, asset.id, idx)}
+                onLongPress={() => handleLongPress(asset.id, idx)}
               />
             ))}
           </div>

--- a/apps/kernel/src/components/media/SelectionToolbar.tsx
+++ b/apps/kernel/src/components/media/SelectionToolbar.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React from "react";
+
+interface SelectionToolbarProps {
+  count: number;
+  total: number;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  onDelete: () => void;
+  onMove: () => void;
+  onSetAccess?: () => void;
+  onDownload?: () => void;
+}
+
+export const SelectionToolbar = React.memo(function SelectionToolbar({
+  count,
+  total,
+  onSelectAll,
+  onClearSelection,
+  onDelete,
+  onMove,
+  onSetAccess,
+  onDownload,
+}: SelectionToolbarProps) {
+  const allSelected = count > 0 && count === total;
+
+  return (
+    <div className="sticky top-0 z-20 flex items-center gap-2 px-4 py-2 bg-[#1a1a1a] border-b border-orange-500/30 shrink-0">
+      {/* Count + close */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onClearSelection}
+          className="flex items-center justify-center w-7 h-7 rounded-full hover:bg-white/10 text-gray-400 hover:text-white transition-colors"
+          title="Exit selection mode"
+          aria-label="Exit selection mode"
+        >
+          ✕
+        </button>
+        <span className="text-sm text-orange-400 font-medium whitespace-nowrap">
+          {count} selected
+        </span>
+      </div>
+
+      <div className="flex-1" />
+
+      {/* Actions */}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <button
+          onClick={allSelected ? onClearSelection : onSelectAll}
+          className="text-xs px-2.5 py-1.5 rounded bg-white/10 text-gray-300 hover:bg-white/20 transition-colors"
+        >
+          {allSelected ? "Deselect All" : "Select All"}
+        </button>
+
+        {onDownload && (
+          <button
+            onClick={onDownload}
+            className="text-xs px-2.5 py-1.5 rounded bg-white/10 text-gray-300 hover:bg-white/20 transition-colors"
+          >
+            ↓ Download
+          </button>
+        )}
+
+        <button
+          onClick={onMove}
+          className="text-xs px-2.5 py-1.5 rounded bg-white/10 text-gray-300 hover:bg-white/20 transition-colors"
+        >
+          Move
+        </button>
+
+        {onSetAccess && (
+          <button
+            onClick={onSetAccess}
+            className="text-xs px-2.5 py-1.5 rounded bg-white/10 text-gray-300 hover:bg-white/20 transition-colors"
+          >
+            Access
+          </button>
+        )}
+
+        <button
+          onClick={onDelete}
+          className="text-xs px-2.5 py-1.5 rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+});
+
+export default SelectionToolbar;

--- a/apps/kernel/src/components/media/useLongPress.ts
+++ b/apps/kernel/src/components/media/useLongPress.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useRef, useCallback } from "react";
+
+interface LongPressHandlers {
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchEnd: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  onPointerLeave: (e: React.PointerEvent) => void;
+}
+
+export function useLongPress(
+  callback: () => void,
+  ms: number = 400
+): LongPressHandlers {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+
+  const start = useCallback(
+    (clientX: number, clientY: number) => {
+      startPosRef.current = { x: clientX, y: clientY };
+      timerRef.current = setTimeout(() => {
+        callback();
+        timerRef.current = null;
+        startPosRef.current = null;
+      }, ms);
+    },
+    [callback, ms]
+  );
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startPosRef.current = null;
+  }, []);
+
+  const move = useCallback(
+    (clientX: number, clientY: number) => {
+      if (!startPosRef.current || !timerRef.current) return;
+      const dx = Math.abs(clientX - startPosRef.current.x);
+      const dy = Math.abs(clientY - startPosRef.current.y);
+      // Cancel if moved more than 10px (prevent scroll from triggering long-press)
+      if (dx > 10 || dy > 10) {
+        cancel();
+      }
+    },
+    [cancel]
+  );
+
+  return {
+    onTouchStart: useCallback(
+      (e: React.TouchEvent) => {
+        const touch = e.touches[0];
+        start(touch.clientX, touch.clientY);
+      },
+      [start]
+    ),
+    onTouchEnd: useCallback(
+      (e: React.TouchEvent) => {
+        cancel();
+      },
+      [cancel]
+    ),
+    onTouchMove: useCallback(
+      (e: React.TouchEvent) => {
+        const touch = e.touches[0];
+        move(touch.clientX, touch.clientY);
+      },
+      [move]
+    ),
+    onPointerDown: useCallback(
+      (e: React.PointerEvent) => {
+        // Only handle primary pointer (mouse left-click or touch)
+        if (e.pointerType === "mouse" && e.button !== 0) return;
+        start(e.clientX, e.clientY);
+      },
+      [start]
+    ),
+    onPointerUp: useCallback(
+      (e: React.PointerEvent) => {
+        cancel();
+      },
+      [cancel]
+    ),
+    onPointerLeave: useCallback(
+      (e: React.PointerEvent) => {
+        cancel();
+      },
+      [cancel]
+    ),
+  };
+}


### PR DESCRIPTION
Implements #975, fixes dykil dashboard copy link 404

- Long-press to enter selection mode on mobile
- SelectionToolbar with count + bulk actions
- Ctrl+A select all, Escape to exit, Delete for bulk delete
- Visual selection state (ring + checkboxes)
- Fix dykil copy link missing /dykil basePath