### PR TITLE
fix(pay): reverse transfer + refund app fee on Stripe Connect refunds

### DIFF
--- a/apps/kernel/src/lib/pay/providers/stripe.ts
+++ b/apps/kernel/src/lib/pay/providers/stripe.ts
@@ -236,6 +236,8 @@ export class StripeProvider implements PaymentProvider {
       payment_intent: request.paymentId,
       amount: request.amount,
       reason: request.reason as Stripe.RefundCreateParams.Reason,
+      reverse_transfer: true,
+      refund_application_fee: true,
     });
     
     return {


### PR DESCRIPTION
## Problem

When issuing a refund for a Stripe Connect destination charge (e.g. event ticket), the refund was deducted from the **platform account** without reversing the transfer to the connected account. This caused the platform balance to go negative, pulling from the corporate bank account.

## Root Cause

`stripe.refunds.create()` was missing two flags:
- `reverse_transfer: true` — reverses the transfer to the connected account
- `refund_application_fee: true` — refunds the platform's application fee

Without these, Stripe's default behavior is to refund the customer entirely from the platform's balance.

## Fix

Two lines added to `StripeProvider.refund()`.

## Edge Case

If the connected account has already withdrawn funds and has insufficient balance, the transfer reversal will fail. This would need manual handling with the organizer.