### PR TITLE
fix: resolve contact_email from identity for email notifications

### DIFF
--- a/apps/kernel/app/notify/api/send/route.ts
+++ b/apps/kernel/app/notify/api/send/route.ts
@@ -3,7 +3,7 @@ import { corsHeaders, corsOptions } from '@imajin/config';
 import { nanoid } from 'nanoid';
 import { withLogger } from '@imajin/logger';
 import { db } from '@/src/db';
-import { notifications, preferences } from '@/src/db';
+import { notifications, preferences, identities } from '@/src/db';
 import { eq, and } from 'drizzle-orm';
 import { getTemplate } from '@/src/lib/notify/templates';
 import { sendEmail } from '@imajin/email';
@@ -78,9 +78,16 @@ export const POST = withLogger('kernel', async (request, { log }) => {
 
   // Send email if enabled and template has email config
   if (emailEnabled && template?.email) {
-    // We need the recipient's email — for now, use `to` if it looks like an email,
-    // otherwise skip (the profile service would need to resolve this)
-    const recipientEmail = (data as any).email as string | undefined;
+    // Resolve recipient email: payload > identity contact_email
+    let recipientEmail = (data as any).email as string | undefined;
+    if (!recipientEmail && to.startsWith('did:')) {
+      const [identity] = await db
+        .select({ contactEmail: identities.contactEmail })
+        .from(identities)
+        .where(eq(identities.id, to))
+        .limit(1);
+      recipientEmail = identity?.contactEmail ?? undefined;
+    }
     if (recipientEmail) {
       try {
         await sendEmail({

--- a/apps/kernel/app/notify/api/send/route.ts
+++ b/apps/kernel/app/notify/api/send/route.ts
@@ -81,21 +81,21 @@ export const POST = withLogger('kernel', async (request, { log }) => {
     // Resolve recipient email: payload > identity contact_email
     let recipientEmail = (data as any).email as string | undefined;
     if (!recipientEmail && to.startsWith('did:')) {
-      // Check auth.identities first (set from Stripe/ticket purchases)
-      const [identity] = await db
-        .select({ contactEmail: identities.contactEmail })
-        .from(identities)
-        .where(eq(identities.id, to))
+      // Check profile first (set from connection invite / register — primary identity)
+      const [profile] = await db
+        .select({ contactEmail: profiles.contactEmail })
+        .from(profiles)
+        .where(eq(profiles.did, to))
         .limit(1);
-      recipientEmail = identity?.contactEmail || undefined;
-      // Fall back to profile.profiles (set from connection invite / register)
+      recipientEmail = profile?.contactEmail || undefined;
+      // Fall back to auth.identities (set from Stripe/ticket purchases)
       if (!recipientEmail) {
-        const [profile] = await db
-          .select({ contactEmail: profiles.contactEmail })
-          .from(profiles)
-          .where(eq(profiles.did, to))
+        const [identity] = await db
+          .select({ contactEmail: identities.contactEmail })
+          .from(identities)
+          .where(eq(identities.id, to))
           .limit(1);
-        recipientEmail = profile?.contactEmail || undefined;
+        recipientEmail = identity?.contactEmail || undefined;
       }
     }
     if (recipientEmail) {

--- a/apps/kernel/app/notify/api/send/route.ts
+++ b/apps/kernel/app/notify/api/send/route.ts
@@ -3,7 +3,7 @@ import { corsHeaders, corsOptions } from '@imajin/config';
 import { nanoid } from 'nanoid';
 import { withLogger } from '@imajin/logger';
 import { db } from '@/src/db';
-import { notifications, preferences, identities } from '@/src/db';
+import { notifications, preferences, identities, profiles } from '@/src/db';
 import { eq, and } from 'drizzle-orm';
 import { getTemplate } from '@/src/lib/notify/templates';
 import { sendEmail } from '@imajin/email';
@@ -81,12 +81,22 @@ export const POST = withLogger('kernel', async (request, { log }) => {
     // Resolve recipient email: payload > identity contact_email
     let recipientEmail = (data as any).email as string | undefined;
     if (!recipientEmail && to.startsWith('did:')) {
+      // Check auth.identities first (set from Stripe/ticket purchases)
       const [identity] = await db
         .select({ contactEmail: identities.contactEmail })
         .from(identities)
         .where(eq(identities.id, to))
         .limit(1);
-      recipientEmail = identity?.contactEmail ?? undefined;
+      recipientEmail = identity?.contactEmail || undefined;
+      // Fall back to profile.profiles (set from connection invite / register)
+      if (!recipientEmail) {
+        const [profile] = await db
+          .select({ contactEmail: profiles.contactEmail })
+          .from(profiles)
+          .where(eq(profiles.did, to))
+          .limit(1);
+        recipientEmail = profile?.contactEmail || undefined;
+      }
     }
     if (recipientEmail) {
       try {

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -356,8 +356,8 @@ Three places where user email addresses live. The notify service checks them in 
 
 **Notify email resolution** (`apps/kernel/app/notify/api/send/route.ts`):
 1. `data.email` in the event payload (explicit, e.g. from Stripe webhook)
-2. `auth.identities.contact_email` (ticket buyers)
-3. `profile.profiles.contact_email` (connection invite signups)
+2. `profile.profiles.contact_email` (primary — connection invite / register flow)
+3. `auth.identities.contact_email` (fallback — Stripe / ticket purchases)
 
 `www.contacts` is **not** checked by the notify service — it's a separate broadcast/newsletter system.
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -343,3 +343,25 @@ Some services need DATABASE_URL at build time (for drizzle schema imports). Set 
 ```bash
 DATABASE_URL="postgresql://x:x@localhost:5432/x" pnpm --filter @imajin/SERVICE build
 ```
+
+## Email Storage Locations
+
+Three places where user email addresses live. The notify service checks them in priority order.
+
+| Table | Column | Set By | Purpose |
+|-------|--------|--------|---------|
+| `auth.identities` | `contact_email` | Stripe checkout (ticket purchase, onboard with payment) | Billing/notification email from payment flow |
+| `profile.profiles` | `contact_email` | Connection invite register form | Profile-level email from registration |
+| `www.contacts` + `www.subscriptions` | `email` | Register form (`optInUpdates` checked) OR website subscribe form | Mailing list / newsletter sends only |
+
+**Notify email resolution** (`apps/kernel/app/notify/api/send/route.ts`):
+1. `data.email` in the event payload (explicit, e.g. from Stripe webhook)
+2. `auth.identities.contact_email` (ticket buyers)
+3. `profile.profiles.contact_email` (connection invite signups)
+
+`www.contacts` is **not** checked by the notify service — it's a separate broadcast/newsletter system.
+
+**When each gets populated:**
+- **Ticket purchase** → `auth.identities.contact_email` (from Stripe checkout email)
+- **Connection invite register** → `profile.profiles.contact_email` + optionally `www.contacts`
+- **Website subscribe form** → `www.contacts` only (no DID, no identity)


### PR DESCRIPTION
The notify send route relied on `data.email` being present in the bus event payload. Most notification types (like `chat.mention`) don't include the recipient's email address, so emails were silently skipped even when the user had email notifications enabled (or defaulted to enabled).

Now falls back to looking up `contact_email` from `auth.identities` when the payload doesn't include one.

**Root cause:** 5 out of 7 mention test messages created in-app notifications correctly, but 0 sent emails because `recipientEmail` was always undefined.

**What this fixes:** Any notification scope with an email template will now resolve the recipient's email from their identity. This covers chat mentions, document signing requests, and any future notification types.

One-line change in `apps/kernel/app/notify/api/send/route.ts`.