### PR TITLE
fix(events): guest list defaults to confirmed tickets, fix survey join

### DIFF
--- a/apps/events/app/admin/[eventId]/guest-list.tsx
+++ b/apps/events/app/admin/[eventId]/guest-list.tsx
@@ -332,6 +332,11 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
   };
 
   // Filter logic
+  // Default view shows valid + used (real tickets with verified payment).
+  // Non-default statuses are revealed by clicking their pills.
+  const DEFAULT_STATUSES = ['valid', 'used'];
+  const NON_DEFAULT_STATUSES = ['held', 'available', 'cancelled', 'refunded', 'refund_pending'];
+
   const toggleFilter = (key: FilterKey, value: string) => {
     if (filterKey === key && filterValue === value) {
       setFilterKey(null);
@@ -343,24 +348,30 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
   };
 
   const filteredGuests = guests.filter(g => {
-    if (!filterKey) return true;
-    if (filterKey === 'type') return g.ticketType === filterValue;
+    // Status pill overrides the default status filter
     if (filterKey === 'status') return g.status === filterValue;
-    return true;
+    // Type pill still restricts to default statuses
+    if (filterKey === 'type') return g.ticketType === filterValue && DEFAULT_STATUSES.includes(g.status);
+    // Default: only valid + used
+    return DEFAULT_STATUSES.includes(g.status);
   });
 
-  // Summary counts
+  // Tier counts only include valid + used tickets
   const typeCounts = guests.reduce<Record<string, number>>((acc, g) => {
-    acc[g.ticketType] = (acc[g.ticketType] || 0) + 1;
+    if (DEFAULT_STATUSES.includes(g.status)) {
+      acc[g.ticketType] = (acc[g.ticketType] || 0) + 1;
+    }
     return acc;
   }, {});
+  // Status counts include ALL tickets so the pills show real numbers
   const statusCounts = guests.reduce<Record<string, number>>((acc, g) => {
     acc[g.status] = (acc[g.status] || 0) + 1;
     return acc;
   }, {});
 
   const uniqueTypes = Object.keys(typeCounts);
-  const uniqueStatuses = Object.keys(statusCounts);
+  // Only show pills for non-default statuses that actually have tickets
+  const uniqueStatuses = NON_DEFAULT_STATUSES.filter(s => statusCounts[s]);
 
   // Collapsed header with summary
   const summaryContent = (
@@ -446,7 +457,7 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
         {guests.length > 0 && (
           <div className="flex flex-wrap gap-2 mt-4 mb-4">
             <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
-              {guests.length} ticket{guests.length !== 1 ? 's' : ''}
+              {filteredGuests.length} of {guests.length} ticket{guests.length !== 1 ? 's' : ''}
             </span>
             {uniqueTypes.map(type => (
               <button
@@ -479,7 +490,7 @@ export function GuestList({ eventId, isOwner, summary, autoExpand }: GuestListPr
                 onClick={() => { setFilterKey(null); setFilterValue(null); }}
                 className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900/40 text-red-600 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/60 transition"
               >
-                Clear filter
+                ✕ Back to confirmed
               </button>
             )}
           </div>

--- a/apps/events/app/api/events/[id]/guests/route.ts
+++ b/apps/events/app/api/events/[id]/guests/route.ts
@@ -75,7 +75,11 @@ export async function GET(
              cred.value as fallback_email
       FROM events.tickets t
       JOIN events.ticket_types tt ON t.ticket_type_id = tt.id
-      LEFT JOIN dykil.survey_responses sr ON sr.ticket_id = t.id
+      LEFT JOIN LATERAL (
+        SELECT answers FROM dykil.survey_responses
+        WHERE ticket_id = t.id
+        ORDER BY created_at DESC LIMIT 1
+      ) sr ON true
       LEFT JOIN events.orders o ON t.order_id = o.id
       LEFT JOIN auth.identities i ON i.id = t.owner_did
       LEFT JOIN LATERAL (


### PR DESCRIPTION
## Changes

**Guest list default filter:**
- Default view shows only `valid` + `used` tickets (confirmed payment, real guests)
- Ticket tier pill counts only include valid + used tickets
- Non-default status pills (held, available, cancelled, refunded, refund_pending) appear only when tickets exist in those states — click to reveal that segment
- Type pill filtering intersects with default status filter (clicking a tier still only shows confirmed tickets for that tier)
- Badge shows "24 of 30 tickets" (filtered vs total)
- Clear button says "✕ Back to confirmed" for clarity

**Survey join fix:**
- `LEFT JOIN dykil.survey_responses` replaced with `LEFT JOIN LATERAL ... ORDER BY created_at DESC LIMIT 1` to pick only the most recent survey response per ticket (same pattern as the credentials join below it)
- Fixes duplicate rows when a ticket has multiple survey responses