### PR TITLE
feat(chat): typeahead @mention picker with conversation context

### DIFF
--- a/apps/kernel/app/chat/api/conversations/[id]/messages/route.ts
+++ b/apps/kernel/app/chat/api/conversations/[id]/messages/route.ts
@@ -4,7 +4,7 @@ import { publish } from '@imajin/bus';
 import { eq, and, desc, lt, isNull, inArray, ilike } from 'drizzle-orm';
 
 const log = createLogger('kernel');
-import { db, conversationsV2, messagesV2, messageReactionsV2, profiles } from '@/src/db';
+import { db, conversationsV2, conversationMembers, messagesV2, messageReactionsV2, profiles } from '@/src/db';
 import { requireAuth, isVerifiedTier } from '@imajin/auth';
 import { jsonResponse, errorResponse, generateId } from '@/src/lib/kernel/utils';
 import { parseConversationDid } from '@/src/lib/chat/conversation-did';
@@ -235,31 +235,93 @@ export async function POST(
 
     // Detect and notify @mentions — fire and forget
     const messageText = typeof content === 'object' && (content as any).text ? (content as any).text : typeof content === 'string' ? content : '';
-    const mentionMatches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m: RegExpMatchArray) => m[1]);
-    if (mentionMatches.length > 0) {
-      const uniqueHandles = [...new Set<string>(mentionMatches)];
+    const structuredMentions = Array.isArray((content as any).mentions) ? (content as any).mentions as Array<{ did: string; handle: string; index: number; length: number }> : [];
+
+    if (structuredMentions.length > 0) {
       (async () => {
-        for (const handle of uniqueHandles) {
+        for (const mention of structuredMentions) {
           try {
-            const mentionedDid = await resolveHandleToDid(handle);
-            if (!mentionedDid || mentionedDid === effectiveDid) continue;
-            publish('chat.mention', {
-              issuer: effectiveDid,
-              subject: mentionedDid,
-              scope: 'chat',
-              payload: {
-                conversationId: conversationDid,
-                messageId,
-                senderName: identity.handle || identity.id.slice(0, 16),
-                messagePreview: messageText.slice(0, 100),
-                interestDids: [mentionedDid],
-              },
-            }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
+            if (mention.did === '__everyone__') {
+              // Check sender has owner or admin role
+              const [callerMembership] = await db
+                .select({ role: conversationMembers.role })
+                .from(conversationMembers)
+                .where(and(
+                  eq(conversationMembers.conversationDid, conversationDid),
+                  eq(conversationMembers.memberDid, effectiveDid),
+                  isNull(conversationMembers.leftAt)
+                ));
+              if (!callerMembership || (callerMembership.role !== 'owner' && callerMembership.role !== 'admin')) {
+                continue;
+              }
+              const allMembers = await db
+                .select({ memberDid: conversationMembers.memberDid })
+                .from(conversationMembers)
+                .where(and(
+                  eq(conversationMembers.conversationDid, conversationDid),
+                  isNull(conversationMembers.leftAt)
+                ));
+              for (const member of allMembers) {
+                if (member.memberDid === effectiveDid) continue;
+                publish('chat.mention', {
+                  issuer: effectiveDid,
+                  subject: member.memberDid,
+                  scope: 'chat',
+                  payload: {
+                    conversationId: conversationDid,
+                    messageId,
+                    senderName: identity.handle || identity.id.slice(0, 16),
+                    messagePreview: messageText.slice(0, 100),
+                    interestDids: [member.memberDid],
+                  },
+                }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
+              }
+            } else if (mention.did && mention.did !== effectiveDid) {
+              publish('chat.mention', {
+                issuer: effectiveDid,
+                subject: mention.did,
+                scope: 'chat',
+                payload: {
+                  conversationId: conversationDid,
+                  messageId,
+                  senderName: identity.handle || identity.id.slice(0, 16),
+                  messagePreview: messageText.slice(0, 100),
+                  interestDids: [mention.did],
+                },
+              }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
+            }
           } catch (err) {
-            log.error({ err: String(err) }, 'Handle resolution error');
+            log.error({ err: String(err) }, 'Mention processing error');
           }
         }
       })().catch(() => {});
+    } else {
+      const mentionMatches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m: RegExpMatchArray) => m[1]);
+      if (mentionMatches.length > 0) {
+        const uniqueHandles = [...new Set<string>(mentionMatches)];
+        (async () => {
+          for (const handle of uniqueHandles) {
+            try {
+              const mentionedDid = await resolveHandleToDid(handle);
+              if (!mentionedDid || mentionedDid === effectiveDid) continue;
+              publish('chat.mention', {
+                issuer: effectiveDid,
+                subject: mentionedDid,
+                scope: 'chat',
+                payload: {
+                  conversationId: conversationDid,
+                  messageId,
+                  senderName: identity.handle || identity.id.slice(0, 16),
+                  messagePreview: messageText.slice(0, 100),
+                  interestDids: [mentionedDid],
+                },
+              }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
+            } catch (err) {
+              log.error({ err: String(err) }, 'Handle resolution error');
+            }
+          }
+        })().catch(() => {});
+      }
     }
 
     return jsonResponse({ message }, 201);

--- a/apps/kernel/app/chat/api/conversations/[id]/messages/route.ts
+++ b/apps/kernel/app/chat/api/conversations/[id]/messages/route.ts
@@ -1,31 +1,16 @@
 import { NextRequest } from 'next/server';
 import { createLogger } from '@imajin/logger';
 import { publish } from '@imajin/bus';
-import { eq, and, desc, lt, isNull, inArray, ilike } from 'drizzle-orm';
+import { eq, and, desc, lt, isNull, inArray } from 'drizzle-orm';
 
 const log = createLogger('kernel');
-import { db, conversationsV2, conversationMembers, messagesV2, messageReactionsV2, profiles } from '@/src/db';
+import { db, conversationsV2, messagesV2, messageReactionsV2, profiles } from '@/src/db';
 import { requireAuth, isVerifiedTier } from '@imajin/auth';
 import { jsonResponse, errorResponse, generateId } from '@/src/lib/kernel/utils';
 import { parseConversationDid } from '@/src/lib/chat/conversation-did';
 import { hasCapability, requiredCapability, CAPABILITY_MESSAGES } from '@/src/lib/chat/capabilities';
 import { checkAccess } from '@/src/lib/kernel/access';
-
-const MENTION_REGEX = /@([a-zA-Z0-9_-]+)/g;
-
-async function resolveHandleToDid(handle: string): Promise<string | null> {
-  try {
-    const result = await db
-      .select({ did: profiles.did, handle: profiles.handle })
-      .from(profiles)
-      .where(ilike(profiles.handle, handle))
-      .limit(5);
-    const profile = result.find((p) => p.handle?.toLowerCase() === handle.toLowerCase());
-    return profile?.did ?? null;
-  } catch {
-    return null;
-  }
-}
+import { processMentions } from '@/src/lib/chat/mentions';
 
 /**
  * GET /api/conversations/:id/messages
@@ -234,95 +219,13 @@ export async function POST(
     }
 
     // Detect and notify @mentions — fire and forget
-    const messageText = typeof content === 'object' && (content as any).text ? (content as any).text : typeof content === 'string' ? content : '';
-    const structuredMentions = Array.isArray((content as any).mentions) ? (content as any).mentions as Array<{ did: string; handle: string; index: number; length: number }> : [];
-
-    if (structuredMentions.length > 0) {
-      (async () => {
-        for (const mention of structuredMentions) {
-          try {
-            if (mention.did === '__everyone__') {
-              // Check sender has owner or admin role
-              const [callerMembership] = await db
-                .select({ role: conversationMembers.role })
-                .from(conversationMembers)
-                .where(and(
-                  eq(conversationMembers.conversationDid, conversationDid),
-                  eq(conversationMembers.memberDid, effectiveDid),
-                  isNull(conversationMembers.leftAt)
-                ));
-              if (!callerMembership || (callerMembership.role !== 'owner' && callerMembership.role !== 'admin')) {
-                continue;
-              }
-              const allMembers = await db
-                .select({ memberDid: conversationMembers.memberDid })
-                .from(conversationMembers)
-                .where(and(
-                  eq(conversationMembers.conversationDid, conversationDid),
-                  isNull(conversationMembers.leftAt)
-                ));
-              for (const member of allMembers) {
-                if (member.memberDid === effectiveDid) continue;
-                publish('chat.mention', {
-                  issuer: effectiveDid,
-                  subject: member.memberDid,
-                  scope: 'chat',
-                  payload: {
-                    conversationId: conversationDid,
-                    messageId,
-                    senderName: identity.handle || identity.id.slice(0, 16),
-                    messagePreview: messageText.slice(0, 100),
-                    interestDids: [member.memberDid],
-                  },
-                }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
-              }
-            } else if (mention.did && mention.did !== effectiveDid) {
-              publish('chat.mention', {
-                issuer: effectiveDid,
-                subject: mention.did,
-                scope: 'chat',
-                payload: {
-                  conversationId: conversationDid,
-                  messageId,
-                  senderName: identity.handle || identity.id.slice(0, 16),
-                  messagePreview: messageText.slice(0, 100),
-                  interestDids: [mention.did],
-                },
-              }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
-            }
-          } catch (err) {
-            log.error({ err: String(err) }, 'Mention processing error');
-          }
-        }
-      })().catch(() => {});
-    } else {
-      const mentionMatches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m: RegExpMatchArray) => m[1]);
-      if (mentionMatches.length > 0) {
-        const uniqueHandles = [...new Set<string>(mentionMatches)];
-        (async () => {
-          for (const handle of uniqueHandles) {
-            try {
-              const mentionedDid = await resolveHandleToDid(handle);
-              if (!mentionedDid || mentionedDid === effectiveDid) continue;
-              publish('chat.mention', {
-                issuer: effectiveDid,
-                subject: mentionedDid,
-                scope: 'chat',
-                payload: {
-                  conversationId: conversationDid,
-                  messageId,
-                  senderName: identity.handle || identity.id.slice(0, 16),
-                  messagePreview: messageText.slice(0, 100),
-                  interestDids: [mentionedDid],
-                },
-              }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
-            } catch (err) {
-              log.error({ err: String(err) }, 'Handle resolution error');
-            }
-          }
-        })().catch(() => {});
-      }
-    }
+    processMentions({
+      conversationDid,
+      messageId,
+      senderDid: effectiveDid,
+      senderName: identity.handle || identity.id.slice(0, 16),
+      content,
+    });
 
     return jsonResponse({ message }, 201);
   } catch (error) {

--- a/apps/kernel/app/chat/api/d/[did]/messages/route.ts
+++ b/apps/kernel/app/chat/api/d/[did]/messages/route.ts
@@ -365,31 +365,93 @@ export async function POST(
 
     // Detect and notify @mentions — fire and forget
     const messageText = typeof content === 'object' && (content as any).text ? (content as any).text : typeof content === 'string' ? content : '';
-    const mentionMatches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m: RegExpMatchArray) => m[1]);
-    if (mentionMatches.length > 0) {
-      const uniqueHandles = [...new Set<string>(mentionMatches)];
+    const structuredMentions = Array.isArray((content as any).mentions) ? (content as any).mentions as Array<{ did: string; handle: string; index: number; length: number }> : [];
+
+    if (structuredMentions.length > 0) {
       (async () => {
-        for (const handle of uniqueHandles) {
+        for (const mention of structuredMentions) {
           try {
-            const mentionedDid = await resolveHandleToDid(handle);
-            if (!mentionedDid || mentionedDid === effectiveDid) continue;
-            publish('chat.mention', {
-              issuer: effectiveDid,
-              subject: mentionedDid,
-              scope: 'chat',
-              payload: {
-                conversationId: did,
-                messageId,
-                senderName: identity.handle || identity.id.slice(0, 16),
-                messagePreview: messageText.slice(0, 100),
-                interestDids: [mentionedDid],
-              },
-            }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
+            if (mention.did === '__everyone__') {
+              // Check sender has owner or admin role
+              const [callerMembership] = await db
+                .select({ role: conversationMembers.role })
+                .from(conversationMembers)
+                .where(and(
+                  eq(conversationMembers.conversationDid, did),
+                  eq(conversationMembers.memberDid, effectiveDid),
+                  isNull(conversationMembers.leftAt)
+                ));
+              if (!callerMembership || (callerMembership.role !== 'owner' && callerMembership.role !== 'admin')) {
+                continue;
+              }
+              const allMembers = await db
+                .select({ memberDid: conversationMembers.memberDid })
+                .from(conversationMembers)
+                .where(and(
+                  eq(conversationMembers.conversationDid, did),
+                  isNull(conversationMembers.leftAt)
+                ));
+              for (const member of allMembers) {
+                if (member.memberDid === effectiveDid) continue;
+                publish('chat.mention', {
+                  issuer: effectiveDid,
+                  subject: member.memberDid,
+                  scope: 'chat',
+                  payload: {
+                    conversationId: did,
+                    messageId,
+                    senderName: identity.handle || identity.id.slice(0, 16),
+                    messagePreview: messageText.slice(0, 100),
+                    interestDids: [member.memberDid],
+                  },
+                }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
+              }
+            } else if (mention.did && mention.did !== effectiveDid) {
+              publish('chat.mention', {
+                issuer: effectiveDid,
+                subject: mention.did,
+                scope: 'chat',
+                payload: {
+                  conversationId: did,
+                  messageId,
+                  senderName: identity.handle || identity.id.slice(0, 16),
+                  messagePreview: messageText.slice(0, 100),
+                  interestDids: [mention.did],
+                },
+              }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
+            }
           } catch (err) {
-            log.error({ err: String(err) }, 'Handle resolution error');
+            log.error({ err: String(err) }, 'Mention processing error');
           }
         }
       })().catch(() => {});
+    } else {
+      const mentionMatches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m: RegExpMatchArray) => m[1]);
+      if (mentionMatches.length > 0) {
+        const uniqueHandles = [...new Set<string>(mentionMatches)];
+        (async () => {
+          for (const handle of uniqueHandles) {
+            try {
+              const mentionedDid = await resolveHandleToDid(handle);
+              if (!mentionedDid || mentionedDid === effectiveDid) continue;
+              publish('chat.mention', {
+                issuer: effectiveDid,
+                subject: mentionedDid,
+                scope: 'chat',
+                payload: {
+                  conversationId: did,
+                  messageId,
+                  senderName: identity.handle || identity.id.slice(0, 16),
+                  messagePreview: messageText.slice(0, 100),
+                  interestDids: [mentionedDid],
+                },
+              }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
+            } catch (err) {
+              log.error({ err: String(err) }, 'Handle resolution error');
+            }
+          }
+        })().catch(() => {});
+      }
     }
 
     // Unfurl link previews async — don't block the response

--- a/apps/kernel/app/chat/api/d/[did]/messages/route.ts
+++ b/apps/kernel/app/chat/api/d/[did]/messages/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { createLogger } from '@imajin/logger';
 import { publish } from '@imajin/bus';
-import { eq, and, desc, lt, ne, isNull, inArray, ilike, or } from 'drizzle-orm';
+import { eq, and, desc, lt, ne, isNull, inArray, or } from 'drizzle-orm';
 
 const log = createLogger('kernel');
 import { db, conversationsV2, conversationMembers, messagesV2, messageReactionsV2, profiles, identities } from '@/src/db';
@@ -16,22 +16,7 @@ import { checkAccess } from '@/src/lib/kernel/access';
 import { crypto as authCrypto } from '@imajin/auth';
 import { getChainByImajinDid } from '@/src/lib/auth/dfos';
 import { verifyChain } from '@imajin/dfos';
-
-const MENTION_REGEX = /@([a-zA-Z0-9_-]+)/g;
-
-async function resolveHandleToDid(handle: string): Promise<string | null> {
-  try {
-    const result = await db
-      .select({ did: profiles.did, handle: profiles.handle })
-      .from(profiles)
-      .where(ilike(profiles.handle, handle))
-      .limit(1);
-    const profile = result.find((p) => p.handle?.toLowerCase() === handle.toLowerCase());
-    return profile?.did ?? null;
-  } catch {
-    return null;
-  }
-}
+import { processMentions } from '@/src/lib/chat/mentions';
 
 /**
  * Sign a message payload with the node's platform key.
@@ -364,95 +349,13 @@ export async function POST(
     }
 
     // Detect and notify @mentions — fire and forget
-    const messageText = typeof content === 'object' && (content as any).text ? (content as any).text : typeof content === 'string' ? content : '';
-    const structuredMentions = Array.isArray((content as any).mentions) ? (content as any).mentions as Array<{ did: string; handle: string; index: number; length: number }> : [];
-
-    if (structuredMentions.length > 0) {
-      (async () => {
-        for (const mention of structuredMentions) {
-          try {
-            if (mention.did === '__everyone__') {
-              // Check sender has owner or admin role
-              const [callerMembership] = await db
-                .select({ role: conversationMembers.role })
-                .from(conversationMembers)
-                .where(and(
-                  eq(conversationMembers.conversationDid, did),
-                  eq(conversationMembers.memberDid, effectiveDid),
-                  isNull(conversationMembers.leftAt)
-                ));
-              if (!callerMembership || (callerMembership.role !== 'owner' && callerMembership.role !== 'admin')) {
-                continue;
-              }
-              const allMembers = await db
-                .select({ memberDid: conversationMembers.memberDid })
-                .from(conversationMembers)
-                .where(and(
-                  eq(conversationMembers.conversationDid, did),
-                  isNull(conversationMembers.leftAt)
-                ));
-              for (const member of allMembers) {
-                if (member.memberDid === effectiveDid) continue;
-                publish('chat.mention', {
-                  issuer: effectiveDid,
-                  subject: member.memberDid,
-                  scope: 'chat',
-                  payload: {
-                    conversationId: did,
-                    messageId,
-                    senderName: identity.handle || identity.id.slice(0, 16),
-                    messagePreview: messageText.slice(0, 100),
-                    interestDids: [member.memberDid],
-                  },
-                }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
-              }
-            } else if (mention.did && mention.did !== effectiveDid) {
-              publish('chat.mention', {
-                issuer: effectiveDid,
-                subject: mention.did,
-                scope: 'chat',
-                payload: {
-                  conversationId: did,
-                  messageId,
-                  senderName: identity.handle || identity.id.slice(0, 16),
-                  messagePreview: messageText.slice(0, 100),
-                  interestDids: [mention.did],
-                },
-              }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
-            }
-          } catch (err) {
-            log.error({ err: String(err) }, 'Mention processing error');
-          }
-        }
-      })().catch(() => {});
-    } else {
-      const mentionMatches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m: RegExpMatchArray) => m[1]);
-      if (mentionMatches.length > 0) {
-        const uniqueHandles = [...new Set<string>(mentionMatches)];
-        (async () => {
-          for (const handle of uniqueHandles) {
-            try {
-              const mentionedDid = await resolveHandleToDid(handle);
-              if (!mentionedDid || mentionedDid === effectiveDid) continue;
-              publish('chat.mention', {
-                issuer: effectiveDid,
-                subject: mentionedDid,
-                scope: 'chat',
-                payload: {
-                  conversationId: did,
-                  messageId,
-                  senderName: identity.handle || identity.id.slice(0, 16),
-                  messagePreview: messageText.slice(0, 100),
-                  interestDids: [mentionedDid],
-                },
-              }).catch((err: unknown) => log.error({ err: String(err) }, 'Mention publish error'));
-            } catch (err) {
-              log.error({ err: String(err) }, 'Handle resolution error');
-            }
-          }
-        })().catch(() => {});
-      }
-    }
+    processMentions({
+      conversationDid: did,
+      messageId,
+      senderDid: effectiveDid,
+      senderName: identity.handle || identity.id.slice(0, 16),
+      content,
+    });
 
     // Unfurl link previews async — don't block the response
     if (message && contentType === 'text' && typeof content === 'string') {

--- a/apps/kernel/src/lib/chat/mentions.ts
+++ b/apps/kernel/src/lib/chat/mentions.ts
@@ -1,0 +1,189 @@
+import { createLogger } from '@imajin/logger';
+import { publish } from '@imajin/bus';
+import { eq, and, isNull, ilike } from 'drizzle-orm';
+import { db, conversationMembers, profiles } from '@/src/db';
+
+const log = createLogger('kernel');
+
+/**
+ * Matches @handle in message text.
+ * Must stay in sync with the frontend regex in packages/chat useMentions.
+ */
+export const MENTION_REGEX = /@([a-zA-Z0-9_-]+)/g;
+
+/** Sentinel DID used by the frontend to represent @everyone. */
+export const EVERYONE_DID = '__everyone__';
+
+export interface StructuredMention {
+  did: string;
+  handle: string;
+  index: number;
+  length: number;
+}
+
+export interface MentionContext {
+  conversationDid: string;
+  messageId: string;
+  senderDid: string;
+  senderName: string;
+  content: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export async function resolveHandleToDid(handle: string): Promise<string | null> {
+  try {
+    const result = await db
+      .select({ did: profiles.did, handle: profiles.handle })
+      .from(profiles)
+      .where(ilike(profiles.handle, handle))
+      .limit(5);
+    const profile = result.find((p) => p.handle?.toLowerCase() === handle.toLowerCase());
+    return profile?.did ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function extractMessageText(content: unknown): string {
+  if (typeof content === 'object' && content !== null && 'text' in content) {
+    return String((content as { text: unknown }).text ?? '');
+  }
+  if (typeof content === 'string') return content;
+  return '';
+}
+
+function parseStructuredMentions(content: unknown): StructuredMention[] {
+  if (typeof content !== 'object' || content === null) return [];
+  const mentions = (content as Record<string, unknown>).mentions;
+  if (!Array.isArray(mentions)) return [];
+  return mentions.filter(
+    (m): m is StructuredMention =>
+      typeof m === 'object' &&
+      m !== null &&
+      typeof (m as Record<string, unknown>).did === 'string' &&
+      typeof (m as Record<string, unknown>).handle === 'string',
+  );
+}
+
+/**
+ * Validate that a structured mention actually appears in the message text.
+ * Prevents clients from sending notifications to arbitrary DIDs.
+ */
+function validateMention(mention: StructuredMention, text: string): boolean {
+  if (mention.did === EVERYONE_DID) {
+    return text.includes('@everyone');
+  }
+  const expected = `@${mention.handle}`;
+  // Prefer positional check when the client provides a valid index
+  if (typeof mention.index === 'number' && mention.index >= 0) {
+    return text.slice(mention.index, mention.index + expected.length) === expected;
+  }
+  return text.includes(expected);
+}
+
+function publishMention(ctx: MentionContext, messageText: string, targetDid: string): Promise<void> {
+  return publish('chat.mention', {
+    issuer: ctx.senderDid,
+    subject: targetDid,
+    scope: 'chat',
+    payload: {
+      conversationId: ctx.conversationDid,
+      messageId: ctx.messageId,
+      senderName: ctx.senderName,
+      messagePreview: messageText.slice(0, 100),
+      interestDids: [targetDid],
+    },
+  }).catch((err: unknown) => {
+    log.error({ err: String(err) }, 'Mention publish error');
+  });
+}
+
+async function processEveryoneMention(ctx: MentionContext, messageText: string): Promise<void> {
+  const [callerMembership] = await db
+    .select({ role: conversationMembers.role })
+    .from(conversationMembers)
+    .where(
+      and(
+        eq(conversationMembers.conversationDid, ctx.conversationDid),
+        eq(conversationMembers.memberDid, ctx.senderDid),
+        isNull(conversationMembers.leftAt),
+      ),
+    );
+
+  if (!callerMembership || (callerMembership.role !== 'owner' && callerMembership.role !== 'admin')) {
+    return;
+  }
+
+  const allMembers = await db
+    .select({ memberDid: conversationMembers.memberDid })
+    .from(conversationMembers)
+    .where(
+      and(
+        eq(conversationMembers.conversationDid, ctx.conversationDid),
+        isNull(conversationMembers.leftAt),
+      ),
+    );
+
+  await Promise.allSettled(
+    allMembers
+      .filter((m) => m.memberDid !== ctx.senderDid)
+      .map((m) => publishMention(ctx, messageText, m.memberDid)),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Process @mentions for a message — fire and forget.
+ *
+ * Handles structured mentions from the typeahead picker (with server-side
+ * validation and deduplication) and falls back to regex parsing for
+ * plain-text clients that don't send a mentions array.
+ */
+export function processMentions(ctx: MentionContext): void {
+  const messageText = extractMessageText(ctx.content);
+  const structuredMentions = parseStructuredMentions(ctx.content);
+
+  if (structuredMentions.length > 0) {
+    (async () => {
+      const seen = new Set<string>();
+      for (const mention of structuredMentions) {
+        if (!validateMention(mention, messageText)) continue;
+        if (seen.has(mention.did)) continue;
+        seen.add(mention.did);
+
+        try {
+          if (mention.did === EVERYONE_DID) {
+            await processEveryoneMention(ctx, messageText);
+          } else if (mention.did !== ctx.senderDid) {
+            publishMention(ctx, messageText, mention.did);
+          }
+        } catch (err) {
+          log.error({ err: String(err) }, 'Mention processing error');
+        }
+      }
+    })().catch(() => {});
+  } else {
+    // Regex fallback for clients that don't send structured mentions
+    const matches = [...messageText.matchAll(new RegExp(MENTION_REGEX))].map((m) => m[1]);
+    if (matches.length === 0) return;
+
+    const uniqueHandles = [...new Set<string>(matches)];
+    (async () => {
+      for (const handle of uniqueHandles) {
+        try {
+          const mentionedDid = await resolveHandleToDid(handle);
+          if (!mentionedDid || mentionedDid === ctx.senderDid) continue;
+          publishMention(ctx, messageText, mentionedDid);
+        } catch (err) {
+          log.error({ err: String(err) }, 'Handle resolution error');
+        }
+      }
+    })().catch(() => {});
+  }
+}

--- a/packages/chat/src/Chat.tsx
+++ b/packages/chat/src/Chat.tsx
@@ -537,7 +537,6 @@ export function Chat({
                 highlightedIndex={mentions.highlightedIndex}
                 onSelect={mentions.selectMention}
                 onClose={mentions.closePicker}
-                isEveryone={isGroup}
                 mediaUrl={mediaUrl}
               />
             )}

--- a/packages/chat/src/Chat.tsx
+++ b/packages/chat/src/Chat.tsx
@@ -10,9 +10,12 @@ import { useChatWebSocket } from './hooks/useChatWebSocket';
 import { useFileUpload } from './hooks/useFileUpload';
 import { useVoiceRecording } from './hooks/useVoiceRecording';
 import { useLocationShare } from './hooks/useLocationShare';
+import { useMentions } from './hooks/useMentions';
 import { MessageBubble } from './MessageBubble';
+import { MentionPicker } from './MentionPicker';
 import { VoiceRecorder } from '@imajin/input';
 import { NameDisplaySelector, type NameDisplayPolicy } from './NameDisplaySelector';
+import { useChatConfig } from './ChatProvider';
 
 interface ChatProps {
   did: string;
@@ -88,6 +91,7 @@ export function Chat({
   const { sendMessage, addReaction, removeReaction, editMessage, deleteMessage, markRead, isSending } =
     useChatActions(did);
   const { typingUsers, sendTyping, stopTyping, lastMessage } = useChatWebSocket(did);
+  const { chatUrl, authUrl } = useChatConfig();
   const { uploadFile } = useFileUpload();
   const { sendVoice } = useVoiceRecording();
   const { shareLocation } = useLocationShare();
@@ -101,6 +105,26 @@ export function Chat({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Fetch conversation members for @mentions
+  const [members, setMembers] = useState<{ did: string; role: string; name: string; handle: string }[]>([]);
+  useEffect(() => {
+    fetch(`${chatUrl}/api/d/${did}/members`, { credentials: 'include' })
+      .then((r) => r.json())
+      .then((data) => setMembers(data.members ?? []))
+      .catch(() => setMembers([]));
+  }, [chatUrl, did]);
+
+  const isGroup = !did.includes(':dm:');
+
+  const mentions = useMentions({
+    text: composerText,
+    setText: setComposerText,
+    textareaRef,
+    members,
+    isGroup,
+    authUrl: authUrl ?? '',
+  });
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevCountRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -210,15 +234,19 @@ export function Chat({
       updateMessage(editingMsg.id, { content: { type: 'text', text }, editedAt: new Date().toISOString() });
       setEditingMsg(null);
     } else {
-      await sendMessage({ type: 'text', text }, replyTo ? { replyTo: replyTo.id } : undefined);
+      await sendMessage(
+        { type: 'text', text, mentions: mentions.mentions },
+        replyTo ? { replyTo: replyTo.id } : undefined
+      );
       setReplyTo(null);
     }
     setComposerText('');
     if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
     stopTyping();
-  }, [composerText, isSending, editingMsg, replyTo, editMessage, sendMessage, stopTyping]);
+  }, [composerText, isSending, editingMsg, replyTo, editMessage, sendMessage, stopTyping, mentions.mentions]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (mentions.handleKeyDown(e)) return;
     if (enterToSend && e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -227,6 +255,7 @@ export function Chat({
 
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setComposerText(e.target.value);
+    mentions.handleChange(e);
     sendTyping();
     if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
     typingTimerRef.current = setTimeout(stopTyping, 3000);
@@ -492,15 +521,27 @@ export function Chat({
           </div>
         )}
         {!voiceActive && (
-          <textarea
-            ref={textareaRef}
-            value={composerText}
-            onChange={handleTextChange}
-            onKeyDown={handleKeyDown}
-            placeholder="Message…"
-            rows={1}
-            className={`flex-1 min-w-0 resize-none overflow-hidden bg-slate-100 dark:bg-zinc-800 rounded-2xl text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 outline-none ${compact ? 'px-2 py-1 min-h-8' : 'px-4 py-2 min-h-9'}`}
-          />
+          <div className="relative flex-1 min-w-0">
+            <textarea
+              ref={textareaRef}
+              value={composerText}
+              onChange={handleTextChange}
+              onKeyDown={handleKeyDown}
+              placeholder="Message…"
+              rows={1}
+              className={`w-full resize-none overflow-hidden bg-slate-100 dark:bg-zinc-800 rounded-2xl text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 outline-none ${compact ? 'px-2 py-1 min-h-8' : 'px-4 py-2 min-h-9'}`}
+            />
+            {mentions.isOpen && (
+              <MentionPicker
+                results={mentions.results}
+                highlightedIndex={mentions.highlightedIndex}
+                onSelect={mentions.selectMention}
+                onClose={mentions.closePicker}
+                isEveryone={isGroup}
+                mediaUrl={mediaUrl}
+              />
+            )}
+          </div>
         )}
         {!voiceActive && enableLocation && (
           <button

--- a/packages/chat/src/MentionPicker.tsx
+++ b/packages/chat/src/MentionPicker.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { MentionResult } from './hooks/useMentions';
+
+interface MentionPickerProps {
+  results: MentionResult[];
+  highlightedIndex: number;
+  onSelect: (result: MentionResult) => void;
+  onClose: () => void;
+  isEveryone: boolean;
+  mediaUrl?: string;
+}
+
+function resolveAvatarSrc(result: MentionResult, mediaUrl?: string): string | null {
+  if (result.avatarAssetId && mediaUrl) {
+    return `${mediaUrl}/api/media/${result.avatarAssetId}`;
+  }
+  if (result.avatarUrl) return result.avatarUrl;
+  return null;
+}
+
+function roleBadgeClass(role?: string): string {
+  switch (role?.toLowerCase()) {
+    case 'owner':
+      return 'bg-amber-900/50 text-amber-400 border-amber-800';
+    case 'admin':
+      return 'bg-red-900/50 text-red-400 border-red-800';
+    case 'moderator':
+      return 'bg-purple-900/50 text-purple-400 border-purple-800';
+    case 'broadcast':
+      return 'bg-red-900/50 text-red-400 border-red-800';
+    default:
+      return 'bg-gray-800 text-gray-400 border-gray-700';
+  }
+}
+
+export function MentionPicker({
+  results,
+  highlightedIndex,
+  onSelect,
+  onClose,
+  isEveryone: _isEveryone,
+  mediaUrl,
+}: MentionPickerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [onClose]);
+
+  if (results.length === 0) {
+    return (
+      <div
+        ref={containerRef}
+        className="absolute bottom-full left-0 mb-1 z-50 w-full bg-[#0a0a0a] border border-gray-800 rounded-lg shadow-xl overflow-hidden"
+      >
+        <div className="px-3 py-2.5 text-sm text-gray-500">No matches</div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute bottom-full left-0 mb-1 z-50 w-full bg-[#0a0a0a] border border-gray-800 rounded-lg shadow-xl overflow-hidden"
+    >
+      <ul className="max-h-60 overflow-y-auto">
+        {results.map((result, index) => {
+          const isHighlighted = index === highlightedIndex;
+          const isEveryoneRow = result.did === '__everyone__';
+          const avatarSrc = resolveAvatarSrc(result, mediaUrl);
+
+          return (
+            <li key={result.did}>
+              <button
+                type="button"
+                onClick={() => onSelect(result)}
+                className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+                  isHighlighted ? 'bg-gray-800/80' : 'hover:bg-gray-800/50'
+                }`}
+              >
+                {isEveryoneRow ? (
+                  <div className="w-8 h-8 rounded-full bg-red-900/30 flex items-center justify-center text-sm shrink-0 border border-red-900/50">
+                    🔔
+                  </div>
+                ) : avatarSrc ? (
+                  <img
+                    src={avatarSrc}
+                    alt=""
+                    className="w-8 h-8 rounded-full object-cover border border-gray-800 shrink-0"
+                  />
+                ) : (
+                  <div className="w-8 h-8 rounded-full bg-gray-800 flex items-center justify-center text-xs text-gray-500 shrink-0">
+                    {result.name?.[0]?.toUpperCase() ?? '?'}
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium truncate">
+                      {isEveryoneRow ? (
+                        <span className="text-white">Everyone</span>
+                      ) : (
+                        <span className="text-white">{result.name || result.handle}</span>
+                      )}
+                    </p>
+                    {result.role && (
+                      <span
+                        className={`text-[10px] px-1.5 py-0.5 rounded border uppercase tracking-wide ${roleBadgeClass(result.role)}`}
+                      >
+                        {result.role}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs truncate">
+                    {isEveryoneRow ? (
+                      <span className="text-red-400">@everyone</span>
+                    ) : (
+                      <span className="text-amber-400">@{result.handle}</span>
+                    )}
+                  </p>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/packages/chat/src/MentionPicker.tsx
+++ b/packages/chat/src/MentionPicker.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import type { MentionResult } from './hooks/useMentions';
+import { EVERYONE_DID, type MentionResult } from './hooks/useMentions';
 
 interface MentionPickerProps {
   results: MentionResult[];
   highlightedIndex: number;
   onSelect: (result: MentionResult) => void;
   onClose: () => void;
-  isEveryone: boolean;
   mediaUrl?: string;
 }
 
@@ -40,10 +39,10 @@ export function MentionPicker({
   highlightedIndex,
   onSelect,
   onClose,
-  isEveryone: _isEveryone,
   mediaUrl,
 }: MentionPickerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const highlightedRef = useRef<HTMLLIElement>(null);
 
   // Close on outside click
   useEffect(() => {
@@ -55,6 +54,11 @@ export function MentionPicker({
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, [onClose]);
+
+  // Scroll highlighted item into view when navigating with keyboard
+  useEffect(() => {
+    highlightedRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
 
   if (results.length === 0) {
     return (
@@ -75,11 +79,11 @@ export function MentionPicker({
       <ul className="max-h-60 overflow-y-auto">
         {results.map((result, index) => {
           const isHighlighted = index === highlightedIndex;
-          const isEveryoneRow = result.did === '__everyone__';
+          const isEveryoneRow = result.did === EVERYONE_DID;
           const avatarSrc = resolveAvatarSrc(result, mediaUrl);
 
           return (
-            <li key={result.did}>
+            <li key={result.did} ref={isHighlighted ? highlightedRef : undefined}>
               <button
                 type="button"
                 onClick={() => onSelect(result)}

--- a/packages/chat/src/hooks/useMentions.ts
+++ b/packages/chat/src/hooks/useMentions.ts
@@ -2,6 +2,15 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 
+/** Sentinel DID for @everyone mentions. Must stay in sync with backend EVERYONE_DID. */
+export const EVERYONE_DID = '__everyone__';
+
+/**
+ * Matches @handle in message text.
+ * Must stay in sync with backend MENTION_REGEX in src/lib/chat/mentions.ts.
+ */
+const MENTION_REGEX = /@([a-zA-Z0-9_-]+)/g;
+
 export interface Member {
   did: string;
   role: string;
@@ -86,7 +95,6 @@ export function useMentions({
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(null);
   const [globalResults, setGlobalResults] = useState<SearchIdentity[]>([]);
-  const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isOpenRef = useRef(isOpen);
 
@@ -138,7 +146,6 @@ export function useMentions({
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(async () => {
-      setLoading(true);
       try {
         const res = await fetch(
           `${authUrl}/api/search?q=${encodeURIComponent(query)}&limit=5`,
@@ -154,8 +161,6 @@ export function useMentions({
         }
       } catch {
         setGlobalResults([]);
-      } finally {
-        setLoading(false);
       }
     }, 300);
 
@@ -171,7 +176,7 @@ export function useMentions({
     // @everyone as first option for group conversations
     if (isGroup && (q.length === 0 || 'everyone'.includes(q))) {
       out.push({
-        did: '__everyone__',
+        did: EVERYONE_DID,
         handle: 'everyone',
         name: 'Everyone',
         role: 'broadcast',
@@ -269,10 +274,11 @@ export function useMentions({
     [results, highlightedIndex, selectMention]
   );
 
-  // Scan text for @mentions to build the mentions array
+  // Scan text for @mentions to build the mentions array (deduplicated by DID)
   const mentions = useMemo(() => {
     const out: Mention[] = [];
-    const regex = /@(\w+)/g;
+    const seen = new Set<string>();
+    const regex = new RegExp(MENTION_REGEX, 'g');
     let match: RegExpExecArray | null;
     const handleToDid = new Map<string, string>();
     for (const m of members) {
@@ -280,17 +286,20 @@ export function useMentions({
     }
     while ((match = regex.exec(text)) !== null) {
       const handle = match[1];
-      const did = handleToDid.get(handle);
-      if (did) {
+      const resolvedDid = handleToDid.get(handle);
+      if (resolvedDid) {
+        if (seen.has(resolvedDid)) continue;
+        seen.add(resolvedDid);
         out.push({
-          did,
+          did: resolvedDid,
           handle,
           index: match.index,
           length: match[0].length,
         });
-      } else if (handle === 'everyone' && isGroup) {
+      } else if (handle === 'everyone' && isGroup && !seen.has(EVERYONE_DID)) {
+        seen.add(EVERYONE_DID);
         out.push({
-          did: '__everyone__',
+          did: EVERYONE_DID,
           handle: 'everyone',
           index: match.index,
           length: match[0].length,

--- a/packages/chat/src/hooks/useMentions.ts
+++ b/packages/chat/src/hooks/useMentions.ts
@@ -1,0 +1,314 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+
+export interface Member {
+  did: string;
+  role: string;
+  name: string;
+  handle: string;
+}
+
+interface SearchIdentity {
+  did: string;
+  handle: string | null;
+  name: string | null;
+  scope: string;
+  subtype: string | null;
+  avatarUrl: string | null;
+  avatarAssetId: string | null;
+}
+
+export interface Mention {
+  did: string;
+  handle: string;
+  index: number;
+  length: number;
+}
+
+export interface MentionResult {
+  did: string;
+  handle: string;
+  name: string;
+  role?: string;
+  avatarUrl?: string | null;
+  avatarAssetId?: string | null;
+}
+
+interface UseMentionsOptions {
+  text: string;
+  setText: (text: string) => void;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  members: Member[];
+  isGroup: boolean;
+  authUrl: string;
+}
+
+interface UseMentionsReturn {
+  isOpen: boolean;
+  query: string;
+  results: MentionResult[];
+  highlightedIndex: number;
+  selectMention: (result: MentionResult) => void;
+  closePicker: () => void;
+  handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => boolean;
+  handleChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  mentions: Mention[];
+}
+
+function detectMentionContext(
+  text: string,
+  cursorPos: number
+): { query: string; startIndex: number } | null {
+  let i = cursorPos - 1;
+  while (i >= 0 && text[i] !== ' ' && text[i] !== '\n') {
+    if (text[i] === '@') {
+      if (i === 0 || text[i - 1] === ' ' || text[i - 1] === '\n') {
+        return { query: text.slice(i + 1, cursorPos), startIndex: i };
+      }
+      return null;
+    }
+    i--;
+  }
+  return null;
+}
+
+export function useMentions({
+  text,
+  setText,
+  textareaRef,
+  members,
+  isGroup,
+  authUrl,
+}: UseMentionsOptions): UseMentionsReturn {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [mentionStartIndex, setMentionStartIndex] = useState<number | null>(null);
+  const [globalResults, setGlobalResults] = useState<SearchIdentity[]>([]);
+  const [loading, setLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isOpenRef = useRef(isOpen);
+
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  const detectMention = useCallback((value: string, cursorPos: number) => {
+    const ctx = detectMentionContext(value, cursorPos);
+    if (ctx) {
+      setQuery(ctx.query);
+      setMentionStartIndex(ctx.startIndex);
+      setIsOpen(true);
+      setHighlightedIndex(0);
+    } else {
+      setIsOpen(false);
+      setQuery('');
+      setMentionStartIndex(null);
+      setGlobalResults([]);
+    }
+  }, []);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      detectMention(e.target.value, e.target.selectionStart);
+    },
+    [detectMention]
+  );
+
+  const localResults = useMemo(() => {
+    const q = query.toLowerCase();
+    return members.filter(
+      (m) =>
+        m.handle.toLowerCase().includes(q) || m.name.toLowerCase().includes(q)
+    );
+  }, [members, query]);
+
+  // Debounced global search when local matches are sparse
+  useEffect(() => {
+    if (!isOpen || query.length < 1) {
+      setGlobalResults([]);
+      return;
+    }
+
+    if (localResults.length >= 3) {
+      setGlobalResults([]);
+      return;
+    }
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `${authUrl}/api/search?q=${encodeURIComponent(query)}&limit=5`,
+          { credentials: 'include' }
+        );
+        if (res.ok) {
+          const data = await res.json();
+          const existingDids = new Set(members.map((m) => m.did));
+          const filtered = (data.results as SearchIdentity[]).filter(
+            (r) => !existingDids.has(r.did) && r.handle
+          );
+          setGlobalResults(filtered);
+        }
+      } catch {
+        setGlobalResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [isOpen, query, localResults.length, members, authUrl]);
+
+  const results = useMemo(() => {
+    const out: MentionResult[] = [];
+    const q = query.toLowerCase();
+
+    // @everyone as first option for group conversations
+    if (isGroup && (q.length === 0 || 'everyone'.includes(q))) {
+      out.push({
+        did: '__everyone__',
+        handle: 'everyone',
+        name: 'Everyone',
+        role: 'broadcast',
+      });
+    }
+
+    // Local members
+    for (const m of localResults) {
+      out.push({
+        did: m.did,
+        handle: m.handle,
+        name: m.name,
+        role: m.role,
+      });
+    }
+
+    // Global search results
+    for (const r of globalResults) {
+      if (r.handle) {
+        out.push({
+          did: r.did,
+          handle: r.handle,
+          name: r.name ?? r.handle,
+          avatarUrl: r.avatarUrl,
+          avatarAssetId: r.avatarAssetId,
+        });
+      }
+    }
+
+    return out;
+  }, [isGroup, query, localResults, globalResults]);
+
+  const selectMention = useCallback(
+    (result: MentionResult) => {
+      if (mentionStartIndex === null) return;
+      const cursorPos = textareaRef.current?.selectionStart ?? text.length;
+      const before = text.slice(0, mentionStartIndex);
+      const after = text.slice(cursorPos);
+      const newText = `${before}@${result.handle} ${after}`;
+      setText(newText);
+      setIsOpen(false);
+      setQuery('');
+      setMentionStartIndex(null);
+      setGlobalResults([]);
+
+      // Restore cursor after inserted mention
+      setTimeout(() => {
+        const el = textareaRef.current;
+        if (el) {
+          const newPos = mentionStartIndex + result.handle.length + 2;
+          el.selectionStart = newPos;
+          el.selectionEnd = newPos;
+          el.focus();
+        }
+      }, 0);
+    },
+    [text, mentionStartIndex, setText, textareaRef]
+  );
+
+  const closePicker = useCallback(() => {
+    setIsOpen(false);
+    setQuery('');
+    setMentionStartIndex(null);
+    setGlobalResults([]);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>): boolean => {
+      if (!isOpenRef.current) return false;
+      const count = results.length;
+      if (count === 0) return false;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setHighlightedIndex((i) => (i + 1) % count);
+        return true;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setHighlightedIndex((i) => (i - 1 + count) % count);
+        return true;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const selected = results[highlightedIndex];
+        if (selected) selectMention(selected);
+        return true;
+      }
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+        return true;
+      }
+      return false;
+    },
+    [results, highlightedIndex, selectMention]
+  );
+
+  // Scan text for @mentions to build the mentions array
+  const mentions = useMemo(() => {
+    const out: Mention[] = [];
+    const regex = /@(\w+)/g;
+    let match: RegExpExecArray | null;
+    const handleToDid = new Map<string, string>();
+    for (const m of members) {
+      handleToDid.set(m.handle, m.did);
+    }
+    while ((match = regex.exec(text)) !== null) {
+      const handle = match[1];
+      const did = handleToDid.get(handle);
+      if (did) {
+        out.push({
+          did,
+          handle,
+          index: match.index,
+          length: match[0].length,
+        });
+      } else if (handle === 'everyone' && isGroup) {
+        out.push({
+          did: '__everyone__',
+          handle: 'everyone',
+          index: match.index,
+          length: match[0].length,
+        });
+      }
+    }
+    return out;
+  }, [text, members, isGroup]);
+
+  return {
+    isOpen,
+    query,
+    results,
+    highlightedIndex,
+    selectMention,
+    closePicker,
+    handleKeyDown,
+    handleChange,
+    mentions,
+  };
+}

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -24,3 +24,6 @@ export type { NameDisplayPolicy, DisplayPref } from './NameDisplaySelector';
 export { useFileUpload } from './hooks/useFileUpload';
 export { useVoiceRecording } from './hooks/useVoiceRecording';
 export { useLocationShare } from './hooks/useLocationShare';
+export { useMentions } from './hooks/useMentions';
+export type { Mention, MentionResult, Member } from './hooks/useMentions';
+export { MentionPicker } from './MentionPicker';

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -24,6 +24,6 @@ export type { NameDisplayPolicy, DisplayPref } from './NameDisplaySelector';
 export { useFileUpload } from './hooks/useFileUpload';
 export { useVoiceRecording } from './hooks/useVoiceRecording';
 export { useLocationShare } from './hooks/useLocationShare';
-export { useMentions } from './hooks/useMentions';
+export { useMentions, EVERYONE_DID } from './hooks/useMentions';
 export type { Mention, MentionResult, Member } from './hooks/useMentions';
 export { MentionPicker } from './MentionPicker';


### PR DESCRIPTION
## Summary

Typeahead @mention picker for chat composer. Type `@` in a conversation to see a dropdown of members, filterable as you type.

### Frontend
- **`MentionPicker`** component — floating dropdown adapted from `IdentityPicker` pattern (avatar, name, @handle, role badge)
- **`useMentions`** hook — @ trigger detection, local member filtering with global search fallback (debounced 300ms)
- **`@everyone`** option in group conversations (🔔 icon, red styling)
- Keyboard navigation (↑↓ Enter Escape)
- Structured `mentions` array sent with message content

### Backend
- Both message POST routes accept optional `content.mentions` array
- Structured mentions skip regex + DB lookup → publish directly to bus
- `@everyone` expands to all conversation members (admin/owner only)
- Regex fallback preserved for backward compatibility

### No migration needed
`mentions` array lives in the existing `messagesV2.content` jsonb column.

Closes #1024