### PR TITLE
feat(bus): broker() — consent-gated data release (#1014)

### DIFF
--- a/apps/kernel/next.config.js
+++ b/apps/kernel/next.config.js
@@ -16,6 +16,7 @@ const nextConfig = {
     '@imajin/pay',
     '@imajin/trust-graph',
     '@imajin/ui',
+    '@imajin/vault-core',
   ],
   async rewrites() {
     return [

--- a/packages/bus/src/broker-config.ts
+++ b/packages/bus/src/broker-config.ts
@@ -1,0 +1,116 @@
+import type { BrokerRejectionReason } from './types';
+
+/**
+ * Consent entry — what a subject has consented to release.
+ */
+export interface ConsentEntry {
+  /** Fields the subject has agreed to share */
+  allowedFields: string[];
+  /** Release mode: attestation (default) or raw */
+  mode: 'attestation' | 'raw';
+  /** Reference ID for the consent grant */
+  consentRef: string;
+  /** Optional expiry (ISO 8601) — future use */
+  expiresAt?: string;
+}
+
+/**
+ * Consent lookup key.
+ * Format: `${subject}|${requester}|${purpose}`
+ * Use `*` as wildcard for requester or purpose.
+ */
+type ConsentKey = string;
+
+/**
+ * Hardcoded consent configuration — Phase 1.
+ *
+ * Maps { subject, requester, purpose } → consent entries.
+ * Multiple entries for the same key are merged permissively (union of fields).
+ * Default: reject (fail-closed).
+ */
+const CONSENT_DEFAULTS: Record<ConsentKey, ConsentEntry[]> = {
+  // Example: alice allows bob for marketing — multiple overlapping grants (union)
+  'did:imajin:alice|did:imajin:bob|marketing': [
+    { allowedFields: ['name', 'email'], mode: 'attestation', consentRef: 'consent-alice-bob-001' },
+    { allowedFields: ['phone', 'address'], mode: 'attestation', consentRef: 'consent-alice-bob-002' },
+  ],
+
+  // Example: alice allows anyone to request name for profile display
+  'did:imajin:alice|*|profile': [
+    { allowedFields: ['name', 'avatar'], mode: 'attestation', consentRef: 'consent-alice-public-001' },
+  ],
+
+  // Example: alice allows bob for raw data access on analytics
+  'did:imajin:alice|did:imajin:bob|analytics': [
+    { allowedFields: ['name', 'email', 'age'], mode: 'raw', consentRef: 'consent-alice-bob-raw-001' },
+  ],
+
+  // Example: carol allows anyone for event registration
+  'did:imajin:carol|*|event-registration': [
+    { allowedFields: ['name', 'email', 'ticketType'], mode: 'attestation', consentRef: 'consent-carol-events-001' },
+  ],
+
+  // Example: dave has no consent entries → fail-closed
+};
+
+/**
+ * Build lookup keys in order of specificity (most specific first).
+ */
+function buildLookupKeys(subject: string, requester: string, purpose: string): ConsentKey[] {
+  return [
+    `${subject}|${requester}|${purpose}`,
+    `${subject}|*|${purpose}`,
+    `${subject}|${requester}|*`,
+    `${subject}|*|*`,
+  ];
+}
+
+/**
+ * Look up consent configuration for a broker request.
+ *
+ * Composes multiple matching grants permissively:
+ * - Unions their allowed field sets
+ * - Returns the consentRef of the most specific match
+ * - Prefers 'raw' mode if any grant allows it (most permissive)
+ *
+ * @returns Resolved consent or undefined if no consent found
+ */
+export function resolveConsent(
+  subject: string,
+  requester: string,
+  purpose: string
+): { allowedFields: string[]; mode: 'attestation' | 'raw'; consentRef: string } | undefined {
+  const keys = buildLookupKeys(subject, requester, purpose);
+  const unionFields = new Set<string>();
+  let mode: 'attestation' | 'raw' = 'attestation';
+  let primaryRef = '';
+
+  for (const key of keys) {
+    const entries = CONSENT_DEFAULTS[key];
+    if (!entries || entries.length === 0) continue;
+
+    for (const entry of entries) {
+      for (const f of entry.allowedFields) {
+        unionFields.add(f);
+      }
+      if (entry.mode === 'raw') mode = 'raw';
+      if (!primaryRef) primaryRef = entry.consentRef;
+    }
+  }
+
+  if (unionFields.size === 0) return undefined;
+
+  return {
+    allowedFields: Array.from(unionFields),
+    mode,
+    consentRef: primaryRef,
+  };
+}
+
+/**
+ * Determine rejection reason when no consent is found.
+ * Phase 1: always 'no_consent' since we have no expiry/revocation tracking.
+ */
+export function getDefaultRejectionReason(): BrokerRejectionReason {
+  return 'no_consent';
+}

--- a/packages/bus/src/broker.ts
+++ b/packages/bus/src/broker.ts
@@ -1,0 +1,160 @@
+import { createLogger } from '@imajin/logger';
+import type {
+  BrokerEventType,
+  BrokerRequest,
+  BrokerResult,
+  BrokerPipelineState,
+  BrokerRejection,
+} from './types';
+import { consentReactor } from './reactors/consent';
+import { scopeReactor } from './reactors/scope';
+import { releaseReactor } from './reactors/release';
+import { auditReactor, auditRejection } from './reactors/audit';
+
+const log = createLogger('bus:broker');
+
+/**
+ * Broker reactors executed in pipeline order.
+ * Each reactor is sync/awaited and passes state to the next.
+ */
+const BROKER_CHAIN = [consentReactor, scopeReactor, releaseReactor, auditReactor];
+
+/**
+ * Execute a consent-gated data release request.
+ *
+ * Pipeline: consent → scope → release → audit
+ * - consent: resolves consent for {subject, requester, purpose}
+ * - scope: filters data to only consented fields
+ * - release: constructs the release envelope
+ * - audit: fires a broker.release event via publish() (fire-and-forget)
+ *
+ * Preview mode: consent + scope run, release envelope + audit are skipped.
+ * Returns what *would* be released with preview: true.
+ *
+ * Fail-closed: no consent → rejection. No bypass.
+ *
+ * @param type - broker event type
+ * @param request - the release request
+ * @returns BrokerRelease on success, BrokerRejection on failure
+ */
+export async function broker<T extends BrokerEventType>(
+  type: T,
+  request: BrokerRequest<T>
+): Promise<BrokerResult> {
+  log.info(
+    { type, requester: request.requester, subject: request.subject, fields: request.fields, preview: request.preview },
+    'Broker request received'
+  );
+
+  let state: BrokerPipelineState = { request };
+
+  // Execute pipeline reactors in order
+  for (const reactor of BROKER_CHAIN) {
+    // In preview mode, skip release and audit reactors
+    if (request.preview && (reactor === releaseReactor || reactor === auditReactor)) {
+      log.info({ reactor: reactor.name, preview: true }, 'Skipping reactor in preview mode');
+      continue;
+    }
+
+    try {
+      const result = await reactor(state);
+
+      // If a reactor returns a rejection, short-circuit
+      if (isRejection(result)) {
+        log.warn(
+          { reason: result.reason, reactor: reactor.name },
+          'Broker pipeline rejected'
+        );
+
+        // Fire audit for rejection (skipped in preview by auditRejection)
+        await auditRejection(request, result);
+        return result;
+      }
+
+      state = result;
+    } catch (err) {
+      log.error({ err: String(err), reactor: reactor.name }, 'Broker reactor threw');
+
+      const rejection: BrokerRejection = {
+        status: 'rejected',
+        reason: 'requester_unauthorized',
+        fields: request.fields,
+        details: `Reactor ${reactor.name} threw: ${String(err)}`,
+      };
+
+      await auditRejection(request, rejection);
+      return rejection;
+    }
+  }
+
+  // Construct final release result
+  if (!state.filteredData) {
+    log.error({}, 'Broker pipeline completed without filtered data');
+
+    const rejection: BrokerRejection = {
+      status: 'rejected',
+      reason: 'requester_unauthorized',
+      fields: request.fields,
+      details: 'Pipeline completed but release data is incomplete',
+    };
+
+    await auditRejection(request, rejection);
+    return rejection;
+  }
+
+  // Preview mode: return what would be released without envelope / audit
+  if (request.preview) {
+    const previewRelease = {
+      status: 'released' as const,
+      data: state.filteredData,
+      envelope: {
+        releaseId: 'preview',
+        scopeId: request.scope,
+        purpose: request.purpose,
+        issuedAt: new Date().toISOString(),
+        consentReference: state.consentReference || 'preview',
+        mode: state.mode || 'attestation',
+      },
+      preview: true as const,
+    };
+
+    log.info({ preview: true }, 'Broker preview complete');
+    return previewRelease;
+  }
+
+  if (!state.envelope) {
+    log.error({}, 'Broker pipeline completed without envelope in non-preview mode');
+
+    const rejection: BrokerRejection = {
+      status: 'rejected',
+      reason: 'requester_unauthorized',
+      fields: request.fields,
+      details: 'Pipeline completed but envelope is missing',
+    };
+
+    await auditRejection(request, rejection);
+    return rejection;
+  }
+
+  const release = {
+    status: 'released' as const,
+    data: state.filteredData,
+    envelope: state.envelope,
+  };
+
+  log.info(
+    { releaseId: release.envelope.releaseId },
+    'Broker release complete'
+  );
+
+  return release;
+}
+
+/**
+ * Type guard to check if a pipeline result is a rejection.
+ */
+function isRejection(
+  value: BrokerPipelineState | BrokerRejection
+): value is BrokerRejection {
+  return 'status' in value && value.status === 'rejected';
+}

--- a/packages/bus/src/config.ts
+++ b/packages/bus/src/config.ts
@@ -235,6 +235,12 @@ const DEFAULTS: Record<string, ReactorConfig[]> = {
     { type: 'vault-hot-reload', config: {}, enabled: true, await: true },
     { type: 'emit', config: {}, enabled: true },
   ],
+  'broker.release': [
+    { type: 'emit', config: {}, enabled: true },
+  ],
+  'broker.rejection': [
+    { type: 'emit', config: {}, enabled: true },
+  ],
 };
 
 export function getChainConfig(eventType: string, _scope: string): ChainConfig {

--- a/packages/bus/src/index.ts
+++ b/packages/bus/src/index.ts
@@ -17,7 +17,26 @@ registerReactor('settle', settleReactor);
 registerReactor('webhook', webhookReactor);
 
 export { publish } from './publish';
+export { broker } from './broker';
 export { registerReactor } from './registry';
 export { getChainConfig } from './config';
 export { EMISSION_SCHEDULE } from './emissions';
-export type { BusEvent, BusEventMap, BusEventType, ReactorConfig, ChainConfig, ReactorHandler } from './types';
+export { resolveConsent } from './broker-config';
+export { isBrokerRelease, isBrokerRejection } from './types';
+export type {
+  BusEvent,
+  BusEventMap,
+  BusEventType,
+  ReactorConfig,
+  ChainConfig,
+  ReactorHandler,
+  BrokerRequest,
+  BrokerRelease,
+  BrokerRejection,
+  BrokerRejectionReason,
+  BrokerResult,
+  BrokerPipelineState,
+  BrokerReactor,
+  BrokerEventType,
+} from './types';
+export type { ConsentEntry } from './broker-config';

--- a/packages/bus/src/reactors/audit.ts
+++ b/packages/bus/src/reactors/audit.ts
@@ -1,0 +1,82 @@
+import { createLogger } from '@imajin/logger';
+import { publish } from '../publish';
+import type { BrokerPipelineState, BrokerReactor, BrokerResult } from '../types';
+
+const log = createLogger('bus:broker:audit');
+
+/**
+ * Audit reactor — fires a broker.release or broker.rejection event.
+ *
+ * Uses publish() fire-and-forget semantics.
+ * Skipped entirely when request.preview === true.
+ */
+export const auditReactor: BrokerReactor = async (state) => {
+  const { request, envelope, filteredData } = state;
+
+  if (request.preview) {
+    log.info({ preview: true }, 'Audit skipped (preview mode)');
+    return state;
+  }
+
+  if (!envelope) {
+    log.error({}, 'Audit reactor called without envelope');
+    throw new Error('Audit reactor: envelope missing');
+  }
+
+  log.info({ releaseId: envelope.releaseId }, 'Firing broker.release audit event');
+
+  publish('broker.release', {
+    issuer: request.requester,
+    subject: request.subject,
+    scope: request.scope,
+    payload: {
+      releaseId: envelope.releaseId,
+      requester: request.requester,
+      subject: request.subject,
+      fields: Object.keys(filteredData || {}),
+      purpose: request.purpose,
+      scope: request.scope,
+      mode: envelope.mode,
+      issuedAt: envelope.issuedAt,
+    },
+  }).catch((err: unknown) => {
+    log.error({ err: String(err), releaseId: envelope.releaseId }, 'Audit publish failed');
+  });
+
+  return state;
+};
+
+/**
+ * Fire a rejection audit event.
+ *
+ * This is called by the broker orchestrator when a reactor returns a rejection.
+ * Skipped in preview mode.
+ */
+export async function auditRejection(
+  request: BrokerPipelineState['request'],
+  result: Extract<BrokerResult, { status: 'rejected' }>
+): Promise<void> {
+  if (request.preview) {
+    log.info({ preview: true }, 'Audit rejection skipped (preview mode)');
+    return;
+  }
+
+  log.info({ reason: result.reason }, 'Firing broker.rejection audit event');
+
+  publish('broker.rejection', {
+    issuer: request.requester,
+    subject: request.subject,
+    scope: request.scope,
+    payload: {
+      requester: request.requester,
+      subject: request.subject,
+      fields: result.fields || request.fields,
+      purpose: request.purpose,
+      scope: request.scope,
+      reason: result.reason,
+      details: result.details,
+    },
+  }).catch((err: unknown) => {
+    log.error({ err: String(err), reason: result.reason }, 'Audit rejection publish failed');
+  });
+}

--- a/packages/bus/src/reactors/consent.ts
+++ b/packages/bus/src/reactors/consent.ts
@@ -1,0 +1,51 @@
+import { createLogger } from '@imajin/logger';
+import type { BrokerPipelineState, BrokerRejection, BrokerReactor } from '../types';
+import { resolveConsent, getDefaultRejectionReason } from '../broker-config';
+
+const log = createLogger('bus:broker:consent');
+
+/**
+ * Consent reactor — resolves consent for the broker request.
+ *
+ * Looks up the hardcoded consent configuration for {subject, requester, purpose}.
+ * Composes multiple overlapping grants permissively (union of fields).
+ * Fail-closed: no matching config → rejection with 'no_consent'.
+ */
+export const consentReactor: BrokerReactor = async (state) => {
+  const { request } = state;
+
+  log.info(
+    { subject: request.subject, requester: request.requester, purpose: request.purpose },
+    'Resolving consent'
+  );
+
+  const resolved = resolveConsent(request.subject, request.requester, request.purpose);
+
+  if (!resolved) {
+    log.warn(
+      { subject: request.subject, requester: request.requester, purpose: request.purpose },
+      'No consent found — rejecting (fail-closed)'
+    );
+
+    const rejection: BrokerRejection = {
+      status: 'rejected',
+      reason: getDefaultRejectionReason(),
+      fields: request.fields,
+      details: `No consent found for subject=${request.subject}, requester=${request.requester}, purpose=${request.purpose}`,
+    };
+
+    return rejection;
+  }
+
+  log.info(
+    { allowedFields: resolved.allowedFields, mode: resolved.mode, consentRef: resolved.consentRef },
+    'Consent resolved'
+  );
+
+  return {
+    ...state,
+    allowedFields: resolved.allowedFields,
+    mode: resolved.mode,
+    consentReference: resolved.consentRef,
+  };
+};

--- a/packages/bus/src/reactors/release.ts
+++ b/packages/bus/src/reactors/release.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from 'crypto';
+import { createLogger } from '@imajin/logger';
+import type { BrokerPipelineState, BrokerRelease, BrokerReactor } from '../types';
+
+const log = createLogger('bus:broker:release');
+
+/**
+ * Release reactor — constructs the release envelope.
+ *
+ * Wraps the filtered data in a release envelope containing:
+ * - releaseId: unique ID for this release
+ * - scopeId: scope reference from the request
+ * - purpose: declared purpose
+ * - issuedAt: ISO 8601 timestamp
+ * - consentReference: reference to the consent grant
+ * - mode: 'attestation' or 'raw'
+ */
+export const releaseReactor: BrokerReactor = async (state) => {
+  const { request, filteredData, mode, consentReference } = state;
+
+  if (!filteredData) {
+    log.error({}, 'Release reactor called without filtered data');
+    throw new Error('Release reactor: filteredData missing');
+  }
+
+  if (!mode || !consentReference) {
+    log.error({}, 'Release reactor called without resolved consent metadata');
+    throw new Error('Release reactor: consent metadata missing');
+  }
+
+  const envelope: BrokerRelease['envelope'] = {
+    releaseId: randomUUID(),
+    scopeId: request.scope,
+    purpose: request.purpose,
+    issuedAt: new Date().toISOString(),
+    consentReference,
+    mode,
+  };
+
+  log.info(
+    { releaseId: envelope.releaseId, mode, fields: Object.keys(filteredData) },
+    'Release envelope constructed'
+  );
+
+  return {
+    ...state,
+    envelope,
+  };
+};

--- a/packages/bus/src/reactors/scope.ts
+++ b/packages/bus/src/reactors/scope.ts
@@ -1,0 +1,72 @@
+import { createLogger } from '@imajin/logger';
+import type { BrokerPipelineState, BrokerRejection, BrokerReactor } from '../types';
+
+const log = createLogger('bus:broker:scope');
+
+/**
+ * Scope reactor — filters subject data to only consented fields.
+ *
+ * Intersects the requested fields with the consented fields.
+ * Absent fields are omitted (not nulled).
+ * If the intersection is empty → rejection with 'no_consent'.
+ */
+export const scopeReactor: BrokerReactor = async (state) => {
+  const { request, allowedFields } = state;
+
+  if (!allowedFields) {
+    log.error({}, 'Scope reactor called without resolved consent');
+    const rejection: BrokerRejection = {
+      status: 'rejected',
+      reason: 'no_consent',
+      fields: request.fields,
+      details: 'Consent not resolved before scope reactor',
+    };
+    return rejection;
+  }
+
+  // Intersect requested fields with consented fields
+  const intersection = request.fields.filter((f) => allowedFields.includes(f));
+
+  if (intersection.length === 0) {
+    log.warn(
+      { requested: request.fields, allowed: allowedFields },
+      'No requested fields are consented — rejecting'
+    );
+
+    const rejection: BrokerRejection = {
+      status: 'rejected',
+      reason: 'no_consent',
+      fields: request.fields,
+      details: `None of the requested fields are consented. Allowed: [${allowedFields.join(', ')}]`,
+    };
+
+    return rejection;
+  }
+
+  // Filter data — only include consented fields that exist in the data
+  const rawData = request.data || {};
+  const filteredData: Record<string, unknown> = {};
+  const missingFields: string[] = [];
+
+  for (const field of intersection) {
+    if (field in rawData) {
+      filteredData[field] = rawData[field];
+    } else {
+      missingFields.push(field);
+    }
+  }
+
+  if (missingFields.length > 0) {
+    log.warn({ missingFields }, 'Some consented fields are absent from data');
+  }
+
+  log.info(
+    { requested: request.fields, allowed: allowedFields, released: Object.keys(filteredData) },
+    'Fields scoped'
+  );
+
+  return {
+    ...state,
+    filteredData,
+  };
+};

--- a/packages/bus/src/types.ts
+++ b/packages/bus/src/types.ts
@@ -536,6 +536,106 @@ export interface BusEventMap {
     context_id: string;
     context_type: 'vault';
   };
+  'broker.release': {
+    releaseId: string;
+    requester: string;
+    subject: string;
+    fields: string[];
+    purpose: string;
+    scope: string;
+    mode: 'attestation' | 'raw';
+    issuedAt: string;
+  };
+  'broker.rejection': {
+    requester: string;
+    subject: string;
+    fields: string[];
+    purpose: string;
+    scope: string;
+    reason: BrokerRejectionReason;
+    details?: string;
+  };
 }
 
 export type BusEventType = keyof BusEventMap;
+
+// ============================================================================
+// Broker types — consent-gated data release (#1014)
+// ============================================================================
+
+/** Broker request — asks for consented field release */
+export interface BrokerRequest<T extends BrokerEventType = BrokerEventType> {
+  type: T;
+  requester: string;        // DID of the requester
+  subject: string;          // DID of the data subject
+  fields: string[];         // requested field names
+  purpose: string;          // declared purpose
+  scope: string;            // service scope
+  data?: Record<string, unknown>; // subject data to filter (Phase 1: inline)
+  preview?: boolean;        // dry-run mode
+}
+
+/** Successful release */
+export interface BrokerRelease {
+  status: 'released';
+  data: Record<string, unknown>;
+  envelope: {
+    releaseId: string;
+    scopeId: string;
+    purpose: string;
+    issuedAt: string;
+    consentReference: string;
+    mode: 'attestation' | 'raw';
+  };
+  preview?: boolean;
+}
+
+/** Rejection */
+export interface BrokerRejection {
+  status: 'rejected';
+  reason: BrokerRejectionReason;
+  fields?: string[];
+  details?: string;
+}
+
+export type BrokerRejectionReason =
+  | 'no_consent'
+  | 'consent_expired'
+  | 'consent_revoked'
+  | 'field_not_found'
+  | 'purpose_mismatch'
+  | 'requester_unauthorized';
+
+/** Result of a broker call */
+export type BrokerResult = BrokerRelease | BrokerRejection;
+
+/** Type guard */
+export function isBrokerRelease(r: BrokerResult): r is BrokerRelease {
+  return r.status === 'released';
+}
+
+/** Type guard */
+export function isBrokerRejection(r: BrokerResult): r is BrokerRejection {
+  return r.status === 'rejected';
+}
+
+/** Pipeline state passed between broker reactors */
+export interface BrokerPipelineState {
+  request: BrokerRequest;
+  // resolved by consent reactor
+  allowedFields?: string[];
+  mode?: 'attestation' | 'raw';
+  consentReference?: string;
+  // resolved by scope reactor
+  filteredData?: Record<string, unknown>;
+  // resolved by release reactor
+  envelope?: BrokerRelease['envelope'];
+}
+
+/** Broker reactor signature — sync/awaited, returns updated state or rejection */
+export type BrokerReactor = (
+  state: BrokerPipelineState
+) => Promise<BrokerPipelineState | BrokerRejection>;
+
+/** Broker event types (Phase 1) */
+export type BrokerEventType = string;

--- a/packages/bus/tests/broker.test.ts
+++ b/packages/bus/tests/broker.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { broker } from '../src/broker';
+import type { BrokerRequest, BrokerRelease, BrokerRejection } from '../src/types';
+
+// Mock publish so audit events don't actually fire during tests
+vi.mock('../src/publish', () => ({
+  publish: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { publish } from '../src/publish';
+
+const mockPublish = vi.mocked(publish);
+
+describe('bus.broker()', () => {
+  beforeEach(() => {
+    mockPublish.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  function makeRequest(overrides: Partial<BrokerRequest> = {}): BrokerRequest {
+    return {
+      type: 'profile.read',
+      requester: 'did:imajin:bob',
+      subject: 'did:imajin:alice',
+      fields: ['name', 'email'],
+      purpose: 'marketing',
+      scope: 'test',
+      data: { name: 'Alice', email: 'alice@example.com', age: 30 },
+      ...overrides,
+    };
+  }
+
+  function assertRelease(result: unknown): asserts result is BrokerRelease {
+    expect(result).toHaveProperty('status', 'released');
+  }
+
+  function assertRejection(result: unknown): asserts result is BrokerRejection {
+    expect(result).toHaveProperty('status', 'rejected');
+  }
+
+  // --------------------------------------------------------------------------
+  // Valid consent → full release with envelope
+  // --------------------------------------------------------------------------
+
+  it('returns a full release with envelope when consent is valid', async () => {
+    const request = makeRequest();
+    const result = await broker('profile.read', request);
+
+    assertRelease(result);
+    expect(result.data).toEqual({ name: 'Alice', email: 'alice@example.com' });
+    expect(result.envelope).toBeDefined();
+    expect(result.envelope.scopeId).toBe('test');
+    expect(result.envelope.purpose).toBe('marketing');
+    expect(result.envelope.mode).toBe('attestation');
+    expect(result.envelope.consentReference).toBe('consent-alice-bob-001');
+    expect(result.envelope.releaseId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(result.envelope.issuedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  // --------------------------------------------------------------------------
+  // No consent → rejection with reason 'no_consent'
+  // --------------------------------------------------------------------------
+
+  it('rejects with no_consent when no consent config exists', async () => {
+    const request = makeRequest({
+      subject: 'did:imajin:unknown',
+      requester: 'did:imajin:stranger',
+      purpose: 'nefarious',
+    });
+    const result = await broker('profile.read', request);
+
+    assertRejection(result);
+    expect(result.reason).toBe('no_consent');
+    expect(result.fields).toEqual(['name', 'email']);
+    expect(result.details).toContain('No consent found');
+  });
+
+  // --------------------------------------------------------------------------
+  // Partial field consent → filtered release (only consented fields)
+  // --------------------------------------------------------------------------
+
+  it('filters release to only consented fields', async () => {
+    const request = makeRequest({
+      fields: ['name', 'email', 'age'],
+    });
+    const result = await broker('profile.read', request);
+
+    assertRelease(result);
+    // alice|bob|marketing only consents to name + email, not age
+    expect(result.data).toEqual({ name: 'Alice', email: 'alice@example.com' });
+    expect(Object.keys(result.data)).not.toContain('age');
+  });
+
+  it('rejects when none of the requested fields are consented', async () => {
+    const request = makeRequest({
+      fields: ['age', 'ssn'],
+    });
+    const result = await broker('profile.read', request);
+
+    assertRejection(result);
+    expect(result.reason).toBe('no_consent');
+    expect(result.fields).toEqual(['age', 'ssn']);
+  });
+
+  // --------------------------------------------------------------------------
+  // Preview mode → returns release shape but preview=true, no audit event
+  // --------------------------------------------------------------------------
+
+  it('returns preview release without envelope and skips audit', async () => {
+    const request = makeRequest({ preview: true });
+    const result = await broker('profile.read', request);
+
+    assertRelease(result);
+    expect(result.preview).toBe(true);
+    expect(result.data).toEqual({ name: 'Alice', email: 'alice@example.com' });
+
+    // Envelope should still be present (release reactor runs in preview for envelope construction?)
+    // Actually per spec: "preview: when true, run consent + scope but skip release envelope + audit"
+    // Wait, re-reading: "Return what *would* be released"
+    // Our implementation skips release + audit in preview, but still returns filtered data.
+    // The envelope may or may not be present depending on implementation.
+    // Per the spec, preview mode returns what WOULD be released, so envelope info is still useful.
+    // Let's check our broker.ts: it skips release and audit reactors in preview, so envelope won't exist.
+    // But we return filtered data. This is acceptable for preview.
+
+    // Audit should NOT have fired
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------------
+  // Purpose mismatch → rejection
+  // --------------------------------------------------------------------------
+
+  it('rejects when purpose does not match consent', async () => {
+    const request = makeRequest({
+      purpose: 'surveillance',
+    });
+    const result = await broker('profile.read', request);
+
+    assertRejection(result);
+    expect(result.reason).toBe('no_consent');
+  });
+
+  // --------------------------------------------------------------------------
+  // Multiple overlapping consent grants → union of fields (most permissive)
+  // --------------------------------------------------------------------------
+
+  it('unions fields from multiple overlapping consent grants', async () => {
+    // alice|bob|marketing has TWO entries:
+    //   consent-alice-bob-001: ['name', 'email']
+    //   consent-alice-bob-002: ['phone', 'address']
+    // Union = ['name', 'email', 'phone', 'address']
+    const request = makeRequest({
+      fields: ['name', 'email', 'phone', 'address'],
+      data: {
+        name: 'Alice',
+        email: 'alice@example.com',
+        phone: '+1-555-0123',
+        address: '123 Main St',
+      },
+    });
+    const result = await broker('profile.read', request);
+
+    assertRelease(result);
+    expect(result.data).toEqual({
+      name: 'Alice',
+      email: 'alice@example.com',
+      phone: '+1-555-0123',
+      address: '123 Main St',
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Wildcard requester consent
+  // --------------------------------------------------------------------------
+
+  it('matches wildcard requester consent', async () => {
+    const request = makeRequest({
+      requester: 'did:imajin:anyone',
+      purpose: 'profile',
+      fields: ['name', 'avatar'],
+      data: { name: 'Alice', avatar: 'https://example.com/alice.png', email: 'alice@example.com' },
+    });
+    const result = await broker('profile.read', request);
+
+    assertRelease(result);
+    expect(result.data).toEqual({
+      name: 'Alice',
+      avatar: 'https://example.com/alice.png',
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Raw mode consent
+  // --------------------------------------------------------------------------
+
+  it('returns raw mode when consent config specifies raw', async () => {
+    const request = makeRequest({
+      purpose: 'analytics',
+      fields: ['name', 'email', 'age'],
+      data: { name: 'Alice', email: 'alice@example.com', age: 30 },
+    });
+    const result = await broker('profile.read', request);
+
+    assertRelease(result);
+    expect(result.envelope.mode).toBe('raw');
+  });
+
+  // --------------------------------------------------------------------------
+  // Absent fields are omitted, not nulled
+  // --------------------------------------------------------------------------
+
+  it('omits absent fields rather than nulling them', async () => {
+    const request = makeRequest({
+      fields: ['name', 'email', 'phone'],
+      data: { name: 'Alice', email: 'alice@example.com' }, // phone is missing
+    });
+    const result = await broker('profile.read', request);
+
+    assertRelease(result);
+    expect(result.data).toHaveProperty('name');
+    expect(result.data).toHaveProperty('email');
+    expect(result.data).not.toHaveProperty('phone');
+    expect(Object.keys(result.data)).not.toContain('phone');
+  });
+
+  // --------------------------------------------------------------------------
+  // Audit event fires on successful release
+  // --------------------------------------------------------------------------
+
+  it('fires broker.release audit event on successful release', async () => {
+    const request = makeRequest();
+    await broker('profile.read', request);
+
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockPublish).toHaveBeenCalledWith(
+      'broker.release',
+      expect.objectContaining({
+        issuer: 'did:imajin:bob',
+        subject: 'did:imajin:alice',
+        scope: 'test',
+        payload: expect.objectContaining({
+          requester: 'did:imajin:bob',
+          subject: 'did:imajin:alice',
+          fields: ['name', 'email'],
+          purpose: 'marketing',
+          scope: 'test',
+          mode: 'attestation',
+        }),
+      })
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // Audit event fires on rejection
+  // --------------------------------------------------------------------------
+
+  it('fires broker.rejection audit event on rejection', async () => {
+    const request = makeRequest({
+      subject: 'did:imajin:unknown',
+      requester: 'did:imajin:stranger',
+      purpose: 'nefarious',
+    });
+    await broker('profile.read', request);
+
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockPublish).toHaveBeenCalledWith(
+      'broker.rejection',
+      expect.objectContaining({
+        issuer: 'did:imajin:stranger',
+        subject: 'did:imajin:unknown',
+        scope: 'test',
+        payload: expect.objectContaining({
+          reason: 'no_consent',
+          fields: ['name', 'email'],
+          purpose: 'nefarious',
+        }),
+      })
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // Preview mode skips audit on rejection too
+  // --------------------------------------------------------------------------
+
+  it('skips audit rejection event in preview mode', async () => {
+    const request = makeRequest({
+      subject: 'did:imajin:unknown',
+      requester: 'did:imajin:stranger',
+      purpose: 'nefarious',
+      preview: true,
+    });
+    await broker('profile.read', request);
+
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -79,6 +79,14 @@ if [ "$ENV_CHECK_FAILED" = true ]; then
 fi
 echo "" >> "$REPORT"
 
+echo "=== Building workspace packages ==="  | tee -a "$REPORT"
+if pnpm -r --filter './packages/**' build >> "$REPORT" 2>&1; then
+  echo "✅ Packages built" | tee -a "$REPORT"
+else
+  echo "⚠️  Package build had errors (non-fatal, some packages may lack build scripts)" | tee -a "$REPORT"
+fi
+echo "" >> "$REPORT"
+
 echo "=== Running migrations ===" | tee -a "$REPORT"
 if node scripts/migrate.mjs >> "$REPORT" 2>&1; then
   echo "✅ Migrations complete" | tee -a "$REPORT"


### PR DESCRIPTION
Closes #1014 | Epic: #786 | Unblocks: #1003

bus.broker() — request/response counterpart to publish(). Consent-gated data release pipeline.

Pipeline: consent → scope → release → audit. Fail-closed. Preview mode. Overlapping grants union permissively. Two modes (attestation/raw). 13 vitest tests passing.

Also fixes: vault-core transpilePackages for kernel, package pre-build step in build.sh.