### PR TITLE
feat(auth): implement Issue #1017 document signing and notifications

### DIFF
--- a/apps/kernel/app/auth/api/documents/[id]/amend/route.ts
+++ b/apps/kernel/app/auth/api/documents/[id]/amend/route.ts
@@ -5,7 +5,7 @@ import { corsHeaders } from '@imajin/config';
 import { requireAuth } from '@/src/lib/auth/middleware';
 import { publish } from '@imajin/bus';
 import { createLogger } from '@imajin/logger';
-import * as jose from 'jose';
+import { verifyDocumentSignatureToken } from '@/src/lib/auth/document-signatures';
 
 const log = createLogger('kernel:documents');
 
@@ -13,28 +13,6 @@ function genId(prefix: string): string {
   return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
 }
 
-const EXPIRY_MAP: Record<string, number> = {
-  '24h': 24 * 60 * 60 * 1000,
-  '7d': 7 * 24 * 60 * 60 * 1000,
-  '1m': 30 * 24 * 60 * 60 * 1000,
-  '1y': 365 * 24 * 60 * 60 * 1000,
-};
-
-async function verifyJws(jws: string, publicKeyHex: string): Promise<boolean> {
-  try {
-    const publicKeyBytes = Buffer.from(publicKeyHex, 'hex');
-    const jwk = {
-      kty: 'OKP',
-      crv: 'Ed25519',
-      x: jose.base64url.encode(publicKeyBytes),
-    };
-    const publicKey = await jose.importJWK(jwk, 'EdDSA');
-    await jose.compactVerify(jws, publicKey);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
@@ -150,7 +128,7 @@ export async function POST(
 
     // Verify author JWS
     const [callerIdentity] = await db
-      .select({ publicKey: identities.publicKey })
+      .select({ publicKey: identities.publicKey, name: identities.name, handle: identities.handle })
       .from(identities)
       .where(eq(identities.id, callerDid))
       .limit(1);
@@ -159,8 +137,13 @@ export async function POST(
       return NextResponse.json({ error: 'Caller identity not found' }, { status: 400, headers: cors });
     }
 
-    const jwsValid = await verifyJws(author_jws, callerIdentity.publicKey);
-    if (!jwsValid) {
+    const signatureValid = await verifyDocumentSignatureToken({
+      token: author_jws,
+      signerPublicKeyHex: callerIdentity.publicKey,
+      signerDid: callerDid,
+      documentHash: document_hash,
+    });
+    if (!signatureValid) {
       return NextResponse.json({ error: 'Invalid author JWS signature' }, { status: 400, headers: cors });
     }
 
@@ -216,20 +199,30 @@ export async function POST(
     // Set asset immutable
     await db.update(assets).set({ immutable: true }).where(eq(assets.id, document_asset_id));
 
-    // Publish event
-    publish('document.created', {
-      issuer: callerDid,
-      subject: callerDid,
-      scope: 'auth',
-      payload: {
-        attestationId,
-        documentAssetId: document_asset_id,
-        creatorDid: callerDid,
-        signerDids,
-        context_id: attestationId,
-        context_type: 'document',
-      },
-    });
+    // Publish one event per pending signer so notify reactors can target recipients directly.
+    const creatorName = callerIdentity.handle
+      ? `@${callerIdentity.handle}`
+      : callerIdentity.name || callerDid;
+    const signUrl = `/auth/documents/${attestationId}`;
+
+    for (const signerDid of signerDids) {
+      publish('document.created', {
+        issuer: callerDid,
+        subject: signerDid,
+        scope: 'auth',
+        payload: {
+          attestationId,
+          documentAssetId: document_asset_id,
+          creatorDid: callerDid,
+          creatorName,
+          signerDids,
+          title: title.trim(),
+          signUrl,
+          context_id: attestationId,
+          context_type: 'document',
+        },
+      }).catch((err) => log.error({ err: String(err), signerDid, attestationId }, 'document.created publish failed'));
+    }
 
     const allSigs = await db
       .select()

--- a/apps/kernel/app/auth/api/documents/[id]/amend/route.ts
+++ b/apps/kernel/app/auth/api/documents/[id]/amend/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, attestations, attestationSignatures, identities, assets } from '@/src/db';
-import { eq, and, inArray } from 'drizzle-orm';
+import { db, attestations, attestationSignatures, assets } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
 import { corsHeaders } from '@imajin/config';
 import { requireAuth } from '@/src/lib/auth/middleware';
-import { publish } from '@imajin/bus';
 import { createLogger } from '@imajin/logger';
-import { verifyDocumentSignatureToken } from '@/src/lib/auth/document-signatures';
+import {
+  buildDocumentSignatureRows,
+  getCreatorDisplayName,
+  parseDocumentRequestBody,
+  publishDocumentCreatedNotifications,
+  validateDocumentRequestInput,
+} from '../../../../../../src/lib/auth/document-attestation';
 
 const log = createLogger('kernel:documents');
 
@@ -34,29 +39,10 @@ export async function POST(
   }
 
   const callerDid = session.sub;
-
-  let body: Record<string, unknown>;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  const parseResult = await parseDocumentRequestBody(request);
+  if (!parseResult.ok) {
+    return NextResponse.json({ error: parseResult.failure.error }, { status: parseResult.failure.status, headers: cors });
   }
-
-  const {
-    title,
-    document_asset_id,
-    document_hash,
-    signers,
-    payload,
-    author_jws,
-  } = body as {
-    title?: string;
-    document_asset_id?: string;
-    document_hash?: string;
-    signers?: string[];
-    payload?: Record<string, unknown>;
-    author_jws?: string;
-  };
 
   try {
     // Load original attestation
@@ -86,66 +72,19 @@ export async function POST(
     if (!isCreator && !callerSig) {
       return NextResponse.json({ error: 'Only the creator or a signer can amend' }, { status: 403, headers: cors });
     }
-
-    // Validate inputs
-    if (!title || typeof title !== 'string') {
-      return NextResponse.json({ error: 'title required' }, { status: 400, headers: cors });
+    const validationResult = await validateDocumentRequestInput({ body: parseResult.body, callerDid });
+    if (!validationResult.ok) {
+      return NextResponse.json({ error: validationResult.failure.error }, { status: validationResult.failure.status, headers: cors });
     }
-    if (!document_asset_id || typeof document_asset_id !== 'string') {
-      return NextResponse.json({ error: 'document_asset_id required' }, { status: 400, headers: cors });
-    }
-    if (!document_hash || typeof document_hash !== 'string') {
-      return NextResponse.json({ error: 'document_hash required' }, { status: 400, headers: cors });
-    }
-    if (!Array.isArray(signers) || signers.length === 0) {
-      return NextResponse.json({ error: 'signers array required (at least 1)' }, { status: 400, headers: cors });
-    }
-    if (!author_jws || typeof author_jws !== 'string') {
-      return NextResponse.json({ error: 'author_jws required' }, { status: 400, headers: cors });
-    }
-
-    const signerDids = signers.filter((s): s is string => typeof s === 'string' && s.startsWith('did:'));
-    if (signerDids.length !== signers.length) {
-      return NextResponse.json({ error: 'All signers must be valid DIDs' }, { status: 400, headers: cors });
-    }
-
-    // Verify caller owns the new document asset
-    const [asset] = await db
-      .select()
-      .from(assets)
-      .where(eq(assets.id, document_asset_id))
-      .limit(1);
-
-    if (!asset) {
-      return NextResponse.json({ error: 'Document asset not found' }, { status: 404, headers: cors });
-    }
-    if (asset.ownerDid !== callerDid) {
-      return NextResponse.json({ error: 'You do not own this document' }, { status: 403, headers: cors });
-    }
-    if (asset.hash !== document_hash) {
-      return NextResponse.json({ error: 'Document hash mismatch' }, { status: 400, headers: cors });
-    }
-
-    // Verify author JWS
-    const [callerIdentity] = await db
-      .select({ publicKey: identities.publicKey, name: identities.name, handle: identities.handle })
-      .from(identities)
-      .where(eq(identities.id, callerDid))
-      .limit(1);
-
-    if (!callerIdentity) {
-      return NextResponse.json({ error: 'Caller identity not found' }, { status: 400, headers: cors });
-    }
-
-    const signatureValid = await verifyDocumentSignatureToken({
-      token: author_jws,
-      signerPublicKeyHex: callerIdentity.publicKey,
-      signerDid: callerDid,
-      documentHash: document_hash,
-    });
-    if (!signatureValid) {
-      return NextResponse.json({ error: 'Invalid author JWS signature' }, { status: 400, headers: cors });
-    }
+    const {
+      title,
+      documentAssetId,
+      documentHash,
+      signerDids,
+      payload,
+      authorJws,
+      callerIdentity,
+    } = validationResult.input;
 
     // Create amendment attestation
     const attestationId = genId('att');
@@ -162,67 +101,40 @@ export async function POST(
           ...(payload ?? {}),
         },
         signature: '',
-        authorJws: author_jws,
+        authorJws,
         attestationStatus: 'collecting',
-        documentHash: document_hash,
-        documentAssetId: document_asset_id,
+        documentHash,
+        documentAssetId: documentAssetId,
         totalSigners: 1 + signerDids.length,
         issuedAt: new Date(),
       })
       .returning();
 
     // Create signature rows
-    const now = new Date();
-    const sigRows = [
-      {
-        id: genId('sig'),
-        attestationId,
-        signerDid: callerDid,
-        jws: author_jws,
-        signedAt: now,
-        status: 'signed',
-        role: 'creator',
-      },
-      ...signerDids.map((did) => ({
-        id: genId('sig'),
-        attestationId,
-        signerDid: did,
-        jws: null as string | null,
-        signedAt: null as Date | null,
-        status: 'pending' as string,
-        role: 'signer' as string,
-      })),
-    ];
+    const sigRows = buildDocumentSignatureRows({
+      attestationId,
+      creatorDid: callerDid,
+      creatorJws: authorJws,
+      signerDids,
+      genId,
+    });
 
     await db.insert(attestationSignatures).values(sigRows);
 
     // Set asset immutable
-    await db.update(assets).set({ immutable: true }).where(eq(assets.id, document_asset_id));
+    await db.update(assets).set({ immutable: true }).where(eq(assets.id, documentAssetId));
 
     // Publish one event per pending signer so notify reactors can target recipients directly.
-    const creatorName = callerIdentity.handle
-      ? `@${callerIdentity.handle}`
-      : callerIdentity.name || callerDid;
-    const signUrl = `/auth/documents/${attestationId}`;
-
-    for (const signerDid of signerDids) {
-      publish('document.created', {
-        issuer: callerDid,
-        subject: signerDid,
-        scope: 'auth',
-        payload: {
-          attestationId,
-          documentAssetId: document_asset_id,
-          creatorDid: callerDid,
-          creatorName,
-          signerDids,
-          title: title.trim(),
-          signUrl,
-          context_id: attestationId,
-          context_type: 'document',
-        },
-      }).catch((err) => log.error({ err: String(err), signerDid, attestationId }, 'document.created publish failed'));
-    }
+    const creatorName = getCreatorDisplayName(callerIdentity, callerDid);
+    publishDocumentCreatedNotifications({
+      attestationId,
+      documentAssetId,
+      creatorDid: callerDid,
+      creatorName,
+      signerDids,
+      title,
+      log,
+    });
 
     const allSigs = await db
       .select()

--- a/apps/kernel/app/auth/api/documents/[id]/amend/route.ts
+++ b/apps/kernel/app/auth/api/documents/[id]/amend/route.ts
@@ -1,14 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, attestations, attestationSignatures, assets } from '@/src/db';
+import { db, attestations, attestationSignatures } from '@/src/db';
 import { eq, and } from 'drizzle-orm';
 import { corsHeaders } from '@imajin/config';
 import { requireAuth } from '@/src/lib/auth/middleware';
 import { createLogger } from '@imajin/logger';
 import {
-  buildDocumentSignatureRows,
-  getCreatorDisplayName,
+  finalizeDocumentAttestation,
   parseDocumentRequestBody,
-  publishDocumentCreatedNotifications,
   validateDocumentRequestInput,
 } from '../../../../../../src/lib/auth/document-attestation';
 
@@ -110,36 +108,17 @@ export async function POST(
       })
       .returning();
 
-    // Create signature rows
-    const sigRows = buildDocumentSignatureRows({
-      attestationId,
-      creatorDid: callerDid,
-      creatorJws: authorJws,
-      signerDids,
-      genId,
-    });
-
-    await db.insert(attestationSignatures).values(sigRows);
-
-    // Set asset immutable
-    await db.update(assets).set({ immutable: true }).where(eq(assets.id, documentAssetId));
-
-    // Publish one event per pending signer so notify reactors can target recipients directly.
-    const creatorName = getCreatorDisplayName(callerIdentity, callerDid);
-    publishDocumentCreatedNotifications({
+    const allSigs = await finalizeDocumentAttestation({
       attestationId,
       documentAssetId,
       creatorDid: callerDid,
-      creatorName,
+      creatorJws: authorJws,
       signerDids,
       title,
+      callerIdentity,
+      genId,
       log,
     });
-
-    const allSigs = await db
-      .select()
-      .from(attestationSignatures)
-      .where(eq(attestationSignatures.attestationId, attestationId));
 
     return NextResponse.json(
       { attestation, signatures: allSigs },

--- a/apps/kernel/app/auth/api/documents/[id]/sign/route.ts
+++ b/apps/kernel/app/auth/api/documents/[id]/sign/route.ts
@@ -5,10 +5,10 @@ import { corsHeaders } from '@imajin/config';
 import { requireAuth } from '@/src/lib/auth/middleware';
 import { publish } from '@imajin/bus';
 import { createLogger } from '@imajin/logger';
-import * as jose from 'jose';
 import { mkdir, copyFile } from 'fs/promises';
 import { nanoid } from 'nanoid';
 import path from 'path';
+import { verifyDocumentSignatureToken } from '@/src/lib/auth/document-signatures';
 
 const log = createLogger('kernel:documents');
 
@@ -22,24 +22,6 @@ function genId(prefix: string): string {
   return `${prefix}_${Math.random().toString(36).slice(2, 14)}${Date.now().toString(36)}`;
 }
 
-/**
- * Verify a JWS compact token against a signer's Ed25519 public key.
- */
-async function verifyJws(jws: string, publicKeyHex: string): Promise<boolean> {
-  try {
-    const publicKeyBytes = Buffer.from(publicKeyHex, 'hex');
-    const jwk = {
-      kty: 'OKP',
-      crv: 'Ed25519',
-      x: jose.base64url.encode(publicKeyBytes),
-    };
-    const publicKey = await jose.importJWK(jwk, 'EdDSA');
-    await jose.compactVerify(jws, publicKey);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Copy a signed document to the signer's media storage.
@@ -239,8 +221,13 @@ export async function POST(
       return NextResponse.json({ error: 'Signer identity not found' }, { status: 400, headers: cors });
     }
 
-    const jwsValid = await verifyJws(jws, callerIdentity.publicKey);
-    if (!jwsValid) {
+    const signatureValid = await verifyDocumentSignatureToken({
+      token: jws,
+      signerPublicKeyHex: callerIdentity.publicKey,
+      signerDid: callerDid,
+      documentHash: document_hash,
+    });
+    if (!signatureValid) {
       return NextResponse.json({ error: 'Invalid JWS signature' }, { status: 400, headers: cors });
     }
 

--- a/apps/kernel/app/auth/api/documents/route.ts
+++ b/apps/kernel/app/auth/api/documents/route.ts
@@ -6,7 +6,7 @@ import { requireAuth } from '@/src/lib/auth/middleware';
 import { ATTESTATION_TYPES } from '@imajin/auth';
 import { publish } from '@imajin/bus';
 import { createLogger } from '@imajin/logger';
-import * as jose from 'jose';
+import { verifyDocumentSignatureToken } from '@/src/lib/auth/document-signatures';
 
 const log = createLogger('kernel:documents');
 
@@ -27,24 +27,6 @@ export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
 }
 
-/**
- * Verify a JWS compact token against a signer's Ed25519 public key.
- */
-async function verifyJws(jws: string, publicKeyHex: string): Promise<boolean> {
-  try {
-    const publicKeyBytes = Buffer.from(publicKeyHex, 'hex');
-    const jwk = {
-      kty: 'OKP',
-      crv: 'Ed25519',
-      x: jose.base64url.encode(publicKeyBytes),
-    };
-    const publicKey = await jose.importJWK(jwk, 'EdDSA');
-    await jose.compactVerify(jws, publicKey);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // POST /api/documents — Create a document signing request
@@ -128,7 +110,7 @@ export async function POST(request: NextRequest) {
 
   // Verify author JWS
   const [callerIdentity] = await db
-    .select({ publicKey: identities.publicKey })
+    .select({ publicKey: identities.publicKey, name: identities.name, handle: identities.handle })
     .from(identities)
     .where(eq(identities.id, callerDid))
     .limit(1);
@@ -137,8 +119,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Caller identity not found' }, { status: 400, headers: cors });
   }
 
-  const jwsValid = await verifyJws(author_jws, callerIdentity.publicKey);
-  if (!jwsValid) {
+  const signatureValid = await verifyDocumentSignatureToken({
+    token: author_jws,
+    signerPublicKeyHex: callerIdentity.publicKey,
+    signerDid: callerDid,
+    documentHash: document_hash,
+  });
+  if (!signatureValid) {
     return NextResponse.json({ error: 'Invalid author JWS signature' }, { status: 400, headers: cors });
   }
 
@@ -200,20 +187,30 @@ export async function POST(request: NextRequest) {
   // Set asset immutable
   await db.update(assets).set({ immutable: true }).where(eq(assets.id, document_asset_id));
 
-  // Publish event
-  publish('document.created', {
-    issuer: callerDid,
-    subject: callerDid,
-    scope: 'auth',
-    payload: {
-      attestationId,
-      documentAssetId: document_asset_id,
-      creatorDid: callerDid,
-      signerDids,
-      context_id: attestationId,
-      context_type: 'document',
-    },
-  });
+  // Publish one event per pending signer so notify reactors can target recipients directly.
+  const creatorName = callerIdentity.handle
+    ? `@${callerIdentity.handle}`
+    : callerIdentity.name || callerDid;
+  const signUrl = `/auth/documents/${attestationId}`;
+
+  for (const signerDid of signerDids) {
+    publish('document.created', {
+      issuer: callerDid,
+      subject: signerDid,
+      scope: 'auth',
+      payload: {
+        attestationId,
+        documentAssetId: document_asset_id,
+        creatorDid: callerDid,
+        creatorName,
+        signerDids,
+        title: title.trim(),
+        signUrl,
+        context_id: attestationId,
+        context_type: 'document',
+      },
+    }).catch((err) => log.error({ err: String(err), signerDid, attestationId }, 'document.created publish failed'));
+  }
 
   // Fetch signatures to return
   const allSigs = await db

--- a/apps/kernel/app/auth/api/documents/route.ts
+++ b/apps/kernel/app/auth/api/documents/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, attestations, attestationSignatures, identities, assets } from '@/src/db';
-import { eq, and, or, isNull, desc, sql, inArray } from 'drizzle-orm';
+import { db, attestations, attestationSignatures, assets } from '@/src/db';
+import { eq, and, or, desc, sql, inArray } from 'drizzle-orm';
 import { corsHeaders } from '@imajin/config';
 import { requireAuth } from '@/src/lib/auth/middleware';
-import { ATTESTATION_TYPES } from '@imajin/auth';
-import { publish } from '@imajin/bus';
 import { createLogger } from '@imajin/logger';
-import { verifyDocumentSignatureToken } from '@/src/lib/auth/document-signatures';
+import {
+  buildDocumentSignatureRows,
+  getCreatorDisplayName,
+  parseDocumentRequestBody,
+  publishDocumentCreatedNotifications,
+  validateDocumentRequestInput,
+} from '../../../../src/lib/auth/document-attestation';
 
 const log = createLogger('kernel:documents');
 
@@ -40,94 +44,24 @@ export async function POST(request: NextRequest) {
   }
 
   const callerDid = session.sub;
-
-  let body: Record<string, unknown>;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  const parseResult = await parseDocumentRequestBody(request);
+  if (!parseResult.ok) {
+    return NextResponse.json({ error: parseResult.failure.error }, { status: parseResult.failure.status, headers: cors });
   }
-
+  const validationResult = await validateDocumentRequestInput({ body: parseResult.body, callerDid });
+  if (!validationResult.ok) {
+    return NextResponse.json({ error: validationResult.failure.error }, { status: validationResult.failure.status, headers: cors });
+  }
   const {
     title,
-    document_asset_id,
-    document_hash,
-    signers,
+    documentAssetId,
+    documentHash,
+    signerDids,
     payload,
+    authorJws,
     expiry,
-    author_jws,
-  } = body as {
-    title?: string;
-    document_asset_id?: string;
-    document_hash?: string;
-    signers?: string[];
-    payload?: Record<string, unknown>;
-    expiry?: '24h' | '7d' | '1m' | '1y' | 'never';
-    author_jws?: string;
-  };
-
-  if (!title || typeof title !== 'string') {
-    return NextResponse.json({ error: 'title required' }, { status: 400, headers: cors });
-  }
-  if (!document_asset_id || typeof document_asset_id !== 'string') {
-    return NextResponse.json({ error: 'document_asset_id required' }, { status: 400, headers: cors });
-  }
-  if (!document_hash || typeof document_hash !== 'string') {
-    return NextResponse.json({ error: 'document_hash required' }, { status: 400, headers: cors });
-  }
-  if (!Array.isArray(signers) || signers.length === 0) {
-    return NextResponse.json({ error: 'signers array required (at least 1)' }, { status: 400, headers: cors });
-  }
-  if (!author_jws || typeof author_jws !== 'string') {
-    return NextResponse.json({ error: 'author_jws required' }, { status: 400, headers: cors });
-  }
-
-  // Verify all signer DIDs exist
-  const signerDids = signers.filter((s): s is string => typeof s === 'string' && s.startsWith('did:'));
-  if (signerDids.length !== signers.length) {
-    return NextResponse.json({ error: 'All signers must be valid DIDs' }, { status: 400, headers: cors });
-  }
-
-  // Verify caller owns the document asset
-  const [asset] = await db
-    .select()
-    .from(assets)
-    .where(eq(assets.id, document_asset_id))
-    .limit(1);
-
-  if (!asset) {
-    return NextResponse.json({ error: 'Document asset not found' }, { status: 404, headers: cors });
-  }
-
-  if (asset.ownerDid !== callerDid) {
-    return NextResponse.json({ error: 'You do not own this document' }, { status: 403, headers: cors });
-  }
-
-  // Verify document hash matches stored asset
-  if (asset.hash !== document_hash) {
-    return NextResponse.json({ error: 'Document hash mismatch' }, { status: 400, headers: cors });
-  }
-
-  // Verify author JWS
-  const [callerIdentity] = await db
-    .select({ publicKey: identities.publicKey, name: identities.name, handle: identities.handle })
-    .from(identities)
-    .where(eq(identities.id, callerDid))
-    .limit(1);
-
-  if (!callerIdentity) {
-    return NextResponse.json({ error: 'Caller identity not found' }, { status: 400, headers: cors });
-  }
-
-  const signatureValid = await verifyDocumentSignatureToken({
-    token: author_jws,
-    signerPublicKeyHex: callerIdentity.publicKey,
-    signerDid: callerDid,
-    documentHash: document_hash,
-  });
-  if (!signatureValid) {
-    return NextResponse.json({ error: 'Invalid author JWS signature' }, { status: 400, headers: cors });
-  }
+    callerIdentity,
+  } = validationResult.input;
 
   // Compute expiry
   const expiresAt = expiry === 'never' || !expiry
@@ -149,10 +83,10 @@ export async function POST(request: NextRequest) {
         ...(payload ?? {}),
       },
       signature: '', // legacy — not used for document attestations
-      authorJws: author_jws,
+      authorJws,
       attestationStatus: 'collecting',
-      documentHash: document_hash,
-      documentAssetId: document_asset_id,
+      documentHash,
+      documentAssetId: documentAssetId,
       totalSigners: 1 + signerDids.length,
       issuedAt: new Date(),
       expiresAt,
@@ -160,57 +94,30 @@ export async function POST(request: NextRequest) {
     .returning();
 
   // Create signature rows
-  const now = new Date();
-  const sigRows: { id: string; attestationId: string; signerDid: string; jws: string | null; signedAt: Date | null; status: string; role: string }[] = [
-    {
-      id: genId('sig'),
-      attestationId,
-      signerDid: callerDid,
-      jws: author_jws,
-      signedAt: now,
-      status: 'signed',
-      role: 'creator',
-    },
-    ...signerDids.map((did) => ({
-      id: genId('sig'),
-      attestationId,
-      signerDid: did,
-      jws: null,
-      signedAt: null,
-      status: 'pending' as string,
-      role: 'signer' as string,
-    })),
-  ];
+  const sigRows = buildDocumentSignatureRows({
+    attestationId,
+    creatorDid: callerDid,
+    creatorJws: authorJws,
+    signerDids,
+    genId,
+  });
 
   await db.insert(attestationSignatures).values(sigRows);
 
   // Set asset immutable
-  await db.update(assets).set({ immutable: true }).where(eq(assets.id, document_asset_id));
+  await db.update(assets).set({ immutable: true }).where(eq(assets.id, documentAssetId));
 
   // Publish one event per pending signer so notify reactors can target recipients directly.
-  const creatorName = callerIdentity.handle
-    ? `@${callerIdentity.handle}`
-    : callerIdentity.name || callerDid;
-  const signUrl = `/auth/documents/${attestationId}`;
-
-  for (const signerDid of signerDids) {
-    publish('document.created', {
-      issuer: callerDid,
-      subject: signerDid,
-      scope: 'auth',
-      payload: {
-        attestationId,
-        documentAssetId: document_asset_id,
-        creatorDid: callerDid,
-        creatorName,
-        signerDids,
-        title: title.trim(),
-        signUrl,
-        context_id: attestationId,
-        context_type: 'document',
-      },
-    }).catch((err) => log.error({ err: String(err), signerDid, attestationId }, 'document.created publish failed'));
-  }
+  const creatorName = getCreatorDisplayName(callerIdentity, callerDid);
+  publishDocumentCreatedNotifications({
+    attestationId,
+    documentAssetId,
+    creatorDid: callerDid,
+    creatorName,
+    signerDids,
+    title,
+    log,
+  });
 
   // Fetch signatures to return
   const allSigs = await db

--- a/apps/kernel/app/auth/api/documents/route.ts
+++ b/apps/kernel/app/auth/api/documents/route.ts
@@ -5,10 +5,8 @@ import { corsHeaders } from '@imajin/config';
 import { requireAuth } from '@/src/lib/auth/middleware';
 import { createLogger } from '@imajin/logger';
 import {
-  buildDocumentSignatureRows,
-  getCreatorDisplayName,
+  finalizeDocumentAttestation,
   parseDocumentRequestBody,
-  publishDocumentCreatedNotifications,
   validateDocumentRequestInput,
 } from '../../../../src/lib/auth/document-attestation';
 
@@ -93,37 +91,17 @@ export async function POST(request: NextRequest) {
     })
     .returning();
 
-  // Create signature rows
-  const sigRows = buildDocumentSignatureRows({
-    attestationId,
-    creatorDid: callerDid,
-    creatorJws: authorJws,
-    signerDids,
-    genId,
-  });
-
-  await db.insert(attestationSignatures).values(sigRows);
-
-  // Set asset immutable
-  await db.update(assets).set({ immutable: true }).where(eq(assets.id, documentAssetId));
-
-  // Publish one event per pending signer so notify reactors can target recipients directly.
-  const creatorName = getCreatorDisplayName(callerIdentity, callerDid);
-  publishDocumentCreatedNotifications({
+  const allSigs = await finalizeDocumentAttestation({
     attestationId,
     documentAssetId,
     creatorDid: callerDid,
-    creatorName,
+    creatorJws: authorJws,
     signerDids,
     title,
+    callerIdentity,
+    genId,
     log,
   });
-
-  // Fetch signatures to return
-  const allSigs = await db
-    .select()
-    .from(attestationSignatures)
-    .where(eq(attestationSignatures.attestationId, attestationId));
 
   return NextResponse.json(
     { attestation, signatures: allSigs },

--- a/apps/kernel/app/auth/api/identity/[did]/sign/route.ts
+++ b/apps/kernel/app/auth/api/identity/[did]/sign/route.ts
@@ -1,13 +1,15 @@
 /**
  * POST /api/identity/:did/sign
  *
- * Internal service-to-service endpoint. Signs a canonical payload on behalf
- * of a chain-verified identity using AUTH_PRIVATE_KEY (the node's platform key).
+ * Signs a canonical payload on behalf of a chain-verified identity using
+ * AUTH_PRIVATE_KEY (the node's platform key).
  *
  * This is the "node attestation" model: the node signs as a witness that the
  * authenticated, chain-verified sender produced this content.
  *
- * Authenticated via Bearer token (INTERNAL_API_KEY).
+ * Supports either:
+ * - Internal Bearer auth via INTERNAL_API_KEY, or
+ * - An authenticated browser session where session DID matches :did.
  * Only signs if the identity has a valid DFOS chain.
  *
  * Body: { payload: string }
@@ -19,6 +21,8 @@ import { crypto as authCrypto } from '@imajin/auth';
 import { getChainByImajinDid } from '@/src/lib/auth/dfos';
 import { verifyChain } from '@imajin/dfos';
 import { createLogger } from '@imajin/logger';
+import { requireAuth } from '@/src/lib/auth/middleware';
+import { parseDocumentSigningPayload } from '@/src/lib/auth/document-signing-payload';
 
 const log = createLogger('kernel');
 
@@ -26,12 +30,23 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ did: string }> }
 ) {
-  // Service-to-service auth
+  const { did } = await params;
+  const decodedDid = decodeURIComponent(did);
+
+  // Service-to-service auth (legacy/internal)
   const apiKey = request.headers.get('authorization')?.replace('Bearer ', '');
   const expectedKey = process.env.INTERNAL_API_KEY;
+  const isInternalRequest = !!expectedKey && apiKey === expectedKey;
 
-  if (!expectedKey || apiKey !== expectedKey) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  // Session auth (browser/client flow)
+  if (!isInternalRequest) {
+    const session = await requireAuth(request);
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (session.sub !== decodedDid) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
   }
 
   const privateKey = process.env.AUTH_PRIVATE_KEY;
@@ -50,8 +65,12 @@ export async function POST(
     return NextResponse.json({ error: 'payload required (string)' }, { status: 400 });
   }
 
-  const { did } = await params;
-  const decodedDid = decodeURIComponent(did);
+  if (!isInternalRequest) {
+    const parsedPayload = parseDocumentSigningPayload(body.payload);
+    if (!parsedPayload || parsedPayload.did !== decodedDid) {
+      return NextResponse.json({ error: 'payload must include matching did and document_hash' }, { status: 400 });
+    }
+  }
 
   // Only sign for chain-verified identities
   const chain = await getChainByImajinDid(decodedDid);

--- a/apps/kernel/app/auth/attestations/components/CreateDocumentForm.tsx
+++ b/apps/kernel/app/auth/attestations/components/CreateDocumentForm.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useRef, useCallback } from 'react';
+import IdentityPicker from '../../components/IdentityPicker';
+import { buildDocumentSigningPayload } from '@/src/lib/auth/document-signing-payload';
 
 interface Props {
   sessionDid: string;
@@ -21,7 +23,6 @@ export default function CreateDocumentForm({ sessionDid, onCreated }: Props) {
   const [assetId, setAssetId] = useState<string | null>(null);
   const [assetHash, setAssetHash] = useState<string | null>(null);
   const [title, setTitle] = useState('');
-  const [signerInput, setSignerInput] = useState('');
   const [signers, setSigners] = useState<LookupResult[]>([]);
   const [expiry, setExpiry] = useState<'24h' | '7d' | '1m' | '1y' | 'never'>('7d');
   const [loading, setLoading] = useState(false);
@@ -67,19 +68,9 @@ export default function CreateDocumentForm({ sessionDid, onCreated }: Props) {
     }
   }
 
-  async function lookupSigner(input: string) {
-    if (!input.trim()) return;
-    try {
-      const res = await fetch(`/auth/api/lookup/${encodeURIComponent(input.trim())}`);
-      if (!res.ok) return;
-      const data = await res.json();
-      if (data.did && !signers.find((s) => s.did === data.did)) {
-        setSigners((prev) => [...prev, { did: data.did, handle: data.handle, name: data.name }]);
-        setSignerInput('');
-      }
-    } catch {
-      // ignore lookup errors
-    }
+  function addSigner(identity: { did: string; handle: string | null; name: string | null }) {
+    if (!identity.did || signers.some((s) => s.did === identity.did)) return;
+    setSigners((prev) => [...prev, { did: identity.did, handle: identity.handle, name: identity.name }]);
   }
 
   function removeSigner(did: string) {
@@ -89,19 +80,28 @@ export default function CreateDocumentForm({ sessionDid, onCreated }: Props) {
   async function handleSubmit() {
     if (!assetId || !assetHash || !title.trim() || signers.length === 0) return;
 
-    // Generate author JWS — in a real app this uses the client's stored key
-    // For this implementation, we prompt the user to generate it externally
-    const jws = window.prompt(
-      'Sign the document hash with your key to create the signing request.\n\n' +
-      'Paste your JWS compact token (sign this hash with your Ed25519 key):\n' +
-      assetHash
-    );
-    if (!jws) return;
-
     setLoading(true);
     setError(null);
 
     try {
+      const signRes = await fetch(`/auth/api/identity/${encodeURIComponent(sessionDid)}/sign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          payload: buildDocumentSigningPayload(sessionDid, assetHash),
+        }),
+      });
+      const signData = await signRes.json();
+      if (!signRes.ok) {
+        setError(signData.error ?? 'Failed to sign document hash');
+        setLoading(false);
+        return;
+      }
+      if (!signData.signature || typeof signData.signature !== 'string') {
+        setError(signData.reason ? `Unable to sign: ${signData.reason}` : 'Unable to sign document hash');
+        setLoading(false);
+        return;
+      }
       const res = await fetch('/auth/api/documents', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -111,7 +111,7 @@ export default function CreateDocumentForm({ sessionDid, onCreated }: Props) {
           document_hash: assetHash,
           signers: signers.map((s) => s.did),
           expiry,
-          author_jws: jws,
+          author_jws: signData.signature,
         }),
       });
 
@@ -214,22 +214,11 @@ export default function CreateDocumentForm({ sessionDid, onCreated }: Props) {
 
           <div>
             <label className="block text-xs text-zinc-500 mb-1.5">Signers</label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={signerInput}
-                onChange={(e) => setSignerInput(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); lookupSigner(signerInput); } }}
-                className="flex-1 bg-black border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white focus:border-amber-500 focus:outline-none"
-                placeholder="@handle or did:imajin:..."
-              />
-              <button
-                onClick={() => lookupSigner(signerInput)}
-                className="px-3 py-2 bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
-              >
-                Add
-              </button>
-            </div>
+            <IdentityPicker
+              onSelect={addSigner}
+              placeholder="Search by handle, name, or DID…"
+              excludeDids={[sessionDid, ...signers.map((s) => s.did)]}
+            />
             {signers.length > 0 && (
               <div className="mt-2 space-y-1">
                 {signers.map((s) => (

--- a/apps/kernel/app/auth/attestations/components/DocumentList.tsx
+++ b/apps/kernel/app/auth/attestations/components/DocumentList.tsx
@@ -1,0 +1,121 @@
+import { db, attestations, attestationSignatures, identities } from '@/src/db';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import Link from 'next/link';
+import DocumentSigningCard from './DocumentSigningCard';
+
+type DocumentRoleFilter = 'created' | 'needs-signature';
+
+const DOCUMENT_TYPES = ['document.created', 'document.amended'] as const;
+
+interface Props {
+  sessionDid: string;
+  role: DocumentRoleFilter;
+}
+
+export default async function DocumentList({ sessionDid, role }: Props) {
+  let rows: typeof attestations.$inferSelect[] = [];
+
+  if (role === 'created') {
+    rows = await db
+      .select()
+      .from(attestations)
+      .where(
+        and(
+          inArray(attestations.type, [...DOCUMENT_TYPES]),
+          eq(attestations.issuerDid, sessionDid)
+        )
+      )
+      .orderBy(desc(attestations.issuedAt))
+      .limit(50);
+  } else {
+    const pendingRows = await db
+      .select({ attestationId: attestationSignatures.attestationId })
+      .from(attestationSignatures)
+      .where(
+        and(
+          eq(attestationSignatures.signerDid, sessionDid),
+          eq(attestationSignatures.status, 'pending')
+        )
+      );
+
+    const pendingIds = [...new Set(pendingRows.map((row) => row.attestationId))];
+    if (pendingIds.length > 0) {
+      rows = await db
+        .select()
+        .from(attestations)
+        .where(
+          and(
+            inArray(attestations.id, pendingIds),
+            inArray(attestations.type, [...DOCUMENT_TYPES]),
+            eq(attestations.attestationStatus, 'collecting')
+          )
+        )
+        .orderBy(desc(attestations.issuedAt))
+        .limit(50);
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-10 text-center text-zinc-500">
+        {role === 'created' ? 'No documents created yet' : 'No documents currently need your signature'}
+      </div>
+    );
+  }
+
+  const attestationIds = rows.map((row) => row.id);
+  const signatures = await db
+    .select()
+    .from(attestationSignatures)
+    .where(inArray(attestationSignatures.attestationId, attestationIds));
+
+  const signerDids = [...new Set(signatures.map((sig) => sig.signerDid))];
+  const signerIdentities = signerDids.length
+    ? await db
+        .select({
+          id: identities.id,
+          handle: identities.handle,
+          name: identities.name,
+          avatarUrl: identities.avatarUrl,
+        })
+        .from(identities)
+        .where(inArray(identities.id, signerDids))
+    : [];
+  const signerIdentityMap = new Map(signerIdentities.map((identity) => [identity.id, identity]));
+
+  const signaturesByAttestation = new Map<string, typeof signatures>();
+  for (const signature of signatures) {
+    const existing = signaturesByAttestation.get(signature.attestationId) ?? [];
+    existing.push(signature);
+    signaturesByAttestation.set(signature.attestationId, existing);
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.map((attestation) => {
+        const signaturesForAttestation = (signaturesByAttestation.get(attestation.id) ?? []).map((signature) => ({
+          ...signature,
+          identity: signerIdentityMap.get(signature.signerDid) ?? null,
+        }));
+
+        return (
+          <div key={attestation.id} className="space-y-2">
+            <DocumentSigningCard
+              attestation={attestation as any}
+              signatures={signaturesForAttestation}
+              sessionDid={sessionDid}
+            />
+            <div className="px-1">
+              <Link
+                href={`/auth/documents/${attestation.id}`}
+                className="text-xs text-zinc-500 hover:text-amber-400 transition-colors"
+              >
+                Open document detail →
+              </Link>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/attestations/components/DocumentList.tsx
+++ b/apps/kernel/app/auth/attestations/components/DocumentList.tsx
@@ -1,7 +1,7 @@
 import { db, attestations, attestationSignatures, identities } from '@/src/db';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import Link from 'next/link';
-import DocumentSigningCard from './DocumentSigningCard';
+import DocumentSigningCard, { type DocumentAttestation, type Signature } from './DocumentSigningCard';
 
 type DocumentRoleFilter = 'created' | 'needs-signature';
 
@@ -93,15 +93,16 @@ export default async function DocumentList({ sessionDid, role }: Props) {
   return (
     <div className="space-y-3">
       {rows.map((attestation) => {
-        const signaturesForAttestation = (signaturesByAttestation.get(attestation.id) ?? []).map((signature) => ({
+        const signaturesForAttestation: Signature[] = (signaturesByAttestation.get(attestation.id) ?? []).map((signature) => ({
           ...signature,
           identity: signerIdentityMap.get(signature.signerDid) ?? null,
         }));
+        const cardAttestation: DocumentAttestation = attestation;
 
         return (
           <div key={attestation.id} className="space-y-2">
             <DocumentSigningCard
-              attestation={attestation as any}
+              attestation={cardAttestation}
               signatures={signaturesForAttestation}
               sessionDid={sessionDid}
             />

--- a/apps/kernel/app/auth/attestations/components/DocumentSigningCard.tsx
+++ b/apps/kernel/app/auth/attestations/components/DocumentSigningCard.tsx
@@ -5,7 +5,7 @@ import SignerList from './SignerList';
 import DocumentViewer from './DocumentViewer';
 import { buildDocumentSigningPayload } from '@/src/lib/auth/document-signing-payload';
 
-interface Signature {
+export interface Signature {
   id: string;
   signerDid: string;
   status: string;
@@ -18,12 +18,12 @@ interface Signature {
   } | null;
 }
 
-interface DocumentAttestation {
+export interface DocumentAttestation {
   id: string;
   issuerDid: string;
   subjectDid: string;
   type: string;
-  payload: Record<string, unknown> | null;
+  payload: unknown;
   attestationStatus: string | null;
   documentHash: string | null;
   documentAssetId: string | null;
@@ -77,6 +77,15 @@ function expiryLabel(expiresAt: Date | null): string | null {
   const days = Math.floor(hrs / 24);
   return `${days}d left`;
 }
+function getDocumentTitle(payload: unknown): string {
+  if (payload && typeof payload === 'object') {
+    const maybeTitle = (payload as { title?: unknown }).title;
+    if (typeof maybeTitle === 'string' && maybeTitle.trim().length > 0) {
+      return maybeTitle;
+    }
+  }
+  return 'Untitled Document';
+}
 
 export default function DocumentSigningCard({ attestation, signatures, sessionDid, defaultExpanded = false }: Props) {
   const [expanded, setExpanded] = useState(defaultExpanded);
@@ -92,7 +101,7 @@ export default function DocumentSigningCard({ attestation, signatures, sessionDi
   const signedCount = localSigs.filter((s) => s.status === 'signed').length;
   const totalCount = attestation.totalSigners ?? localSigs.length;
 
-  const title = (attestation.payload?.title as string) ?? 'Untitled Document';
+  const title = getDocumentTitle(attestation.payload);
 
   async function handleSign() {
     setLoading(true);

--- a/apps/kernel/app/auth/attestations/components/DocumentSigningCard.tsx
+++ b/apps/kernel/app/auth/attestations/components/DocumentSigningCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import SignerList from './SignerList';
 import DocumentViewer from './DocumentViewer';
+import { buildDocumentSigningPayload } from '@/src/lib/auth/document-signing-payload';
 
 interface Signature {
   id: string;
@@ -35,6 +36,7 @@ interface Props {
   attestation: DocumentAttestation;
   signatures: Signature[];
   sessionDid: string;
+  defaultExpanded?: boolean;
 }
 
 function statusBadge(status: string | null): { label: string; classes: string } {
@@ -52,14 +54,6 @@ function statusBadge(status: string | null): { label: string; classes: string } 
   }
 }
 
-function resolvedName(
-  did: string,
-  identity: { handle?: string | null; name?: string | null } | undefined
-): string {
-  if (identity?.handle) return `@${identity.handle}`;
-  if (identity?.name) return identity.name;
-  return did.slice(0, 22) + '…';
-}
 
 function relativeTime(date: Date): string {
   const diff = Date.now() - date.getTime();
@@ -84,15 +78,14 @@ function expiryLabel(expiresAt: Date | null): string | null {
   return `${days}d left`;
 }
 
-export default function DocumentSigningCard({ attestation, signatures, sessionDid }: Props) {
-  const [expanded, setExpanded] = useState(false);
+export default function DocumentSigningCard({ attestation, signatures, sessionDid, defaultExpanded = false }: Props) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [localStatus, setLocalStatus] = useState(attestation.attestationStatus);
   const [localSigs, setLocalSigs] = useState(signatures);
 
   const badge = statusBadge(localStatus);
-  const isCreator = attestation.issuerDid === sessionDid;
   const mySig = localSigs.find((s) => s.signerDid === sessionDid);
   const canSign = mySig?.status === 'pending' && localStatus === 'collecting';
   const canDecline = mySig?.status === 'pending' && localStatus === 'collecting';
@@ -105,10 +98,26 @@ export default function DocumentSigningCard({ attestation, signatures, sessionDi
     setLoading(true);
     setError(null);
     try {
-      // Client must provide their JWS and document_hash
-      // For now, we prompt for JWS (in a real app this would be auto-generated from stored keys)
-      const jws = window.prompt('Paste your JWS signature for this document:');
-      if (!jws) {
+      if (!attestation.documentHash) {
+        setError('Document hash missing');
+        setLoading(false);
+        return;
+      }
+      const signRes = await fetch(`/auth/api/identity/${encodeURIComponent(sessionDid)}/sign`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          payload: buildDocumentSigningPayload(sessionDid, attestation.documentHash),
+        }),
+      });
+      const signData = await signRes.json();
+      if (!signRes.ok) {
+        setError(signData.error ?? 'Unable to sign document hash');
+        setLoading(false);
+        return;
+      }
+      if (!signData.signature || typeof signData.signature !== 'string') {
+        setError(signData.reason ? `Unable to sign: ${signData.reason}` : 'Unable to sign document hash');
         setLoading(false);
         return;
       }
@@ -117,7 +126,7 @@ export default function DocumentSigningCard({ attestation, signatures, sessionDi
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          jws,
+          jws: signData.signature,
           document_hash: attestation.documentHash,
         }),
       });
@@ -193,6 +202,9 @@ export default function DocumentSigningCard({ attestation, signatures, sessionDi
           </div>
           <div className="text-xs text-zinc-500 mt-0.5">
             {signedCount}/{totalCount} signed
+            {canSign && (
+              <span className="ml-2 text-amber-400">· Needs your signature</span>
+            )}
             {expiry && (
               <span className="ml-2 text-zinc-600">· {expiry}</span>
             )}

--- a/apps/kernel/app/auth/attestations/page.tsx
+++ b/apps/kernel/app/auth/attestations/page.tsx
@@ -1,13 +1,17 @@
 import { cookies } from 'next/headers';
 import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 import AttestationList from '../components/AttestationList';
 import CreateDocumentForm from './components/CreateDocumentForm';
+import DocumentList from './components/DocumentList';
 
 interface SearchParams {
   type?: string;
   role?: string;
   page?: string;
+  view?: string;
+  doc_role?: string;
 }
 
 export default async function AttestationsPage({ searchParams }: { searchParams: SearchParams }) {
@@ -28,6 +32,8 @@ export default async function AttestationsPage({ searchParams }: { searchParams:
   // Effective DID: actingAs cookie OR personal DID
   const actingAs = cookieStore.get('x-acting-as')?.value || null;
   const effectiveDid = actingAs || sessionDid;
+  const view = searchParams.view === 'documents' ? 'documents' : 'attestations';
+  const documentRole = searchParams.doc_role === 'created' ? 'created' : 'needs-signature';
 
   return (
     <div className="space-y-4">
@@ -35,7 +41,59 @@ export default async function AttestationsPage({ searchParams }: { searchParams:
         <h2 className="text-xl font-bold text-white">Attestations</h2>
         <CreateDocumentForm sessionDid={effectiveDid} />
       </div>
-      <AttestationList sessionDid={effectiveDid} searchParams={searchParams} />
+
+      <div className="flex items-center gap-2">
+        <Link
+          href="/auth/attestations"
+          className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+            view === 'attestations'
+              ? 'bg-amber-500/20 border-amber-500 text-amber-300'
+              : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-zinc-200'
+          }`}
+        >
+          Attestations
+        </Link>
+        <Link
+          href={`/auth/attestations?view=documents&doc_role=${documentRole}`}
+          className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+            view === 'documents'
+              ? 'bg-amber-500/20 border-amber-500 text-amber-300'
+              : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-zinc-200'
+          }`}
+        >
+          Documents
+        </Link>
+      </div>
+
+      {view === 'documents' ? (
+        <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Link
+              href="/auth/attestations?view=documents&doc_role=needs-signature"
+              className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+                documentRole === 'needs-signature'
+                  ? 'bg-amber-500/20 border-amber-500 text-amber-300'
+                  : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-zinc-200'
+              }`}
+            >
+              Needs my signature
+            </Link>
+            <Link
+              href="/auth/attestations?view=documents&doc_role=created"
+              className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+                documentRole === 'created'
+                  ? 'bg-amber-500/20 border-amber-500 text-amber-300'
+                  : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-zinc-200'
+              }`}
+            >
+              Created by me
+            </Link>
+          </div>
+          <DocumentList sessionDid={effectiveDid} role={documentRole} />
+        </div>
+      ) : (
+        <AttestationList sessionDid={effectiveDid} searchParams={searchParams} excludeDocumentTypes />
+      )}
     </div>
   );
 }

--- a/apps/kernel/app/auth/attestations/page.tsx
+++ b/apps/kernel/app/auth/attestations/page.tsx
@@ -14,7 +14,8 @@ interface SearchParams {
   doc_role?: string;
 }
 
-export default async function AttestationsPage({ searchParams }: { searchParams: SearchParams }) {
+export default async function AttestationsPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
+  const resolvedSearchParams = await searchParams;
   const cookieConfig = getSessionCookieOptions();
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(cookieConfig.name)?.value;
@@ -32,8 +33,8 @@ export default async function AttestationsPage({ searchParams }: { searchParams:
   // Effective DID: actingAs cookie OR personal DID
   const actingAs = cookieStore.get('x-acting-as')?.value || null;
   const effectiveDid = actingAs || sessionDid;
-  const view = searchParams.view === 'documents' ? 'documents' : 'attestations';
-  const documentRole = searchParams.doc_role === 'created' ? 'created' : 'needs-signature';
+  const view = resolvedSearchParams.view === 'documents' ? 'documents' : 'attestations';
+  const documentRole = resolvedSearchParams.doc_role === 'created' ? 'created' : 'needs-signature';
 
   return (
     <div className="space-y-4">
@@ -92,7 +93,7 @@ export default async function AttestationsPage({ searchParams }: { searchParams:
           <DocumentList sessionDid={effectiveDid} role={documentRole} />
         </div>
       ) : (
-        <AttestationList sessionDid={effectiveDid} searchParams={searchParams} excludeDocumentTypes />
+        <AttestationList sessionDid={effectiveDid} searchParams={resolvedSearchParams} excludeDocumentTypes />
       )}
     </div>
   );

--- a/apps/kernel/app/auth/attestations/page.tsx
+++ b/apps/kernel/app/auth/attestations/page.tsx
@@ -1,10 +1,9 @@
-import { cookies } from 'next/headers';
-import { verifySessionToken, getSessionCookieOptions } from '@/src/lib/auth/jwt';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import AttestationList from '../components/AttestationList';
 import CreateDocumentForm from './components/CreateDocumentForm';
 import DocumentList from './components/DocumentList';
+import { getEffectiveDid } from '../lib/get-effective-did';
 
 interface SearchParams {
   type?: string;
@@ -16,23 +15,11 @@ interface SearchParams {
 
 export default async function AttestationsPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
   const resolvedSearchParams = await searchParams;
-  const cookieConfig = getSessionCookieOptions();
-  const cookieStore = await cookies();
-  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
-
-  let sessionDid: string | null = null;
-  if (sessionToken) {
-    const session = await verifySessionToken(sessionToken);
-    sessionDid = session?.sub ?? null;
-  }
+  const { sessionDid, effectiveDid } = await getEffectiveDid();
 
   if (!sessionDid) {
     redirect('/auth');
   }
-
-  // Effective DID: actingAs cookie OR personal DID
-  const actingAs = cookieStore.get('x-acting-as')?.value || null;
-  const effectiveDid = actingAs || sessionDid;
   const view = resolvedSearchParams.view === 'documents' ? 'documents' : 'attestations';
   const documentRole = resolvedSearchParams.doc_role === 'created' ? 'created' : 'needs-signature';
 

--- a/apps/kernel/app/auth/components/AttestationList.tsx
+++ b/apps/kernel/app/auth/components/AttestationList.tsx
@@ -1,5 +1,5 @@
 import { db, identities, attestations, attestationSignatures } from '@/src/db';
-import { eq, or, and, isNull, desc, inArray, sql } from 'drizzle-orm';
+import { eq, or, and, isNull, desc, inArray, notInArray, sql } from 'drizzle-orm';
 import Link from 'next/link';
 import DocumentSigningCard from '../attestations/components/DocumentSigningCard';
 
@@ -75,9 +75,10 @@ const PAGE_SIZE = 20;
 interface Props {
   sessionDid: string;
   searchParams: { type?: string; role?: string; page?: string };
+  excludeDocumentTypes?: boolean;
 }
 
-export default async function AttestationList({ sessionDid, searchParams }: Props) {
+export default async function AttestationList({ sessionDid, searchParams, excludeDocumentTypes = false }: Props) {
   const { type: typeFilter, role = 'all' } = searchParams;
   const page = Math.max(1, parseInt(searchParams.page || '1'));
   const offset = (page - 1) * PAGE_SIZE;
@@ -90,6 +91,7 @@ export default async function AttestationList({ sessionDid, searchParams }: Prop
 
   const conditions = [roleCondition, isNull(attestations.revokedAt)];
   if (typeFilter) conditions.push(eq(attestations.type, typeFilter));
+  if (excludeDocumentTypes && !typeFilter) conditions.push(notInArray(attestations.type, DOCUMENT_TYPES));
 
   const rows = await db
     .select()

--- a/apps/kernel/app/auth/components/AttestationList.tsx
+++ b/apps/kernel/app/auth/components/AttestationList.tsx
@@ -1,7 +1,7 @@
 import { db, identities, attestations, attestationSignatures } from '@/src/db';
 import { eq, or, and, isNull, desc, inArray, notInArray, sql } from 'drizzle-orm';
 import Link from 'next/link';
-import DocumentSigningCard from '../attestations/components/DocumentSigningCard';
+import DocumentSigningCard, { type DocumentAttestation, type Signature } from '../attestations/components/DocumentSigningCard';
 
 const TYPE_BADGE: Record<string, { label: string; classes: string }> = {
   'session.created': {
@@ -220,14 +220,15 @@ export default async function AttestationList({ sessionDid, searchParams, exclud
             // Document attestations get the rich card
             if (DOCUMENT_TYPES.includes(att.type)) {
               const sigs = sigsByAttestation.get(att.id) ?? [];
-              const sigsWithIdentity = sigs.map((sig) => ({
+              const sigsWithIdentity: Signature[] = sigs.map((sig) => ({
                 ...sig,
                 identity: signerIdentityMap.get(sig.signerDid) ?? null,
               }));
+              const cardAttestation: DocumentAttestation = att;
               return (
                 <DocumentSigningCard
                   key={att.id}
-                  attestation={att as any}
+                  attestation={cardAttestation}
                   signatures={sigsWithIdentity}
                   sessionDid={sessionDid}
                 />

--- a/apps/kernel/app/auth/components/IdentityTabBar.tsx
+++ b/apps/kernel/app/auth/components/IdentityTabBar.tsx
@@ -21,6 +21,7 @@ const ALL_TABS: Tab[] = [
   { label: 'Profile', href: '/auth', exact: true },
   { label: 'Agents', href: '/auth/agents', exact: false },
   { label: 'Attestations', href: '/auth/attestations', exact: false },
+  { label: 'Documents', href: '/auth/documents', exact: false },
   { label: 'Notifications', href: '/auth/notifications', exact: false },
   { label: 'Developer', href: '/auth/developer/apps', exact: false },
   { label: 'Apps', href: '/auth/apps', exact: false },

--- a/apps/kernel/app/auth/documents/[id]/page.tsx
+++ b/apps/kernel/app/auth/documents/[id]/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { and, eq, inArray } from 'drizzle-orm';
 import { attestations, attestationSignatures, db, identities } from '@/src/db';
-import DocumentSigningCard from '../../attestations/components/DocumentSigningCard';
+import DocumentSigningCard, { type DocumentAttestation, type Signature } from '../../attestations/components/DocumentSigningCard';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -90,10 +90,11 @@ export default async function DocumentDetailPage({ params }: PageProps) {
     : [];
   const signerIdentityMap = new Map(signerIdentities.map((identity) => [identity.id, identity]));
 
-  const signaturesWithIdentity = signatures.map((signature) => ({
+  const signaturesWithIdentity: Signature[] = signatures.map((signature) => ({
     ...signature,
     identity: signerIdentityMap.get(signature.signerDid) ?? null,
   }));
+  const cardAttestation: DocumentAttestation = attestation;
 
   return (
     <div className="space-y-4">
@@ -104,7 +105,7 @@ export default async function DocumentDetailPage({ params }: PageProps) {
         </Link>
       </div>
       <DocumentSigningCard
-        attestation={attestation as any}
+        attestation={cardAttestation}
         signatures={signaturesWithIdentity}
         sessionDid={effectiveDid}
         defaultExpanded

--- a/apps/kernel/app/auth/documents/[id]/page.tsx
+++ b/apps/kernel/app/auth/documents/[id]/page.tsx
@@ -1,0 +1,114 @@
+import { cookies } from 'next/headers';
+import { getSessionCookieOptions, verifySessionToken } from '@/src/lib/auth/jwt';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { and, eq, inArray } from 'drizzle-orm';
+import { attestations, attestationSignatures, db, identities } from '@/src/db';
+import DocumentSigningCard from '../../attestations/components/DocumentSigningCard';
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+const DOCUMENT_TYPES = ['document.created', 'document.amended'] as const;
+
+export default async function DocumentDetailPage({ params }: PageProps) {
+  const { id } = await params;
+
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  if (!sessionDid) {
+    redirect('/auth');
+  }
+
+  const actingAs = cookieStore.get('x-acting-as')?.value || null;
+  const effectiveDid = actingAs || sessionDid;
+
+  const [attestation] = await db
+    .select()
+    .from(attestations)
+    .where(
+      and(
+        eq(attestations.id, id),
+        inArray(attestations.type, [...DOCUMENT_TYPES])
+      )
+    )
+    .limit(1);
+
+  const [mySignature] = attestation
+    ? await db
+        .select({ id: attestationSignatures.id })
+        .from(attestationSignatures)
+        .where(
+          and(
+            eq(attestationSignatures.attestationId, attestation.id),
+            eq(attestationSignatures.signerDid, effectiveDid)
+          )
+        )
+        .limit(1)
+    : [];
+
+  const canAccess = !!attestation && (attestation.issuerDid === effectiveDid || !!mySignature);
+
+  if (!canAccess || !attestation) {
+    return (
+      <div className="space-y-4">
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-8 text-center text-zinc-500">
+          Document not found or access denied.
+        </div>
+        <Link href="/auth/documents" className="text-sm text-zinc-500 hover:text-amber-400 transition-colors">
+          ← Back to documents
+        </Link>
+      </div>
+    );
+  }
+
+  const signatures = await db
+    .select()
+    .from(attestationSignatures)
+    .where(eq(attestationSignatures.attestationId, attestation.id));
+
+  const signerDids = [...new Set(signatures.map((signature) => signature.signerDid))];
+  const signerIdentities = signerDids.length
+    ? await db
+        .select({
+          id: identities.id,
+          handle: identities.handle,
+          name: identities.name,
+          avatarUrl: identities.avatarUrl,
+        })
+        .from(identities)
+        .where(inArray(identities.id, signerDids))
+    : [];
+  const signerIdentityMap = new Map(signerIdentities.map((identity) => [identity.id, identity]));
+
+  const signaturesWithIdentity = signatures.map((signature) => ({
+    ...signature,
+    identity: signerIdentityMap.get(signature.signerDid) ?? null,
+  }));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold text-white">Document</h2>
+        <Link href="/auth/documents" className="text-sm text-zinc-500 hover:text-amber-400 transition-colors">
+          ← Back to documents
+        </Link>
+      </div>
+      <DocumentSigningCard
+        attestation={attestation as any}
+        signatures={signaturesWithIdentity}
+        sessionDid={effectiveDid}
+        defaultExpanded
+      />
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/documents/page.tsx
+++ b/apps/kernel/app/auth/documents/page.tsx
@@ -1,8 +1,7 @@
-import { cookies } from 'next/headers';
-import { getSessionCookieOptions, verifySessionToken } from '@/src/lib/auth/jwt';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import DocumentList from '../attestations/components/DocumentList';
+import { getEffectiveDid } from '../lib/get-effective-did';
 
 interface SearchParams {
   role?: string;
@@ -10,22 +9,11 @@ interface SearchParams {
 
 export default async function DocumentsPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
   const resolvedSearchParams = await searchParams;
-  const cookieConfig = getSessionCookieOptions();
-  const cookieStore = await cookies();
-  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
-
-  let sessionDid: string | null = null;
-  if (sessionToken) {
-    const session = await verifySessionToken(sessionToken);
-    sessionDid = session?.sub ?? null;
-  }
+  const { sessionDid, effectiveDid } = await getEffectiveDid();
 
   if (!sessionDid) {
     redirect('/auth');
   }
-
-  const actingAs = cookieStore.get('x-acting-as')?.value || null;
-  const effectiveDid = actingAs || sessionDid;
   const role = resolvedSearchParams.role === 'created' ? 'created' : 'needs-signature';
 
   return (

--- a/apps/kernel/app/auth/documents/page.tsx
+++ b/apps/kernel/app/auth/documents/page.tsx
@@ -1,0 +1,68 @@
+import { cookies } from 'next/headers';
+import { getSessionCookieOptions, verifySessionToken } from '@/src/lib/auth/jwt';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import DocumentList from '../attestations/components/DocumentList';
+
+interface SearchParams {
+  role?: string;
+}
+
+export default async function DocumentsPage({ searchParams }: { searchParams: SearchParams }) {
+  const cookieConfig = getSessionCookieOptions();
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(cookieConfig.name)?.value;
+
+  let sessionDid: string | null = null;
+  if (sessionToken) {
+    const session = await verifySessionToken(sessionToken);
+    sessionDid = session?.sub ?? null;
+  }
+
+  if (!sessionDid) {
+    redirect('/auth');
+  }
+
+  const actingAs = cookieStore.get('x-acting-as')?.value || null;
+  const effectiveDid = actingAs || sessionDid;
+  const role = searchParams.role === 'created' ? 'created' : 'needs-signature';
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold text-white">Documents</h2>
+        <Link
+          href="/auth/attestations?view=documents"
+          className="text-sm text-zinc-500 hover:text-amber-400 transition-colors"
+        >
+          Open in attestations view →
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Link
+          href="/auth/documents?role=needs-signature"
+          className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+            role === 'needs-signature'
+              ? 'bg-amber-500/20 border-amber-500 text-amber-300'
+              : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-zinc-200'
+          }`}
+        >
+          Needs my signature
+        </Link>
+        <Link
+          href="/auth/documents?role=created"
+          className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+            role === 'created'
+              ? 'bg-amber-500/20 border-amber-500 text-amber-300'
+              : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-zinc-200'
+          }`}
+        >
+          Created by me
+        </Link>
+      </div>
+
+      <DocumentList sessionDid={effectiveDid} role={role} />
+    </div>
+  );
+}

--- a/apps/kernel/app/auth/documents/page.tsx
+++ b/apps/kernel/app/auth/documents/page.tsx
@@ -8,7 +8,8 @@ interface SearchParams {
   role?: string;
 }
 
-export default async function DocumentsPage({ searchParams }: { searchParams: SearchParams }) {
+export default async function DocumentsPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
+  const resolvedSearchParams = await searchParams;
   const cookieConfig = getSessionCookieOptions();
   const cookieStore = await cookies();
   const sessionToken = cookieStore.get(cookieConfig.name)?.value;
@@ -25,7 +26,7 @@ export default async function DocumentsPage({ searchParams }: { searchParams: Se
 
   const actingAs = cookieStore.get('x-acting-as')?.value || null;
   const effectiveDid = actingAs || sessionDid;
-  const role = searchParams.role === 'created' ? 'created' : 'needs-signature';
+  const role = resolvedSearchParams.role === 'created' ? 'created' : 'needs-signature';
 
   return (
     <div className="space-y-4">

--- a/apps/kernel/src/lib/auth/__tests__/document-list-ui.test.ts
+++ b/apps/kernel/src/lib/auth/__tests__/document-list-ui.test.ts
@@ -1,0 +1,103 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+(globalThis as { React?: typeof React }).React = React;
+
+const mocks = vi.hoisted(() => {
+  const whereMock = vi.fn();
+  const fromMock = vi.fn(() => ({ where: whereMock }));
+  const selectMock = vi.fn(() => ({ from: fromMock }));
+  return { whereMock, selectMock };
+});
+
+vi.mock('@/src/db', () => ({
+  db: {
+    select: mocks.selectMock,
+  },
+  attestations: {},
+  attestationSignatures: {},
+  identities: {},
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) =>
+    React.createElement('a', { href, className }, children),
+}));
+
+vi.mock('../../../../app/auth/attestations/components/DocumentSigningCard', () => ({
+  default: () => React.createElement('div', null, 'MockDocumentSigningCard'),
+}));
+
+function makeWhereOrderByLimitResult(rows: unknown[]) {
+  return {
+    orderBy: vi.fn(() => ({
+      limit: vi.fn().mockResolvedValue(rows),
+    })),
+  };
+}
+
+describe('DocumentList (documents UI)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders needs-signature documents with direct detail links', async () => {
+    const { default: DocumentList } = await import('../../../../app/auth/attestations/components/DocumentList');
+    mocks.whereMock
+      .mockResolvedValueOnce([{ attestationId: 'att_1' }])
+      .mockImplementationOnce(() =>
+        makeWhereOrderByLimitResult([
+          {
+            id: 'att_1',
+            issuerDid: 'did:imajin:alice',
+            subjectDid: 'did:imajin:alice',
+            type: 'document.created',
+            payload: { title: 'NDA' },
+            attestationStatus: 'collecting',
+            documentHash: 'bafy-doc-hash',
+            documentAssetId: 'asset_1',
+            totalSigners: 2,
+            issuedAt: new Date('2026-05-22T00:00:00Z'),
+            expiresAt: null,
+          },
+        ])
+      )
+      .mockResolvedValueOnce([
+        {
+          id: 'sig_1',
+          attestationId: 'att_1',
+          signerDid: 'did:imajin:me',
+          status: 'pending',
+          role: 'signer',
+          signedAt: null,
+          jws: null,
+          createdAt: new Date('2026-05-22T00:00:00Z'),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'did:imajin:me',
+          handle: 'me',
+          name: 'Me',
+          avatarUrl: null,
+        },
+      ]);
+
+    const element = await DocumentList({ sessionDid: 'did:imajin:me', role: 'needs-signature' });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('Open document detail');
+    expect(html).toContain('/auth/documents/att_1');
+    expect(html).toContain('MockDocumentSigningCard');
+  });
+
+  it('renders an empty-state message when no documents need signature', async () => {
+    const { default: DocumentList } = await import('../../../../app/auth/attestations/components/DocumentList');
+    mocks.whereMock.mockResolvedValueOnce([]);
+
+    const element = await DocumentList({ sessionDid: 'did:imajin:me', role: 'needs-signature' });
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('No documents currently need your signature');
+  });
+});

--- a/apps/kernel/src/lib/auth/__tests__/documents-create-route.test.ts
+++ b/apps/kernel/src/lib/auth/__tests__/documents-create-route.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const whereMock = vi.fn();
+  const fromMock = vi.fn(() => ({ where: whereMock }));
+  const selectMock = vi.fn(() => ({ from: fromMock }));
+  const returningMock = vi.fn();
+  const valuesMock = vi.fn(() => ({ returning: returningMock }));
+  const insertMock = vi.fn(() => ({ values: valuesMock }));
+  const updateWhereMock = vi.fn();
+  const setMock = vi.fn(() => ({ where: updateWhereMock }));
+  const updateMock = vi.fn(() => ({ set: setMock }));
+  return {
+    requireAuthMock: vi.fn(),
+    verifyDocumentSignatureTokenMock: vi.fn(),
+    publishMock: vi.fn(),
+    whereMock,
+    selectMock,
+    insertMock,
+    returningMock,
+    updateMock,
+    updateWhereMock,
+  };
+});
+
+vi.mock('@/src/lib/auth/middleware', () => ({
+  requireAuth: mocks.requireAuthMock,
+}));
+
+vi.mock('@/src/lib/auth/document-signatures', () => ({
+  verifyDocumentSignatureToken: mocks.verifyDocumentSignatureTokenMock,
+}));
+
+vi.mock('@imajin/bus', () => ({
+  publish: mocks.publishMock,
+}));
+
+vi.mock('@imajin/logger', () => ({
+  createLogger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock('@imajin/config', () => ({
+  corsHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock('@/src/db', () => ({
+  db: {
+    select: mocks.selectMock,
+    insert: mocks.insertMock,
+    update: mocks.updateMock,
+  },
+  attestations: {},
+  attestationSignatures: {},
+  identities: {},
+  assets: {},
+}));
+
+import { POST } from '../../../../app/auth/api/documents/route';
+
+function makeWhereResult(rows: unknown[]) {
+  const promise = Promise.resolve(rows) as Promise<unknown[]> & { limit: (n: number) => Promise<unknown[]> };
+  promise.limit = vi.fn().mockResolvedValue(rows);
+  return promise;
+}
+
+describe('POST /auth/api/documents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.whereMock
+      .mockImplementationOnce(() =>
+        makeWhereResult([
+          { id: 'asset_1', ownerDid: 'did:imajin:alice', hash: 'bafy-hash-1' },
+        ])
+      )
+      .mockImplementationOnce(() =>
+        makeWhereResult([
+          { publicKey: 'f'.repeat(64), handle: 'alice', name: 'Alice' },
+        ])
+      )
+      .mockImplementationOnce(() =>
+        makeWhereResult([
+          { id: 'sig_1', signerDid: 'did:imajin:alice', status: 'signed' },
+          { id: 'sig_2', signerDid: 'did:imajin:bob', status: 'pending' },
+          { id: 'sig_3', signerDid: 'did:imajin:carol', status: 'pending' },
+        ])
+      );
+    mocks.returningMock.mockResolvedValueOnce([
+      {
+        id: 'att_123',
+        issuerDid: 'did:imajin:alice',
+        documentHash: 'bafy-hash-1',
+      },
+    ]);
+    mocks.updateWhereMock.mockResolvedValue(undefined);
+    mocks.requireAuthMock.mockResolvedValue({ sub: 'did:imajin:alice' });
+    mocks.verifyDocumentSignatureTokenMock.mockResolvedValue(true);
+    mocks.publishMock.mockResolvedValue(undefined);
+  });
+
+  it('publishes one document.created event per signer with sign URL metadata', async () => {
+    const request = new Request('https://test.imajin.ai/auth/api/documents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: '  Team Agreement  ',
+        document_asset_id: 'asset_1',
+        document_hash: 'bafy-hash-1',
+        signers: ['did:imajin:bob', 'did:imajin:carol'],
+        expiry: '7d',
+        author_jws: 'node-signature-token',
+      }),
+    });
+
+    const response = await POST(request as any);
+    expect(response.status).toBe(201);
+
+    expect(mocks.publishMock).toHaveBeenCalledTimes(2);
+    const [firstEventName, firstEventBody] = mocks.publishMock.mock.calls[0] as [string, any];
+    const [secondEventName, secondEventBody] = mocks.publishMock.mock.calls[1] as [string, any];
+
+    expect(firstEventName).toBe('document.created');
+    expect(secondEventName).toBe('document.created');
+
+    expect(firstEventBody).toMatchObject({
+      issuer: 'did:imajin:alice',
+      subject: 'did:imajin:bob',
+      scope: 'auth',
+      payload: expect.objectContaining({
+        title: 'Team Agreement',
+        creatorName: '@alice',
+        creatorDid: 'did:imajin:alice',
+        documentAssetId: 'asset_1',
+        signerDids: ['did:imajin:bob', 'did:imajin:carol'],
+      }),
+    });
+    expect(secondEventBody).toMatchObject({
+      issuer: 'did:imajin:alice',
+      subject: 'did:imajin:carol',
+      scope: 'auth',
+    });
+
+    const attestationId = firstEventBody.payload.attestationId;
+    expect(typeof attestationId).toBe('string');
+    expect(firstEventBody.payload.signUrl).toBe(`/auth/documents/${attestationId}`);
+    expect(secondEventBody.payload.attestationId).toBe(attestationId);
+    expect(secondEventBody.payload.signUrl).toBe(`/auth/documents/${attestationId}`);
+  });
+});

--- a/apps/kernel/src/lib/auth/__tests__/identity-sign-route.test.ts
+++ b/apps/kernel/src/lib/auth/__tests__/identity-sign-route.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildDocumentSigningPayload } from '../document-signing-payload';
+const mocks = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  getChainByImajinDidMock: vi.fn(),
+  verifyChainMock: vi.fn(),
+  signSyncMock: vi.fn(),
+  parseDocumentSigningPayloadMock: vi.fn(),
+}));
+
+vi.mock('@/src/lib/auth/middleware', () => ({
+  requireAuth: mocks.requireAuthMock,
+}));
+
+vi.mock('@/src/lib/auth/dfos', () => ({
+  getChainByImajinDid: mocks.getChainByImajinDidMock,
+}));
+
+vi.mock('@imajin/dfos', () => ({
+  verifyChain: mocks.verifyChainMock,
+}));
+
+vi.mock('@imajin/auth', () => ({
+  crypto: {
+    signSync: mocks.signSyncMock,
+  },
+}));
+
+vi.mock('@imajin/logger', () => ({
+  createLogger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock('@/src/lib/auth/document-signing-payload', () => ({
+  parseDocumentSigningPayload: mocks.parseDocumentSigningPayloadMock,
+}));
+
+import { POST } from '../../../../app/auth/api/identity/[did]/sign/route';
+
+describe('POST /auth/api/identity/[did]/sign', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AUTH_PRIVATE_KEY = 'a'.repeat(64);
+    delete process.env.INTERNAL_API_KEY;
+  });
+
+  it('allows authenticated session signing for matching DID and valid payload', async () => {
+    mocks.requireAuthMock.mockResolvedValueOnce({ sub: 'did:imajin:alice' });
+    mocks.getChainByImajinDidMock.mockResolvedValueOnce({ log: ['cid1'] });
+    mocks.verifyChainMock.mockResolvedValueOnce({ isDeleted: false, authKeys: ['key1'] });
+    mocks.signSyncMock.mockReturnValueOnce('deadbeefsignature');
+    mocks.parseDocumentSigningPayloadMock.mockReturnValueOnce({
+      did: 'did:imajin:alice',
+      documentHash: 'bafyhash123',
+    });
+
+    const payload = buildDocumentSigningPayload('did:imajin:alice', 'bafyhash123');
+    const request = new Request('https://test.imajin.ai/auth/api/identity/did%3Aimajin%3Aalice/sign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payload }),
+    });
+
+    const response = await POST(request as any, { params: Promise.resolve({ did: 'did%3Aimajin%3Aalice' }) });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.signature).toBe('deadbeefsignature');
+    expect(mocks.signSyncMock).toHaveBeenCalledWith(payload, process.env.AUTH_PRIVATE_KEY);
+  });
+
+  it('returns 400 when session-auth payload did does not match path did', async () => {
+    mocks.requireAuthMock.mockResolvedValueOnce({ sub: 'did:imajin:alice' });
+    mocks.parseDocumentSigningPayloadMock.mockReturnValueOnce({
+      did: 'did:imajin:bob',
+      documentHash: 'bafyhash123',
+    });
+
+    const payload = buildDocumentSigningPayload('did:imajin:bob', 'bafyhash123');
+    const request = new Request('https://test.imajin.ai/auth/api/identity/did%3Aimajin%3Aalice/sign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payload }),
+    });
+
+    const response = await POST(request as any, { params: Promise.resolve({ did: 'did%3Aimajin%3Aalice' }) });
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('payload must include matching did and document_hash');
+  });
+
+  it('returns 403 when session DID does not match route DID', async () => {
+    mocks.requireAuthMock.mockResolvedValueOnce({ sub: 'did:imajin:alice' });
+
+    const payload = buildDocumentSigningPayload('did:imajin:bob', 'bafyhash123');
+    const request = new Request('https://test.imajin.ai/auth/api/identity/did%3Aimajin%3Abob/sign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payload }),
+    });
+
+    const response = await POST(request as any, { params: Promise.resolve({ did: 'did%3Aimajin%3Abob' }) });
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe('Forbidden');
+  });
+});

--- a/apps/kernel/src/lib/auth/document-attestation.ts
+++ b/apps/kernel/src/lib/auth/document-attestation.ts
@@ -1,5 +1,5 @@
 import { publish } from '@imajin/bus';
-import { db, assets, identities, type NewAttestationSignature } from '@/src/db';
+import { db, assets, identities, attestationSignatures, type NewAttestationSignature } from '@/src/db';
 import { eq } from 'drizzle-orm';
 import { verifyDocumentSignatureToken } from '@/src/lib/auth/document-signatures';
 
@@ -207,4 +207,54 @@ export function publishDocumentCreatedNotifications(params: {
       },
     }).catch((err) => log.error({ err: String(err), signerDid, attestationId }, 'document.created publish failed'));
   }
+}
+
+export async function finalizeDocumentAttestation(params: {
+  attestationId: string;
+  documentAssetId: string;
+  creatorDid: string;
+  creatorJws: string;
+  signerDids: string[];
+  title: string;
+  callerIdentity: CallerIdentity;
+  genId: (prefix: string) => string;
+  log: LoggerLike;
+}) {
+  const {
+    attestationId,
+    documentAssetId,
+    creatorDid,
+    creatorJws,
+    signerDids,
+    title,
+    callerIdentity,
+    genId,
+    log,
+  } = params;
+
+  const sigRows = buildDocumentSignatureRows({
+    attestationId,
+    creatorDid,
+    creatorJws,
+    signerDids,
+    genId,
+  });
+  await db.insert(attestationSignatures).values(sigRows);
+  await db.update(assets).set({ immutable: true }).where(eq(assets.id, documentAssetId));
+
+  const creatorName = getCreatorDisplayName(callerIdentity, creatorDid);
+  publishDocumentCreatedNotifications({
+    attestationId,
+    documentAssetId,
+    creatorDid,
+    creatorName,
+    signerDids,
+    title,
+    log,
+  });
+
+  return db
+    .select()
+    .from(attestationSignatures)
+    .where(eq(attestationSignatures.attestationId, attestationId));
 }

--- a/apps/kernel/src/lib/auth/document-attestation.ts
+++ b/apps/kernel/src/lib/auth/document-attestation.ts
@@ -1,0 +1,210 @@
+import { publish } from '@imajin/bus';
+import { db, assets, identities, type NewAttestationSignature } from '@/src/db';
+import { eq } from 'drizzle-orm';
+import { verifyDocumentSignatureToken } from '@/src/lib/auth/document-signatures';
+
+interface ValidationFailure {
+  status: number;
+  error: string;
+}
+
+interface CallerIdentity {
+  publicKey: string;
+  name: string | null;
+  handle: string | null;
+}
+
+interface DocumentRequestInput {
+  title: string;
+  documentAssetId: string;
+  documentHash: string;
+  signerDids: string[];
+  payload: Record<string, unknown> | undefined;
+  authorJws: string;
+  expiry: string | undefined;
+  callerIdentity: CallerIdentity;
+}
+
+type DocumentBodyParseResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; failure: ValidationFailure };
+
+type DocumentValidationResult =
+  | { ok: true; input: DocumentRequestInput }
+  | { ok: false; failure: ValidationFailure };
+
+type LoggerLike = {
+  error: (data: unknown, message: string) => void;
+};
+
+export async function parseDocumentRequestBody(request: Request): Promise<DocumentBodyParseResult> {
+  try {
+    const body = await request.json();
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return { ok: false, failure: { status: 400, error: 'Invalid JSON' } };
+    }
+    return { ok: true, body: body as Record<string, unknown> };
+  } catch {
+    return { ok: false, failure: { status: 400, error: 'Invalid JSON' } };
+  }
+}
+
+export async function validateDocumentRequestInput(params: {
+  body: Record<string, unknown>;
+  callerDid: string;
+}): Promise<DocumentValidationResult> {
+  const { body, callerDid } = params;
+
+  const title = typeof body.title === 'string' ? body.title : '';
+  if (!title.trim()) {
+    return { ok: false, failure: { status: 400, error: 'title required' } };
+  }
+
+  const documentAssetId = typeof body.document_asset_id === 'string' ? body.document_asset_id : '';
+  if (!documentAssetId) {
+    return { ok: false, failure: { status: 400, error: 'document_asset_id required' } };
+  }
+
+  const documentHash = typeof body.document_hash === 'string' ? body.document_hash : '';
+  if (!documentHash) {
+    return { ok: false, failure: { status: 400, error: 'document_hash required' } };
+  }
+
+  const signers = body.signers;
+  if (!Array.isArray(signers) || signers.length === 0) {
+    return { ok: false, failure: { status: 400, error: 'signers array required (at least 1)' } };
+  }
+
+  const authorJws = typeof body.author_jws === 'string' ? body.author_jws : '';
+  if (!authorJws) {
+    return { ok: false, failure: { status: 400, error: 'author_jws required' } };
+  }
+
+  const signerDids = signers.filter((s): s is string => typeof s === 'string' && s.startsWith('did:'));
+  if (signerDids.length !== signers.length) {
+    return { ok: false, failure: { status: 400, error: 'All signers must be valid DIDs' } };
+  }
+
+  const [asset] = await db
+    .select()
+    .from(assets)
+    .where(eq(assets.id, documentAssetId))
+    .limit(1);
+
+  if (!asset) {
+    return { ok: false, failure: { status: 404, error: 'Document asset not found' } };
+  }
+  if (asset.ownerDid !== callerDid) {
+    return { ok: false, failure: { status: 403, error: 'You do not own this document' } };
+  }
+  if (asset.hash !== documentHash) {
+    return { ok: false, failure: { status: 400, error: 'Document hash mismatch' } };
+  }
+
+  const [callerIdentity] = await db
+    .select({ publicKey: identities.publicKey, name: identities.name, handle: identities.handle })
+    .from(identities)
+    .where(eq(identities.id, callerDid))
+    .limit(1);
+
+  if (!callerIdentity) {
+    return { ok: false, failure: { status: 400, error: 'Caller identity not found' } };
+  }
+
+  const signatureValid = await verifyDocumentSignatureToken({
+    token: authorJws,
+    signerPublicKeyHex: callerIdentity.publicKey,
+    signerDid: callerDid,
+    documentHash,
+  });
+  if (!signatureValid) {
+    return { ok: false, failure: { status: 400, error: 'Invalid author JWS signature' } };
+  }
+
+  const payload =
+    body.payload && typeof body.payload === 'object' && !Array.isArray(body.payload)
+      ? (body.payload as Record<string, unknown>)
+      : undefined;
+
+  return {
+    ok: true,
+    input: {
+      title,
+      documentAssetId,
+      documentHash,
+      signerDids,
+      payload,
+      authorJws,
+      expiry: typeof body.expiry === 'string' ? body.expiry : undefined,
+      callerIdentity,
+    },
+  };
+}
+
+export function buildDocumentSignatureRows(params: {
+  attestationId: string;
+  creatorDid: string;
+  creatorJws: string;
+  signerDids: string[];
+  genId: (prefix: string) => string;
+}): NewAttestationSignature[] {
+  const { attestationId, creatorDid, creatorJws, signerDids, genId } = params;
+  const now = new Date();
+
+  return [
+    {
+      id: genId('sig'),
+      attestationId,
+      signerDid: creatorDid,
+      jws: creatorJws,
+      signedAt: now,
+      status: 'signed',
+      role: 'creator',
+    },
+    ...signerDids.map((did) => ({
+      id: genId('sig'),
+      attestationId,
+      signerDid: did,
+      jws: null,
+      signedAt: null,
+      status: 'pending',
+      role: 'signer',
+    })),
+  ];
+}
+
+export function getCreatorDisplayName(callerIdentity: CallerIdentity, callerDid: string): string {
+  return callerIdentity.handle ? `@${callerIdentity.handle}` : callerIdentity.name || callerDid;
+}
+
+export function publishDocumentCreatedNotifications(params: {
+  attestationId: string;
+  documentAssetId: string;
+  creatorDid: string;
+  creatorName: string;
+  signerDids: string[];
+  title: string;
+  log: LoggerLike;
+}): void {
+  const { attestationId, documentAssetId, creatorDid, creatorName, signerDids, title, log } = params;
+  const signUrl = `/auth/documents/${attestationId}`;
+
+  for (const signerDid of signerDids) {
+    publish('document.created', {
+      issuer: creatorDid,
+      subject: signerDid,
+      scope: 'auth',
+      payload: {
+        attestationId,
+        documentAssetId,
+        creatorDid,
+        creatorName,
+        signerDids,
+        title: title.trim(),
+        signUrl,
+        context_id: attestationId,
+        context_type: 'document',
+      },
+    }).catch((err) => log.error({ err: String(err), signerDid, attestationId }, 'document.created publish failed'));
+  }
+}

--- a/apps/kernel/src/lib/auth/document-signatures.ts
+++ b/apps/kernel/src/lib/auth/document-signatures.ts
@@ -1,0 +1,53 @@
+import * as jose from 'jose';
+import { crypto as authCrypto } from '@imajin/auth';
+import { buildDocumentSigningPayload } from './document-signing-payload';
+
+function isLikelyCompactJws(token: string): boolean {
+  return token.split('.').length === 3;
+}
+
+function resolveNodePublicKey(): string | null {
+  const privateKey = process.env.AUTH_PRIVATE_KEY;
+  if (!privateKey) return null;
+
+  try {
+    return authCrypto.getPublicKey(privateKey);
+  } catch {
+    return null;
+  }
+}
+
+async function verifyLegacyJws(token: string, signerPublicKeyHex: string): Promise<boolean> {
+  try {
+    const publicKeyBytes = Buffer.from(signerPublicKeyHex, 'hex');
+    const jwk = {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      x: jose.base64url.encode(publicKeyBytes),
+    };
+    const publicKey = await jose.importJWK(jwk, 'EdDSA');
+    await jose.compactVerify(token, publicKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function verifyDocumentSignatureToken(params: {
+  token: string;
+  signerPublicKeyHex: string;
+  signerDid: string;
+  documentHash: string;
+}): Promise<boolean> {
+  const { token, signerPublicKeyHex, signerDid, documentHash } = params;
+
+  if (isLikelyCompactJws(token)) {
+    return verifyLegacyJws(token, signerPublicKeyHex);
+  }
+
+  const nodePublicKey = resolveNodePublicKey();
+  if (!nodePublicKey) return false;
+
+  const payload = buildDocumentSigningPayload(signerDid, documentHash);
+  return authCrypto.verifySync(token, payload, nodePublicKey);
+}

--- a/apps/kernel/src/lib/auth/document-signing-payload.ts
+++ b/apps/kernel/src/lib/auth/document-signing-payload.ts
@@ -1,0 +1,31 @@
+export interface DocumentSigningPayload {
+  did: string;
+  document_hash: string;
+}
+
+export function buildDocumentSigningPayload(did: string, documentHash: string): string {
+  return JSON.stringify({
+    did,
+    document_hash: documentHash,
+  });
+}
+
+export function parseDocumentSigningPayload(payload: string): DocumentSigningPayload | null {
+  try {
+    const parsed = JSON.parse(payload) as Partial<DocumentSigningPayload>;
+    if (
+      typeof parsed.did !== 'string' ||
+      !parsed.did.startsWith('did:') ||
+      typeof parsed.document_hash !== 'string' ||
+      parsed.document_hash.length === 0
+    ) {
+      return null;
+    }
+    return {
+      did: parsed.did,
+      document_hash: parsed.document_hash,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/bus/src/config.ts
+++ b/packages/bus/src/config.ts
@@ -227,6 +227,9 @@ const DEFAULTS: Record<string, ReactorConfig[]> = {
   'asset.fair.upgraded': [
     { type: 'attestation', config: { attestationType: 'asset.fair.upgraded' }, enabled: true },
   ],
+  'document.created': [
+    { type: 'notify', config: { scope: 'auth:document-signature-request' }, enabled: true },
+  ],
   'vault.secret.updated': [
     { type: 'vault-hot-reload', config: {}, enabled: true, await: true },
     { type: 'emit', config: {}, enabled: true },

--- a/packages/bus/src/types.ts
+++ b/packages/bus/src/types.ts
@@ -495,7 +495,10 @@ export interface BusEventMap {
     attestationId: string;
     documentAssetId: string;
     creatorDid: string;
+    creatorName?: string;
     signerDids: string[];
+    title?: string;
+    signUrl?: string;
     context_id: string;
     context_type: string;
   };


### PR DESCRIPTION
## Summary
- replace prompt-based signing with server-mediated identity sign flow and shared signing payload/signature verification helpers
- wire IdentityPicker into document creation and add dedicated documents surfaces (/auth/documents and /auth/documents/[id]) with role-focused listing
- publish signer-targeted document.created events with notify-reactor-ready payload metadata and update bus config/types
- add integration tests for identity sign route, documents create route notifications, and documents list UI behavior

## Validation
- pnpm test -- apps/kernel/src/lib/auth/__tests__/identity-sign-route.test.ts apps/kernel/src/lib/auth/__tests__/documents-create-route.test.ts apps/kernel/src/lib/auth/__tests__/document-list-ui.test.ts
- pnpm --filter kernel exec next lint --file src/lib/auth/__tests__/identity-sign-route.test.ts --file src/lib/auth/__tests__/documents-create-route.test.ts --file src/lib/auth/__tests__/document-list-ui.test.ts

Co-Authored-By: Oz <oz-agent@warp.dev>