### PR TITLE
feat: agent delegation for media uploads (#972)

### DIFF
--- a/apps/kernel/app/auth/api/agents/route.ts
+++ b/apps/kernel/app/auth/api/agents/route.ts
@@ -154,6 +154,14 @@ export async function POST(request: NextRequest) {
       addedBy: caller.id,
     });
 
+    // Reverse membership: agent is delegated to human
+    await db.insert(identityMembers).values({
+      identityDid: caller.id,
+      memberDid: agentDid,
+      role: 'agent',
+      addedBy: caller.id,
+    });
+
     return NextResponse.json(
       {
         did: agentDid,

--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -192,7 +192,7 @@ export async function GET(
         { status: 403 }
       );
     }
-    const requesterDid = authResult.identity.actingAs || authResult.identity.id;
+    const requesterDid = authResult.identity.actingFor || authResult.identity.actingAs || authResult.identity.id;
 
     if (accessType === "private") {
       if (requesterDid !== asset.ownerDid) {
@@ -552,7 +552,20 @@ export async function DELETE(
   if ("error" in authResult) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
-  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
+  const { identity } = authResult;
+
+  // Approval gate: agents cannot delete via delegation
+  if (identity.actingFor) {
+    return NextResponse.json({
+      error: "Agent delegation does not permit destructive operations",
+      code: "AGENT_APPROVAL_REQUIRED",
+      action: "delete",
+      assetId: id,
+      ownerDid: identity.actingFor,
+    }, { status: 403 });
+  }
+
+  const requesterDid = identity.actingAs || identity.id;
 
   let asset;
   try {
@@ -604,7 +617,20 @@ export async function PATCH(
   if ("error" in authResult) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
-  const requesterDid = authResult.identity.actingAs || authResult.identity.id;
+  const { identity } = authResult;
+
+  // Approval gate: agents cannot rename via delegation
+  if (identity.actingFor) {
+    return NextResponse.json({
+      error: "Agent delegation does not permit destructive operations",
+      code: "AGENT_APPROVAL_REQUIRED",
+      action: "rename",
+      assetId: id,
+      ownerDid: identity.actingFor,
+    }, { status: 403 });
+  }
+
+  const requesterDid = identity.actingAs || identity.id;
 
   let body: { filename?: unknown };
   try {

--- a/apps/kernel/app/media/api/assets/route.ts
+++ b/apps/kernel/app/media/api/assets/route.ts
@@ -103,7 +103,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: authResult.error }, { status: authResult.status, headers: cors });
   }
   const { identity } = authResult;
-  const ownerDid = identity.actingAs || identity.id;
+  const ownerDid = identity.actingFor || identity.actingAs || identity.id;
+  const uploadedBy = identity.id;
 
   // Fetch full identity row to get uploadLimitMb
   const [identityRow] = await db
@@ -263,6 +264,7 @@ export async function POST(request: NextRequest) {
       .values({
         id: assetId,
         ownerDid,
+        uploadedBy,
         filename: originalName,
         mimeType,
         size: file.size,
@@ -393,6 +395,7 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   let ownerDid: string;
+  let uploadedBy: string | undefined;
   let isAgentQuery = false;
   if (bearerToken && internalApiKey && bearerToken === internalApiKey) {
     const ownerDidHeader = request.headers.get("X-Owner-DID");
@@ -400,6 +403,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "X-Owner-DID header required" }, { status: 400, headers: cors });
     }
     ownerDid = ownerDidHeader;
+    // NEW: capture uploaded-by from internal caller
+    uploadedBy = request.headers.get("X-Uploaded-By") || ownerDidHeader;
   } else {
     const authResult = await requireAuth(request);
     if ("error" in authResult) {
@@ -413,7 +418,7 @@ export async function GET(request: NextRequest) {
       ownerDid = didParam;
       isAgentQuery = true;
     } else {
-      ownerDid = identity.actingAs || identity.id;
+      ownerDid = identity.actingFor || identity.actingAs || identity.id;
     }
   }
 

--- a/apps/kernel/src/db/schemas/media.ts
+++ b/apps/kernel/src/db/schemas/media.ts
@@ -17,7 +17,8 @@ export const assets = mediaSchema.table(
   "assets",
   {
     id: text("id").primaryKey(),                               // asset_xxx
-    ownerDid: text("owner_did").notNull(),                     // DID of uploader
+    ownerDid: text("owner_did").notNull(),                     // DID of owner (may differ from uploader)
+    uploadedBy: text("uploaded_by"),                            // DID of actual uploader (audit trail)
     filename: text("filename").notNull(),                      // original filename
     mimeType: text("mime_type").notNull(),                     // image/jpeg, etc.
     size: integer("size").notNull(),                           // bytes
@@ -52,6 +53,7 @@ export const assets = mediaSchema.table(
   },
   (table) => ({
     ownerIdx: index("idx_assets_owner").on(table.ownerDid),
+    uploadedByIdx: index("idx_assets_uploaded_by").on(table.uploadedBy),
     statusIdx: index("idx_assets_status").on(table.status),
     mimeIdx: index("idx_assets_mime").on(table.mimeType),
     folderIdx: index("idx_assets_folder").on(table.folderId),

--- a/migrations/0035_assets_uploaded_by.sql
+++ b/migrations/0035_assets_uploaded_by.sql
@@ -1,0 +1,6 @@
+-- Add uploaded_by column for audit trail
+ALTER TABLE media.assets ADD COLUMN IF NOT EXISTS uploaded_by TEXT;
+CREATE INDEX IF NOT EXISTS idx_assets_uploaded_by ON media.assets(uploaded_by);
+
+-- Backfill: existing uploads were done by the owner
+UPDATE media.assets SET uploaded_by = owner_did WHERE uploaded_by IS NULL;

--- a/migrations/0036_agent_reverse_membership.sql
+++ b/migrations/0036_agent_reverse_membership.sql
@@ -1,0 +1,7 @@
+-- Create reverse membership records: agent is a delegated member of human's identity
+INSERT INTO auth.identity_members (identity_did, member_did, role, added_by, added_at)
+SELECT im.member_did, im.identity_did, 'agent', im.member_did, NOW()
+FROM auth.identity_members im
+JOIN auth.identities i ON i.id = im.identity_did
+WHERE i.subtype = 'agent' AND im.role = 'owner' AND im.removed_at IS NULL
+ON CONFLICT DO NOTHING;

--- a/packages/auth/src/require-auth.ts
+++ b/packages/auth/src/require-auth.ts
@@ -212,5 +212,22 @@ export async function requireAuth(
     }
   }
 
+  // Handle X-Acting-For header for agent delegation (separate from group acting-as)
+  if ("identity" in result && result.identity) {
+    const actingFor = request.headers.get("x-acting-for");
+    if (actingFor) {
+      const actingForResult = await validateActingAs(
+        result.identity.id,
+        actingFor,
+        options?.service
+      );
+      if (!actingForResult.valid || actingForResult.role !== 'agent') {
+        return { error: "Not authorized to act for this identity", status: 403 };
+      }
+      result.identity.actingFor = actingFor;
+      result.identity.actingForRole = actingForResult.role;
+    }
+  }
+
   return result;
 }

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -35,7 +35,7 @@ async function validateActingAsCookie(
     );
     if (!res.ok) return { valid: false };
     const data = await res.json();
-    if (data.valid !== true || !["owner", "admin", "maintainer"].includes(data.role)) {
+    if (data.valid !== true || !["owner", "admin", "maintainer", "agent"].includes(data.role)) {
       return { valid: false };
     }
 

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -10,6 +10,8 @@ export interface Identity {
   actingAs?: string;            // DID of group the caller is acting on behalf of
   actingAsRole?: string;        // Role of the caller in the group (e.g. 'agent')
   actingAsServices?: string[];  // Services this controller can access (undefined = full access)
+  actingFor?: string;           // DID of identity agent is delegated to
+  actingForRole?: string;       // always 'agent' for now
 }
 
 export interface AuthResult {

--- a/packages/llm/src/tools/media.ts
+++ b/packages/llm/src/tools/media.ts
@@ -11,6 +11,7 @@ export function createMediaTools(config: {
   const authHeaders: Record<string, string> = {
     Authorization: `Bearer ${config.apiKey}`,
     'X-Owner-DID': config.targetDid,
+    'X-Uploaded-By': config.requesterDid,
   };
 
   return {


### PR DESCRIPTION
## Summary

Implements agent delegation for media uploads (act-on-behalf-of) per #972.

## Changes

### Schema + Migrations
- **media.assets**: Added \+uploaded_by` column + index for audit trail
- **Migration 0035**: Add column, create index, backfill existing rows
- **Migration 0036**: Backfill reverse membership records for existing agents

### Auth
- Added `actingFor` / `actingForRole` to Identity type
- Added `X-Acting-For` header validation in `requireAuth()` — separate from group `X-Acting-As`
- Fixed `session.ts` to allow `agent` role in `validateActingAsCookie()`

### Agent Creation
- New agents now get a reverse membership record: agent → human with role `agent`

### Media Endpoints
- **POST /media/api/assets**: `ownerDid` resolves from `actingFor || actingAs || id`, records `uploadedBy`
- **GET /media/api/assets**: Same `ownerDid` resolution for listing; internal API key path accepts `X-Uploaded-By`
- **GET /media/api/assets/[id]**: Access check uses `actingFor` resolution
- **DELETE /media/api/assets/[id]**: Approval gate — delegated agents get 403 `AGENT_APPROVAL_REQUIRED`
- **PATCH /media/api/assets/[id]**: Same approval gate for rename operations

### LLM Tools
- `packages/llm/src/tools/media.ts` passes `X-Uploaded-By: requesterDid` for audit trail

## Design Decisions
1. `X-Acting-For` is a new header, separate from `X-Acting-As` — different semantics (delegation vs impersonation)
2. Agents can upload/read/list/move but cannot delete or rename without owner approval
3. Internal API key path gets `X-Uploaded-By` for LLM tool audit trail

Closes #972