### PR TITLE
fix(sonar): refactor nested ternaries (S3358) — other scope

### DIFF
--- a/apps/coffee/app/[handle]/page.tsx
+++ b/apps/coffee/app/[handle]/page.tsx
@@ -21,9 +21,10 @@ export async function generateMetadata({ params }: Readonly<PageProps>): Promise
   const description = page.bio || 'Support this creator on the Imajin network';
   const url = `${buildPublicUrl('coffee')}/${page.handle}`;
   const avatarIsImage = page.avatar && (page.avatar.startsWith('http') || page.avatar.startsWith('/'));
-  const ogImage = avatarIsImage
-    ? (page.avatar!.startsWith('http') ? page.avatar! : `${buildPublicUrl('coffee')}${page.avatar}`)
-    : null;
+  let ogImage: string | null = null;
+  if (avatarIsImage) {
+    ogImage = page.avatar!.startsWith('http') ? page.avatar! : `${buildPublicUrl('coffee')}${page.avatar}`;
+  }
 
   return {
     title,

--- a/apps/coffee/app/[handle]/tip-form.tsx
+++ b/apps/coffee/app/[handle]/tip-form.tsx
@@ -284,12 +284,11 @@ export default function TipForm({ page, primaryColor, sellerConnected = true }: 
           className="w-full py-4 rounded-xl text-white font-semibold text-lg transition-all hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
           style={{ backgroundColor: primaryColor }}
         >
-          {isLoading
-            ? 'Processing...'
-            : isRecurring
-              ? `☕ Support with ${formatAmount(getAmount())}/month`
-              : `☕ Send ${formatAmount(getAmount())}`
-          }
+          {(() => {
+            if (isLoading) return 'Processing...';
+            if (isRecurring) return `☕ Support with ${formatAmount(getAmount())}/month`;
+            return `☕ Send ${formatAmount(getAmount())}`;
+          })()}
         </button>
       )}
     </form>

--- a/apps/coffee/app/edit/page.tsx
+++ b/apps/coffee/app/edit/page.tsx
@@ -487,7 +487,10 @@ export default function EditPage() {
               disabled={isSaving}
               className="flex-1 py-3 rounded-xl bg-orange-500 hover:bg-orange-600 text-white font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isSaving ? 'Saving...' : existingPage ? 'Update Page' : 'Create Page'}
+              {(() => {
+                if (isSaving) return 'Saving...';
+                return existingPage ? 'Update Page' : 'Create Page';
+              })()}
             </button>
             {existingPage && (
               <button

--- a/apps/dykil/app/(chrome)/create/page.tsx
+++ b/apps/dykil/app/(chrome)/create/page.tsx
@@ -590,13 +590,15 @@ function CreateSurveyContent() {
                   </p>
                 )}
 
-                {survey.fields.elements.length === 0 ? (
+                {(() => {
+                  if (survey.fields.elements.length === 0) return (
                   <div className="text-center py-12 text-gray-500 text-sm">
                     Preview will appear here as you add questions
                   </div>
-                ) : previewModel ? (
-                  <Survey model={previewModel} />
-                ) : null}
+                  );
+                  if (previewModel) return <Survey model={previewModel} />;
+                  return null;
+                })()}
               </div>
             </div>
           </div>

--- a/apps/dykil/app/(chrome)/survey/[id]/results/page.tsx
+++ b/apps/dykil/app/(chrome)/survey/[id]/results/page.tsx
@@ -372,15 +372,14 @@ export default function ResultsPage() {
                             {field.title}
                           </div>
                           <div className="mt-1">
-                            {answer === undefined || answer === null || answer === '' ? (
-                              <span className="text-gray-400 text-sm italic">No answer</span>
-                            ) : field.type === 'boolean' ? (
-                              <span>{answer ? 'Yes' : 'No'}</span>
-                            ) : Array.isArray(answer) ? (
-                              <span>{answer.join(', ')}</span>
-                            ) : (
-                              <span>{String(answer)}</span>
-                            )}
+                            {(() => {
+                              if (answer === undefined || answer === null || answer === '') {
+                                return <span className="text-gray-400 text-sm italic">No answer</span>;
+                              }
+                              if (field.type === 'boolean') return <span>{answer ? 'Yes' : 'No'}</span>;
+                              if (Array.isArray(answer)) return <span>{answer.join(', ')}</span>;
+                              return <span>{String(answer)}</span>;
+                            })()}
                           </div>
                         </div>
                       );

--- a/apps/learn/app/course/[slug]/page.tsx
+++ b/apps/learn/app/course/[slug]/page.tsx
@@ -234,14 +234,21 @@ export default function CourseDetailPage() {
                 ▶ Present
               </Link>
             )}
-            {course.isCreator ? (
+            {(() => {
+              const enrollButtonText = (() => {
+                if (enrolling) return 'Loading...';
+                if (course.price === 0) return isDeck ? '▶ View Presentation' : 'Start Learning — Free';
+                return `Enroll — $${(course.price / 100).toFixed(2)}`;
+              })();
+              if (course.isCreator) return (
               <Link
                 href={`/dashboard/${course.slug}`}
                 className="px-6 py-3 bg-amber-500 text-white rounded-lg hover:bg-amber-600 font-medium"
               >
                 Edit Course
               </Link>
-            ) : course.enrollment ? (
+              );
+              if (course.enrollment) return (
               <Link
                 href={isDeck ? `/course/${course.slug}/present` : `/course/${course.slug}/${course.modules[0]?.lessons[0]?.id || ''}`}
                 className="px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 font-medium"
@@ -257,21 +264,22 @@ export default function CourseDetailPage() {
                   </>
                 )}
               </Link>
-            ) : course.price > 0 && !sellerConnected ? (
+              );
+              if (course.price > 0 && !sellerConnected) return (
               <p className="text-sm text-gray-500 italic px-1">
                 Payments not yet available
               </p>
-            ) : course.isAuthenticated ? (
+              );
+              if (course.isAuthenticated) return (
               <button
                 onClick={handleEnroll}
                 disabled={enrolling}
                 className="px-6 py-3 bg-amber-500 text-white rounded-lg hover:bg-amber-600 font-medium disabled:opacity-50"
               >
-                {enrolling ? 'Loading...' : course.price === 0
-                  ? (isDeck ? '▶ View Presentation' : 'Start Learning — Free')
-                  : `Enroll — $${(course.price / 100).toFixed(2)}`}
+                {enrollButtonText}
               </button>
-            ) : (
+              );
+              return (
               <OnboardGate
                 action={isDeck ? `view "${course.title}"` : `enroll in "${course.title}"`}
                 redirectUrl={`${typeof window !== 'undefined' ? globalThis.location.origin : ''}/course/${slug}?enroll=1`}
@@ -282,12 +290,11 @@ export default function CourseDetailPage() {
                   disabled={enrolling}
                   className="px-6 py-3 bg-amber-500 text-white rounded-lg hover:bg-amber-600 font-medium disabled:opacity-50"
                 >
-                  {enrolling ? 'Loading...' : course.price === 0
-                    ? (isDeck ? '▶ View Presentation' : 'Start Learning — Free')
-                    : `Enroll — $${(course.price / 100).toFixed(2)}`}
+                  {enrollButtonText}
                 </button>
               </OnboardGate>
-            )}
+              );
+            })()}
           </div>
         </div>
 

--- a/apps/learn/app/dashboard/[slug]/students/page.tsx
+++ b/apps/learn/app/dashboard/[slug]/students/page.tsx
@@ -142,15 +142,17 @@ export default function StudentsPage() {
                       </div>
                     </td>
                     <td className="px-5 py-3 text-right">
-                      {student.completedAt ? (
+                      {(() => {
+                        if (student.completedAt) return (
                         <span className="inline-flex items-center gap-1 text-green-600 text-xs font-medium">
                           ✓ Complete
                         </span>
-                      ) : student.progress.completed > 0 ? (
+                        );
+                        if (student.progress.completed > 0) return (
                         <span className="text-amber-500 text-xs font-medium">In progress</span>
-                      ) : (
-                        <span className="text-gray-400 text-xs">Enrolled</span>
-                      )}
+                        );
+                        return <span className="text-gray-400 text-xs">Enrolled</span>;
+                      })()}
                     </td>
                   </tr>
                 ))}

--- a/apps/learn/app/page.tsx
+++ b/apps/learn/app/page.tsx
@@ -72,9 +72,11 @@ export default function DiscoveryPage() {
           </div>
 
           {/* Course Grid */}
-          {loading ? (
+          {(() => {
+            if (loading) return (
             <div className="text-center py-12 text-gray-500">Loading courses...</div>
-          ) : filtered.length === 0 ? (
+            );
+            if (filtered.length === 0) return (
             <div className="text-center py-12">
               <p className="text-gray-500 mb-4">
                 {search ? 'No courses match your search.' : 'No courses available yet.'}
@@ -83,7 +85,8 @@ export default function DiscoveryPage() {
                 Are you a creator? <Link href="/dashboard" className="text-amber-500 hover:underline">Create your first course</Link>
               </p>
             </div>
-          ) : (
+            );
+            return (
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {filtered.map(course => (
                 <Link
@@ -126,7 +129,8 @@ export default function DiscoveryPage() {
                 </Link>
               ))}
             </div>
-          )}
+          );
+          })()}
         </div>
       </div>
       <ImajinFooter />

--- a/apps/links/app/[handle]/page.tsx
+++ b/apps/links/app/[handle]/page.tsx
@@ -23,9 +23,10 @@ export async function generateMetadata({ params }: Readonly<PageProps>): Promise
   const description = page.bio || 'Sovereign link-in-bio page on the Imajin network';
   const url = `${buildPublicUrl('links')}/${page.handle}`;
   const avatarIsImage = page.avatar && (page.avatar.startsWith('http') || page.avatar.startsWith('/'));
-  const ogImage = avatarIsImage
-    ? (page.avatar!.startsWith('http') ? page.avatar! : `${buildPublicUrl('links')}${page.avatar}`)
-    : null;
+  let ogImage: string | null = null;
+  if (avatarIsImage) {
+    ogImage = page.avatar!.startsWith('http') ? page.avatar! : `${buildPublicUrl('links')}${page.avatar}`;
+  }
 
   return {
     title,

--- a/apps/market/app/components/ImageUpload.tsx
+++ b/apps/market/app/components/ImageUpload.tsx
@@ -191,13 +191,11 @@ export function ImageUpload({ images, onChange }: Readonly<ImageUploadProps>) {
                 onDragOver={(e) => onThumbDragOver(e, i)}
                 onDrop={(e) => onThumbDrop(e, i)}
                 onDragEnd={onThumbDragEnd}
-                className={`relative w-20 h-20 rounded-lg overflow-hidden border group cursor-grab active:cursor-grabbing transition ${
-                  isDragged
-                    ? 'opacity-50 border-gray-700'
-                    : isDropTarget
-                    ? 'border-blue-500 ring-2 ring-blue-500/40'
-                    : 'border-gray-700'
-                }`}
+                className={`relative w-20 h-20 rounded-lg overflow-hidden border group cursor-grab active:cursor-grabbing transition ${(() => {
+                  if (isDragged) return 'opacity-50 border-gray-700';
+                  if (isDropTarget) return 'border-blue-500 ring-2 ring-blue-500/40';
+                  return 'border-gray-700';
+                })()}`}
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img src={imgUrl} alt={`Image ${i + 1}`} className="w-full h-full object-cover" />

--- a/apps/market/app/components/SearchFilters.tsx
+++ b/apps/market/app/components/SearchFilters.tsx
@@ -5,6 +5,8 @@ import { useCallback, useRef } from 'react';
 
 const CURRENCIES = ['CAD', 'USD', 'EUR', 'GBP', 'CHF', 'AUD', 'JPY', 'ZAR'];
 
+const TIER_LABELS: Record<string, string> = { all: 'All', direct: 'Direct', protected: 'Protected' };
+
 export default function SearchFilters() {
   const router = useRouter();
   const pathname = usePathname();
@@ -92,7 +94,7 @@ export default function SearchFilters() {
                   : 'bg-gray-900 text-gray-400 hover:bg-gray-800'
               }`}
             >
-              {t === 'all' ? 'All' : t === 'direct' ? 'Direct' : 'Protected'}
+              {TIER_LABELS[t] ?? t}
             </button>
           );
         })}

--- a/apps/market/app/dashboard/page.tsx
+++ b/apps/market/app/dashboard/page.tsx
@@ -327,7 +327,8 @@ export default function DashboardPage() {
         </div>
 
         {/* Listings */}
-        {loading ? (
+        {(() => {
+          if (loading) return (
           <div className="space-y-2">
             {[0, 1, 2, 3].map((i) => (
               <div key={i} className="bg-gray-900 border border-gray-800 rounded-xl p-4 animate-pulse flex gap-4">
@@ -339,7 +340,8 @@ export default function DashboardPage() {
               </div>
             ))}
           </div>
-        ) : error ? (
+          );
+          if (error) return (
           <div className="text-center py-16">
             <p className="text-red-400 mb-4">{error}</p>
             <button
@@ -349,7 +351,8 @@ export default function DashboardPage() {
               Retry
             </button>
           </div>
-        ) : listings.length === 0 ? (
+          );
+          if (listings.length === 0) return (
           <div className="text-center py-20">
             <div className="text-5xl mb-4">🏪</div>
             <p className="text-lg font-medium text-gray-200 mb-2">
@@ -366,7 +369,8 @@ export default function DashboardPage() {
               </Link>
             )}
           </div>
-        ) : (
+          );
+          return (
           <>
             {/* Desktop table */}
             <div className="hidden md:block bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
@@ -458,9 +462,10 @@ export default function DashboardPage() {
                 >
                   Next →
                 </button>
-              </div>
-            )}
+            </div>
           </>
+          );
+        })()}
         )}
       </div>
 

--- a/apps/market/app/listings/[id]/ListingDetail.tsx
+++ b/apps/market/app/listings/[id]/ListingDetail.tsx
@@ -347,18 +347,16 @@ export default function ListingDetail() {
   const isRental = listing.type === 'rental';
   const isOnplatform = listing.sellerTier === 'public_onplatform' || listing.sellerTier === 'trust_gated';
 
-  const tierLabel =
-    listing.sellerTier === 'public_onplatform'
-      ? 'Protected'
-      : listing.sellerTier === 'trust_gated'
-      ? 'Trusted'
-      : 'Direct';
-  const tierColor =
-    listing.sellerTier === 'public_onplatform'
-      ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
-      : listing.sellerTier === 'trust_gated'
-      ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300'
-      : 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300';
+  const TIER_LABEL_MAP: Record<string, string> = {
+    public_onplatform: 'Protected',
+    trust_gated: 'Trusted',
+  };
+  const TIER_COLOR_MAP: Record<string, string> = {
+    public_onplatform: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+    trust_gated: 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300',
+  };
+  const tierLabel = TIER_LABEL_MAP[listing.sellerTier] ?? 'Direct';
+  const tierColor = TIER_COLOR_MAP[listing.sellerTier] ?? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300';
 
   const showContactSection =
     listing.sellerTier === 'public_offplatform' ||
@@ -584,7 +582,7 @@ export default function ListingDetail() {
                       disabled={buyLoading}
                       className="px-6 py-3 bg-orange-500 text-white rounded-xl font-semibold hover:bg-orange-600 transition hover:shadow-lg disabled:opacity-60 disabled:cursor-not-allowed"
                     >
-                      {buyLoading ? 'Processing…' : isRental ? 'Rent Now' : 'Buy Now'}
+                      {(() => { if (buyLoading) return 'Processing…'; return isRental ? 'Rent Now' : 'Buy Now'; })()}
                     </button>
                     {buyError && (
                       <p className="text-sm text-red-500">{buyError}</p>
@@ -607,7 +605,7 @@ export default function ListingDetail() {
                     disabled={buyLoading}
                     className="px-6 py-3 bg-orange-500 text-white rounded-xl font-semibold hover:bg-orange-600 transition hover:shadow-lg disabled:opacity-60 disabled:cursor-not-allowed"
                   >
-                    {buyLoading ? 'Processing…' : isRental ? 'Rent Now' : 'Buy Now'}
+                    {(() => { if (buyLoading) return 'Processing…'; return isRental ? 'Rent Now' : 'Buy Now'; })()}
                   </button>
                   {buyError && (
                     <p className="text-sm text-red-500">{buyError}</p>

--- a/apps/market/app/page.tsx
+++ b/apps/market/app/page.tsx
@@ -164,7 +164,8 @@ function MarketPageContent() {
         </div>
 
         {/* Results */}
-        {loading ? (
+        {(() => {
+          if (loading) return (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden animate-pulse">
@@ -176,7 +177,8 @@ function MarketPageContent() {
               </div>
             ))}
           </div>
-        ) : error ? (
+          );
+          if (error) return (
           <div className="text-center py-16">
             <p className="text-red-500 mb-4">{error}</p>
             <button
@@ -186,19 +188,22 @@ function MarketPageContent() {
               Retry
             </button>
           </div>
-        ) : listings.length === 0 ? (
+          );
+          if (listings.length === 0) return (
           <div className="text-center py-16 text-gray-500 dark:text-gray-400">
             <div className="text-5xl mb-4">🏪</div>
             <p className="text-lg font-medium mb-2">No listings found</p>
             <p className="text-sm">Try adjusting your search or filters.</p>
           </div>
-        ) : (
+          );
+          return (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {listings.map((listing) => (
               <ListingCard key={listing.id} listing={listing} />
             ))}
           </div>
-        )}
+          );
+        })()}
 
         {/* Pagination */}
         {totalPages > 1 && (

--- a/apps/market/app/seller/[handle]/page.tsx
+++ b/apps/market/app/seller/[handle]/page.tsx
@@ -83,7 +83,8 @@ function SellerPageContent() {
         </div>
 
         {/* Results */}
-        {loading ? (
+        {(() => {
+          if (loading) return (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden animate-pulse">
@@ -95,26 +96,30 @@ function SellerPageContent() {
               </div>
             ))}
           </div>
-        ) : error ? (
+          );
+          if (error) return (
           <div className="text-center py-16">
             <p className="text-red-500 mb-4">{error}</p>
             <Link href="/" className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition">
               Back to Market
             </Link>
           </div>
-        ) : listings.length === 0 ? (
+          );
+          if (listings.length === 0) return (
           <div className="text-center py-16 text-gray-500 dark:text-gray-400">
             <div className="text-5xl mb-4">📭</div>
             <p className="text-lg font-medium mb-2">No active listings</p>
             <p className="text-sm">This seller has no active listings right now.</p>
           </div>
-        ) : (
+          );
+          return (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {listings.map((listing) => (
               <ListingCard key={listing.id} listing={listing} />
             ))}
           </div>
-        )}
+          );
+        })()}
 
       </div>
 

--- a/packages/chat/src/MentionPicker.tsx
+++ b/packages/chat/src/MentionPicker.tsx
@@ -91,21 +91,25 @@ export function MentionPicker({
                   isHighlighted ? 'bg-gray-800/80' : 'hover:bg-gray-800/50'
                 }`}
               >
-                {isEveryoneRow ? (
+                {(() => {
+                  if (isEveryoneRow) return (
                   <div className="w-8 h-8 rounded-full bg-red-900/30 flex items-center justify-center text-sm shrink-0 border border-red-900/50">
                     🔔
                   </div>
-                ) : avatarSrc ? (
+                  );
+                  if (avatarSrc) return (
                   <img
                     src={avatarSrc}
                     alt=""
                     className="w-8 h-8 rounded-full object-cover border border-gray-800 shrink-0"
                   />
-                ) : (
+                  );
+                  return (
                   <div className="w-8 h-8 rounded-full bg-gray-800 flex items-center justify-center text-xs text-gray-500 shrink-0">
                     {result.name?.[0]?.toUpperCase() ?? '?'}
                   </div>
-                )}
+                  );
+                })()}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <p className="text-sm font-medium truncate">

--- a/packages/chat/src/MessageBubble.tsx
+++ b/packages/chat/src/MessageBubble.tsx
@@ -272,19 +272,19 @@ export function MessageBubble({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const text =
-    typeof message.content === 'object' && (message.content as any)?.text
-      ? (message.content as any).text
-      : typeof message.content === 'string'
-        ? message.content
-        : '';
+  const text = (() => {
+    if (typeof message.content === 'object' && (message.content as any)?.text) return (message.content as any).text;
+    if (typeof message.content === 'string') return message.content;
+    return '';
+  })();
 
-  const replyToText =
-    replyToMessage && typeof replyToMessage.content === 'object' && (replyToMessage.content as any)?.text
-      ? (replyToMessage.content as any).text
-      : replyToMessage && typeof replyToMessage.content === 'string'
-        ? replyToMessage.content
-        : '';
+  const replyToText = (() => {
+    if (replyToMessage && typeof replyToMessage.content === 'object' && (replyToMessage.content as any)?.text) {
+      return (replyToMessage.content as any).text;
+    }
+    if (replyToMessage && typeof replyToMessage.content === 'string') return replyToMessage.content;
+    return '';
+  })();
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();

--- a/packages/chat/src/VoiceMessage.tsx
+++ b/packages/chat/src/VoiceMessage.tsx
@@ -126,11 +126,10 @@ export function VoiceMessage({ assetId, transcript, durationMs, waveform, isOwn,
                 return (
                   <div
                     key={i}
-                    className={`w-[2px] rounded-full transition-colors ${
-                      filled
-                        ? isOwn ? 'bg-white' : 'bg-orange-500'
-                        : isOwn ? 'bg-white/30' : 'bg-gray-300 dark:bg-gray-600'
-                    }`}
+                    className={`w-[2px] rounded-full transition-colors ${(() => {
+                      if (filled) return isOwn ? 'bg-white' : 'bg-orange-500';
+                      return isOwn ? 'bg-white/30' : 'bg-gray-300 dark:bg-gray-600';
+                    })()}`}
                     style={{ height: `${height}px` }}
                   />
                 );

--- a/packages/chat/src/VoiceRecorder.tsx
+++ b/packages/chat/src/VoiceRecorder.tsx
@@ -70,11 +70,9 @@ export function VoiceRecorder({ onRecordingComplete, onCancel, onRecordingStart,
       source.connect(analyser);
       analyserRef.current = analyser;
 
-      const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-        ? 'audio/webm;codecs=opus'
-        : MediaRecorder.isTypeSupported('audio/webm')
-        ? 'audio/webm'
-        : '';
+      let mimeType = '';
+      if (MediaRecorder.isTypeSupported('audio/webm;codecs=opus')) mimeType = 'audio/webm;codecs=opus';
+      else if (MediaRecorder.isTypeSupported('audio/webm')) mimeType = 'audio/webm';
       const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
       mediaRecorderRef.current = recorder;
       chunksRef.current = [];

--- a/packages/config/src/services.ts
+++ b/packages/config/src/services.ts
@@ -76,7 +76,8 @@ export function getService(name: string): ServiceDefinition | undefined {
 /** Get the port for a service in a given environment */
 export function getPort(name: string, env: "dev" | "prod" = "dev"): number | undefined {
   const svc = getService(name);
-  return svc ? (env === "prod" ? svc.prodPort : svc.devPort) : undefined;
+  if (!svc) return undefined;
+  return env === "prod" ? svc.prodPort : svc.devPort;
 }
 
 /** Get internal URL for a service (server-side calls) */

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -17,9 +17,14 @@ export async function sendEmail(options: SendEmailOptions): Promise<{ success: b
     ? appendUnsubscribeFooter(options.html, options.unsubscribeUrl)
     : options.html;
 
-  const textBody = options.text
-    ? (options.unsubscribeUrl ? `${options.text}\n\n---\nTo unsubscribe: ${options.unsubscribeUrl}\n${PHYSICAL_ADDRESS}` : options.text)
-    : stripHtml(htmlBody);
+  let textBody: string;
+  if (options.text) {
+    textBody = options.unsubscribeUrl
+      ? `${options.text}\n\n---\nTo unsubscribe: ${options.unsubscribeUrl}\n${PHYSICAL_ADDRESS}`
+      : options.text;
+  } else {
+    textBody = stripHtml(htmlBody);
+  }
 
   return provider.send({
     ...options,

--- a/packages/email/src/templates/broadcast.ts
+++ b/packages/email/src/templates/broadcast.ts
@@ -29,22 +29,24 @@ export function renderBroadcastEmail(
           </tr>`
     : '';
 
+  const headerBorderRadius = eventContext?.imageUrl ? '' : 'border-radius:8px 8px 0 0;';
   const eventHeader = eventContext
     ? `
           <!-- Event Header -->
           <tr>
-            <td style="background-color:#111111;padding:24px 32px 8px;${eventContext.imageUrl ? '' : 'border-radius:8px 8px 0 0;'}">
+            <td style="background-color:#111111;padding:24px 32px 8px;${headerBorderRadius}">
               <p style="margin:0;font-size:13px;color:#71717a;text-transform:uppercase;letter-spacing:0.5px;">Message from</p>
               <h1 style="margin:4px 0 0;font-size:24px;font-weight:700;color:#ffffff;letter-spacing:-0.5px;">${eventContext.title}</h1>
             </td>
           </tr>`
     : '';
 
+  const footerBorderRadius = eventContext?.imageUrl ? '' : 'border-radius:0 0 8px 8px;';
   const eventFooter = eventContext?.eventUrl
     ? `
           <!-- Event Link -->
           <tr>
-            <td style="background-color:#111111;padding:16px 32px 24px;${eventContext.imageUrl ? '' : 'border-radius:0 0 8px 8px;'}text-align:center;">
+            <td style="background-color:#111111;padding:16px 32px 24px;${footerBorderRadius}text-align:center;">
               <a href="${eventContext.eventUrl}" style="display:inline-block;background-color:#ffffff;color:#000000;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">View Event →</a>
             </td>
           </tr>`

--- a/packages/fair/src/components/FairAccordion.tsx
+++ b/packages/fair/src/components/FairAccordion.tsx
@@ -107,12 +107,12 @@ export function FairAccordion({ manifest, resolveProfile, nodeDid, viewerDid, vi
   // Chain: revenue split
   const rawChain = manifest.chain ?? [];
   // Resolve placeholders for display
-  const resolvedChain = rawChain.map(e => ({
-    ...e,
-    did: e.did === 'NODE_PLACEHOLDER' ? (nodeDid || e.did)
-       : e.did === 'BUYER_PLACEHOLDER' ? (viewerDid || e.did)
-       : e.did,
-  }));
+  const resolvePlaceholder = (did: string): string => {
+    if (did === 'NODE_PLACEHOLDER') return nodeDid || did;
+    if (did === 'BUYER_PLACEHOLDER') return viewerDid || did;
+    return did;
+  };
+  const resolvedChain = rawChain.map(e => ({ ...e, did: resolvePlaceholder(e.did) }));
   const chain = normalizeShares(resolvedChain);
   const hasContent = attribution.length > 0 || chain.length > 0;
 

--- a/packages/input/src/FileAttachment.tsx
+++ b/packages/input/src/FileAttachment.tsx
@@ -114,7 +114,7 @@ export function FileAttachment({
           />
         ) : (
           <span className="text-lg">
-            {attachment.type === 'audio' ? '🎵' : attachment.type === 'video' ? '🎬' : '📄'}
+            {({ audio: '🎵', video: '🎬' } as Record<string, string>)[attachment.type] ?? '📄'}
           </span>
         )}
         <div className="flex-1 min-w-0">

--- a/packages/input/src/ImajinInput.tsx
+++ b/packages/input/src/ImajinInput.tsx
@@ -222,7 +222,7 @@ export function ImajinInput({
             <img src={attachment.preview} alt="" className="w-10 h-10 rounded-lg object-cover" />
           ) : (
             <span className="text-lg">
-              {attachment.type === 'audio' ? '🎵' : attachment.type === 'video' ? '🎬' : '📄'}
+              {({ audio: '🎵', video: '🎬' } as Record<string, string>)[attachment.type] ?? '📄'}
             </span>
           )}
           <div className="flex-1 min-w-0">

--- a/packages/input/src/VoiceRecorder.tsx
+++ b/packages/input/src/VoiceRecorder.tsx
@@ -105,11 +105,9 @@ export function VoiceRecorder({ onRecordingComplete, onRecorded, onCancel, onRec
       source.connect(analyser);
       analyserRef.current = analyser;
 
-      const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-        ? 'audio/webm;codecs=opus'
-        : MediaRecorder.isTypeSupported('audio/webm')
-        ? 'audio/webm'
-        : '';
+      let mimeType = '';
+      if (MediaRecorder.isTypeSupported('audio/webm;codecs=opus')) mimeType = 'audio/webm;codecs=opus';
+      else if (MediaRecorder.isTypeSupported('audio/webm')) mimeType = 'audio/webm';
       const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
       mediaRecorderRef.current = recorder;
       chunksRef.current = [];

--- a/packages/logger/src/adapters/pino.ts
+++ b/packages/logger/src/adapters/pino.ts
@@ -81,7 +81,8 @@ function writeAppLog(entry: {
 function wrapPino(instance: pino.Logger): Logger {
   function persist(level: string, ctx: LogContext, message: string) {
     const { service, correlationId, did, method, path, err, error, ...rest } = ctx;
-    const errorMessage = err ? String(err) : error ? String(error) : undefined;
+    const errorSource = err ?? error;
+    const errorMessage = errorSource ? String(errorSource) : undefined;
     writeAppLog({
       service: service || 'unknown',
       level,

--- a/packages/logger/src/middleware.ts
+++ b/packages/logger/src/middleware.ts
@@ -34,7 +34,10 @@ function writeRequestLog(entry: {
     .then(({ getClient }) => {
       const sql = getClient();
       const id = `req_${nanoid(16)}`;
-      const level = entry.status >= 500 ? 'error' : entry.status >= 400 ? 'warn' : 'info';
+      let level: string;
+      if (entry.status >= 500) level = 'error';
+      else if (entry.status >= 400) level = 'warn';
+      else level = 'info';
       const message = entry.errorMessage || `${entry.method} ${entry.path} → ${entry.status}`;
       return sql`
         INSERT INTO registry.logs

--- a/packages/media/src/AssetCard.tsx
+++ b/packages/media/src/AssetCard.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 
+const ASSET_TYPE_ICON: Record<string, string> = {
+  image: '🖼️',
+  video: '🎬',
+  audio: '🎵',
+};
+
 export interface AssetCardProps {
   id: string;
   type: string;
@@ -37,7 +43,7 @@ export function AssetCard({
         <img src={thumbPath} alt={filename} className="w-full h-32 object-cover" />
       ) : (
         <div className="w-full h-32 flex items-center justify-center bg-[#111] text-gray-600 text-4xl">
-          {type === 'image' ? '🖼️' : type === 'video' ? '🎬' : type === 'audio' ? '🎵' : '📄'}
+          {ASSET_TYPE_ICON[type] ?? '📄'}
         </div>
       )}
       <div className="p-3">

--- a/packages/ui/src/DidShareListEditor.tsx
+++ b/packages/ui/src/DidShareListEditor.tsx
@@ -419,13 +419,11 @@ export function DidShareListEditor({
 
       <div className="flex items-center justify-between text-xs">
         <span
-          className={
-            isValid
-              ? 'text-gray-500'
-              : isOver
-                ? 'text-red-400 font-medium'
-                : 'text-orange-400 font-medium'
-          }
+          className={(() => {
+            if (isValid) return 'text-gray-500';
+            if (isOver) return 'text-red-400 font-medium';
+            return 'text-orange-400 font-medium';
+          })()}
         >
           Total: {(totalShare * 100).toFixed(1)}%
           {!isValid && (

--- a/packages/ui/src/connection-picker.tsx
+++ b/packages/ui/src/connection-picker.tsx
@@ -61,15 +61,15 @@ export function ConnectionPicker({
         disabled={disabled || loading}
         className="w-full px-3 py-2 text-sm border border-gray-600 rounded-lg bg-gray-900 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:opacity-50"
       />
-      {loading ? (
-        <p className="text-sm text-gray-500 px-1">Loading connections...</p>
-      ) : error ? (
-        <p className="text-sm text-red-400 px-1">{error}</p>
-      ) : filtered.length === 0 ? (
+      {(() => {
+        if (loading) return <p className="text-sm text-gray-500 px-1">Loading connections...</p>;
+        if (error) return <p className="text-sm text-red-400 px-1">{error}</p>;
+        if (filtered.length === 0) return (
         <p className="text-sm text-gray-500 px-1">
           {available.length === 0 ? 'No connections available.' : 'No matching connections.'}
         </p>
-      ) : (
+        );
+        return (
         <div className="space-y-0 max-h-48 overflow-y-auto rounded-lg border border-gray-700 bg-gray-900">
           {filtered.map(conn => (
             <button
@@ -100,7 +100,8 @@ export function ConnectionPicker({
             </button>
           ))}
         </div>
-      )}
+      );
+      })()}
     </div>
   );
 }

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -129,11 +129,12 @@ function useAutoIdentity(servicePrefix: string, domain: string, overrides?: Serv
                 onRegister: () => { globalThis.location.href = `${authUrl}/register`; },
               });
             },
-            onViewProfile: data.handle
-              ? () => { globalThis.location.href = `${profileUrl}/${data.handle}`; }
-              : data.did
-              ? () => { globalThis.location.href = `${profileUrl}/${data.did}`; }
-              : undefined,
+            onViewProfile: (() => {
+              const viewProfileId = data.handle ?? data.did;
+              return viewProfileId
+                ? () => { globalThis.location.href = `${profileUrl}/${viewProfileId}`; }
+                : undefined;
+            })(),
             onEditProfile: () => { globalThis.location.href = `${profileUrl}/edit`; },
             onLogin: () => { globalThis.location.href = `${authUrl}/login?next=${encodeURIComponent(globalThis.location.href)}`; },
             onRegister: () => { globalThis.location.href = `${authUrl}/register`; },
@@ -347,7 +348,8 @@ export function NavBar({
 
         {/* Right - Auth Section */}
         <div className="flex items-center gap-2">
-          {identity?.isLoggedIn && identity?.tier === 'soft' ? (
+          {(() => {
+            if (identity?.isLoggedIn && identity?.tier === 'soft') return (
             /* Soft DID — just a logout button, no dropdown */
             <button
               onClick={() => identity.onLogout?.()}
@@ -355,7 +357,8 @@ export function NavBar({
             >
               Logout
             </button>
-          ) : identity?.isLoggedIn ? (
+          );
+            if (identity?.isLoggedIn) return (
             <div className="flex items-center gap-2">
               {(cashBalance !== null && cashBalance > 0) && (
                 <a
@@ -388,13 +391,12 @@ export function NavBar({
                     </span>
                   )}
                   <span className="text-sm font-medium leading-none">
-                    {activeIdentityData
-                      ? (activeIdentityData.name || activeIdentityData.handle || 'Identity')
-                      : identity.handle
-                      ? `@${identity.handle}`
-                      : identity.name
-                      ? identity.name
-                      : identity.did?.slice(0, 12) + '...'}
+                    {(() => {
+                      if (activeIdentityData) return activeIdentityData.name || activeIdentityData.handle || 'Identity';
+                      if (identity.handle) return `@${identity.handle}`;
+                      if (identity.name) return identity.name;
+                      return identity.did?.slice(0, 12) + '...';
+                    })()}
                   </span>
                 </span>
               </button>
@@ -555,7 +557,8 @@ export function NavBar({
               )}
             </div>
             </div>
-          ) : identity ? (
+          );
+            if (identity) return (
             <>
               {identity.onLogin && (
                 <button
@@ -566,7 +569,9 @@ export function NavBar({
                 </button>
               )}
             </>
-          ) : null}
+          );
+            return null;
+          })()}
         </div>
       </div>
 

--- a/packages/ui/src/notification-bell.tsx
+++ b/packages/ui/src/notification-bell.tsx
@@ -107,11 +107,10 @@ export function NotificationBell() {
 
           {/* Body */}
           <div className="overflow-y-auto flex-1">
-            {loading ? (
-              <div className="px-4 py-6 text-center text-sm text-gray-400">Loading…</div>
-            ) : notifications.length === 0 ? (
-              <div className="px-4 py-6 text-center text-sm text-gray-400">No notifications yet</div>
-            ) : (
+            {(() => {
+              if (loading) return <div className="px-4 py-6 text-center text-sm text-gray-400">Loading…</div>;
+              if (notifications.length === 0) return <div className="px-4 py-6 text-center text-sm text-gray-400">No notifications yet</div>;
+              return (
               notifications.map(notification => (
                 <button
                   key={notification.id}
@@ -135,7 +134,8 @@ export function NotificationBell() {
                   </div>
                 </button>
               ))
-            )}
+            );
+            })()}
           </div>
         </div>
       )}

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -201,9 +201,11 @@ function printResult(result: ServiceResult, env: "dev" | "prod"): void {
     return;
   }
 
+  const errorSuffix = errors > 1 ? "s" : "";
+  const warningSuffix = warnings > 1 ? "s" : "";
   const summary = [
-    errors > 0 ? red(`${errors} error${errors > 1 ? "s" : ""}`) : null,
-    warnings > 0 ? yellow(`${warnings} warning${warnings > 1 ? "s" : ""}`) : null,
+    errors > 0 ? red(`${errors} error${errorSuffix}`) : null,
+    warnings > 0 ? yellow(`${warnings} warning${warningSuffix}`) : null,
   ].filter(Boolean).join(", ");
 
   console.log(`  ${errors > 0 ? sym.err : sym.warn}  ${label} ${portLabel}  ${summary}`);


### PR DESCRIPTION
﻿## Summary
Refactor all nested ternary operators (SonarCloud S3358) across pps/learn/, pps/market/, pps/coffee/, pps/dykil/, pps/links/, packages/, and scripts/.

## Fix patterns applied
- **Lookup maps**: Record<string, string> for type-to-icon and tier-to-label mappings (AssetCard, SearchFilters, ImajinInput, FileAttachment, ListingDetail)
- **Pre-computed variables**: Extract nested conditions into const/let before use (pino.ts, middleware.ts, services.ts, send.ts, broadcast.ts, check-env.ts, coffee/links page metadata, FairAccordion, VoiceRecorder mime detection)
- **IIFEs / if-else chains**: Replace nested ternary JSX with (() => { if (...) return ...; ... })() (nav-bar auth section, course detail action buttons, loading/error/empty patterns across market, learn, dykil, connection-picker, notification-bell, MentionPicker, etc.)
- **Inline IIFEs for className**: Replace nested ternary class computations (VoiceMessage waveform bars, ImageUpload drag state, DidShareListEditor validation)

## Files changed (34 files)
All S3358 instances from the assigned scope addressed. No instances skipped.

---

_Conversation: https://app.warp.dev/conversation/6324c43a-9de4-44a2-baf0-64677b55f1a8_
_Run: https://oz.warp.dev/runs/019e55e2-8765-7051-b488-761d5e206d8a_
_This PR was generated with [Oz](https://warp.dev/oz)._
