### PR TITLE
feat(auth): hub infrastructure — dynamic service tabs from forest_config

### DIFF
--- a/apps/kernel/app/auth/coffee/page.tsx
+++ b/apps/kernel/app/auth/coffee/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { getEffectiveDid } from '../lib/get-effective-did';
+import ServiceEmbed from '../components/ServiceEmbed';
+
+export default async function CoffeePage() {
+  const { effectiveDid } = await getEffectiveDid();
+  if (!effectiveDid) {
+    redirect('/auth/login');
+  }
+  return <ServiceEmbed service="coffee" did={effectiveDid} />;
+}

--- a/apps/kernel/app/auth/components/AuthLayoutShell.tsx
+++ b/apps/kernel/app/auth/components/AuthLayoutShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 const BYPASS_PREFIXES = ['/auth/login', '/auth/register', '/auth/onboard'];
 
@@ -9,10 +10,19 @@ interface Props {
   identityDetail: React.ReactNode;
   tabBar: React.ReactNode;
   children: React.ReactNode;
+  landingService?: string | null;
 }
 
-export default function AuthLayoutShell({ leftRail, identityDetail, tabBar, children }: Props) {
+export default function AuthLayoutShell({ leftRail, identityDetail, tabBar, children, landingService }: Props) {
   const pathname = usePathname();
+  const router = useRouter();
+
+  // Redirect to landing service when landing on /auth directly
+  useEffect(() => {
+    if (pathname === '/auth' && landingService) {
+      router.replace(`/auth/${landingService}`);
+    }
+  }, [pathname, landingService, router]);
 
   if (BYPASS_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
     return <>{children}</>;

--- a/apps/kernel/app/auth/components/IdentityTabBar.tsx
+++ b/apps/kernel/app/auth/components/IdentityTabBar.tsx
@@ -7,6 +7,8 @@ interface Props {
   showSettings: boolean;
   showMembers: boolean;
   showSecurity: boolean;
+  enabledServices: string[];
+  landingService?: string | null;
 }
 
 interface Tab {
@@ -27,7 +29,44 @@ const ALL_TABS: Tab[] = [
   { label: 'Members', href: '/auth/members', exact: false },
 ];
 
-export default function IdentityTabBar({ showSettings, showMembers, showSecurity }: Props) {
+const SERVICE_TABS: Tab[] = [
+  { label: 'Events', href: '/auth/events', exact: false },
+  { label: 'Market', href: '/auth/market', exact: false },
+  { label: 'Coffee', href: '/auth/coffee', exact: false },
+  { label: 'Dykil', href: '/auth/dykil', exact: false },
+  { label: 'Learn', href: '/auth/learn', exact: false },
+  { label: 'Links', href: '/auth/links', exact: false },
+  { label: 'Pay', href: '/auth/pay', exact: false },
+  { label: 'Media', href: '/auth/media', exact: false },
+];
+
+function serviceFromHref(href: string): string {
+  return href.split('/').pop() ?? '';
+}
+
+function TabLink({ tab, pathname }: { tab: Tab; pathname: string }) {
+  const isActive = tab.exact ? pathname === tab.href : pathname.startsWith(tab.href);
+  return (
+    <Link
+      key={tab.href}
+      href={tab.href}
+      className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+        isActive
+          ? 'border-amber-500 text-amber-400'
+          : 'border-transparent text-zinc-400 hover:text-white hover:border-zinc-600'
+      }`}
+    >
+      {tab.label}
+    </Link>
+  );
+}
+
+export default function IdentityTabBar({
+  showSettings,
+  showMembers,
+  showSecurity,
+  enabledServices,
+}: Props) {
   const pathname = usePathname();
 
   const tabs = ALL_TABS.filter((tab) => {
@@ -37,24 +76,24 @@ export default function IdentityTabBar({ showSettings, showMembers, showSecurity
     return true;
   });
 
+  const serviceTabs = SERVICE_TABS.filter((tab) => {
+    const service = serviceFromHref(tab.href);
+    return enabledServices.includes(service);
+  });
+
   return (
-    <div className="border-b border-zinc-800 flex gap-1">
-      {tabs.map((tab) => {
-        const isActive = tab.exact ? pathname === tab.href : pathname.startsWith(tab.href);
-        return (
-          <Link
-            key={tab.href}
-            href={tab.href}
-            className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
-              isActive
-                ? 'border-amber-500 text-amber-400'
-                : 'border-transparent text-zinc-400 hover:text-white hover:border-zinc-600'
-            }`}
-          >
-            {tab.label}
-          </Link>
-        );
-      })}
+    <div className="border-b border-zinc-800 flex gap-1 flex-wrap">
+      {tabs.map((tab) => (
+        <TabLink key={tab.href} tab={tab} pathname={pathname} />
+      ))}
+      {serviceTabs.length > 0 && (
+        <div className="flex items-center mx-1">
+          <div className="w-px h-5 bg-zinc-700" />
+        </div>
+      )}
+      {serviceTabs.map((tab) => (
+        <TabLink key={tab.href} tab={tab} pathname={pathname} />
+      ))}
     </div>
   );
 }

--- a/apps/kernel/app/auth/components/ServiceEmbed.tsx
+++ b/apps/kernel/app/auth/components/ServiceEmbed.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+interface Props {
+  service: string;
+  did: string;
+}
+
+const SERVICE_URLS: Record<string, string> = {
+  events: process.env.NEXT_PUBLIC_EVENTS_URL ?? '',
+  market: process.env.NEXT_PUBLIC_MARKET_URL ?? '',
+  coffee: process.env.NEXT_PUBLIC_COFFEE_URL ?? '',
+  dykil: process.env.NEXT_PUBLIC_DYKIL_URL ?? '',
+  learn: process.env.NEXT_PUBLIC_LEARN_URL ?? '',
+  links: process.env.NEXT_PUBLIC_LINKS_URL ?? '',
+  pay: '', // kernel service, same origin
+  media: '', // kernel service, same origin
+};
+
+export default function ServiceEmbed({ service, did }: Props) {
+  const baseUrl = SERVICE_URLS[service] ?? '';
+  const src = baseUrl
+    ? `${baseUrl}/dashboard?embed=hub&did=${encodeURIComponent(did)}`
+    : `/dashboard?embed=hub&did=${encodeURIComponent(did)}`;
+
+  return (
+    <iframe
+      src={src}
+      className="w-full min-h-[600px] border-0 rounded-lg"
+      allow="clipboard-write"
+      title={`${service} dashboard`}
+    />
+  );
+}

--- a/apps/kernel/app/auth/dykil/page.tsx
+++ b/apps/kernel/app/auth/dykil/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { getEffectiveDid } from '../lib/get-effective-did';
+import ServiceEmbed from '../components/ServiceEmbed';
+
+export default async function DykilPage() {
+  const { effectiveDid } = await getEffectiveDid();
+  if (!effectiveDid) {
+    redirect('/auth/login');
+  }
+  return <ServiceEmbed service="dykil" did={effectiveDid} />;
+}

--- a/apps/kernel/app/auth/events/page.tsx
+++ b/apps/kernel/app/auth/events/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { getEffectiveDid } from '../lib/get-effective-did';
+import ServiceEmbed from '../components/ServiceEmbed';
+
+export default async function EventsPage() {
+  const { effectiveDid } = await getEffectiveDid();
+  if (!effectiveDid) {
+    redirect('/auth/login');
+  }
+  return <ServiceEmbed service="events" did={effectiveDid} />;
+}

--- a/apps/kernel/app/auth/layout.tsx
+++ b/apps/kernel/app/auth/layout.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
-import { db, identities, identityMembers } from '@/src/db';
+import { db, identities, identityMembers, forestConfig } from '@/src/db';
 import { eq, and, isNull } from 'drizzle-orm';
 import IdentitySwitcher from './components/IdentitySwitcher';
 import IdentityDetail from './components/IdentityDetail';
@@ -48,7 +48,20 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
   let showSettings = false;
   let showMembers = false;
   const showSecurity = effectiveIdentity?.scope === 'actor';
+
+  // Query forest_config for enabled services and landing service
+  let enabledServices: string[] = [];
+  let landingService: string | null = null;
+
   if (effectiveIdentity?.scope && effectiveIdentity.scope !== 'actor') {
+    const [forestRow] = await db
+      .select({ enabledServices: forestConfig.enabledServices, landingService: forestConfig.landingService })
+      .from(forestConfig)
+      .where(eq(forestConfig.groupDid, effectiveDid))
+      .limit(1);
+    enabledServices = forestRow?.enabledServices ?? [];
+    landingService = forestRow?.landingService ?? null;
+
     const [membership] = await db
       .select({ role: identityMembers.role })
       .from(identityMembers)
@@ -64,6 +77,9 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
       showSettings = true;
       showMembers = true;
     }
+  } else {
+    // Actor scope: all services visible
+    enabledServices = ['events', 'market', 'coffee', 'dykil', 'learn', 'links', 'pay', 'media'];
   }
 
   const authUrl = '/auth';
@@ -83,10 +99,18 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
   );
 
   const identityDetail = <IdentityDetail did={effectiveDid} sessionDid={sessionDid} />;
-  const tabBar = <IdentityTabBar showSettings={showSettings} showMembers={showMembers} showSecurity={showSecurity} />;
+  const tabBar = (
+    <IdentityTabBar
+      showSettings={showSettings}
+      showMembers={showMembers}
+      showSecurity={showSecurity}
+      enabledServices={enabledServices}
+      landingService={landingService}
+    />
+  );
 
   return (
-    <AuthLayoutShell leftRail={leftRail} identityDetail={identityDetail} tabBar={tabBar}>
+    <AuthLayoutShell leftRail={leftRail} identityDetail={identityDetail} tabBar={tabBar} landingService={landingService}>
       {children}
     </AuthLayoutShell>
   );

--- a/apps/kernel/app/auth/learn/page.tsx
+++ b/apps/kernel/app/auth/learn/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { getEffectiveDid } from '../lib/get-effective-did';
+import ServiceEmbed from '../components/ServiceEmbed';
+
+export default async function LearnPage() {
+  const { effectiveDid } = await getEffectiveDid();
+  if (!effectiveDid) {
+    redirect('/auth/login');
+  }
+  return <ServiceEmbed service="learn" did={effectiveDid} />;
+}

--- a/apps/kernel/app/auth/lib/get-effective-did.ts
+++ b/apps/kernel/app/auth/lib/get-effective-did.ts
@@ -1,0 +1,19 @@
+import { cookies } from 'next/headers';
+import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
+
+export async function getEffectiveDid(): Promise<{ sessionDid: string | null; effectiveDid: string | null }> {
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  const actingAs = cookieStore.get('x-acting-as')?.value || null;
+  const effectiveDid = actingAs || sessionDid;
+
+  return { sessionDid, effectiveDid };
+}

--- a/apps/kernel/app/auth/links/page.tsx
+++ b/apps/kernel/app/auth/links/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { getEffectiveDid } from '../lib/get-effective-did';
+import ServiceEmbed from '../components/ServiceEmbed';
+
+export default async function LinksPage() {
+  const { effectiveDid } = await getEffectiveDid();
+  if (!effectiveDid) {
+    redirect('/auth/login');
+  }
+  return <ServiceEmbed service="links" did={effectiveDid} />;
+}

--- a/apps/kernel/app/auth/market/page.tsx
+++ b/apps/kernel/app/auth/market/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { getEffectiveDid } from '../lib/get-effective-did';
+import ServiceEmbed from '../components/ServiceEmbed';
+
+export default async function MarketPage() {
+  const { effectiveDid } = await getEffectiveDid();
+  if (!effectiveDid) {
+    redirect('/auth/login');
+  }
+  return <ServiceEmbed service="market" did={effectiveDid} />;
+}

--- a/apps/kernel/app/auth/media/page.tsx
+++ b/apps/kernel/app/auth/media/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { getEffectiveDid } from '../lib/get-effective-did';
+import ServiceEmbed from '../components/ServiceEmbed';
+
+export default async function MediaPage() {
+  const { effectiveDid } = await getEffectiveDid();
+  if (!effectiveDid) {
+    redirect('/auth/login');
+  }
+  return <ServiceEmbed service="media" did={effectiveDid} />;
+}

--- a/apps/kernel/app/auth/pay/page.tsx
+++ b/apps/kernel/app/auth/pay/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { getEffectiveDid } from '../lib/get-effective-did';
+import ServiceEmbed from '../components/ServiceEmbed';
+
+export default async function PayPage() {
+  const { effectiveDid } = await getEffectiveDid();
+  if (!effectiveDid) {
+    redirect('/auth/login');
+  }
+  return <ServiceEmbed service="pay" did={effectiveDid} />;
+}


### PR DESCRIPTION
Resolves #988

## What changed

- **Layout** (): Queries  and  for group identities. Actor scope shows all services.
- **IdentityTabBar** (): Added dynamic  array filtered by . Service tabs render after existing tabs with a visual divider.
- **AuthLayoutShell** (): Added client-side redirect to  when landing on  directly.
- **ServiceEmbed** (): New iframe component that loads service dashboards with  and passes the DID.
- **Page wrappers** (): Server components that resolve effective DID and render ServiceEmbed.
- **Helper** (): Reusable helper to resolve session/effective DID from cookies.