### PR TITLE
fix(sonar): add label associations for form accessibility (S6853) — events

### DIFF
--- a/apps/events/app/admin/[eventId]/invite-manager.tsx
+++ b/apps/events/app/admin/[eventId]/invite-manager.tsx
@@ -137,10 +137,11 @@ export function InviteManager({ eventId, accessMode }: Readonly<Props>) {
         <form onSubmit={handleCreate} className="mb-6 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg space-y-3">
           <h3 className="font-medium text-sm">New Invite Link</h3>
           <div>
-            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+            <label htmlFor="invite-label" className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
               Label (optional)
             </label>
             <input
+              id="invite-label"
               type="text"
               value={label}
               onChange={e => setLabel(e.target.value)}
@@ -150,10 +151,11 @@ export function InviteManager({ eventId, accessMode }: Readonly<Props>) {
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+              <label htmlFor="invite-max-uses" className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
                 Max Uses (optional)
               </label>
               <input
+                id="invite-max-uses"
                 type="number"
                 min="1"
                 value={maxUses}
@@ -163,10 +165,11 @@ export function InviteManager({ eventId, accessMode }: Readonly<Props>) {
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+              <label htmlFor="invite-expires-at" className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
                 Expires At (optional)
               </label>
               <input
+                id="invite-expires-at"
                 type="datetime-local"
                 value={expiresAt}
                 onChange={e => setExpiresAt(e.target.value)}

--- a/apps/events/app/admin/[eventId]/message-composer.tsx
+++ b/apps/events/app/admin/[eventId]/message-composer.tsx
@@ -134,10 +134,11 @@ export function MessageComposer({ eventId, recipientCount: initialCount, tiers }
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow space-y-4">
         {/* Recipient filter */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          <label htmlFor="message-recipients" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Recipients
           </label>
           <select
+            id="message-recipients"
             value={filterType}
             onChange={(e) => {
               setFilterType(e.target.value as FilterType);
@@ -180,10 +181,11 @@ export function MessageComposer({ eventId, recipientCount: initialCount, tiers }
 
         {/* Subject */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          <label htmlFor="message-subject" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Subject
           </label>
           <input
+            id="message-subject"
             type="text"
             value={subject}
             onChange={(e) => setSubject(e.target.value)}

--- a/apps/events/app/components/ImageUpload.tsx
+++ b/apps/events/app/components/ImageUpload.tsx
@@ -129,7 +129,7 @@ export function ImageUpload({ currentImage, onUploadComplete }: Readonly<ImageUp
 
   return (
     <div>
-      <label className="block text-sm font-medium mb-1">Cover Image</label>
+      <label htmlFor="cover-image-upload" className="block text-sm font-medium mb-1">Cover Image</label>
 
       {displayImage && (
         <div className="mb-3 rounded-lg overflow-hidden border border-gray-300 dark:border-gray-600">
@@ -159,6 +159,7 @@ export function ImageUpload({ currentImage, onUploadComplete }: Readonly<ImageUp
       >
         <input
           ref={fileInputRef}
+          id="cover-image-upload"
           type="file"
           accept="image/jpeg,image/png,image/gif,image/webp"
           onChange={onFileInputChange}

--- a/apps/events/app/create/form.tsx
+++ b/apps/events/app/create/form.tsx
@@ -125,7 +125,7 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
 
         {/* Event Type */}
         <div>
-          <label className="block text-sm font-medium mb-2">Event Type</label>
+          <span className="block text-sm font-medium mb-2">Event Type</span>
           <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden">
             {(['event', 'campaign'] as const).map((type) => (
               <button
@@ -153,8 +153,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         {eventType === 'campaign' && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-xl">
             <div>
-              <label className="block text-sm font-medium mb-1">Funding Goal (CAD) *</label>
+              <label htmlFor="create-funding-goal" className="block text-sm font-medium mb-1">Funding Goal (CAD) *</label>
               <input
+                id="create-funding-goal"
                 type="number"
                 min="1"
                 step="0.01"
@@ -167,8 +168,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
               <p className="text-xs text-gray-500 mt-1">Minimum $1.00</p>
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Deadline</label>
+              <label htmlFor="create-campaign-deadline" className="block text-sm font-medium mb-1">Deadline</label>
               <input
+                id="create-campaign-deadline"
                 type="datetime-local"
                 value={campaignDeadline}
                 onChange={(e) => setCampaignDeadline(e.target.value)}
@@ -180,8 +182,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         )}
 
         <div>
-          <label className="block text-sm font-medium mb-1">Event Name *</label>
+          <label htmlFor="create-event-name" className="block text-sm font-medium mb-1">Event Name *</label>
           <input
+            id="create-event-name"
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -192,8 +195,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Tagline</label>
+          <label htmlFor="create-tagline" className="block text-sm font-medium mb-1">Tagline</label>
           <input
+            id="create-tagline"
             type="text"
             value={tagline}
             onChange={(e) => setTagline(e.target.value)}
@@ -204,8 +208,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium mb-1">Start Date & Time *</label>
+            <label htmlFor="create-start-date" className="block text-sm font-medium mb-1">Start Date & Time *</label>
             <input
+              id="create-start-date"
               type="datetime-local"
               value={dateTime}
               onChange={(e) => setDateTime(e.target.value)}
@@ -215,8 +220,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1">End Date & Time</label>
+            <label htmlFor="create-end-date" className="block text-sm font-medium mb-1">End Date & Time</label>
             <input
+              id="create-end-date"
               type="datetime-local"
               value={endDateTime}
               onChange={(e) => setEndDateTime(e.target.value)}
@@ -244,8 +250,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
 
         {locationType !== 'physical' && (
           <div>
-            <label className="block text-sm font-medium mb-1">Virtual URL</label>
+            <label htmlFor="create-virtual-url" className="block text-sm font-medium mb-1">Virtual URL</label>
             <input
+              id="create-virtual-url"
               type="url"
               value={virtualUrl}
               onChange={(e) => setVirtualUrl(e.target.value)}
@@ -258,8 +265,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         {locationType !== 'virtual' && (
           <>
             <div>
-              <label className="block text-sm font-medium mb-1">Venue</label>
+              <label htmlFor="create-venue" className="block text-sm font-medium mb-1">Venue</label>
               <input
+                id="create-venue"
                 type="text"
                 value={venue}
                 onChange={(e) => setVenue(e.target.value)}
@@ -268,8 +276,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Address</label>
+              <label htmlFor="create-address" className="block text-sm font-medium mb-1">Address</label>
               <input
+                id="create-address"
                 type="text"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
@@ -279,8 +288,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium mb-1">City</label>
+                <label htmlFor="create-city" className="block text-sm font-medium mb-1">City</label>
                 <input
+                  id="create-city"
                   type="text"
                   value={city}
                   onChange={(e) => setCity(e.target.value)}
@@ -289,8 +299,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Country</label>
+                <label htmlFor="create-country" className="block text-sm font-medium mb-1">Country</label>
                 <input
+                  id="create-country"
                   type="text"
                   value={country}
                   onChange={(e) => setCountry(e.target.value)}
@@ -303,8 +314,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         )}
 
         <div>
-          <label className="block text-sm font-medium mb-1">Linked Course Slug</label>
+          <label htmlFor="create-course-slug" className="block text-sm font-medium mb-1">Linked Course Slug</label>
           <input
+            id="create-course-slug"
             type="text"
             value={courseSlug}
             onChange={(e) => setCourseSlug(e.target.value)}
@@ -319,12 +331,14 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         />
 
         <div>
-          <label className="block text-sm font-medium mb-1">Description</label>
-          <MarkdownEditor
-            value={description}
-            onChange={setDescription}
-            placeholder="Tell people what your event is about..."
-          />
+          <label className="block">
+            <span className="text-sm font-medium block mb-1">Description</span>
+            <MarkdownEditor
+              value={description}
+              onChange={setDescription}
+              placeholder="Tell people what your event is about..."
+            />
+          </label>
         </div>
       </div>
 
@@ -347,8 +361,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
               <div className="flex justify-between items-start">
                 <div className="flex-1 grid grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-sm font-medium mb-1">Tier Name</label>
+                    <label htmlFor={`create-tier-name-${index}`} className="block text-sm font-medium mb-1">Tier Name</label>
                     <input
+                      id={`create-tier-name-${index}`}
                       type="text"
                       value={tier.name}
                       onChange={(e) => updateTier(index, 'name', e.target.value)}
@@ -357,8 +372,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium mb-1">Price (CAD)</label>
+                    <label htmlFor={`create-tier-price-${index}`} className="block text-sm font-medium mb-1">Price (CAD)</label>
                     <input
+                      id={`create-tier-price-${index}`}
                       type="number"
                       min="0"
                       step="0.01"
@@ -368,8 +384,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium mb-1">Quantity (blank = unlimited)</label>
+                    <label htmlFor={`create-tier-quantity-${index}`} className="block text-sm font-medium mb-1">Quantity (blank = unlimited)</label>
                     <input
+                      id={`create-tier-quantity-${index}`}
                       type="number"
                       min="1"
                       value={tier.quantity || ''}
@@ -379,8 +396,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium mb-1">Description</label>
+                    <label htmlFor={`create-tier-description-${index}`} className="block text-sm font-medium mb-1">Description</label>
                     <input
+                      id={`create-tier-description-${index}`}
                       type="text"
                       value={tier.description}
                       onChange={(e) => updateTier(index, 'description', e.target.value)}

--- a/apps/events/app/e/[eventId]/edit/form.tsx
+++ b/apps/events/app/e/[eventId]/edit/form.tsx
@@ -438,8 +438,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         <h2 className="text-xl font-semibold">Basic Info</h2>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Event Name *</label>
+          <label htmlFor="edit-event-name" className="block text-sm font-medium mb-1">Event Name *</label>
           <input
+            id="edit-event-name"
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -449,17 +450,20 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Description</label>
-          <MarkdownEditor
-            value={description}
-            onChange={setDescription}
-          />
+          <label className="block">
+            <span className="text-sm font-medium block mb-1">Description</span>
+            <MarkdownEditor
+              value={description}
+              onChange={setDescription}
+            />
+          </label>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium mb-1">Start Date & Time *</label>
+            <label htmlFor="edit-start-date" className="block text-sm font-medium mb-1">Start Date & Time *</label>
             <input
+              id="edit-start-date"
               type="datetime-local"
               value={dateTime}
               onChange={(e) => setDateTime(e.target.value)}
@@ -469,8 +473,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1">End Date & Time</label>
+            <label htmlFor="edit-end-date" className="block text-sm font-medium mb-1">End Date & Time</label>
             <input
+              id="edit-end-date"
               type="datetime-local"
               value={endDateTime}
               onChange={(e) => setEndDateTime(e.target.value)}
@@ -480,8 +485,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Timezone</label>
+          <label htmlFor="edit-timezone" className="block text-sm font-medium mb-1">Timezone</label>
           <select
+            id="edit-timezone"
             value={timezone}
             onChange={(e) => setTimezone(e.target.value)}
             className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-orange-500"
@@ -511,8 +517,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
 
         {locationType !== 'physical' && (
           <div>
-            <label className="block text-sm font-medium mb-1">Virtual URL</label>
+            <label htmlFor="edit-virtual-url" className="block text-sm font-medium mb-1">Virtual URL</label>
             <input
+              id="edit-virtual-url"
               type="url"
               value={virtualUrl}
               onChange={(e) => setVirtualUrl(e.target.value)}
@@ -525,8 +532,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         {locationType !== 'virtual' && (
           <>
             <div>
-              <label className="block text-sm font-medium mb-1">Venue</label>
+              <label htmlFor="edit-venue" className="block text-sm font-medium mb-1">Venue</label>
               <input
+                id="edit-venue"
                 type="text"
                 value={venue}
                 onChange={(e) => setVenue(e.target.value)}
@@ -535,8 +543,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Address</label>
+              <label htmlFor="edit-address" className="block text-sm font-medium mb-1">Address</label>
               <input
+                id="edit-address"
                 type="text"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
@@ -546,8 +555,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium mb-1">City</label>
+                <label htmlFor="edit-city" className="block text-sm font-medium mb-1">City</label>
                 <input
+                  id="edit-city"
                   type="text"
                   value={city}
                   onChange={(e) => setCity(e.target.value)}
@@ -556,8 +566,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Country</label>
+                <label htmlFor="edit-country" className="block text-sm font-medium mb-1">Country</label>
                 <input
+                  id="edit-country"
                   type="text"
                   value={country}
                   onChange={(e) => setCountry(e.target.value)}
@@ -575,8 +586,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         />
 
         <div>
-          <label className="block text-sm font-medium mb-1">Linked Course Slug</label>
+          <label htmlFor="edit-course-slug" className="block text-sm font-medium mb-1">Linked Course Slug</label>
           <input
+            id="edit-course-slug"
             type="text"
             value={courseSlug}
             onChange={(e) => setCourseSlug(e.target.value)}
@@ -587,8 +599,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Status</label>
+          <label htmlFor="edit-status" className="block text-sm font-medium mb-1">Status</label>
           <select
+            id="edit-status"
             value={status}
             onChange={(e) => setStatus(e.target.value)}
             className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-orange-500"
@@ -608,8 +621,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
           Control who can purchase tickets to this event.
         </p>
         <div className="space-y-3">
-          <label className="flex items-start gap-3 cursor-pointer">
+          <label htmlFor="edit-access-public" className="flex items-start gap-3 cursor-pointer">
             <input
+              id="edit-access-public"
               type="radio"
               name="accessMode"
               value="public"
@@ -622,8 +636,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               <div className="text-sm text-gray-500 dark:text-gray-400">Anyone can discover and buy tickets.</div>
             </div>
           </label>
-          <label className="flex items-start gap-3 cursor-pointer">
+          <label htmlFor="edit-access-invite" className="flex items-start gap-3 cursor-pointer">
             <input
+              id="edit-access-invite"
               type="radio"
               name="accessMode"
               value="invite_only"
@@ -678,8 +693,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="block text-sm font-medium mb-1">Tier Name</label>
+                <label htmlFor={`edit-tier-name-${index}`} className="block text-sm font-medium mb-1">Tier Name</label>
                 <input
+                  id={`edit-tier-name-${index}`}
                   type="text"
                   value={tier.name}
                   onChange={(e) => updateTier(index, 'name', e.target.value)}
@@ -687,9 +703,10 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Price</label>
+                <label htmlFor={`edit-tier-price-${index}`} className="block text-sm font-medium mb-1">Price</label>
                 <div className="flex gap-2">
                   <input
+                    id={`edit-tier-price-${index}`}
                     type="number"
                     step="0.01"
                     min="0"
@@ -708,8 +725,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Quantity {tier.sold ? `(${tier.sold} sold)` : ''}</label>
+                <label htmlFor={`edit-tier-quantity-${index}`} className="block text-sm font-medium mb-1">Quantity {tier.sold ? `(${tier.sold} sold)` : ''}</label>
                 <input
+                  id={`edit-tier-quantity-${index}`}
                   type="number"
                   min={tier.sold || 0}
                   value={tier.quantity === null ? '' : tier.quantity}
@@ -719,8 +737,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Sold</label>
+                <label htmlFor={`edit-tier-sold-${index}`} className="block text-sm font-medium mb-1">Sold</label>
                 <input
+                  id={`edit-tier-sold-${index}`}
                   type="text"
                   value={tier.sold || 0}
                   disabled
@@ -729,8 +748,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               </div>
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Description</label>
+              <label htmlFor={`edit-tier-description-${index}`} className="block text-sm font-medium mb-1">Description</label>
               <input
+                id={`edit-tier-description-${index}`}
                 type="text"
                 value={tier.description}
                 onChange={(e) => updateTier(index, 'description', e.target.value)}
@@ -739,8 +759,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Perks (one per line)</label>
+              <label htmlFor={`edit-tier-perks-${index}`} className="block text-sm font-medium mb-1">Perks (one per line)</label>
               <textarea
+                id={`edit-tier-perks-${index}`}
                 value={(tier.perks || []).join('\n')}
                 onChange={(e) => updateTier(index, 'perks', e.target.value.split('\n').filter(Boolean))}
                 rows={4}
@@ -761,7 +782,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               </label>
               {tier.requiresRegistration && (
                 <div className="mt-2">
-                  <label className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400">
+                  <label htmlFor={`edit-tier-registration-form-${index}`} className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400">
                     Registration Form <span className="text-red-500">*</span>
                   </label>
                   {(() => {
@@ -769,6 +790,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                     if (surveys.length === 0) return <p className="text-xs text-gray-400">No forms found. Create one in Dykil first.</p>;
                     return (
                     <select
+                      id={`edit-tier-registration-form-${index}`}
                       value={tier.registrationFormId}
                       onChange={(e) => updateTier(index, 'registrationFormId', e.target.value)}
                       required
@@ -788,9 +810,10 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               )}
             </div>
             <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
-              <label className="block text-sm font-medium mb-1">Access Code (optional)</label>
+              <label htmlFor={`edit-tier-access-code-${index}`} className="block text-sm font-medium mb-1">Access Code (optional)</label>
               <div className="flex items-center gap-2">
                 <input
+                  id={`edit-tier-access-code-${index}`}
                   type="text"
                   value={tier.accessCode || ''}
                   onChange={(e) => updateTier(index, 'accessCode', e.target.value)}
@@ -872,8 +895,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
 
                   <div className="flex items-center gap-4 flex-wrap">
                     <div className="flex items-center gap-2">
-                      <label className="text-sm text-gray-600 dark:text-gray-400">Show:</label>
+                      <label htmlFor={`edit-survey-visibility-${index}`} className="text-sm text-gray-600 dark:text-gray-400">Show:</label>
                       <select
+                        id={`edit-survey-visibility-${index}`}
                         value={linked.visibility}
                         onChange={(e) => {
                           const updated = [...linkedSurveys];
@@ -949,7 +973,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         {/* Chat Toggle */}
         <div className="flex items-center justify-between py-3 border-b border-gray-200 dark:border-gray-700">
           <div>
-            <label className="font-medium text-sm">Event Chat</label>
+            <span className="font-medium text-sm">Event Chat</span>
             <p className="text-xs text-gray-500">Allow ticket holders to chat</p>
           </div>
           <button
@@ -968,8 +992,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             { value: 'handle', label: 'Handle only', description: 'Show @handle, no real name' },
             { value: 'anonymous', label: 'Anonymous', description: 'Show "Attendee" — no names visible' },
           ] as const).map((option) => (
-            <label key={option.value} className="flex items-start gap-3 cursor-pointer group">
+            <label key={option.value} htmlFor={`edit-name-display-${option.value}`} className="flex items-start gap-3 cursor-pointer group">
               <input
+                id={`edit-name-display-${option.value}`}
                 type="radio"
                 name="nameDisplayPolicy"
                 value={option.value}
@@ -1005,10 +1030,11 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         </label>
         {emtEnabled && (
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="edit-emt-email" className="block text-sm font-medium mb-1">
               e-Transfer Email <span className="text-red-500">*</span>
             </label>
             <input
+              id="edit-emt-email"
               type="email"
               value={emtEmail}
               onChange={(e) => setEmtEmail(e.target.value)}


### PR DESCRIPTION
## Fix S6853: Add label associations for form accessibility � events

Fix all 49 SonarCloud S6853 ("A form label must be associated with a control") issues in `apps/events/`.

### Changes across 5 files

**Pattern 1 � `htmlFor`/`id` pairs** (most labels):
Added `htmlFor` to `<label>` and `id` to the associated `<input>`/`<select>`/`<textarea>`. Used context prefixes (`edit-`, `create-`, `invite-`, `message-`) to avoid ID collisions. Fields inside `.map()` loops use `$`{index}` suffixes.

**Pattern 2 � Wrap input inside label** (MarkdownEditor):
For `<MarkdownEditor>` (custom component), wrapped the editor inside `<label>` with a `<span>` for the label text to preserve styling.

**Pattern 3 � Replace `<label>` with `<span>`** (non-form controls):
For "Event Type" button group (create form) and "Event Chat" toggle button (edit form), replaced `<label>` with `<span>` since these control non-labelable elements (buttons).

### Files modified
- `apps/events/app/e/[eventId]/edit/form.tsx` � 25 issues
- `apps/events/app/create/form.tsx` � 18 issues
- `apps/events/app/admin/[eventId]/invite-manager.tsx` � 3 issues
- `apps/events/app/admin/[eventId]/message-composer.tsx` � 2 issues
- `apps/events/app/components/ImageUpload.tsx` � 1 issue

_Conversation: https://app.warp.dev/conversation/64226875-4719-4e7a-ac53-37c57647d9cd_
_Run: https://oz.warp.dev/runs/019e5653-3b62-774e-9f04-bd075b2ea31a_

_This PR was generated with [Oz](https://warp.dev/oz)._
