### PR TITLE
feat: deep link to conversation in mention email notifications

### DIFF
--- a/apps/kernel/src/lib/notify/templates.ts
+++ b/apps/kernel/src/lib/notify/templates.ts
@@ -532,10 +532,31 @@ export const templates: NotifyTemplate[] = [
     body: (data) => data.messagePreview || "You were mentioned in a conversation.",
     email: {
       subject: (data) => `${data.senderName || "Someone"} mentioned you — Imajin Chat`,
-      html: (data) => simpleEmailHtml(
-        `${data.senderName || "Someone"} mentioned you`,
-        data.messagePreview || "You were mentioned in a conversation."
-      ),
+      html: (data) => {
+        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXT_PUBLIC_WWW_URL || 'https://jin.imajin.ai';
+        let chatUrl: string | null = null;
+        if (data.conversationId) {
+          // Parse DID: did:imajin:dm:abc123 → /chat/conversations/dm/abc123
+          const prefix = 'did:imajin:';
+          if (data.conversationId.startsWith(prefix)) {
+            const rest = data.conversationId.slice(prefix.length);
+            const colonIdx = rest.indexOf(':');
+            if (colonIdx !== -1) {
+              const type = rest.slice(0, colonIdx);
+              const slug = rest.slice(colonIdx + 1);
+              chatUrl = `${baseUrl}/chat/conversations/${type}/${slug}`;
+            }
+          }
+        }
+        const preview = data.messagePreview || "You were mentioned in a conversation.";
+        const body = chatUrl
+          ? `${preview}<br><br><a href="${chatUrl}" style="color:#f97316;text-decoration:none;font-weight:600;">Open conversation &rarr;</a>`
+          : preview;
+        return simpleEmailHtml(
+          `${data.senderName || "Someone"} mentioned you`,
+          body
+        );
+      },
     },
   },
   {


### PR DESCRIPTION
Cherry-picked from the notify fix branch — this commit was pushed after #1021 was merged so it didn't make it in.

Adds an 'Open conversation →' link to mention notification emails that deep links directly to the conversation (e.g. `/chat/conversations/dm/bf1de15540c3fc3b`). Parses the conversation DID from the event payload to build the URL path.