### PR TITLE
feat(admin): scaffold vault management UI panel (#1005)

### DIFF
--- a/apps/kernel/app/admin/layout.tsx
+++ b/apps/kernel/app/admin/layout.tsx
@@ -14,6 +14,7 @@ const NAV_ITEMS = [
   { label: 'Services', href: '/admin/services', icon: '⚙️' },
   { label: 'Federation', href: '/admin/federation', icon: '🌐' },
   { label: 'Storage', href: '/admin/storage', icon: '💾' },
+  { label: 'Vault', href: '/admin/vault', icon: '🔐' },
   { label: 'Config', href: '/admin/config', icon: '🔧' },
   { label: 'Moderation', href: '/admin/moderation', icon: '🛡️' },
   { label: 'Events', href: '/admin/events', icon: '🔔' },

--- a/apps/kernel/app/admin/vault/history-dialog.tsx
+++ b/apps/kernel/app/admin/vault/history-dialog.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { formatDistanceToNow } from 'date-fns';
+import type { VaultHistoryEntry } from './types';
+
+interface HistoryDialogProps {
+  field: string | null;
+  entries: VaultHistoryEntry[];
+  open: boolean;
+  onClose: () => void;
+}
+
+function actionLabel(action: VaultHistoryEntry['action']): string {
+  return action === 'rotate' ? 'Rotated' : 'Set';
+}
+
+export function HistoryDialog({ field, entries, open, onClose }: HistoryDialogProps) {
+  if (!open || !field) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-2xl rounded-xl bg-white dark:bg-gray-800 shadow-xl border border-gray-100 dark:border-gray-700 p-6">
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">History</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 font-mono">{field}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Close
+          </button>
+        </div>
+
+        {entries.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No history entries yet.</p>
+        ) : (
+          <div className="rounded-lg border border-gray-100 dark:border-gray-700 overflow-hidden">
+            <div className="divide-y divide-gray-100 dark:divide-gray-700">
+              {entries.map((entry) => (
+                <div key={`${entry.cid}:${entry.updatedAt}`} className="px-4 py-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium text-gray-900 dark:text-white">
+                      {actionLabel(entry.action)}
+                    </span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {formatDistanceToNow(new Date(entry.updatedAt), { addSuffix: true })}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 font-mono break-all">
+                    {entry.cid}
+                  </p>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">by {entry.setBy}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/vault/page.tsx
+++ b/apps/kernel/app/admin/vault/page.tsx
@@ -1,0 +1,63 @@
+import { VaultPanel } from './vault-panel';
+import type { VaultHistoryEntry, VaultSecretRow } from './types';
+
+const initialSecrets: VaultSecretRow[] = [
+  {
+    field: 'GH_TOKEN',
+    hint: 'ghp_...',
+    cid: 'bafyrei0ghv12token0seed',
+    setBy: '@ryan',
+    updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+    status: 'confirmed',
+  },
+  {
+    field: 'OPENAI_API_KEY',
+    hint: 'sk-p...',
+    cid: 'bafyrei0opn12apikeyseed',
+    setBy: '@debbie',
+    updatedAt: new Date(Date.now() - 1000 * 60 * 35).toISOString(),
+    status: 'pending',
+  },
+];
+
+const initialHistory: Record<string, VaultHistoryEntry[]> = {
+  GH_TOKEN: [
+    {
+      field: 'GH_TOKEN',
+      cid: 'bafyrei0ghv12token0seed',
+      setBy: '@ryan',
+      updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+      action: 'set',
+    },
+  ],
+  OPENAI_API_KEY: [
+    {
+      field: 'OPENAI_API_KEY',
+      cid: 'bafyrei0opn12apikeyseed',
+      setBy: '@debbie',
+      updatedAt: new Date(Date.now() - 1000 * 60 * 35).toISOString(),
+      action: 'rotate',
+    },
+    {
+      field: 'OPENAI_API_KEY',
+      cid: 'bafyrei0opn12apikeyold0',
+      setBy: '@debbie',
+      updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 28).toISOString(),
+      action: 'set',
+    },
+  ],
+};
+
+export default function AdminVaultPage() {
+  return (
+    <div className="p-6 lg:p-8 max-w-6xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Vault</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Manage encrypted secrets with set, rotate, and history workflows.
+        </p>
+      </div>
+      <VaultPanel initialSecrets={initialSecrets} initialHistory={initialHistory} />
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/vault/rotate-secret-dialog.tsx
+++ b/apps/kernel/app/admin/vault/rotate-secret-dialog.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+import type { RotateSecretInput } from './types';
+
+interface RotateSecretDialogProps {
+  field: string | null;
+  open: boolean;
+  submitting: boolean;
+  onClose: () => void;
+  onSubmit: (input: RotateSecretInput) => Promise<void>;
+}
+
+export function RotateSecretDialog({
+  field,
+  open,
+  submitting,
+  onClose,
+  onSubmit,
+}: RotateSecretDialogProps) {
+  const [setBy, setSetBy] = useState('@operator');
+
+  if (!open || !field) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-md rounded-xl bg-white dark:bg-gray-800 shadow-xl border border-gray-100 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Rotate Secret</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+          Rotate key material for <span className="font-mono">{field}</span> and publish update events.
+        </p>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Requested by</label>
+        <input
+          value={setBy}
+          onChange={(event) => setSetBy(event.target.value)}
+          className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-orange-500"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => onSubmit({ field, setBy: setBy.trim() || '@operator' })}
+            className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+          >
+            {submitting ? 'Rotating…' : 'Rotate'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/vault/set-secret-dialog.tsx
+++ b/apps/kernel/app/admin/vault/set-secret-dialog.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+import type { SetSecretInput } from './types';
+
+interface SetSecretDialogProps {
+  open: boolean;
+  submitting: boolean;
+  onClose: () => void;
+  onSubmit: (input: SetSecretInput) => Promise<void>;
+}
+
+export function SetSecretDialog({ open, submitting, onClose, onSubmit }: SetSecretDialogProps) {
+  const [field, setField] = useState('');
+  const [value, setValue] = useState('');
+  const [hint, setHint] = useState('');
+  const [setBy, setSetBy] = useState('@operator');
+
+  if (!open) {
+    return null;
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    await onSubmit({
+      field: field.trim().toUpperCase(),
+      value,
+      hint: hint.trim(),
+      setBy: setBy.trim() || '@operator',
+    });
+    setField('');
+    setValue('');
+    setHint('');
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-lg rounded-xl bg-white dark:bg-gray-800 shadow-xl border border-gray-100 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">Set Secret</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">
+          UI scaffold only: value stays local in browser state until backend wiring from #1006 is connected.
+        </p>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Field</label>
+            <input
+              required
+              value={field}
+              onChange={(event) => setField(event.target.value)}
+              placeholder="GH_TOKEN"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Value</label>
+            <input
+              required
+              type="password"
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              placeholder="••••••••"
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Hint <span className="text-gray-400">(optional)</span>
+              </label>
+              <input
+                value={hint}
+                onChange={(event) => setHint(event.target.value)}
+                placeholder="ghp_"
+                className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Set by</label>
+              <input
+                value={setBy}
+                onChange={(event) => setSetBy(event.target.value)}
+                placeholder="@operator"
+                className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </div>
+          </div>
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            >
+              {submitting ? 'Saving…' : 'Save Secret'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/kernel/app/admin/vault/types.ts
+++ b/apps/kernel/app/admin/vault/types.ts
@@ -1,0 +1,31 @@
+export type VaultReloadStatus = 'confirmed' | 'pending';
+export type VaultHistoryAction = 'set' | 'rotate';
+
+export interface VaultSecretRow {
+  field: string;
+  hint: string;
+  cid: string;
+  setBy: string;
+  updatedAt: string;
+  status: VaultReloadStatus;
+}
+
+export interface VaultHistoryEntry {
+  field: string;
+  cid: string;
+  setBy: string;
+  updatedAt: string;
+  action: VaultHistoryAction;
+}
+
+export interface SetSecretInput {
+  field: string;
+  value: string;
+  hint: string;
+  setBy: string;
+}
+
+export interface RotateSecretInput {
+  field: string;
+  setBy: string;
+}

--- a/apps/kernel/app/admin/vault/vault-panel.tsx
+++ b/apps/kernel/app/admin/vault/vault-panel.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { HistoryDialog } from './history-dialog';
+import { RotateSecretDialog } from './rotate-secret-dialog';
+import { SetSecretDialog } from './set-secret-dialog';
+import type {
+  RotateSecretInput,
+  SetSecretInput,
+  VaultHistoryEntry,
+  VaultSecretRow,
+} from './types';
+
+interface VaultPanelProps {
+  initialSecrets: VaultSecretRow[];
+  initialHistory: Record<string, VaultHistoryEntry[]>;
+}
+
+function createCid(field: string): string {
+  const cleanField = field.replace(/[^A-Z0-9]/gi, '').toLowerCase().slice(0, 8);
+  const random = Math.random().toString(36).slice(2, 12);
+  return `bafy${cleanField}${random}`;
+}
+
+function createHint(value: string, hint: string): string {
+  const source = hint.trim() || value.trim();
+  if (!source) return '••••';
+  return `${source.slice(0, 4)}...`;
+}
+
+function statusBadge(status: VaultSecretRow['status']): string {
+  if (status === 'confirmed') {
+    return '🟢 confirmed';
+  }
+  return '🟡 pending';
+}
+
+export function VaultPanel({ initialSecrets, initialHistory }: VaultPanelProps) {
+  const [secrets, setSecrets] = useState<VaultSecretRow[]>(initialSecrets);
+  const [historyByField, setHistoryByField] = useState<Record<string, VaultHistoryEntry[]>>(initialHistory);
+  const [setOpen, setSetOpen] = useState(false);
+  const [rotateField, setRotateField] = useState<string | null>(null);
+  const [historyField, setHistoryField] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const sortedSecrets = useMemo(
+    () => [...secrets].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
+    [secrets]
+  );
+
+  async function handleSetSecret(input: SetSecretInput): Promise<void> {
+    setSubmitting(true);
+    try {
+      const now = new Date().toISOString();
+      const nextCid = createCid(input.field);
+      const nextRow: VaultSecretRow = {
+        field: input.field,
+        hint: createHint(input.value, input.hint),
+        cid: nextCid,
+        setBy: input.setBy,
+        updatedAt: now,
+        status: 'pending',
+      };
+      setSecrets((current) => {
+        const withoutField = current.filter((row) => row.field !== input.field);
+        return [nextRow, ...withoutField];
+      });
+      setHistoryByField((current) => ({
+        ...current,
+        [input.field]: [
+          {
+            field: input.field,
+            cid: nextCid,
+            setBy: input.setBy,
+            updatedAt: now,
+            action: 'set',
+          },
+          ...(current[input.field] ?? []),
+        ],
+      }));
+      setSetOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRotateSecret(input: RotateSecretInput): Promise<void> {
+    setSubmitting(true);
+    try {
+      const now = new Date().toISOString();
+      const nextCid = createCid(input.field);
+      setSecrets((current) =>
+        current.map((row) =>
+          row.field === input.field
+            ? {
+                ...row,
+                cid: nextCid,
+                setBy: input.setBy,
+                updatedAt: now,
+                status: 'pending',
+              }
+            : row
+        )
+      );
+      setHistoryByField((current) => ({
+        ...current,
+        [input.field]: [
+          {
+            field: input.field,
+            cid: nextCid,
+            setBy: input.setBy,
+            updatedAt: now,
+            action: 'rotate',
+          },
+          ...(current[input.field] ?? []),
+        ],
+      }));
+      setRotateField(null);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function markConfirmed(field: string): void {
+    setSecrets((current) =>
+      current.map((row) =>
+        row.field === field
+          ? {
+              ...row,
+              status: 'confirmed',
+            }
+          : row
+      )
+    );
+  }
+
+  const historyEntries = historyField ? historyByField[historyField] ?? [] : [];
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 p-4">
+        <p className="text-sm text-orange-800 dark:text-orange-300">
+          Vault UI scaffolding is active. Final API wiring, browser encryption, and live status confirmations will attach to #1006 backend endpoints/events.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Secrets</h2>
+        <button
+          type="button"
+          onClick={() => setSetOpen(true)}
+          className="rounded-lg bg-orange-500 hover:bg-orange-600 text-white px-3 py-1.5 text-sm font-medium"
+        >
+          + Set Secret
+        </button>
+      </div>
+
+      <div className="hidden md:block rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-50 dark:bg-gray-700/50 border-b border-gray-100 dark:border-gray-700">
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Field</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Hint</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">CID</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Set by</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Updated</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Status</th>
+                <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+              {sortedSecrets.map((secret) => (
+                <tr key={secret.field} className="hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors">
+                  <td className="px-4 py-3 font-mono text-xs text-gray-900 dark:text-white">{secret.field}</td>
+                  <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{secret.hint}</td>
+                  <td className="px-4 py-3 text-xs font-mono text-gray-500 dark:text-gray-400 truncate max-w-[180px]">{secret.cid}</td>
+                  <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{secret.setBy}</td>
+                  <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                    {formatDistanceToNow(new Date(secret.updatedAt), { addSuffix: true })}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-gray-700 dark:text-gray-300">{statusBadge(secret.status)}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setRotateField(secret.field)}
+                        className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                      >
+                        Rotate
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setHistoryField(secret.field)}
+                        className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                      >
+                        History
+                      </button>
+                      {secret.status === 'pending' && (
+                        <button
+                          type="button"
+                          onClick={() => markConfirmed(secret.field)}
+                          className="rounded-lg border border-green-300 dark:border-green-700 px-2 py-1 text-xs text-green-700 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20"
+                        >
+                          Mark confirmed
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="md:hidden space-y-3">
+        {sortedSecrets.map((secret) => (
+          <div key={secret.field} className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-mono text-xs text-gray-900 dark:text-white">{secret.field}</p>
+                <p className="text-sm text-gray-700 dark:text-gray-300">{secret.hint}</p>
+              </div>
+              <span className="text-xs text-gray-700 dark:text-gray-300">{statusBadge(secret.status)}</span>
+            </div>
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 font-mono break-all">{secret.cid}</p>
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              {secret.setBy} · {formatDistanceToNow(new Date(secret.updatedAt), { addSuffix: true })}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => setRotateField(secret.field)}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                Rotate
+              </button>
+              <button
+                type="button"
+                onClick={() => setHistoryField(secret.field)}
+                className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                History
+              </button>
+              {secret.status === 'pending' && (
+                <button
+                  type="button"
+                  onClick={() => markConfirmed(secret.field)}
+                  className="rounded-lg border border-green-300 dark:border-green-700 px-2 py-1 text-xs text-green-700 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20"
+                >
+                  Mark confirmed
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <SetSecretDialog
+        open={setOpen}
+        submitting={submitting}
+        onClose={() => setSetOpen(false)}
+        onSubmit={handleSetSecret}
+      />
+      <RotateSecretDialog
+        field={rotateField}
+        open={rotateField !== null}
+        submitting={submitting}
+        onClose={() => setRotateField(null)}
+        onSubmit={handleRotateSecret}
+      />
+      <HistoryDialog
+        field={historyField}
+        entries={historyEntries}
+        open={historyField !== null}
+        onClose={() => setHistoryField(null)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new Admin → Vault panel route at /admin/vault
- scaffold write-only vault management UI components for set, rotate, status, and history flows
- include mobile and desktop layouts for secret list/actions
- add placeholder client-state wiring designed for backend/API hookup from #1006

## Issue
- refs #1005

## Validation
- pnpm --filter @imajin/kernel exec eslint app/admin/vault/*.tsx app/admin/vault/*.ts app/admin/layout.tsx --max-warnings 0

## Artifacts
- Conversation: https://app.warp.dev/conversation/5e6a858b-4ced-42ee-aff6-eee976757ca9

Co-Authored-By: Oz <oz-agent@warp.dev>