### PR TITLE
feat: link to notification preferences from profile edit

### DIFF
--- a/apps/kernel/app/api/subscribe/status/route.ts
+++ b/apps/kernel/app/api/subscribe/status/route.ts
@@ -1,0 +1,108 @@
+/**
+ * GET /api/subscribe/status?email=...
+ * Returns the subscription status for an email address.
+ *
+ * PATCH /api/subscribe/status
+ * Toggle subscription on/off. Body: { email, subscribed: boolean }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, contacts, subscriptions, mailingLists } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+
+export async function GET(request: NextRequest) {
+  const email = request.nextUrl.searchParams.get('email');
+  if (!email) {
+    return NextResponse.json({ subscribed: false });
+  }
+
+  const normalized = email.toLowerCase().trim();
+
+  const contact = await db.query.contacts.findFirst({
+    where: eq(contacts.email, normalized),
+  });
+
+  if (!contact) {
+    return NextResponse.json({ subscribed: false });
+  }
+
+  const [sub] = await db
+    .select({ status: subscriptions.status, listName: mailingLists.name })
+    .from(subscriptions)
+    .innerJoin(mailingLists, eq(mailingLists.id, subscriptions.mailingListId))
+    .where(and(
+      eq(subscriptions.contactId, contact.id),
+      eq(mailingLists.slug, 'updates'),
+    ))
+    .limit(1);
+
+  return NextResponse.json({
+    subscribed: sub?.status === 'subscribed',
+  });
+}
+
+export async function PATCH(request: NextRequest) {
+  const body = await request.json();
+  const { email: rawEmail, subscribed } = body;
+
+  if (!rawEmail || typeof rawEmail !== 'string') {
+    return NextResponse.json({ error: 'email required' }, { status: 400 });
+  }
+
+  const email = rawEmail.toLowerCase().trim();
+
+  // Get or create the updates mailing list
+  let list = await db.query.mailingLists.findFirst({
+    where: eq(mailingLists.slug, 'updates'),
+  });
+  if (!list) {
+    const [newList] = await db.insert(mailingLists).values({
+      slug: 'updates',
+      name: 'Imajin Updates',
+      description: 'Progress updates on sovereign infrastructure',
+    }).returning();
+    list = newList;
+  }
+
+  // Get or create contact
+  let contact = await db.query.contacts.findFirst({
+    where: eq(contacts.email, email),
+  });
+  if (!contact) {
+    const [newContact] = await db.insert(contacts).values({
+      email,
+      source: 'profile',
+      isVerified: true, // they're logged in and it's their profile email
+    }).returning();
+    contact = newContact;
+  }
+
+  // Find existing subscription
+  const existingSub = await db.query.subscriptions.findFirst({
+    where: and(
+      eq(subscriptions.contactId, contact.id),
+      eq(subscriptions.mailingListId, list.id),
+    ),
+  });
+
+  if (subscribed) {
+    if (existingSub) {
+      await db.update(subscriptions)
+        .set({ status: 'subscribed', subscribedAt: new Date(), unsubscribedAt: null })
+        .where(eq(subscriptions.id, existingSub.id));
+    } else {
+      await db.insert(subscriptions).values({
+        contactId: contact.id,
+        mailingListId: list.id,
+      });
+    }
+  } else {
+    if (existingSub) {
+      await db.update(subscriptions)
+        .set({ status: 'unsubscribed', unsubscribedAt: new Date() })
+        .where(eq(subscriptions.id, existingSub.id));
+    }
+  }
+
+  return NextResponse.json({ subscribed: !!subscribed });
+}

--- a/apps/kernel/app/profile/edit/page.tsx
+++ b/apps/kernel/app/profile/edit/page.tsx
@@ -314,6 +314,14 @@ function EditProfileContent() {
                 />
               </div>
             </div>
+            <div className="pt-3">
+              <a
+                href="/notify/settings"
+                className="text-sm text-[#F59E0B] hover:text-[#FBBF24] transition-colors"
+              >
+                Notification preferences →
+              </a>
+            </div>
           </div>
 
           {/* Visibility — preliminary+ only */}

--- a/apps/kernel/app/profile/edit/page.tsx
+++ b/apps/kernel/app/profile/edit/page.tsx
@@ -66,6 +66,8 @@ function EditProfileContent() {
   const [showMarketItems, setShowMarketItems] = useState(false);
   const [showEvents, setShowEvents] = useState(false);
   const [tier, setTier] = useState<string>('soft');
+  const [emailUpdates, setEmailUpdates] = useState(false);
+  const [emailUpdatesLoading, setEmailUpdatesLoading] = useState(false);
 
   const isSoftTier = tier === 'soft';
 
@@ -118,6 +120,14 @@ function EditProfileContent() {
       setHandle(profile.handle || '');
       setEmail(profile.contactEmail || '');
       setPhone(profile.phone || '');
+
+      // Load email subscription status
+      if (profile.contactEmail) {
+        fetch(`/api/subscribe/status?email=${encodeURIComponent(profile.contactEmail)}`)
+          .then(r => r.json())
+          .then(d => setEmailUpdates(!!d.subscribed))
+          .catch(() => {});
+      }
       setVisibility((profile.visibility as 'public' | 'incognito') || 'public');
 
       // Set service toggles from feature_toggles
@@ -314,10 +324,46 @@ function EditProfileContent() {
                 />
               </div>
             </div>
-            <div className="pt-3">
+            <div className="pt-4 space-y-3 border-t border-gray-800">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-300">Email Updates</p>
+                  <p className="text-xs text-gray-500">Receive progress updates from Imajin</p>
+                </div>
+                <button
+                  type="button"
+                  disabled={emailUpdatesLoading || !email}
+                  onClick={async () => {
+                    if (!email) return;
+                    setEmailUpdatesLoading(true);
+                    try {
+                      const res = await fetch('/api/subscribe/status', {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ email, subscribed: !emailUpdates }),
+                      });
+                      if (res.ok) {
+                        const data = await res.json();
+                        setEmailUpdates(data.subscribed);
+                      }
+                    } catch { /* non-fatal */ }
+                    setEmailUpdatesLoading(false);
+                  }}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                    emailUpdates ? 'bg-[#F59E0B]' : 'bg-gray-700'
+                  } ${(!email || emailUpdatesLoading) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+                >
+                  <span className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                    emailUpdates ? 'translate-x-6' : 'translate-x-1'
+                  }`} />
+                </button>
+              </div>
+              {!email && (
+                <p className="text-xs text-gray-600">Add an email address above to enable updates</p>
+              )}
               <a
                 href="/notify/settings"
-                className="text-sm text-[#F59E0B] hover:text-[#FBBF24] transition-colors"
+                className="block text-sm text-[#F59E0B] hover:text-[#FBBF24] transition-colors"
               >
                 Notification preferences →
               </a>


### PR DESCRIPTION
Adds a 'Notification preferences →' link in the contact info section of profile/edit, pointing to /notify/settings.