### PR TITLE
fix(sonar): add label associations for form accessibility (S6853) — other

### DIFF
--- a/apps/coffee/app/edit/page.tsx
+++ b/apps/coffee/app/edit/page.tsx
@@ -197,12 +197,13 @@ export default function EditPage() {
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Handle */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6">
-            <label className="block text-sm font-medium mb-2">
+            <label htmlFor="coffee-handle" className="block text-sm font-medium mb-2">
               Handle *
             </label>
             <div className="flex items-center gap-2">
               <span className="text-gray-500">coffee.imajin.ai/</span>
               <input
+                id="coffee-handle"
                 type="text"
                 value={handle}
                 onChange={(e) => setHandle(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
@@ -220,10 +221,11 @@ export default function EditPage() {
           {/* Title & Bio */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 space-y-4">
             <div>
-              <label className="block text-sm font-medium mb-2">
+              <label htmlFor="coffee-title" className="block text-sm font-medium mb-2">
                 Title *
               </label>
               <input
+                id="coffee-title"
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
@@ -234,10 +236,11 @@ export default function EditPage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-2">
+              <label htmlFor="coffee-bio" className="block text-sm font-medium mb-2">
                 Bio
               </label>
               <textarea
+                id="coffee-bio"
                 value={bio}
                 onChange={(e) => setBio(e.target.value)}
                 rows={3}
@@ -249,9 +252,9 @@ export default function EditPage() {
 
           {/* Avatar */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6">
-            <label className="block text-sm font-medium mb-2">
+            <span className="block text-sm font-medium mb-2">
               Avatar
-            </label>
+            </span>
             <div className="flex items-center gap-4">
               <div className="text-6xl">{avatar}</div>
               <div className="flex-1">
@@ -288,8 +291,9 @@ export default function EditPage() {
             <h3 className="font-medium">Theme</h3>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm mb-2">Primary Color</label>
+                <label htmlFor="coffee-primary-color" className="block text-sm mb-2">Primary Color</label>
                 <input
+                  id="coffee-primary-color"
                   type="color"
                   value={primaryColor}
                   onChange={(e) => setPrimaryColor(e.target.value)}
@@ -297,8 +301,9 @@ export default function EditPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm mb-2">Background Color</label>
+                <label htmlFor="coffee-bg-color" className="block text-sm mb-2">Background Color</label>
                 <input
+                  id="coffee-bg-color"
                   type="color"
                   value={backgroundColor}
                   onChange={(e) => setBackgroundColor(e.target.value)}
@@ -310,10 +315,11 @@ export default function EditPage() {
 
           {/* Presets */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6">
-            <label className="block text-sm font-medium mb-2">
+            <label htmlFor="coffee-presets" className="block text-sm font-medium mb-2">
               Preset Amounts (cents, comma-separated) *
             </label>
             <input
+              id="coffee-presets"
               type="text"
               value={presets}
               onChange={(e) => setPresets(e.target.value)}

--- a/apps/dykil/app/(chrome)/create/page.tsx
+++ b/apps/dykil/app/(chrome)/create/page.tsx
@@ -40,8 +40,9 @@ function FieldFormPanel({
 
       <div className="space-y-3">
         <div>
-          <label className="block text-sm font-medium mb-1">Question Text *</label>
+          <label htmlFor={`field-question-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Question Text *</label>
           <input
+            id={`field-question-${isEditing ? 'edit' : 'new'}`}
             type="text"
             value={fieldForm.title}
             onChange={(e) => setFieldForm({ ...fieldForm, title: e.target.value })}
@@ -52,8 +53,9 @@ function FieldFormPanel({
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Export Label (optional)</label>
+          <label htmlFor={`field-export-label-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Export Label (optional)</label>
           <input
+            id={`field-export-label-${isEditing ? 'edit' : 'new'}`}
             type="text"
             value={fieldForm.exportLabel || ''}
             onChange={(e) => setFieldForm({ ...fieldForm, exportLabel: e.target.value || undefined })}
@@ -75,12 +77,13 @@ function FieldFormPanel({
 
         {(fieldForm.type === 'radiogroup' || fieldForm.type === 'checkbox' || fieldForm.type === 'dropdown') && (
           <div>
-            <label className="block text-sm font-medium mb-1">Answer Choices</label>
+            <label htmlFor={`field-choice-0-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Answer Choices</label>
             {(fieldForm.choices || []).map((choice, i) => {
               const choiceText = typeof choice === 'string' ? choice : choice.text || '';
               return (
                 <div key={i} className="flex gap-2 mb-2">
                   <input
+                    id={i === 0 ? `field-choice-0-${isEditing ? 'edit' : 'new'}` : undefined}
                     type="text"
                     value={choiceText}
                     onChange={(e) => {
@@ -119,8 +122,9 @@ function FieldFormPanel({
         {fieldForm.type === 'rating' && (
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="block text-sm font-medium mb-1">Min Value</label>
+              <label htmlFor={`field-rate-min-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Min Value</label>
               <input
+                id={`field-rate-min-${isEditing ? 'edit' : 'new'}`}
                 type="number"
                 value={fieldForm.rateMin || 1}
                 onChange={(e) => setFieldForm({ ...fieldForm, rateMin: Number(e.target.value) })}
@@ -128,8 +132,9 @@ function FieldFormPanel({
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Max Value</label>
+              <label htmlFor={`field-rate-max-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Max Value</label>
               <input
+                id={`field-rate-max-${isEditing ? 'edit' : 'new'}`}
                 type="number"
                 value={fieldForm.rateMax || 5}
                 onChange={(e) => setFieldForm({ ...fieldForm, rateMax: Number(e.target.value) })}
@@ -141,8 +146,9 @@ function FieldFormPanel({
 
         {fieldForm.type === 'text' && (
           <div>
-            <label className="block text-sm font-medium mb-1">Input Type</label>
+            <label htmlFor={`field-input-type-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Input Type</label>
             <select
+              id={`field-input-type-${isEditing ? 'edit' : 'new'}`}
               value={fieldForm.inputType || 'text'}
               onChange={(e) => setFieldForm({ ...fieldForm, inputType: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 text-sm"
@@ -401,8 +407,9 @@ function CreateSurveyContent() {
 
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium mb-2">Title *</label>
+                  <label htmlFor="survey-title" className="block text-sm font-medium mb-2">Title *</label>
                   <input
+                    id="survey-title"
                     type="text"
                     value={survey.title}
                     onChange={(e) => setSurvey({ ...survey, title: e.target.value })}
@@ -412,8 +419,9 @@ function CreateSurveyContent() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium mb-2">Description</label>
+                  <label htmlFor="survey-description" className="block text-sm font-medium mb-2">Description</label>
                   <textarea
+                    id="survey-description"
                     value={survey.description}
                     onChange={(e) => setSurvey({ ...survey, description: e.target.value })}
                     placeholder="Optional description"

--- a/apps/learn/app/dashboard/[slug]/page.tsx
+++ b/apps/learn/app/dashboard/[slug]/page.tsx
@@ -195,16 +195,18 @@ export default function CourseEditorPage() {
           <h2 className="font-semibold text-lg mb-4">Course Settings</h2>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium mb-1">Title</label>
+              <label htmlFor="course-title" className="block text-sm font-medium mb-1">Title</label>
               <input
+                id="course-title"
                 value={editTitle}
                 onChange={(e) => setEditTitle(e.target.value)}
                 className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Description</label>
+              <label htmlFor="course-description" className="block text-sm font-medium mb-1">Description</label>
               <textarea
+                id="course-description"
                 value={editDescription}
                 onChange={(e) => setEditDescription(e.target.value)}
                 rows={3}
@@ -212,8 +214,9 @@ export default function CourseEditorPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Linked Event</label>
+              <label htmlFor="course-event-slug" className="block text-sm font-medium mb-1">Linked Event</label>
               <input
+                id="course-event-slug"
                 value={editEventSlug}
                 onChange={(e) => setEditEventSlug(e.target.value)}
                 placeholder="Event ID (e.g. jins-launch-party)"
@@ -223,8 +226,9 @@ export default function CourseEditorPage() {
             </div>
             <div className="grid grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium mb-1">Price (cents)</label>
+                <label htmlFor="course-price" className="block text-sm font-medium mb-1">Price (cents)</label>
                 <input
+                  id="course-price"
                   type="number"
                   value={editPrice}
                   onChange={(e) => setEditPrice(Number.parseInt(e.target.value) || 0)}
@@ -232,8 +236,9 @@ export default function CourseEditorPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Visibility</label>
+                <label htmlFor="course-visibility" className="block text-sm font-medium mb-1">Visibility</label>
                 <select
+                  id="course-visibility"
                   value={editVisibility}
                   onChange={(e) => setEditVisibility(e.target.value)}
                   className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
@@ -244,8 +249,9 @@ export default function CourseEditorPage() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Status</label>
+                <label htmlFor="course-status" className="block text-sm font-medium mb-1">Status</label>
                 <select
+                  id="course-status"
                   value={editStatus}
                   onChange={(e) => setEditStatus(e.target.value)}
                   className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"

--- a/apps/links/app/edit/page.tsx
+++ b/apps/links/app/edit/page.tsx
@@ -366,8 +366,9 @@ export default function EditPage() {
             <h2 className="text-xl font-semibold mb-4">Edit Page</h2>
             <form onSubmit={updatePage} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-2">Theme</label>
+                <label htmlFor="links-theme" className="block text-sm font-medium mb-2">Theme</label>
                 <select
+                  id="links-theme"
                   value={formData.theme}
                   onChange={(e) => setFormData({ ...formData, theme: e.target.value })}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800"
@@ -416,8 +417,9 @@ export default function EditPage() {
             </h3>
             <form onSubmit={editingLink ? updateLink : addLink} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-2">Title *</label>
+                <label htmlFor="link-title" className="block text-sm font-medium mb-2">Title *</label>
                 <input
+                  id="link-title"
                   type="text"
                   value={linkFormData.title}
                   onChange={(e) => setLinkFormData({ ...linkFormData, title: e.target.value })}
@@ -428,8 +430,9 @@ export default function EditPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">URL *</label>
+                <label htmlFor="link-url" className="block text-sm font-medium mb-2">URL *</label>
                 <input
+                  id="link-url"
                   type="url"
                   value={linkFormData.url}
                   onChange={(e) => setLinkFormData({ ...linkFormData, url: e.target.value })}
@@ -440,8 +443,9 @@ export default function EditPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">Icon (emoji)</label>
+                <label htmlFor="link-icon" className="block text-sm font-medium mb-2">Icon (emoji)</label>
                 <input
+                  id="link-icon"
                   type="text"
                   value={linkFormData.icon}
                   onChange={(e) => setLinkFormData({ ...linkFormData, icon: e.target.value })}
@@ -451,8 +455,9 @@ export default function EditPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">Visibility</label>
+                <label htmlFor="link-visibility" className="block text-sm font-medium mb-2">Visibility</label>
                 <select
+                  id="link-visibility"
                   value={linkFormData.visibility}
                   onChange={(e) => setLinkFormData({ ...linkFormData, visibility: e.target.value })}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800"

--- a/apps/market/app/components/ListingForm.tsx
+++ b/apps/market/app/components/ListingForm.tsx
@@ -318,6 +318,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
         </h2>
         <div className="space-y-3">
           <label
+            htmlFor="seller-tier-direct"
             className={`flex items-start gap-4 p-4 rounded-lg border cursor-pointer transition ${
               sellerTier === 'public_offplatform'
                 ? 'border-blue-500 bg-blue-500/10'
@@ -325,6 +326,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
             }`}
           >
             <input
+              id="seller-tier-direct"
               type="radio"
               name="sellerTier"
               value="public_offplatform"
@@ -339,6 +341,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
           </label>
 
           <label
+            htmlFor="seller-tier-protected"
             className={`flex items-start gap-4 p-4 rounded-lg border cursor-pointer transition ${
               sellerTier === 'public_onplatform'
                 ? 'border-blue-500 bg-blue-500/10'
@@ -346,6 +349,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
             }`}
           >
             <input
+              id="seller-tier-protected"
               type="radio"
               name="sellerTier"
               value="public_onplatform"
@@ -360,6 +364,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
           </label>
 
           <label
+            htmlFor="seller-tier-trusted"
             className={`flex items-start gap-4 p-4 rounded-lg border cursor-pointer transition ${
               sellerTier === 'trust_gated'
                 ? 'border-blue-500 bg-blue-500/10'
@@ -367,6 +372,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
             }`}
           >
             <input
+              id="seller-tier-trusted"
               type="radio"
               name="sellerTier"
               value="trust_gated"

--- a/apps/market/app/settings/page.tsx
+++ b/apps/market/app/settings/page.tsx
@@ -92,7 +92,7 @@ export default function SettingsPage() {
                 <div className="w-11 h-6 bg-gray-800 rounded-full" />
               </div>
             ) : (
-              <label className="flex items-center justify-between gap-4 cursor-pointer select-none">
+              <label htmlFor="show-market-items" className="flex items-center justify-between gap-4 cursor-pointer select-none">
                 <div>
                   <p className="text-sm font-medium text-gray-100">Show listings on my profile</p>
                   <p className="text-xs text-gray-400 mt-0.5">
@@ -100,6 +100,7 @@ export default function SettingsPage() {
                   </p>
                 </div>
                 <button
+                  id="show-market-items"
                   role="switch"
                   aria-checked={showMarketItems}
                   disabled={saving}

--- a/packages/input/src/FileAttachment.tsx
+++ b/packages/input/src/FileAttachment.tsx
@@ -46,6 +46,7 @@ export function FileAttachment({
   const [error, setError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const fileInputId = React.useId();
 
   const processFile = useCallback(
     (file: File) => {
@@ -138,6 +139,7 @@ export function FileAttachment({
   return (
     <div className="relative">
       <input
+        id={fileInputId}
         ref={inputRef}
         type="file"
         accept={accept}
@@ -149,6 +151,7 @@ export function FileAttachment({
         renderTrigger(openPicker)
       ) : (
         <label
+          htmlFor={fileInputId}
           className={`p-2 text-gray-500 hover:text-orange-400 transition-colors cursor-pointer inline-block ${
             disabled ? 'opacity-40 cursor-not-allowed' : ''
           } ${isDragging ? 'text-orange-400' : ''}`}


### PR DESCRIPTION
﻿## Fix SonarCloud S6853: Add label associations for form accessibility — other apps/packages

Fixes 31 instances of S6853 ("A form label must be associated with a control") across remaining apps and packages.

### Changes by file

**apps/dykil/app/(chrome)/create/page.tsx** (8 fixes)
- Added htmlFor/id pairs to FieldFormPanel labels (question text, export label, answer choices, rate min/max, input type) using isEditing context for uniqueness
- Added htmlFor/id for survey title and description in CreateSurveyContent

**apps/coffee/app/edit/page.tsx** (7 fixes)
- Added htmlFor/id for handle, title, bio, primary color, background color, and presets labels
- Changed Avatar <label> to <span> (no associated form control — emoji picker uses buttons)

**apps/learn/app/dashboard/[slug]/page.tsx** (6 fixes)
- Added htmlFor/id for course title, description, linked event, price, visibility, and status

**apps/links/app/edit/page.tsx** (5 fixes)
- Added htmlFor/id for theme select, link title, URL, icon, and visibility

**apps/market/app/components/ListingForm.tsx** (3 fixes)
- Added explicit htmlFor/id to seller tier radio button labels (Direct, Protected, Trusted)

**apps/market/app/settings/page.tsx** (1 fix)
- Added htmlFor/id linking label to the switch button

**packages/input/src/FileAttachment.tsx** (1 fix)
- Used React.useId() for unique ID, linked label to hidden file input via htmlFor

### Skipped instances
None — all 31 issues addressed.

---
_Conversation: https://app.warp.dev/conversation/a0a366c6-e4f0-4b43-a346-4c7326719c71_
_Run: https://oz.warp.dev/runs/019e5653-3b62-70d6-916e-2d94b55014b1_
_This PR was generated with [Oz](https://warp.dev/oz)._
