### PR TITLE
feat: npm publish pipeline for @ima-jin packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,133 @@
+name: Publish Packages to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Package to publish"
+        required: true
+        type: choice
+        options:
+          - tokens
+          - config
+          - ui
+          - all
+      version_bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      dry_run:
+        description: "Dry run (skip actual publish)"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  # Publish order matters — tokens first, then config, then ui
+  ALL_PACKAGES: "tokens config ui"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Determine packages to publish
+        id: packages
+        run: |
+          if [ "${{ inputs.package }}" = "all" ]; then
+            echo "list=${{ env.ALL_PACKAGES }}" >> $GITHUB_OUTPUT
+          else
+            echo "list=${{ inputs.package }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump versions
+        run: |
+          for pkg in ${{ steps.packages.outputs.list }}; do
+            echo "::group::Bumping $pkg"
+            cd packages/$pkg
+            # Use npm version to bump (modifies package.json in place)
+            NEW_VERSION=$(npm version ${{ inputs.version_bump }} --no-git-tag-version | tr -d 'v')
+            echo "Bumped @imajin/$pkg to $NEW_VERSION"
+            cd ../..
+            echo "::endgroup::"
+          done
+
+      - name: Build packages
+        run: |
+          for pkg in ${{ steps.packages.outputs.list }}; do
+            echo "::group::Building $pkg"
+            cd packages/$pkg
+            if grep -q '"build"' package.json; then
+              pnpm build
+              echo "Built $pkg"
+            else
+              echo "No build script for $pkg, skipping"
+            fi
+            cd ../..
+            echo "::endgroup::"
+          done
+
+      - name: Prepare and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for pkg in ${{ steps.packages.outputs.list }}; do
+            echo "::group::Publishing @ima-jin/$pkg"
+
+            PUBLISH_DIR=$(mktemp -d)
+
+            # Prepare the package (rewrite names, resolve deps)
+            node scripts/prepare-npm-publish.mjs "packages/$pkg" "$PUBLISH_DIR"
+
+            # Show what we're about to publish
+            echo "--- package.json ---"
+            cat "$PUBLISH_DIR/package.json"
+            echo ""
+            echo "--- files ---"
+            find "$PUBLISH_DIR" -type f | head -50
+
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo "DRY RUN — skipping publish"
+              cd "$PUBLISH_DIR"
+              npm publish --dry-run --access public 2>&1 || true
+              cd -
+            else
+              cd "$PUBLISH_DIR"
+              npm publish --access public
+              cd -
+              echo "Published @ima-jin/$pkg"
+            fi
+
+            rm -rf "$PUBLISH_DIR"
+            echo "::endgroup::"
+          done
+
+      - name: Commit version bumps
+        if: ${{ inputs.dry_run != true }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add packages/*/package.json
+          PKGS="${{ steps.packages.outputs.list }}"
+          git commit -m "chore: publish ${PKGS// /, } to npm [skip ci]" || echo "No changes to commit"
+          git push

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,30 @@
+# @ima-jin/config
+
+Shared configuration for Imajin services — CORS, service routing, session config, handle validation, and route helpers.
+
+## Install
+
+```bash
+npm install @ima-jin/config
+```
+
+## Usage
+
+```ts
+import { getServiceUrl, getPort, SERVICES } from '@ima-jin/config';
+import { isValidHandle, normalizeHandleInput } from '@ima-jin/config';
+import { corsHeaders, withCors } from '@ima-jin/config';
+import { eventPath, profileUrl } from '@ima-jin/config';
+```
+
+## What's included
+
+- **Services** — port mappings, URL builders, service definitions
+- **CORS** — origin validation, headers, middleware
+- **Session** — cookie config, session cookie helpers
+- **Handles** — validation, normalization, reserved handle list
+- **Routes** — type-safe path builders for all Imajin services
+
+## Part of Imajin
+
+[Imajin](https://imajin.ai) — sovereign technology infrastructure. Open source.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,10 +7,21 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "files": [
+    "dist/",
+    "src/"
+  ],
   "dependencies": {
     "@imajin/tokens": "workspace:*"
   },
   "peerDependencies": {
     "next": ">=14"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5"
+  },
+  "scripts": {
+    "build": "tsup"
   }
 }

--- a/packages/config/tsup.config.ts
+++ b/packages/config/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  external: ['next'],
+});

--- a/packages/config/tsup.config.ts
+++ b/packages/config/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
-  dts: true,
+  dts: false,
   clean: true,
-  external: ['next'],
+  external: ['next', 'next/server', 'next/headers'],
 });

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,78 +1,29 @@
-# @imajin/tokens
+# @ima-jin/tokens
 
-Imajin design tokens — DTCG-format JSON, Style Dictionary build, generated
-CSS variables and Tailwind theme.
+Design tokens for the Imajin platform in DTCG format, built with Style Dictionary v4.
 
-## Two tiers
-
-### Raw tokens
-The literal values. Brand colors, spacing units, font stacks. **Use only
-inside `packages/ui` primitives** — never reference these from app code.
-
-```
-imajin-purple   #8b5cf6
-imajin-orange   #f97316
-surface-base    #0a0a0f
-surface-input   #15151f
-```
-
-### Semantic tokens
-Role-based aliases over the raw tier. **App code and `packages/ui` primitives
-reference these.** If you change the brand from orange to teal tomorrow, you
-edit `semantic.accent` in `tokens.json` — not 200 components.
-
-| Token | Maps to | When to use |
-|---|---|---|
-| `bg-accent` | sunset orange | Single-color brand accent (badges, tags, decorative) |
-| `bg-cta-primary` | sunset gradient | Primary CTA background |
-| `bg-cta-secondary` | elevated surface | Secondary/quiet button background |
-| `bg-surface-1` | page bg | Outermost app shell |
-| `bg-surface-2` | card bg | Cards, panels, modals |
-| `bg-surface-3` | raised | Hover states, dropdowns |
-| `bg-surface-input` | input bg | Form fields |
-| `text-text-heading` | bright | Primary content, headings |
-| `text-text-body` | mid | Body copy, labels |
-| `text-text-quiet` | muted | Placeholders, disabled |
-| `text-text-on-accent` | bright | Text on accent/gradient backgrounds |
-| `border-border-subtle` | white/0.1 | Default card/panel border |
-| `border-border-strong` | white/0.2 | Hover/emphasis border |
-| `border-border-input-field` | white/0.12 | Form field border |
-| `border-border-nav` | white/0.08 | Nav divider |
-| `ring-focus-ring` | purple | Focus rings on inputs/buttons |
-| `text-status-success` etc. | green/yellow/red/blue | Success/warning/error/info |
-
-## Workflow
+## Install
 
 ```bash
-# 1. Edit tokens.json (DTCG format with $value/$type)
-# 2. Rebuild dist/
-node build.mjs
-# 3. Commit dist/ — generated files are checked in so consumers don't need to rebuild
-git add tokens.json dist/
+npm install @ima-jin/tokens
 ```
 
-## Importing
+## Usage
 
-**CSS** (each app's `globals.css`):
-```css
-@import '@imajin/tokens/dist/variables.css';
-```
+### Tailwind
 
-**Tailwind** (`packages/config/tailwind.config.js`):
 ```js
-const tokens = require('@imajin/tokens/dist/tailwind.js');
-module.exports = {
-  theme: { extend: tokens },
-};
+// tailwind.config.js
+const tokens = require('@ima-jin/tokens');
+// Use tokens.colors, tokens.spacing, etc.
 ```
 
-## Rules
+### CSS Variables
 
-1. **App code never references raw tokens.** No `bg-imajin-orange` — use `bg-accent`.
-2. **Add a semantic alias before using a raw token in a new place.** If you find
-   yourself reaching for a raw color in a component, that's a missing semantic
-   token; add it to `tokens.json` first.
-3. **Generated `dist/` is committed.** Don't add it to .gitignore — downstream
-   consumers shouldn't need a build step.
+```css
+@import '@ima-jin/tokens/css';
+```
 
-See also: `DESIGN.md` (visual spec), issue #808 (architecture).
+## Part of Imajin
+
+[Imajin](https://imajin.ai) — sovereign technology infrastructure. Open source.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,36 @@
+# @ima-jin/ui
+
+Shared UI components for Imajin apps — NavBar, identity management, app launcher, theming, and common patterns.
+
+## Install
+
+```bash
+npm install @ima-jin/ui
+```
+
+## Components
+
+- **NavBar** — Full navigation bar with identity switching, app launcher, notifications, and balance display
+- **AppLauncher** — Grid launcher for Imajin services
+- **BalanceBadge** — MJNx/cash balance display
+- **AppShell** — Layout shell with header, body, footer, and split pane support
+- **Button** — Styled button component
+- **MarkdownEditor** — MDX editor with toolbar
+- **MarkdownContent** — Markdown renderer
+- **ConnectionPicker** — DID connection selector
+- **ToastProvider / useToast** — Toast notification system
+- **NotificationProvider / NotificationBell** — Real-time notifications
+- **ActionSheet** — Mobile-friendly bottom sheet
+- **MoneyInput** — Currency input with formatting
+- **ImajinFooter** — Standard footer
+- **BuildInfo** — Version/build info display
+
+## Hooks & Utilities
+
+- `useIdentities()` — Fetch and manage personal + group identities
+- `getActingAs() / setActingAs()` — Acting-as DID cookie management
+- `themeInitScript` — Dark/light mode initialization
+
+## Part of Imajin
+
+[Imajin](https://imajin.ai) — sovereign technology infrastructure. Open source.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,6 +7,10 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "files": [
+    "dist/",
+    "src/"
+  ],
   "dependencies": {
     "@imajin/config": "workspace:*",
     "@mdxeditor/editor": "^3.52.4",
@@ -15,6 +19,10 @@
   },
   "devDependencies": {
     "@types/react": "^18",
+    "tsup": "^8.0.0",
     "typescript": "^5"
+  },
+  "scripts": {
+    "build": "tsup"
   }
 }

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  external: ['react', 'react-dom', 'next', '@imajin/config', '@mdxeditor/editor', 'react-markdown'],
+  jsx: 'automatic',
+});

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
-  dts: true,
+  dts: false,
   clean: true,
   external: ['react', 'react-dom', 'next', '@imajin/config', '@mdxeditor/editor', 'react-markdown'],
   jsx: 'automatic',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 9.1.7
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -56,13 +56,16 @@ importers:
     dependencies:
       '@imajin/db':
         specifier: workspace:*
-        version: link:../rescue-882/packages/db
+        version: link:../imajin-ai/packages/db
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
+      jose:
+        specifier: ^5.2.0
+        version: 5.10.0
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -123,7 +126,7 @@ importers:
     dependencies:
       '@imajin/db':
         specifier: workspace:*
-        version: link:../rescue-882/packages/db
+        version: link:../imajin-ai/packages/db
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
@@ -202,7 +205,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -257,7 +260,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -357,7 +360,7 @@ importers:
         version: 12.0.2
       next:
         specifier: 14.2.35
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -511,7 +514,7 @@ importers:
         version: 5.1.7
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       otplib:
         specifier: ^13.4.0
         version: 13.4.0
@@ -647,7 +650,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -708,7 +711,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -781,7 +784,7 @@ importers:
         version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -833,7 +836,7 @@ importers:
         version: 1.8.0
       next:
         specifier: '>=14'
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       drizzle-orm:
         specifier: ^0.45.1
@@ -855,7 +858,7 @@ importers:
         version: link:../notify
       next:
         specifier: '>=14'
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   packages/chat:
     dependencies:
@@ -898,7 +901,14 @@ importers:
         version: link:../tokens
       next:
         specifier: '>=14'
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   packages/db:
     dependencies:
@@ -1029,7 +1039,7 @@ importers:
         version: 5.1.7
       next:
         specifier: '>=14'
-        version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       pino:
         specifier: ^9
         version: 9.14.0
@@ -1134,6 +1144,9 @@ importers:
       '@types/react':
         specifier: ^18
         version: 18.3.28
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -3921,6 +3934,12 @@ packages:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -4005,6 +4024,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -4073,6 +4096,10 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -4709,6 +4736,9 @@ packages:
   find-yarn-workspace-root@2.0.0:
     resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -5201,6 +5231,10 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -5305,6 +5339,10 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
@@ -6058,6 +6096,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
@@ -6098,6 +6140,10 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -6248,6 +6294,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -6521,6 +6571,10 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -6547,6 +6601,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -9973,6 +10046,11 @@ snapshots:
       node-gyp-build: 4.8.4
     optional: true
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -10061,6 +10139,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   ci-info@3.9.0: {}
 
   classnames@2.5.1: {}
@@ -10117,6 +10199,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -10561,8 +10645,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@1.21.7))
@@ -10584,6 +10668,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@1.21.7)
+      get-tsconfig: 4.13.7
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -10599,21 +10698,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@1.21.7)
-      get-tsconfig: 4.13.7
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
@@ -10625,14 +10709,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -10665,7 +10749,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10676,7 +10760,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11037,6 +11121,12 @@ snapshots:
   find-yarn-workspace-root@2.0.0:
     dependencies:
       micromatch: 4.0.8
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.1
 
   flat-cache@3.2.0:
     dependencies:
@@ -11569,6 +11659,8 @@ snapshots:
 
   jose@6.2.3: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -11663,6 +11755,8 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
 
   local-pkg@0.5.1:
     dependencies:
@@ -12302,32 +12396,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 14.2.35
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001787
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.33
-      '@next/swc-darwin-x64': 14.2.33
-      '@next/swc-linux-arm64-gnu': 14.2.33
-      '@next/swc-linux-arm64-musl': 14.2.33
-      '@next/swc-linux-x64-gnu': 14.2.33
-      '@next/swc-linux-x64-musl': 14.2.33
-      '@next/swc-win32-arm64-msvc': 14.2.33
-      '@next/swc-win32-ia32-msvc': 14.2.33
-      '@next/swc-win32-x64-msvc': 14.2.33
-      '@opentelemetry/api': 1.9.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -12754,6 +12822,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  readdirp@4.1.2: {}
+
   real-require@0.2.0: {}
 
   reflect.getprototypeof@1.0.10:
@@ -12832,6 +12902,8 @@ snapshots:
   require-main-filename@2.0.0: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -13058,6 +13130,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   space-separated-tokens@2.0.2: {}
 
   split2@4.2.0: {}
@@ -13236,11 +13310,6 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  styled-jsx@5.1.1(react@18.3.1):
-    dependencies:
-      client-only: 0.0.1
-      react: 18.3.1
-
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -13368,6 +13437,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -13390,6 +13461,34 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
+      resolve-from: 5.0.0
+      rollup: 4.60.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.9
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.21.0:
     dependencies:

--- a/scripts/prepare-npm-publish.mjs
+++ b/scripts/prepare-npm-publish.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Prepare a package for npm publishing under @ima-jin scope.
+ * Usage: node scripts/prepare-npm-publish.mjs <package-dir> <output-dir>
+ *
+ * - Copies distributable files to output dir
+ * - Rewrites @imajin/* → @ima-jin/* in package name and deps
+ * - Resolves workspace:* to actual versions
+ * - Removes "private" flag and devDependencies
+ * - Sets publishConfig for public access
+ */
+import { readFileSync, writeFileSync, cpSync, existsSync, mkdirSync } from "fs";
+import { join, resolve } from "path";
+
+const [, , pkgDir, outDir] = process.argv;
+if (!pkgDir || !outDir) {
+  console.error(
+    "Usage: node scripts/prepare-npm-publish.mjs <package-dir> <output-dir>"
+  );
+  process.exit(1);
+}
+
+const srcDir = resolve(pkgDir);
+const destDir = resolve(outDir);
+const packagesDir = resolve(srcDir, "..");
+
+// Read source package.json
+const pkg = JSON.parse(readFileSync(join(srcDir, "package.json"), "utf8"));
+
+console.log(`Preparing ${pkg.name}@${pkg.version} for npm publish...`);
+
+// Create output directory
+mkdirSync(destDir, { recursive: true });
+
+// Copy files listed in "files" field, plus common extras
+const filesToCopy = pkg.files || ["dist", "src"];
+for (const f of filesToCopy) {
+  const srcPath = join(srcDir, f);
+  if (existsSync(srcPath)) {
+    cpSync(srcPath, join(destDir, f), { recursive: true });
+    console.log(`  Copied ${f}`);
+  } else {
+    console.warn(`  Warning: ${f} not found, skipping`);
+  }
+}
+
+// Copy extra files if they exist
+for (const extra of ["README.md", "LICENSE", "CHANGELOG.md"]) {
+  const p = join(srcDir, extra);
+  if (existsSync(p)) {
+    cpSync(p, join(destDir, extra));
+    console.log(`  Copied ${extra}`);
+  }
+}
+
+// Rewrite package name: @imajin/* → @ima-jin/*
+const originalName = pkg.name;
+pkg.name = pkg.name.replace("@imajin/", "@ima-jin/");
+
+// Remove private flag
+delete pkg.private;
+
+// Set publishConfig
+pkg.publishConfig = { access: "public" };
+
+// Remove scripts (not needed by consumers)
+delete pkg.scripts;
+
+// Remove devDependencies (not needed by consumers)
+delete pkg.devDependencies;
+
+// Rewrite exports/main/types to point to dist/ instead of src/
+if (pkg.main && pkg.main.startsWith("./src/")) {
+  pkg.main = pkg.main.replace("./src/", "./dist/").replace(".ts", ".js");
+}
+if (pkg.types && pkg.types.startsWith("./src/")) {
+  pkg.types = pkg.types.replace("./src/", "./dist/").replace(".ts", ".d.ts");
+}
+if (pkg.exports) {
+  for (const [key, value] of Object.entries(pkg.exports)) {
+    if (typeof value === "string" && value.startsWith("./src/")) {
+      // For tsup-built packages, provide proper ESM/CJS exports
+      const base = value.replace("./src/", "./dist/").replace(/\.tsx?$/, "");
+      pkg.exports[key] = {
+        import: base + ".mjs",
+        require: base + ".js",
+        types: base + ".d.ts",
+      };
+    }
+  }
+}
+// Also rewrite @imajin/* in external references within exports
+if (pkg.exports) {
+  const newExports = {};
+  for (const [key, value] of Object.entries(pkg.exports)) {
+    const newKey = key.replace("@imajin/", "@ima-jin/");
+    newExports[newKey] = value;
+  }
+  pkg.exports = newExports;
+}
+
+// Rewrite workspace:* dependencies
+for (const depType of ["dependencies", "peerDependencies"]) {
+  if (!pkg[depType]) continue;
+  const newDeps = {};
+  for (const [dep, ver] of Object.entries(pkg[depType])) {
+    if (typeof ver === "string" && ver.startsWith("workspace:")) {
+      // Resolve to @ima-jin scope and actual version
+      const depLocalName = dep.replace("@imajin/", "");
+      try {
+        const depPkg = JSON.parse(
+          readFileSync(
+            join(packagesDir, depLocalName, "package.json"),
+            "utf8"
+          )
+        );
+        const npmName = dep.replace("@imajin/", "@ima-jin/");
+        newDeps[npmName] = "^" + depPkg.version;
+        console.log(`  Rewrote dep ${dep}@${ver} → ${npmName}@^${depPkg.version}`);
+      } catch {
+        console.warn(`  Warning: could not resolve ${dep}, keeping as-is`);
+        newDeps[dep] = ver;
+      }
+    } else {
+      newDeps[dep] = ver;
+    }
+  }
+  pkg[depType] = newDeps;
+}
+
+// Write modified package.json to output
+writeFileSync(join(destDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+
+console.log(`\nReady to publish: ${pkg.name}@${pkg.version}`);
+console.log(`Output: ${destDir}`);


### PR DESCRIPTION
Adds infrastructure to publish shared packages to npm under `@ima-jin` scope.

- `scripts/prepare-npm-publish.mjs` — rewrites `@imajin/*` → `@ima-jin/*`, resolves workspace deps
- `.github/workflows/publish-packages.yml` — manual dispatch, supports dry run
- tsup build configs for config + ui
- READMEs for tokens, config, ui

Publish order: `@ima-jin/tokens` → `@ima-jin/config` → `@ima-jin/ui`

Internal monorepo unchanged — packages still use `@imajin/*` and `workspace:*` internally.

Refs #994