### PR TITLE
fix(sonar): add label associations for form accessibility (S6853)

### DIFF
--- a/apps/coffee/app/edit/page.tsx
+++ b/apps/coffee/app/edit/page.tsx
@@ -197,12 +197,13 @@ export default function EditPage() {
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Handle */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6">
-            <label className="block text-sm font-medium mb-2">
+            <label htmlFor="coffee-handle" className="block text-sm font-medium mb-2">
               Handle *
             </label>
             <div className="flex items-center gap-2">
               <span className="text-gray-500">coffee.imajin.ai/</span>
               <input
+                id="coffee-handle"
                 type="text"
                 value={handle}
                 onChange={(e) => setHandle(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
@@ -220,10 +221,11 @@ export default function EditPage() {
           {/* Title & Bio */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 space-y-4">
             <div>
-              <label className="block text-sm font-medium mb-2">
+              <label htmlFor="coffee-title" className="block text-sm font-medium mb-2">
                 Title *
               </label>
               <input
+                id="coffee-title"
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
@@ -234,10 +236,11 @@ export default function EditPage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-2">
+              <label htmlFor="coffee-bio" className="block text-sm font-medium mb-2">
                 Bio
               </label>
               <textarea
+                id="coffee-bio"
                 value={bio}
                 onChange={(e) => setBio(e.target.value)}
                 rows={3}
@@ -249,9 +252,9 @@ export default function EditPage() {
 
           {/* Avatar */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6">
-            <label className="block text-sm font-medium mb-2">
+            <span className="block text-sm font-medium mb-2">
               Avatar
-            </label>
+            </span>
             <div className="flex items-center gap-4">
               <div className="text-6xl">{avatar}</div>
               <div className="flex-1">
@@ -288,8 +291,9 @@ export default function EditPage() {
             <h3 className="font-medium">Theme</h3>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm mb-2">Primary Color</label>
+                <label htmlFor="coffee-primary-color" className="block text-sm mb-2">Primary Color</label>
                 <input
+                  id="coffee-primary-color"
                   type="color"
                   value={primaryColor}
                   onChange={(e) => setPrimaryColor(e.target.value)}
@@ -297,8 +301,9 @@ export default function EditPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm mb-2">Background Color</label>
+                <label htmlFor="coffee-bg-color" className="block text-sm mb-2">Background Color</label>
                 <input
+                  id="coffee-bg-color"
                   type="color"
                   value={backgroundColor}
                   onChange={(e) => setBackgroundColor(e.target.value)}
@@ -310,10 +315,11 @@ export default function EditPage() {
 
           {/* Presets */}
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6">
-            <label className="block text-sm font-medium mb-2">
+            <label htmlFor="coffee-presets" className="block text-sm font-medium mb-2">
               Preset Amounts (cents, comma-separated) *
             </label>
             <input
+              id="coffee-presets"
               type="text"
               value={presets}
               onChange={(e) => setPresets(e.target.value)}

--- a/apps/dykil/app/(chrome)/create/page.tsx
+++ b/apps/dykil/app/(chrome)/create/page.tsx
@@ -40,8 +40,9 @@ function FieldFormPanel({
 
       <div className="space-y-3">
         <div>
-          <label className="block text-sm font-medium mb-1">Question Text *</label>
+          <label htmlFor={`field-question-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Question Text *</label>
           <input
+            id={`field-question-${isEditing ? 'edit' : 'new'}`}
             type="text"
             value={fieldForm.title}
             onChange={(e) => setFieldForm({ ...fieldForm, title: e.target.value })}
@@ -52,8 +53,9 @@ function FieldFormPanel({
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Export Label (optional)</label>
+          <label htmlFor={`field-export-label-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Export Label (optional)</label>
           <input
+            id={`field-export-label-${isEditing ? 'edit' : 'new'}`}
             type="text"
             value={fieldForm.exportLabel || ''}
             onChange={(e) => setFieldForm({ ...fieldForm, exportLabel: e.target.value || undefined })}
@@ -75,12 +77,13 @@ function FieldFormPanel({
 
         {(fieldForm.type === 'radiogroup' || fieldForm.type === 'checkbox' || fieldForm.type === 'dropdown') && (
           <div>
-            <label className="block text-sm font-medium mb-1">Answer Choices</label>
+            <label htmlFor={`field-choice-0-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Answer Choices</label>
             {(fieldForm.choices || []).map((choice, i) => {
               const choiceText = typeof choice === 'string' ? choice : choice.text || '';
               return (
                 <div key={i} className="flex gap-2 mb-2">
                   <input
+                    id={i === 0 ? `field-choice-0-${isEditing ? 'edit' : 'new'}` : undefined}
                     type="text"
                     value={choiceText}
                     onChange={(e) => {
@@ -119,8 +122,9 @@ function FieldFormPanel({
         {fieldForm.type === 'rating' && (
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="block text-sm font-medium mb-1">Min Value</label>
+              <label htmlFor={`field-rate-min-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Min Value</label>
               <input
+                id={`field-rate-min-${isEditing ? 'edit' : 'new'}`}
                 type="number"
                 value={fieldForm.rateMin || 1}
                 onChange={(e) => setFieldForm({ ...fieldForm, rateMin: Number(e.target.value) })}
@@ -128,8 +132,9 @@ function FieldFormPanel({
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Max Value</label>
+              <label htmlFor={`field-rate-max-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Max Value</label>
               <input
+                id={`field-rate-max-${isEditing ? 'edit' : 'new'}`}
                 type="number"
                 value={fieldForm.rateMax || 5}
                 onChange={(e) => setFieldForm({ ...fieldForm, rateMax: Number(e.target.value) })}
@@ -141,8 +146,9 @@ function FieldFormPanel({
 
         {fieldForm.type === 'text' && (
           <div>
-            <label className="block text-sm font-medium mb-1">Input Type</label>
+            <label htmlFor={`field-input-type-${isEditing ? 'edit' : 'new'}`} className="block text-sm font-medium mb-1">Input Type</label>
             <select
+              id={`field-input-type-${isEditing ? 'edit' : 'new'}`}
               value={fieldForm.inputType || 'text'}
               onChange={(e) => setFieldForm({ ...fieldForm, inputType: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 text-sm"
@@ -401,8 +407,9 @@ function CreateSurveyContent() {
 
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium mb-2">Title *</label>
+                  <label htmlFor="survey-title" className="block text-sm font-medium mb-2">Title *</label>
                   <input
+                    id="survey-title"
                     type="text"
                     value={survey.title}
                     onChange={(e) => setSurvey({ ...survey, title: e.target.value })}
@@ -412,8 +419,9 @@ function CreateSurveyContent() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium mb-2">Description</label>
+                  <label htmlFor="survey-description" className="block text-sm font-medium mb-2">Description</label>
                   <textarea
+                    id="survey-description"
                     value={survey.description}
                     onChange={(e) => setSurvey({ ...survey, description: e.target.value })}
                     placeholder="Optional description"

--- a/apps/events/app/admin/[eventId]/invite-manager.tsx
+++ b/apps/events/app/admin/[eventId]/invite-manager.tsx
@@ -137,10 +137,11 @@ export function InviteManager({ eventId, accessMode }: Readonly<Props>) {
         <form onSubmit={handleCreate} className="mb-6 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg space-y-3">
           <h3 className="font-medium text-sm">New Invite Link</h3>
           <div>
-            <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+            <label htmlFor="invite-label" className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
               Label (optional)
             </label>
             <input
+              id="invite-label"
               type="text"
               value={label}
               onChange={e => setLabel(e.target.value)}
@@ -150,10 +151,11 @@ export function InviteManager({ eventId, accessMode }: Readonly<Props>) {
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+              <label htmlFor="invite-max-uses" className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
                 Max Uses (optional)
               </label>
               <input
+                id="invite-max-uses"
                 type="number"
                 min="1"
                 value={maxUses}
@@ -163,10 +165,11 @@ export function InviteManager({ eventId, accessMode }: Readonly<Props>) {
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+              <label htmlFor="invite-expires-at" className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
                 Expires At (optional)
               </label>
               <input
+                id="invite-expires-at"
                 type="datetime-local"
                 value={expiresAt}
                 onChange={e => setExpiresAt(e.target.value)}

--- a/apps/events/app/admin/[eventId]/message-composer.tsx
+++ b/apps/events/app/admin/[eventId]/message-composer.tsx
@@ -134,10 +134,11 @@ export function MessageComposer({ eventId, recipientCount: initialCount, tiers }
       <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow space-y-4">
         {/* Recipient filter */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          <label htmlFor="message-recipients" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Recipients
           </label>
           <select
+            id="message-recipients"
             value={filterType}
             onChange={(e) => {
               setFilterType(e.target.value as FilterType);
@@ -180,10 +181,11 @@ export function MessageComposer({ eventId, recipientCount: initialCount, tiers }
 
         {/* Subject */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          <label htmlFor="message-subject" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Subject
           </label>
           <input
+            id="message-subject"
             type="text"
             value={subject}
             onChange={(e) => setSubject(e.target.value)}

--- a/apps/events/app/components/ImageUpload.tsx
+++ b/apps/events/app/components/ImageUpload.tsx
@@ -129,7 +129,7 @@ export function ImageUpload({ currentImage, onUploadComplete }: Readonly<ImageUp
 
   return (
     <div>
-      <label className="block text-sm font-medium mb-1">Cover Image</label>
+      <label htmlFor="cover-image-upload" className="block text-sm font-medium mb-1">Cover Image</label>
 
       {displayImage && (
         <div className="mb-3 rounded-lg overflow-hidden border border-gray-300 dark:border-gray-600">
@@ -159,6 +159,7 @@ export function ImageUpload({ currentImage, onUploadComplete }: Readonly<ImageUp
       >
         <input
           ref={fileInputRef}
+          id="cover-image-upload"
           type="file"
           accept="image/jpeg,image/png,image/gif,image/webp"
           onChange={onFileInputChange}

--- a/apps/events/app/create/form.tsx
+++ b/apps/events/app/create/form.tsx
@@ -125,7 +125,7 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
 
         {/* Event Type */}
         <div>
-          <label className="block text-sm font-medium mb-2">Event Type</label>
+          <span className="block text-sm font-medium mb-2">Event Type</span>
           <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden">
             {(['event', 'campaign'] as const).map((type) => (
               <button
@@ -153,8 +153,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         {eventType === 'campaign' && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-xl">
             <div>
-              <label className="block text-sm font-medium mb-1">Funding Goal (CAD) *</label>
+              <label htmlFor="create-funding-goal" className="block text-sm font-medium mb-1">Funding Goal (CAD) *</label>
               <input
+                id="create-funding-goal"
                 type="number"
                 min="1"
                 step="0.01"
@@ -167,8 +168,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
               <p className="text-xs text-gray-500 mt-1">Minimum $1.00</p>
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Deadline</label>
+              <label htmlFor="create-campaign-deadline" className="block text-sm font-medium mb-1">Deadline</label>
               <input
+                id="create-campaign-deadline"
                 type="datetime-local"
                 value={campaignDeadline}
                 onChange={(e) => setCampaignDeadline(e.target.value)}
@@ -180,8 +182,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         )}
 
         <div>
-          <label className="block text-sm font-medium mb-1">Event Name *</label>
+          <label htmlFor="create-event-name" className="block text-sm font-medium mb-1">Event Name *</label>
           <input
+            id="create-event-name"
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -192,8 +195,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Tagline</label>
+          <label htmlFor="create-tagline" className="block text-sm font-medium mb-1">Tagline</label>
           <input
+            id="create-tagline"
             type="text"
             value={tagline}
             onChange={(e) => setTagline(e.target.value)}
@@ -204,8 +208,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium mb-1">Start Date & Time *</label>
+            <label htmlFor="create-start-date" className="block text-sm font-medium mb-1">Start Date & Time *</label>
             <input
+              id="create-start-date"
               type="datetime-local"
               value={dateTime}
               onChange={(e) => setDateTime(e.target.value)}
@@ -215,8 +220,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1">End Date & Time</label>
+            <label htmlFor="create-end-date" className="block text-sm font-medium mb-1">End Date & Time</label>
             <input
+              id="create-end-date"
               type="datetime-local"
               value={endDateTime}
               onChange={(e) => setEndDateTime(e.target.value)}
@@ -244,8 +250,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
 
         {locationType !== 'physical' && (
           <div>
-            <label className="block text-sm font-medium mb-1">Virtual URL</label>
+            <label htmlFor="create-virtual-url" className="block text-sm font-medium mb-1">Virtual URL</label>
             <input
+              id="create-virtual-url"
               type="url"
               value={virtualUrl}
               onChange={(e) => setVirtualUrl(e.target.value)}
@@ -258,8 +265,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         {locationType !== 'virtual' && (
           <>
             <div>
-              <label className="block text-sm font-medium mb-1">Venue</label>
+              <label htmlFor="create-venue" className="block text-sm font-medium mb-1">Venue</label>
               <input
+                id="create-venue"
                 type="text"
                 value={venue}
                 onChange={(e) => setVenue(e.target.value)}
@@ -268,8 +276,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Address</label>
+              <label htmlFor="create-address" className="block text-sm font-medium mb-1">Address</label>
               <input
+                id="create-address"
                 type="text"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
@@ -279,8 +288,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium mb-1">City</label>
+                <label htmlFor="create-city" className="block text-sm font-medium mb-1">City</label>
                 <input
+                  id="create-city"
                   type="text"
                   value={city}
                   onChange={(e) => setCity(e.target.value)}
@@ -289,8 +299,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Country</label>
+                <label htmlFor="create-country" className="block text-sm font-medium mb-1">Country</label>
                 <input
+                  id="create-country"
                   type="text"
                   value={country}
                   onChange={(e) => setCountry(e.target.value)}
@@ -303,8 +314,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         )}
 
         <div>
-          <label className="block text-sm font-medium mb-1">Linked Course Slug</label>
+          <label htmlFor="create-course-slug" className="block text-sm font-medium mb-1">Linked Course Slug</label>
           <input
+            id="create-course-slug"
             type="text"
             value={courseSlug}
             onChange={(e) => setCourseSlug(e.target.value)}
@@ -319,12 +331,14 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
         />
 
         <div>
-          <label className="block text-sm font-medium mb-1">Description</label>
-          <MarkdownEditor
-            value={description}
-            onChange={setDescription}
-            placeholder="Tell people what your event is about..."
-          />
+          <label className="block">
+            <span className="text-sm font-medium block mb-1">Description</span>
+            <MarkdownEditor
+              value={description}
+              onChange={setDescription}
+              placeholder="Tell people what your event is about..."
+            />
+          </label>
         </div>
       </div>
 
@@ -347,8 +361,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
               <div className="flex justify-between items-start">
                 <div className="flex-1 grid grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-sm font-medium mb-1">Tier Name</label>
+                    <label htmlFor={`create-tier-name-${index}`} className="block text-sm font-medium mb-1">Tier Name</label>
                     <input
+                      id={`create-tier-name-${index}`}
                       type="text"
                       value={tier.name}
                       onChange={(e) => updateTier(index, 'name', e.target.value)}
@@ -357,8 +372,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium mb-1">Price (CAD)</label>
+                    <label htmlFor={`create-tier-price-${index}`} className="block text-sm font-medium mb-1">Price (CAD)</label>
                     <input
+                      id={`create-tier-price-${index}`}
                       type="number"
                       min="0"
                       step="0.01"
@@ -368,8 +384,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium mb-1">Quantity (blank = unlimited)</label>
+                    <label htmlFor={`create-tier-quantity-${index}`} className="block text-sm font-medium mb-1">Quantity (blank = unlimited)</label>
                     <input
+                      id={`create-tier-quantity-${index}`}
                       type="number"
                       min="1"
                       value={tier.quantity || ''}
@@ -379,8 +396,9 @@ export default function EventCreateForm({ organizerDid }: Readonly<Props>) {
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium mb-1">Description</label>
+                    <label htmlFor={`create-tier-description-${index}`} className="block text-sm font-medium mb-1">Description</label>
                     <input
+                      id={`create-tier-description-${index}`}
                       type="text"
                       value={tier.description}
                       onChange={(e) => updateTier(index, 'description', e.target.value)}

--- a/apps/events/app/e/[eventId]/edit/form.tsx
+++ b/apps/events/app/e/[eventId]/edit/form.tsx
@@ -621,7 +621,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
           Control who can purchase tickets to this event.
         </p>
         <div className="space-y-3">
-          <label htmlFor="edit-access-public" className="flex items-start gap-3 cursor-pointer">
+          <label htmlFor="edit-access-public" aria-label="Public" className="flex items-start gap-3 cursor-pointer">
             <input
               id="edit-access-public"
               type="radio"
@@ -636,7 +636,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               <div className="text-sm text-gray-500 dark:text-gray-400">Anyone can discover and buy tickets.</div>
             </div>
           </label>
-          <label htmlFor="edit-access-invite" className="flex items-start gap-3 cursor-pointer">
+          <label htmlFor="edit-access-invite" aria-label="Invite Only" className="flex items-start gap-3 cursor-pointer">
             <input
               id="edit-access-invite"
               type="radio"
@@ -992,7 +992,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             { value: 'handle', label: 'Handle only', description: 'Show @handle, no real name' },
             { value: 'anonymous', label: 'Anonymous', description: 'Show "Attendee" — no names visible' },
           ] as const).map((option) => (
-            <label key={option.value} htmlFor={`edit-name-display-${option.value}`} className="flex items-start gap-3 cursor-pointer group">
+            <label key={option.value} htmlFor={`edit-name-display-${option.value}`} aria-label={option.label} className="flex items-start gap-3 cursor-pointer group">
               <input
                 id={`edit-name-display-${option.value}`}
                 type="radio"

--- a/apps/events/app/e/[eventId]/edit/form.tsx
+++ b/apps/events/app/e/[eventId]/edit/form.tsx
@@ -438,8 +438,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         <h2 className="text-xl font-semibold">Basic Info</h2>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Event Name *</label>
+          <label htmlFor="edit-event-name" className="block text-sm font-medium mb-1">Event Name *</label>
           <input
+            id="edit-event-name"
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
@@ -449,17 +450,20 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Description</label>
-          <MarkdownEditor
-            value={description}
-            onChange={setDescription}
-          />
+          <label className="block">
+            <span className="text-sm font-medium block mb-1">Description</span>
+            <MarkdownEditor
+              value={description}
+              onChange={setDescription}
+            />
+          </label>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium mb-1">Start Date & Time *</label>
+            <label htmlFor="edit-start-date" className="block text-sm font-medium mb-1">Start Date & Time *</label>
             <input
+              id="edit-start-date"
               type="datetime-local"
               value={dateTime}
               onChange={(e) => setDateTime(e.target.value)}
@@ -469,8 +473,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1">End Date & Time</label>
+            <label htmlFor="edit-end-date" className="block text-sm font-medium mb-1">End Date & Time</label>
             <input
+              id="edit-end-date"
               type="datetime-local"
               value={endDateTime}
               onChange={(e) => setEndDateTime(e.target.value)}
@@ -480,8 +485,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Timezone</label>
+          <label htmlFor="edit-timezone" className="block text-sm font-medium mb-1">Timezone</label>
           <select
+            id="edit-timezone"
             value={timezone}
             onChange={(e) => setTimezone(e.target.value)}
             className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-orange-500"
@@ -511,8 +517,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
 
         {locationType !== 'physical' && (
           <div>
-            <label className="block text-sm font-medium mb-1">Virtual URL</label>
+            <label htmlFor="edit-virtual-url" className="block text-sm font-medium mb-1">Virtual URL</label>
             <input
+              id="edit-virtual-url"
               type="url"
               value={virtualUrl}
               onChange={(e) => setVirtualUrl(e.target.value)}
@@ -525,8 +532,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         {locationType !== 'virtual' && (
           <>
             <div>
-              <label className="block text-sm font-medium mb-1">Venue</label>
+              <label htmlFor="edit-venue" className="block text-sm font-medium mb-1">Venue</label>
               <input
+                id="edit-venue"
                 type="text"
                 value={venue}
                 onChange={(e) => setVenue(e.target.value)}
@@ -535,8 +543,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Address</label>
+              <label htmlFor="edit-address" className="block text-sm font-medium mb-1">Address</label>
               <input
+                id="edit-address"
                 type="text"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
@@ -546,8 +555,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium mb-1">City</label>
+                <label htmlFor="edit-city" className="block text-sm font-medium mb-1">City</label>
                 <input
+                  id="edit-city"
                   type="text"
                   value={city}
                   onChange={(e) => setCity(e.target.value)}
@@ -556,8 +566,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Country</label>
+                <label htmlFor="edit-country" className="block text-sm font-medium mb-1">Country</label>
                 <input
+                  id="edit-country"
                   type="text"
                   value={country}
                   onChange={(e) => setCountry(e.target.value)}
@@ -575,8 +586,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         />
 
         <div>
-          <label className="block text-sm font-medium mb-1">Linked Course Slug</label>
+          <label htmlFor="edit-course-slug" className="block text-sm font-medium mb-1">Linked Course Slug</label>
           <input
+            id="edit-course-slug"
             type="text"
             value={courseSlug}
             onChange={(e) => setCourseSlug(e.target.value)}
@@ -587,8 +599,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-1">Status</label>
+          <label htmlFor="edit-status" className="block text-sm font-medium mb-1">Status</label>
           <select
+            id="edit-status"
             value={status}
             onChange={(e) => setStatus(e.target.value)}
             className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-orange-500"
@@ -608,8 +621,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
           Control who can purchase tickets to this event.
         </p>
         <div className="space-y-3">
-          <label className="flex items-start gap-3 cursor-pointer">
+          <label htmlFor="edit-access-public" className="flex items-start gap-3 cursor-pointer">
             <input
+              id="edit-access-public"
               type="radio"
               name="accessMode"
               value="public"
@@ -622,8 +636,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               <div className="text-sm text-gray-500 dark:text-gray-400">Anyone can discover and buy tickets.</div>
             </div>
           </label>
-          <label className="flex items-start gap-3 cursor-pointer">
+          <label htmlFor="edit-access-invite" className="flex items-start gap-3 cursor-pointer">
             <input
+              id="edit-access-invite"
               type="radio"
               name="accessMode"
               value="invite_only"
@@ -678,8 +693,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className="block text-sm font-medium mb-1">Tier Name</label>
+                <label htmlFor={`edit-tier-name-${index}`} className="block text-sm font-medium mb-1">Tier Name</label>
                 <input
+                  id={`edit-tier-name-${index}`}
                   type="text"
                   value={tier.name}
                   onChange={(e) => updateTier(index, 'name', e.target.value)}
@@ -687,9 +703,10 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Price</label>
+                <label htmlFor={`edit-tier-price-${index}`} className="block text-sm font-medium mb-1">Price</label>
                 <div className="flex gap-2">
                   <input
+                    id={`edit-tier-price-${index}`}
                     type="number"
                     step="0.01"
                     min="0"
@@ -708,8 +725,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Quantity {tier.sold ? `(${tier.sold} sold)` : ''}</label>
+                <label htmlFor={`edit-tier-quantity-${index}`} className="block text-sm font-medium mb-1">Quantity {tier.sold ? `(${tier.sold} sold)` : ''}</label>
                 <input
+                  id={`edit-tier-quantity-${index}`}
                   type="number"
                   min={tier.sold || 0}
                   value={tier.quantity === null ? '' : tier.quantity}
@@ -719,8 +737,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Sold</label>
+                <label htmlFor={`edit-tier-sold-${index}`} className="block text-sm font-medium mb-1">Sold</label>
                 <input
+                  id={`edit-tier-sold-${index}`}
                   type="text"
                   value={tier.sold || 0}
                   disabled
@@ -729,8 +748,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               </div>
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Description</label>
+              <label htmlFor={`edit-tier-description-${index}`} className="block text-sm font-medium mb-1">Description</label>
               <input
+                id={`edit-tier-description-${index}`}
                 type="text"
                 value={tier.description}
                 onChange={(e) => updateTier(index, 'description', e.target.value)}
@@ -739,8 +759,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Perks (one per line)</label>
+              <label htmlFor={`edit-tier-perks-${index}`} className="block text-sm font-medium mb-1">Perks (one per line)</label>
               <textarea
+                id={`edit-tier-perks-${index}`}
                 value={(tier.perks || []).join('\n')}
                 onChange={(e) => updateTier(index, 'perks', e.target.value.split('\n').filter(Boolean))}
                 rows={4}
@@ -761,7 +782,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               </label>
               {tier.requiresRegistration && (
                 <div className="mt-2">
-                  <label className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400">
+                  <label htmlFor={`edit-tier-registration-form-${index}`} className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400">
                     Registration Form <span className="text-red-500">*</span>
                   </label>
                   {(() => {
@@ -769,6 +790,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
                     if (surveys.length === 0) return <p className="text-xs text-gray-400">No forms found. Create one in Dykil first.</p>;
                     return (
                     <select
+                      id={`edit-tier-registration-form-${index}`}
                       value={tier.registrationFormId}
                       onChange={(e) => updateTier(index, 'registrationFormId', e.target.value)}
                       required
@@ -788,9 +810,10 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
               )}
             </div>
             <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
-              <label className="block text-sm font-medium mb-1">Access Code (optional)</label>
+              <label htmlFor={`edit-tier-access-code-${index}`} className="block text-sm font-medium mb-1">Access Code (optional)</label>
               <div className="flex items-center gap-2">
                 <input
+                  id={`edit-tier-access-code-${index}`}
                   type="text"
                   value={tier.accessCode || ''}
                   onChange={(e) => updateTier(index, 'accessCode', e.target.value)}
@@ -872,8 +895,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
 
                   <div className="flex items-center gap-4 flex-wrap">
                     <div className="flex items-center gap-2">
-                      <label className="text-sm text-gray-600 dark:text-gray-400">Show:</label>
+                      <label htmlFor={`edit-survey-visibility-${index}`} className="text-sm text-gray-600 dark:text-gray-400">Show:</label>
                       <select
+                        id={`edit-survey-visibility-${index}`}
                         value={linked.visibility}
                         onChange={(e) => {
                           const updated = [...linkedSurveys];
@@ -949,7 +973,7 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         {/* Chat Toggle */}
         <div className="flex items-center justify-between py-3 border-b border-gray-200 dark:border-gray-700">
           <div>
-            <label className="font-medium text-sm">Event Chat</label>
+            <span className="font-medium text-sm">Event Chat</span>
             <p className="text-xs text-gray-500">Allow ticket holders to chat</p>
           </div>
           <button
@@ -968,8 +992,9 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
             { value: 'handle', label: 'Handle only', description: 'Show @handle, no real name' },
             { value: 'anonymous', label: 'Anonymous', description: 'Show "Attendee" — no names visible' },
           ] as const).map((option) => (
-            <label key={option.value} className="flex items-start gap-3 cursor-pointer group">
+            <label key={option.value} htmlFor={`edit-name-display-${option.value}`} className="flex items-start gap-3 cursor-pointer group">
               <input
+                id={`edit-name-display-${option.value}`}
                 type="radio"
                 name="nameDisplayPolicy"
                 value={option.value}
@@ -1005,10 +1030,11 @@ export default function EventEditForm({ event, existingTickets, creatorEmail, or
         </label>
         {emtEnabled && (
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="edit-emt-email" className="block text-sm font-medium mb-1">
               e-Transfer Email <span className="text-red-500">*</span>
             </label>
             <input
+              id="edit-emt-email"
               type="email"
               value={emtEmail}
               onChange={(e) => setEmtEmail(e.target.value)}

--- a/apps/kernel/app/admin/config/config-form.tsx
+++ b/apps/kernel/app/admin/config/config-form.tsx
@@ -67,11 +67,12 @@ export function ConfigForm({ registrationMode, maxIdentities, maxStoragePerDidMb
         <h2 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">Resource Limits</h2>
         <div className="space-y-4">
           <div>
-            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+            <label htmlFor="config-max-identities" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
               Max Identities (0 = unlimited)
             </label>
             <div className="flex items-center gap-3">
               <input
+                id="config-max-identities"
                 type="number"
                 min={0}
                 value={maxIds}
@@ -88,11 +89,12 @@ export function ConfigForm({ registrationMode, maxIdentities, maxStoragePerDidMb
             </div>
           </div>
           <div>
-            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+            <label htmlFor="config-max-storage" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
               Max Storage per DID (MB, 0 = unlimited)
             </label>
             <div className="flex items-center gap-3">
               <input
+                id="config-max-storage"
                 type="number"
                 min={0}
                 value={maxStorage}

--- a/apps/kernel/app/admin/deposits/deposit-form.tsx
+++ b/apps/kernel/app/admin/deposits/deposit-form.tsx
@@ -110,11 +110,12 @@ export default function DepositForm() {
     >
       {/* Handle / DID */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="deposit-target" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Target Handle or DID
         </label>
         <div className="flex gap-2">
           <input
+            id="deposit-target"
             type="text"
             value={handle}
             onChange={(e) => {
@@ -146,10 +147,11 @@ export default function DepositForm() {
 
       {/* Amount */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="deposit-amount" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Amount (CAD)
         </label>
         <input
+          id="deposit-amount"
           type="number"
           step="0.01"
           min="0.01"
@@ -162,10 +164,11 @@ export default function DepositForm() {
 
       {/* Memo */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="deposit-memo" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Memo
         </label>
         <input
+          id="deposit-memo"
           type="text"
           value={memo}
           onChange={(e) => setMemo(e.target.value)}

--- a/apps/kernel/app/admin/events/events-client.tsx
+++ b/apps/kernel/app/admin/events/events-client.tsx
@@ -227,8 +227,9 @@ export default function EventsClient() {
       {/* Filters */}
       <div className="mb-4 flex flex-wrap gap-2 items-end">
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">Service</label>
+          <label htmlFor="events-filter-service" className="text-xs text-gray-500 dark:text-gray-400">Service</label>
           <select
+            id="events-filter-service"
             value={pendingFilters.service}
             onChange={(e) => setPendingFilters({ ...pendingFilters, service: e.target.value })}
             className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
@@ -240,8 +241,9 @@ export default function EventsClient() {
           </select>
         </div>
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">Action</label>
+          <label htmlFor="events-filter-action" className="text-xs text-gray-500 dark:text-gray-400">Action</label>
           <input
+            id="events-filter-action"
             type="text"
             value={pendingFilters.action}
             onChange={(e) => setPendingFilters({ ...pendingFilters, action: e.target.value })}
@@ -250,8 +252,9 @@ export default function EventsClient() {
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">DID</label>
+          <label htmlFor="events-filter-did" className="text-xs text-gray-500 dark:text-gray-400">DID</label>
           <input
+            id="events-filter-did"
             type="text"
             value={pendingFilters.did}
             onChange={(e) => setPendingFilters({ ...pendingFilters, did: e.target.value })}
@@ -260,8 +263,9 @@ export default function EventsClient() {
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
+          <label htmlFor="events-filter-from" className="text-xs text-gray-500 dark:text-gray-400">From</label>
           <input
+            id="events-filter-from"
             type="datetime-local"
             value={pendingFilters.from}
             onChange={(e) => setPendingFilters({ ...pendingFilters, from: e.target.value })}
@@ -269,8 +273,9 @@ export default function EventsClient() {
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
+          <label htmlFor="events-filter-to" className="text-xs text-gray-500 dark:text-gray-400">To</label>
           <input
+            id="events-filter-to"
             type="datetime-local"
             value={pendingFilters.to}
             onChange={(e) => setPendingFilters({ ...pendingFilters, to: e.target.value })}

--- a/apps/kernel/app/admin/federation/peer-manager.tsx
+++ b/apps/kernel/app/admin/federation/peer-manager.tsx
@@ -123,8 +123,9 @@ export default function PeerManager() {
         <form onSubmit={addPeer} className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
           <div className="flex flex-col sm:flex-row gap-3">
             <div className="flex-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Relay URL</label>
+              <label htmlFor="peer-relay-url" className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Relay URL</label>
               <input
+                id="peer-relay-url"
                 type="url"
                 value={newPeerUrl}
                 onChange={(e) => setNewPeerUrl(e.target.value)}
@@ -134,8 +135,9 @@ export default function PeerManager() {
               />
             </div>
             <div className="sm:w-48">
-              <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Label (optional)</label>
+              <label htmlFor="peer-label" className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Label (optional)</label>
               <input
+                id="peer-label"
                 type="text"
                 value={newPeerLabel}
                 onChange={(e) => setNewPeerLabel(e.target.value)}

--- a/apps/kernel/app/admin/logs/logs-client.tsx
+++ b/apps/kernel/app/admin/logs/logs-client.tsx
@@ -313,8 +313,9 @@ export default function LogsClient() {
           <div className="mb-4 flex flex-wrap gap-2 items-end">
             {/* Service */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">Service</label>
+              <label htmlFor="logs-filter-service" className="text-xs text-gray-500 dark:text-gray-400">Service</label>
               <select
+                id="logs-filter-service"
                 value={pendingFilters.service}
                 onChange={(e) => setPendingFilters({ ...pendingFilters, service: e.target.value })}
                 className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-36"
@@ -328,7 +329,7 @@ export default function LogsClient() {
 
             {/* Level pills */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">Level</label>
+              <span className="text-xs text-gray-500 dark:text-gray-400">Level</span>
               <div className="flex gap-1">
                 {ALL_LEVELS.map((level) => {
                   const active = pendingFilters.levels.includes(level);
@@ -351,8 +352,9 @@ export default function LogsClient() {
 
             {/* Search */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">Search</label>
+              <label htmlFor="logs-filter-search" className="text-xs text-gray-500 dark:text-gray-400">Search</label>
               <input
+                id="logs-filter-search"
                 type="text"
                 value={pendingFilters.search}
                 onChange={(e) => setPendingFilters({ ...pendingFilters, search: e.target.value })}
@@ -363,8 +365,9 @@ export default function LogsClient() {
 
             {/* Correlation ID */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">Correlation ID</label>
+              <label htmlFor="logs-filter-correlation-id" className="text-xs text-gray-500 dark:text-gray-400">Correlation ID</label>
               <input
+                id="logs-filter-correlation-id"
                 type="text"
                 value={pendingFilters.correlationId}
                 onChange={(e) => setPendingFilters({ ...pendingFilters, correlationId: e.target.value })}
@@ -375,8 +378,9 @@ export default function LogsClient() {
 
             {/* DID */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">DID</label>
+              <label htmlFor="logs-filter-did" className="text-xs text-gray-500 dark:text-gray-400">DID</label>
               <input
+                id="logs-filter-did"
                 type="text"
                 value={pendingFilters.did}
                 onChange={(e) => setPendingFilters({ ...pendingFilters, did: e.target.value })}
@@ -387,8 +391,9 @@ export default function LogsClient() {
 
             {/* From / To */}
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">From</label>
+              <label htmlFor="logs-filter-from" className="text-xs text-gray-500 dark:text-gray-400">From</label>
               <input
+                id="logs-filter-from"
                 type="datetime-local"
                 value={pendingFilters.from}
                 onChange={(e) => setPendingFilters({ ...pendingFilters, from: e.target.value })}
@@ -396,8 +401,9 @@ export default function LogsClient() {
               />
             </div>
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">To</label>
+              <label htmlFor="logs-filter-to" className="text-xs text-gray-500 dark:text-gray-400">To</label>
               <input
+                id="logs-filter-to"
                 type="datetime-local"
                 value={pendingFilters.to}
                 onChange={(e) => setPendingFilters({ ...pendingFilters, to: e.target.value })}
@@ -587,8 +593,9 @@ export default function LogsClient() {
         <div className="space-y-4">
           <div className="flex flex-wrap gap-2 items-end">
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">Service</label>
+              <label htmlFor="raw-logs-service" className="text-xs text-gray-500 dark:text-gray-400">Service</label>
               <select
+                id="raw-logs-service"
                 value={rawService}
                 onChange={(e) => setRawService(e.target.value)}
                 className="rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 w-40"
@@ -599,8 +606,9 @@ export default function LogsClient() {
               </select>
             </div>
             <div className="flex flex-col gap-1">
-              <label className="text-xs text-gray-500 dark:text-gray-400">Lines</label>
+              <label htmlFor="raw-logs-lines" className="text-xs text-gray-500 dark:text-gray-400">Lines</label>
               <input
+                id="raw-logs-lines"
                 type="number"
                 min={1}
                 max={500}

--- a/apps/kernel/app/admin/moderation/create-flag.tsx
+++ b/apps/kernel/app/admin/moderation/create-flag.tsx
@@ -47,8 +47,9 @@ export function CreateFlag() {
       <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">Create Manual Flag</h3>
       <form onSubmit={submit} className="space-y-3">
         <div>
-          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target DID</label>
+          <label htmlFor="flag-target-did" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target DID</label>
           <input
+            id="flag-target-did"
             required
             type="text"
             value={targetDid}
@@ -59,8 +60,9 @@ export function CreateFlag() {
         </div>
         <div className="grid grid-cols-2 gap-3">
           <div>
-            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target Type</label>
+            <label htmlFor="flag-target-type" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target Type</label>
             <select
+              id="flag-target-type"
               value={targetType}
               onChange={(e) => setTargetType(e.target.value)}
               className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
@@ -73,8 +75,9 @@ export function CreateFlag() {
             </select>
           </div>
           <div>
-            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target ID</label>
+            <label htmlFor="flag-target-id" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Target ID</label>
             <input
+              id="flag-target-id"
               required
               type="text"
               value={targetId}
@@ -85,8 +88,9 @@ export function CreateFlag() {
           </div>
         </div>
         <div>
-          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Reason</label>
+          <label htmlFor="flag-reason" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Reason</label>
           <textarea
+            id="flag-reason"
             required
             value={reason}
             onChange={(e) => setReason(e.target.value)}

--- a/apps/kernel/app/admin/newsletter/composer.tsx
+++ b/apps/kernel/app/admin/newsletter/composer.tsx
@@ -110,8 +110,9 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
         <div className="space-y-4">
           {/* Subject */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Subject</label>
+            <label htmlFor="newsletter-subject" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Subject</label>
             <input
+              id="newsletter-subject"
               type="text"
               value={subject}
               onChange={(e) => setSubject(e.target.value)}
@@ -122,8 +123,9 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
 
           {/* Reply-To */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Reply-To (optional)</label>
+            <label htmlFor="newsletter-reply-to" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Reply-To (optional)</label>
             <input
+              id="newsletter-reply-to"
               type="email"
               value={replyTo}
               onChange={(e) => setReplyTo(e.target.value)}
@@ -138,7 +140,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
           {/* Body */}
           <div>
             <div className="flex items-center justify-between mb-1">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Body (Markdown)</label>
+              <label htmlFor="newsletter-body" className="text-sm font-medium text-gray-700 dark:text-gray-300">Body (Markdown)</label>
               <button
                 type="button"
                 onClick={() => setPreview((v) => !v)}
@@ -154,6 +156,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
               />
             ) : (
               <textarea
+                id="newsletter-body"
                 value={markdown}
                 onChange={(e) => setMarkdown(e.target.value)}
                 rows={12}
@@ -165,7 +168,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
 
           {/* Audience */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Audience</label>
+            <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Audience</span>
             <div className="flex gap-2 mb-3">
               {(['newsletter', 'connections'] as const).map((t) => (
                 <button

--- a/apps/kernel/app/admin/subscribers/create-list.tsx
+++ b/apps/kernel/app/admin/subscribers/create-list.tsx
@@ -59,8 +59,9 @@ export default function CreateList() {
         <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Create Mailing List</h2>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+            <label htmlFor="create-list-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
             <input
+              id="create-list-name"
               type="text"
               required
               value={name}
@@ -70,8 +71,9 @@ export default function CreateList() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Slug</label>
+            <label htmlFor="create-list-slug" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Slug</label>
             <input
+              id="create-list-slug"
               type="text"
               required
               value={slug}
@@ -81,10 +83,11 @@ export default function CreateList() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label htmlFor="create-list-description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Description <span className="text-gray-400">(optional)</span>
             </label>
             <textarea
+              id="create-list-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={2}

--- a/apps/kernel/app/admin/vault/rotate-secret-dialog.tsx
+++ b/apps/kernel/app/admin/vault/rotate-secret-dialog.tsx
@@ -38,17 +38,19 @@ export function RotateSecretDialog({
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
           Submit a new encrypted value for <span className="font-mono">{field}</span> and publish a rotation event.
         </p>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">New value</label>
+        <label htmlFor="rotate-secret-value" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">New value</label>
         <input
+          id="rotate-secret-value"
           type="password"
           value={value}
           onChange={(event) => setValue(event.target.value)}
           className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-orange-500"
         />
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label htmlFor="rotate-secret-hint" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
           Hint <span className="text-gray-400">(optional)</span>
         </label>
         <input
+          id="rotate-secret-hint"
           value={hint}
           onChange={(event) => setHint(event.target.value)}
           className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-orange-500"

--- a/apps/kernel/app/admin/vault/set-secret-dialog.tsx
+++ b/apps/kernel/app/admin/vault/set-secret-dialog.tsx
@@ -40,8 +40,9 @@ export function SetSecretDialog({ open, submitting, onClose, onSubmit }: Readonl
         </p>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Field</label>
+            <label htmlFor="vault-secret-field" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Field</label>
             <input
+              id="vault-secret-field"
               required
               value={field}
               onChange={(event) => setField(event.target.value)}
@@ -50,8 +51,9 @@ export function SetSecretDialog({ open, submitting, onClose, onSubmit }: Readonl
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Value</label>
+            <label htmlFor="vault-secret-value" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Value</label>
             <input
+              id="vault-secret-value"
               required
               type="password"
               value={value}
@@ -61,10 +63,11 @@ export function SetSecretDialog({ open, submitting, onClose, onSubmit }: Readonl
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            <label htmlFor="vault-secret-hint" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Hint <span className="text-gray-400">(optional)</span>
             </label>
             <input
+              id="vault-secret-hint"
               value={hint}
               onChange={(event) => setHint(event.target.value)}
               placeholder="ghp_"

--- a/apps/kernel/app/auth/agents/page.tsx
+++ b/apps/kernel/app/auth/agents/page.tsx
@@ -227,12 +227,13 @@ export default function AgentsPage() {
             <h2 className="text-lg font-semibold text-white mb-4">Create new agent</h2>
             <form onSubmit={handleCreate} className="space-y-4">
               <div>
-                <label className="block text-sm text-gray-400 mb-1">Handle</label>
+                <label htmlFor="create-agent-handle" className="block text-sm text-gray-400 mb-1">Handle</label>
                 <div className="flex items-center gap-2">
                   {handlePrefix && (
                     <span className="text-sm text-gray-500 shrink-0">{handlePrefix}-</span>
                   )}
                   <input
+                    id="create-agent-handle"
                     type="text"
                     value={handle}
                     onChange={(e) => setHandle(e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ''))}
@@ -246,8 +247,9 @@ export default function AgentsPage() {
                 </p>
               </div>
               <div>
-                <label className="block text-sm text-gray-400 mb-1">Display name</label>
+                <label htmlFor="create-agent-display-name" className="block text-sm text-gray-400 mb-1">Display name</label>
                 <input
+                  id="create-agent-display-name"
                   type="text"
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
@@ -256,8 +258,9 @@ export default function AgentsPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm text-gray-400 mb-1">Bio</label>
+                <label htmlFor="create-agent-bio" className="block text-sm text-gray-400 mb-1">Bio</label>
                 <textarea
+                  id="create-agent-bio"
                   value={bio}
                   onChange={(e) => setBio(e.target.value)}
                   placeholder="Helps plan trips"

--- a/apps/kernel/app/auth/attestations/components/CreateDocumentForm.tsx
+++ b/apps/kernel/app/auth/attestations/components/CreateDocumentForm.tsx
@@ -203,8 +203,9 @@ export default function CreateDocumentForm({ sessionDid, onCreated }: Readonly<P
       {step === 'details' && (
         <div className="space-y-4">
           <div>
-            <label className="block text-xs text-zinc-500 mb-1.5">Title</label>
+            <label htmlFor="doc-signing-title" className="block text-xs text-zinc-500 mb-1.5">Title</label>
             <input
+              id="doc-signing-title"
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -214,7 +215,7 @@ export default function CreateDocumentForm({ sessionDid, onCreated }: Readonly<P
           </div>
 
           <div>
-            <label className="block text-xs text-zinc-500 mb-1.5">Signers</label>
+            <span className="block text-xs text-zinc-500 mb-1.5">Signers</span>
             <IdentityPicker
               onSelect={addSigner}
               placeholder="Search by handle, name, or DID…"
@@ -241,8 +242,9 @@ export default function CreateDocumentForm({ sessionDid, onCreated }: Readonly<P
           </div>
 
           <div>
-            <label className="block text-xs text-zinc-500 mb-1.5">Expiry</label>
+            <label htmlFor="doc-signing-expiry" className="block text-xs text-zinc-500 mb-1.5">Expiry</label>
             <select
+              id="doc-signing-expiry"
               value={expiry}
               onChange={(e) => setExpiry(e.target.value as typeof expiry)}
               className="w-full bg-black border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white focus:border-amber-500 focus:outline-none"

--- a/apps/kernel/app/auth/authorize/page.tsx
+++ b/apps/kernel/app/auth/authorize/page.tsx
@@ -162,6 +162,7 @@ function AuthorizeForm() {
               {scopeEntries.map(([scope, enabled]) => (
                 <label
                   key={scope}
+                  htmlFor={`authorize-scope-${scope}`}
                   className="flex items-center justify-between p-3 rounded-lg bg-gray-900 border border-gray-800 cursor-pointer hover:border-gray-700 transition"
                 >
                   <div>
@@ -171,6 +172,7 @@ function AuthorizeForm() {
                     </p>
                   </div>
                   <input
+                    id={`authorize-scope-${scope}`}
                     type="checkbox"
                     checked={enabled}
                     onChange={e => setEnabledScopes(prev => ({ ...prev, [scope]: e.target.checked }))}

--- a/apps/kernel/app/auth/components/AttestationList.tsx
+++ b/apps/kernel/app/auth/components/AttestationList.tsx
@@ -156,8 +156,9 @@ export default async function AttestationList({ sessionDid, searchParams, exclud
         className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 flex flex-wrap gap-3 items-end"
       >
         <div className="flex-1 min-w-[160px]">
-          <label className="block text-xs text-zinc-500 mb-1.5">Role</label>
+          <label htmlFor="attestation-filter-role" className="block text-xs text-zinc-500 mb-1.5">Role</label>
           <select
+            id="attestation-filter-role"
             name="role"
             defaultValue={role}
             className="w-full bg-black border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white focus:border-amber-500 focus:outline-none"
@@ -169,8 +170,9 @@ export default async function AttestationList({ sessionDid, searchParams, exclud
         </div>
 
         <div className="flex-1 min-w-[180px]">
-          <label className="block text-xs text-zinc-500 mb-1.5">Type</label>
+          <label htmlFor="attestation-filter-type" className="block text-xs text-zinc-500 mb-1.5">Type</label>
           <select
+            id="attestation-filter-type"
             name="type"
             defaultValue={typeFilter || ''}
             className="w-full bg-black border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white focus:border-amber-500 focus:outline-none"

--- a/apps/kernel/app/auth/components/IdentitySettingsPanel.tsx
+++ b/apps/kernel/app/auth/components/IdentitySettingsPanel.tsx
@@ -235,8 +235,9 @@ export default function IdentitySettingsPanel({ groupDid }: Readonly<{ groupDid:
 
           {joinVisibility === 'network' && (
             <div>
-              <label className="block text-sm text-gray-400 mb-2">Network depth</label>
+              <label htmlFor="identity-network-depth" className="block text-sm text-gray-400 mb-2">Network depth</label>
               <select
+                id="identity-network-depth"
                 value={joinNetworkDepth}
                 onChange={(e) => setJoinNetworkDepth(Number(e.target.value))}
                 className="w-full px-4 py-2 border border-gray-700 rounded-lg bg-black text-white focus:ring-2 focus:ring-amber-500 focus:border-transparent"

--- a/apps/kernel/app/auth/developer/apps/[appId]/components/AppDetailClient.tsx
+++ b/apps/kernel/app/auth/developer/apps/[appId]/components/AppDetailClient.tsx
@@ -157,10 +157,11 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
 
           {/* Name */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="edit-app-name" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Name <span className="text-red-400">*</span>
             </label>
             <input
+              id="edit-app-name"
               type="text"
               value={editName}
               onChange={e => setEditName(e.target.value)}
@@ -172,10 +173,11 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
 
           {/* Description */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="edit-app-description" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Description
             </label>
             <textarea
+              id="edit-app-description"
               value={editDescription}
               onChange={e => setEditDescription(e.target.value)}
               rows={2}
@@ -186,10 +188,11 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
 
           {/* Callback URL */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="edit-app-callback-url" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Callback URL <span className="text-red-400">*</span>
             </label>
             <input
+              id="edit-app-callback-url"
               type="url"
               value={editCallbackUrl}
               onChange={e => setEditCallbackUrl(e.target.value)}
@@ -200,10 +203,11 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
 
           {/* Homepage URL */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="edit-app-homepage-url" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Homepage URL
             </label>
             <input
+              id="edit-app-homepage-url"
               type="url"
               value={editHomepageUrl}
               onChange={e => setEditHomepageUrl(e.target.value)}
@@ -213,10 +217,11 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
 
           {/* Logo URL */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="edit-app-logo-url" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Logo URL
             </label>
             <input
+              id="edit-app-logo-url"
               type="url"
               value={editLogoUrl}
               onChange={e => setEditLogoUrl(e.target.value)}
@@ -226,13 +231,14 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
 
           {/* Scopes */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
+            <span className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
               Requested Scopes
-            </label>
+            </span>
             <div className="space-y-1.5">
               {Object.entries(SCOPES).map(([scope, label]) => (
-                <label key={scope} className="flex items-center gap-3 cursor-pointer">
+                <label key={scope} htmlFor={`edit-app-scope-${scope}`} className="flex items-center gap-3 cursor-pointer">
                   <input
+                    id={`edit-app-scope-${scope}`}
                     type="checkbox"
                     checked={editScopes.includes(scope)}
                     onChange={() => toggleEditScope(scope)}

--- a/apps/kernel/app/auth/developer/apps/[appId]/components/AppDetailClient.tsx
+++ b/apps/kernel/app/auth/developer/apps/[appId]/components/AppDetailClient.tsx
@@ -236,7 +236,7 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
             </span>
             <div className="space-y-1.5">
               {Object.entries(SCOPES).map(([scope, label]) => (
-                <label key={scope} htmlFor={`edit-app-scope-${scope}`} className="flex items-center gap-3 cursor-pointer">
+                <label key={scope} htmlFor={`edit-app-scope-${scope}`} aria-label={label} className="flex items-center gap-3 cursor-pointer">
                   <input
                     id={`edit-app-scope-${scope}`}
                     type="checkbox"

--- a/apps/kernel/app/auth/developer/apps/components/RegisterAppForm.tsx
+++ b/apps/kernel/app/auth/developer/apps/components/RegisterAppForm.tsx
@@ -166,10 +166,11 @@ export default function RegisterAppForm({ onSuccess, onCancel }: Readonly<Props>
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Name */}
         <div>
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+          <label htmlFor="register-app-name" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
             App Name <span className="text-red-400">*</span>
           </label>
           <input
+            id="register-app-name"
             type="text"
             value={name}
             onChange={e => setName(e.target.value)}
@@ -182,10 +183,11 @@ export default function RegisterAppForm({ onSuccess, onCancel }: Readonly<Props>
 
         {/* Description */}
         <div>
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+          <label htmlFor="register-app-description" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
             Description <span className="text-zinc-600">(optional)</span>
           </label>
           <textarea
+            id="register-app-description"
             value={description}
             onChange={e => setDescription(e.target.value)}
             placeholder="What does your app do?"
@@ -197,10 +199,11 @@ export default function RegisterAppForm({ onSuccess, onCancel }: Readonly<Props>
 
         {/* Callback URL */}
         <div>
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+          <label htmlFor="register-app-callback-url" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
             Callback URL <span className="text-red-400">*</span>
           </label>
           <input
+            id="register-app-callback-url"
             type="url"
             value={callbackUrl}
             onChange={e => setCallbackUrl(e.target.value)}
@@ -213,10 +216,11 @@ export default function RegisterAppForm({ onSuccess, onCancel }: Readonly<Props>
 
         {/* Homepage URL */}
         <div>
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+          <label htmlFor="register-app-homepage-url" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
             Homepage URL <span className="text-zinc-600">(optional)</span>
           </label>
           <input
+            id="register-app-homepage-url"
             type="url"
             value={homepageUrl}
             onChange={e => setHomepageUrl(e.target.value)}
@@ -227,10 +231,11 @@ export default function RegisterAppForm({ onSuccess, onCancel }: Readonly<Props>
 
         {/* Logo URL */}
         <div>
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+          <label htmlFor="register-app-logo-url" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
             Logo URL <span className="text-zinc-600">(optional)</span>
           </label>
           <input
+            id="register-app-logo-url"
             type="url"
             value={logoUrl}
             onChange={e => setLogoUrl(e.target.value)}
@@ -241,13 +246,14 @@ export default function RegisterAppForm({ onSuccess, onCancel }: Readonly<Props>
 
         {/* Requested Scopes */}
         <div>
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
+          <span className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
             Requested Scopes
-          </label>
+          </span>
           <div className="space-y-1.5">
             {Object.entries(SCOPES).map(([scope, label]) => (
-              <label key={scope} className="flex items-center gap-3 cursor-pointer group">
+              <label key={scope} htmlFor={`register-app-scope-${scope}`} className="flex items-center gap-3 cursor-pointer group">
                 <input
+                  id={`register-app-scope-${scope}`}
                   type="checkbox"
                   checked={selectedScopes.includes(scope)}
                   onChange={() => toggleScope(scope)}
@@ -264,9 +270,9 @@ export default function RegisterAppForm({ onSuccess, onCancel }: Readonly<Props>
 
         {/* Keypair option */}
         <div className="border-t border-zinc-800 pt-4">
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
+          <span className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
             Identity Keypair
-          </label>
+          </span>
           <div className="space-y-2">
             <label className="flex items-center gap-3 cursor-pointer">
               <input

--- a/apps/kernel/app/auth/developer/apps/components/RegisterAppForm.tsx
+++ b/apps/kernel/app/auth/developer/apps/components/RegisterAppForm.tsx
@@ -251,7 +251,7 @@ export default function RegisterAppForm({ onSuccess, onCancel }: Readonly<Props>
           </span>
           <div className="space-y-1.5">
             {Object.entries(SCOPES).map(([scope, label]) => (
-              <label key={scope} htmlFor={`register-app-scope-${scope}`} className="flex items-center gap-3 cursor-pointer group">
+              <label key={scope} htmlFor={`register-app-scope-${scope}`} aria-label={label} className="flex items-center gap-3 cursor-pointer group">
                 <input
                   id={`register-app-scope-${scope}`}
                   type="checkbox"

--- a/apps/kernel/app/auth/groups/new/page.tsx
+++ b/apps/kernel/app/auth/groups/new/page.tsx
@@ -236,9 +236,9 @@ function NewGroupForm() {
             </div>
           ) : (
             <div>
-              <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              <span className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
                 Type
-              </label>
+              </span>
               <div className="grid grid-cols-3 gap-2">
                 {SCOPES.map(s => (
                   <button
@@ -264,10 +264,11 @@ function NewGroupForm() {
 
           {/* Name */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="create-group-name" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Name <span className="text-red-400">*</span>
             </label>
             <input
+              id="create-group-name"
               type="text"
               value={name}
               onChange={e => setName(e.target.value)}
@@ -280,12 +281,13 @@ function NewGroupForm() {
 
           {/* Handle */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="create-group-handle" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Handle <span className="text-zinc-600">(optional)</span>
             </label>
             <div className="relative">
               <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 text-sm">@</span>
               <input
+                id="create-group-handle"
                 type="text"
                 value={handle}
                 onChange={e => setHandle(normalizeHandleInput(e.target.value))}
@@ -299,10 +301,11 @@ function NewGroupForm() {
 
           {/* Description */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="create-group-description" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Bio / Description <span className="text-zinc-600">(optional)</span>
             </label>
             <textarea
+              id="create-group-description"
               value={description}
               onChange={e => setDescription(e.target.value)}
               placeholder="Describe this identity"
@@ -314,9 +317,9 @@ function NewGroupForm() {
           {/* Subtype pills */}
           {subtypeOptions.length > 0 && (
             <div>
-              <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              <span className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
                 Subtype <span className="text-zinc-600">(optional)</span>
-              </label>
+              </span>
               <div className="flex flex-wrap gap-2">
                 {subtypeOptions.map(st => (
                   <button
@@ -339,7 +342,7 @@ function NewGroupForm() {
           {/* Business: Category */}
           {scope === 'business' && (
             <div>
-              <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+              <label htmlFor="create-group-category" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
                 Category
               </label>
               <div className="flex flex-wrap gap-2 mb-2">
@@ -359,6 +362,7 @@ function NewGroupForm() {
                 ))}
               </div>
               <input
+                id="create-group-category"
                 type="text"
                 value={category}
                 onChange={e => setCategory(e.target.value)}
@@ -373,7 +377,7 @@ function NewGroupForm() {
           {needsLocation && (
             <div>
               <div className="flex items-center justify-between mb-1.5">
-                <label className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+                <label htmlFor="create-group-location" className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
                   Location
                 </label>
                 {deviceLoc ? (
@@ -391,6 +395,7 @@ function NewGroupForm() {
               <div className="relative flex gap-2">
                 <div className="relative flex-1">
                   <input
+                    id="create-group-location"
                     type="text"
                     value={location}
                     onChange={e => handleLocationChange(e.target.value)}

--- a/apps/kernel/app/auth/login/components/KeyAuthTab.tsx
+++ b/apps/kernel/app/auth/login/components/KeyAuthTab.tsx
@@ -226,8 +226,9 @@ export default function KeyAuthTab({ nextUrl, onMfaRequired, onSuccess }: Readon
       {method === 'paste' && (
         <form onSubmit={handlePasteImport} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium mb-1 text-gray-300">Private Key (hex)</label>
+            <label htmlFor="login-private-key" className="block text-sm font-medium mb-1 text-gray-300">Private Key (hex)</label>
             <textarea
+              id="login-private-key"
               value={privateKeyHex}
               onChange={e => setPrivateKeyHex(e.target.value)}
               placeholder="64 character hex string..."

--- a/apps/kernel/app/auth/login/components/PasswordAuthTab.tsx
+++ b/apps/kernel/app/auth/login/components/PasswordAuthTab.tsx
@@ -243,8 +243,9 @@ export default function PasswordAuthTab({ nextUrl, onMfaRequired, onSuccess }: R
 
         <form onSubmit={handlePasswordSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium mb-1 text-gray-300">Password</label>
+            <label htmlFor="login-password" className="block text-sm font-medium mb-1 text-gray-300">Password</label>
             <input
+              id="login-password"
               type="password"
               value={password}
               onChange={e => setPassword(e.target.value)}
@@ -276,8 +277,9 @@ export default function PasswordAuthTab({ nextUrl, onMfaRequired, onSuccess }: R
   return (
     <form onSubmit={handleIdentifierSubmit} className="space-y-4">
       <div>
-        <label className="block text-sm font-medium mb-1 text-gray-300">Handle</label>
+        <label htmlFor="login-handle" className="block text-sm font-medium mb-1 text-gray-300">Handle</label>
         <input
+          id="login-handle"
           type="text"
           value={handle}
           onChange={e => setHandle(e.target.value)}

--- a/apps/kernel/app/auth/notifications/page.tsx
+++ b/apps/kernel/app/auth/notifications/page.tsx
@@ -121,9 +121,10 @@ export default function NotificationsPage() {
                   <div key={scope} className="flex items-center justify-between px-4 py-3">
                     <span className="text-sm text-zinc-200">{label}</span>
                     <div className="flex items-center gap-6">
-                      <label className="flex items-center gap-2 cursor-pointer">
+                      <label htmlFor={`notif-inapp-${scope}`} className="flex items-center gap-2 cursor-pointer">
                         <span className="text-xs text-zinc-500">In-app</span>
                         <button
+                          id={`notif-inapp-${scope}`}
                           onClick={() => toggle(scope, 'inapp', !pref.inapp)}
                           disabled={saving === `${scope}:inapp`}
                           className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${
@@ -137,9 +138,10 @@ export default function NotificationsPage() {
                           />
                         </button>
                       </label>
-                      <label className="flex items-center gap-2 cursor-pointer">
+                      <label htmlFor={`notif-email-${scope}`} className="flex items-center gap-2 cursor-pointer">
                         <span className="text-xs text-zinc-500">Email</span>
                         <button
+                          id={`notif-email-${scope}`}
                           onClick={() => toggle(scope, 'email', !pref.email)}
                           disabled={saving === `${scope}:email`}
                           className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${

--- a/apps/kernel/app/auth/register/page.tsx
+++ b/apps/kernel/app/auth/register/page.tsx
@@ -338,10 +338,11 @@ function RegisterPage() {
         
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium mb-1">Handle</label>
+            <label htmlFor="register-handle" className="block text-sm font-medium mb-1">Handle</label>
             <div className="flex items-center">
               <span className="text-gray-400 mr-1">@</span>
               <input
+                id="register-handle"
                 type="text"
                 value={handle}
                 onChange={(e) => setHandle(normalizeHandleInput(e.target.value))}
@@ -355,8 +356,9 @@ function RegisterPage() {
           </div>
           
           <div>
-            <label className="block text-sm font-medium mb-1">Display Name</label>
+            <label htmlFor="register-display-name" className="block text-sm font-medium mb-1">Display Name</label>
             <input
+              id="register-display-name"
               type="text"
               value={name}
               onChange={(e) => setDisplayName(e.target.value)}
@@ -367,10 +369,11 @@ function RegisterPage() {
           </div>
           
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="register-email" className="block text-sm font-medium mb-1">
               Email <span className="text-gray-400 font-normal">(optional)</span>
             </label>
             <input
+              id="register-email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -380,10 +383,11 @@ function RegisterPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1">
+            <label htmlFor="register-phone" className="block text-sm font-medium mb-1">
               Phone <span className="text-gray-400 font-normal">(optional)</span>
             </label>
             <input
+              id="register-phone"
               type="tel"
               value={phone}
               onChange={(e) => setPhone(e.target.value)}
@@ -407,8 +411,9 @@ function RegisterPage() {
           )}
 
           <div>
-            <label className="block text-sm font-medium mb-1">Account Type</label>
+            <label htmlFor="register-account-type" className="block text-sm font-medium mb-1">Account Type</label>
             <select
+              id="register-account-type"
               value={subtype}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
               disabled

--- a/apps/kernel/app/auth/stubs/[did]/page.tsx
+++ b/apps/kernel/app/auth/stubs/[did]/page.tsx
@@ -438,9 +438,9 @@ export default function EditStubPage() {
 
         {/* Avatar upload */}
         <div className="mb-5">
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
+          <span className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
             Avatar
-          </label>
+          </span>
           <div className="flex items-center gap-4">
             {avatar ? (
               <img
@@ -476,9 +476,9 @@ export default function EditStubPage() {
 
         {/* Banner upload */}
         <div className="mb-6">
-          <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
+          <span className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-2">
             Banner
-          </label>
+          </span>
           {banner && (
             <div
               className="w-full h-24 rounded-lg bg-cover bg-center mb-2 border border-gray-700"
@@ -508,10 +508,11 @@ export default function EditStubPage() {
         <form onSubmit={handleSubmit} className="space-y-5">
           {/* Name */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="stub-edit-name" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Name <span className="text-red-400">*</span>
             </label>
             <input
+              id="stub-edit-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -524,7 +525,7 @@ export default function EditStubPage() {
 
           {/* Category */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="stub-edit-category" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Category
             </label>
             <div className="flex flex-wrap gap-2 mb-2">
@@ -544,6 +545,7 @@ export default function EditStubPage() {
               ))}
             </div>
             <input
+              id="stub-edit-category"
               type="text"
               value={category}
               onChange={(e) => setCategory(e.target.value)}
@@ -556,7 +558,7 @@ export default function EditStubPage() {
           {/* Location */}
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <label className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+              <label htmlFor="stub-edit-location" className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
                 Location
               </label>
               {deviceLoc ? (
@@ -574,6 +576,7 @@ export default function EditStubPage() {
             <div className="relative flex gap-2">
               <div className="relative flex-1">
                 <input
+                  id="stub-edit-location"
                   type="text"
                   value={location}
                   onChange={(e) => handleLocationChange(e.target.value)}
@@ -640,12 +643,13 @@ export default function EditStubPage() {
 
           {/* Handle */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="stub-edit-handle" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Handle <span className="text-zinc-600">(optional)</span>
             </label>
             <div className="relative">
               <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 text-sm">@</span>
               <input
+                id="stub-edit-handle"
                 type="text"
                 value={handle}
                 onChange={(e) => setHandle(normalizeHandleInput(e.target.value))}
@@ -660,10 +664,11 @@ export default function EditStubPage() {
 
           {/* Bio */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="stub-edit-bio" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Bio
             </label>
             <textarea
+              id="stub-edit-bio"
               value={bio}
               onChange={(e) => setBio(e.target.value)}
               placeholder="A short description of this place…"

--- a/apps/kernel/app/auth/stubs/new/page.tsx
+++ b/apps/kernel/app/auth/stubs/new/page.tsx
@@ -204,10 +204,11 @@ export default function NewStubPage() {
         <form onSubmit={handleSubmit} className="space-y-5">
           {/* Name */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="new-stub-name" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Name <span className="text-red-400">*</span>
             </label>
             <input
+              id="new-stub-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -220,7 +221,7 @@ export default function NewStubPage() {
 
           {/* Category */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="new-stub-category" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Category
             </label>
             <div className="flex flex-wrap gap-2 mb-2">
@@ -240,6 +241,7 @@ export default function NewStubPage() {
               ))}
             </div>
             <input
+              id="new-stub-category"
               type="text"
               value={category}
               onChange={(e) => setCategory(e.target.value)}
@@ -252,7 +254,7 @@ export default function NewStubPage() {
           {/* Location */}
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <label className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+              <label htmlFor="new-stub-location" className="text-xs font-semibold text-zinc-400 uppercase tracking-wider">
                 Location
               </label>
               {deviceLoc ? (
@@ -270,6 +272,7 @@ export default function NewStubPage() {
             <div className="relative flex gap-2">
               <div className="relative flex-1">
                 <input
+                  id="new-stub-location"
                   type="text"
                   value={location}
                   onChange={(e) => handleLocationChange(e.target.value)}
@@ -338,12 +341,13 @@ export default function NewStubPage() {
 
           {/* Handle */}
           <div>
-            <label className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
+            <label htmlFor="new-stub-handle" className="block text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-1.5">
               Handle <span className="text-zinc-600">(optional)</span>
             </label>
             <div className="relative">
               <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 text-sm">@</span>
               <input
+                id="new-stub-handle"
                 type="text"
                 value={handle}
                 onChange={(e) => setHandle(normalizeHandleInput(e.target.value))}

--- a/apps/kernel/app/notify/settings/page.tsx
+++ b/apps/kernel/app/notify/settings/page.tsx
@@ -141,9 +141,10 @@ export default function SettingsPage() {
                   <div key={scope} className="flex items-center justify-between px-4 py-3">
                     <span className="text-sm text-zinc-200">{label}</span>
                     <div className="flex items-center gap-6">
-                      <label className="flex items-center gap-2 cursor-pointer">
+                      <label htmlFor={`settings-inapp-${scope}`} className="flex items-center gap-2 cursor-pointer">
                         <span className="text-xs text-zinc-500">In-app</span>
                         <button
+                          id={`settings-inapp-${scope}`}
                           onClick={() => toggle(scope, 'inapp', !pref.inapp)}
                           disabled={saving === `${scope}:inapp`}
                           className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${
@@ -157,9 +158,10 @@ export default function SettingsPage() {
                           />
                         </button>
                       </label>
-                      <label className="flex items-center gap-2 cursor-pointer">
+                      <label htmlFor={`settings-email-${scope}`} className="flex items-center gap-2 cursor-pointer">
                         <span className="text-xs text-zinc-500">Email</span>
                         <button
+                          id={`settings-email-${scope}`}
                           onClick={() => toggle(scope, 'email', !pref.email)}
                           disabled={saving === `${scope}:email`}
                           className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${

--- a/apps/kernel/app/pay/history/page.tsx
+++ b/apps/kernel/app/pay/history/page.tsx
@@ -127,8 +127,9 @@ export default async function HistoryPage({
         className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 flex flex-wrap gap-3 items-end"
       >
         <div className="flex-1 min-w-[150px]">
-          <label className="block text-xs text-zinc-500 mb-1.5">Service</label>
+          <label htmlFor="history-filter-service" className="block text-xs text-zinc-500 mb-1.5">Service</label>
           <select
+            id="history-filter-service"
             name="service"
             defaultValue={service || ''}
             className="w-full bg-black border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none"
@@ -143,8 +144,9 @@ export default async function HistoryPage({
         </div>
 
         <div className="flex-1 min-w-[120px]">
-          <label className="block text-xs text-zinc-500 mb-1.5">Currency</label>
+          <label htmlFor="history-filter-currency" className="block text-xs text-zinc-500 mb-1.5">Currency</label>
           <select
+            id="history-filter-currency"
             name="currency"
             defaultValue={currency || ''}
             className="w-full bg-black border border-zinc-700 rounded-lg px-3 py-2 text-sm text-white focus:border-orange-500 focus:outline-none"
@@ -156,8 +158,9 @@ export default async function HistoryPage({
         </div>
 
         <div className="flex-1 min-w-[140px]">
-          <label className="block text-xs text-zinc-500 mb-1.5">From</label>
+          <label htmlFor="history-filter-from" className="block text-xs text-zinc-500 mb-1.5">From</label>
           <input
+            id="history-filter-from"
             type="date"
             name="from"
             defaultValue={from || ''}
@@ -166,8 +169,9 @@ export default async function HistoryPage({
         </div>
 
         <div className="flex-1 min-w-[140px]">
-          <label className="block text-xs text-zinc-500 mb-1.5">To</label>
+          <label htmlFor="history-filter-to" className="block text-xs text-zinc-500 mb-1.5">To</label>
           <input
+            id="history-filter-to"
             type="date"
             name="to"
             defaultValue={to || ''}

--- a/apps/kernel/app/profile/edit/page.tsx
+++ b/apps/kernel/app/profile/edit/page.tsx
@@ -263,7 +263,7 @@ function EditProfileContent() {
           {/* Handle (read-only) */}
           {handle && (
             <div>
-              <label className="block text-sm font-medium mb-1 text-gray-300">Handle</label>
+              <span className="block text-sm font-medium mb-1 text-gray-300">Handle</span>
               <div className="flex items-center px-4 py-2 border border-gray-700 rounded-lg bg-gray-900/50 text-gray-500">
                 <span className="mr-1">@</span>
                 <span>{handle}</span>
@@ -274,8 +274,9 @@ function EditProfileContent() {
 
           {/* Display Name */}
           <div>
-            <label className="block text-sm font-medium mb-1 text-gray-300">Display Name *</label>
+            <label htmlFor="profile-edit-display-name" className="block text-sm font-medium mb-1 text-gray-300">Display Name *</label>
             <input
+              id="profile-edit-display-name"
               type="text"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
@@ -287,8 +288,9 @@ function EditProfileContent() {
 
           {/* Bio */}
           <div>
-            <label className="block text-sm font-medium mb-1 text-gray-300">Bio</label>
+            <label htmlFor="profile-edit-bio" className="block text-sm font-medium mb-1 text-gray-300">Bio</label>
             <textarea
+              id="profile-edit-bio"
               value={bio}
               onChange={(e) => setBio(e.target.value)}
               placeholder="Tell us about yourself..."
@@ -304,8 +306,9 @@ function EditProfileContent() {
             <p className="text-xs text-gray-500 mb-3">🔒 Contact info is only visible to your connections</p>
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-1 text-gray-300">Email</label>
+                <label htmlFor="profile-edit-email" className="block text-sm font-medium mb-1 text-gray-300">Email</label>
                 <input
+                  id="profile-edit-email"
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -314,8 +317,9 @@ function EditProfileContent() {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1 text-gray-300">Phone</label>
+                <label htmlFor="profile-edit-phone" className="block text-sm font-medium mb-1 text-gray-300">Phone</label>
                 <input
+                  id="profile-edit-phone"
                   type="tel"
                   value={phone}
                   onChange={(e) => setPhone(e.target.value)}
@@ -421,8 +425,9 @@ function EditProfileContent() {
               />
             ) : (
               <div>
-                <label className="block text-sm font-medium mb-1 text-gray-300">Avatar (emoji)</label>
+                <label htmlFor="profile-edit-avatar-emoji" className="block text-sm font-medium mb-1 text-gray-300">Avatar (emoji)</label>
                 <input
+                  id="profile-edit-avatar-emoji"
                   type="text"
                   value={avatar}
                   onChange={(e) => setAvatar(e.target.value)}

--- a/apps/kernel/app/profile/register/page.tsx
+++ b/apps/kernel/app/profile/register/page.tsx
@@ -441,8 +441,9 @@ function RegisterPage() {
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium mb-1 text-gray-300">Display Name *</label>
+            <label htmlFor="profile-register-display-name" className="block text-sm font-medium mb-1 text-gray-300">Display Name *</label>
             <input
+              id="profile-register-display-name"
               type="text"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
@@ -453,10 +454,11 @@ function RegisterPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1 text-gray-300">Handle</label>
+            <label htmlFor="profile-register-handle" className="block text-sm font-medium mb-1 text-gray-300">Handle</label>
             <div className="flex items-center">
               <span className="text-gray-500 mr-1">@</span>
               <input
+                id="profile-register-handle"
                 type="text"
                 value={handle}
                 onChange={(e) => setHandle(normalizeHandleInput(e.target.value))}
@@ -481,8 +483,9 @@ function RegisterPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium mb-1 text-gray-300">Bio (optional)</label>
+            <label htmlFor="profile-register-bio" className="block text-sm font-medium mb-1 text-gray-300">Bio (optional)</label>
             <textarea
+              id="profile-register-bio"
               value={bio}
               onChange={(e) => setBio(e.target.value)}
               placeholder="Tell us about yourself..."
@@ -507,8 +510,9 @@ function RegisterPage() {
               />
             ) : (
               <div>
-                <label className="block text-sm font-medium mb-1 text-gray-300">Avatar (emoji)</label>
+                <label htmlFor="profile-register-avatar-emoji" className="block text-sm font-medium mb-1 text-gray-300">Avatar (emoji)</label>
                 <input
+                  id="profile-register-avatar-emoji"
                   type="text"
                   value={avatar}
                   onChange={(e) => setAvatar(e.target.value)}

--- a/apps/kernel/src/components/www/bug-report-modal.tsx
+++ b/apps/kernel/src/components/www/bug-report-modal.tsx
@@ -189,9 +189,9 @@ export function BugReportModal({ onClose }: Readonly<Props>) {
 
             {/* Screenshot drop zone */}
             <div>
-              <label className="block text-sm text-gray-400 mb-1">
+              <span className="block text-sm text-gray-400 mb-1">
                 Screenshot <span className="text-gray-600">(optional)</span>
-              </label>
+              </span>
               <div
                 onDrop={onDrop}
                 onDragOver={onDragOver}

--- a/apps/learn/app/dashboard/[slug]/page.tsx
+++ b/apps/learn/app/dashboard/[slug]/page.tsx
@@ -195,16 +195,18 @@ export default function CourseEditorPage() {
           <h2 className="font-semibold text-lg mb-4">Course Settings</h2>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium mb-1">Title</label>
+              <label htmlFor="course-title" className="block text-sm font-medium mb-1">Title</label>
               <input
+                id="course-title"
                 value={editTitle}
                 onChange={(e) => setEditTitle(e.target.value)}
                 className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Description</label>
+              <label htmlFor="course-description" className="block text-sm font-medium mb-1">Description</label>
               <textarea
+                id="course-description"
                 value={editDescription}
                 onChange={(e) => setEditDescription(e.target.value)}
                 rows={3}
@@ -212,8 +214,9 @@ export default function CourseEditorPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">Linked Event</label>
+              <label htmlFor="course-event-slug" className="block text-sm font-medium mb-1">Linked Event</label>
               <input
+                id="course-event-slug"
                 value={editEventSlug}
                 onChange={(e) => setEditEventSlug(e.target.value)}
                 placeholder="Event ID (e.g. jins-launch-party)"
@@ -223,8 +226,9 @@ export default function CourseEditorPage() {
             </div>
             <div className="grid grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium mb-1">Price (cents)</label>
+                <label htmlFor="course-price" className="block text-sm font-medium mb-1">Price (cents)</label>
                 <input
+                  id="course-price"
                   type="number"
                   value={editPrice}
                   onChange={(e) => setEditPrice(Number.parseInt(e.target.value) || 0)}
@@ -232,8 +236,9 @@ export default function CourseEditorPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Visibility</label>
+                <label htmlFor="course-visibility" className="block text-sm font-medium mb-1">Visibility</label>
                 <select
+                  id="course-visibility"
                   value={editVisibility}
                   onChange={(e) => setEditVisibility(e.target.value)}
                   className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
@@ -244,8 +249,9 @@ export default function CourseEditorPage() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium mb-1">Status</label>
+                <label htmlFor="course-status" className="block text-sm font-medium mb-1">Status</label>
                 <select
+                  id="course-status"
                   value={editStatus}
                   onChange={(e) => setEditStatus(e.target.value)}
                   className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"

--- a/apps/links/app/edit/page.tsx
+++ b/apps/links/app/edit/page.tsx
@@ -366,8 +366,9 @@ export default function EditPage() {
             <h2 className="text-xl font-semibold mb-4">Edit Page</h2>
             <form onSubmit={updatePage} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-2">Theme</label>
+                <label htmlFor="links-theme" className="block text-sm font-medium mb-2">Theme</label>
                 <select
+                  id="links-theme"
                   value={formData.theme}
                   onChange={(e) => setFormData({ ...formData, theme: e.target.value })}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800"
@@ -416,8 +417,9 @@ export default function EditPage() {
             </h3>
             <form onSubmit={editingLink ? updateLink : addLink} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-2">Title *</label>
+                <label htmlFor="link-title" className="block text-sm font-medium mb-2">Title *</label>
                 <input
+                  id="link-title"
                   type="text"
                   value={linkFormData.title}
                   onChange={(e) => setLinkFormData({ ...linkFormData, title: e.target.value })}
@@ -428,8 +430,9 @@ export default function EditPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">URL *</label>
+                <label htmlFor="link-url" className="block text-sm font-medium mb-2">URL *</label>
                 <input
+                  id="link-url"
                   type="url"
                   value={linkFormData.url}
                   onChange={(e) => setLinkFormData({ ...linkFormData, url: e.target.value })}
@@ -440,8 +443,9 @@ export default function EditPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">Icon (emoji)</label>
+                <label htmlFor="link-icon" className="block text-sm font-medium mb-2">Icon (emoji)</label>
                 <input
+                  id="link-icon"
                   type="text"
                   value={linkFormData.icon}
                   onChange={(e) => setLinkFormData({ ...linkFormData, icon: e.target.value })}
@@ -451,8 +455,9 @@ export default function EditPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">Visibility</label>
+                <label htmlFor="link-visibility" className="block text-sm font-medium mb-2">Visibility</label>
                 <select
+                  id="link-visibility"
                   value={linkFormData.visibility}
                   onChange={(e) => setLinkFormData({ ...linkFormData, visibility: e.target.value })}
                   className="w-full px-4 py-2 border border-gray-300 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800"

--- a/apps/market/app/components/ListingForm.tsx
+++ b/apps/market/app/components/ListingForm.tsx
@@ -318,6 +318,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
         </h2>
         <div className="space-y-3">
           <label
+            htmlFor="seller-tier-direct"
             className={`flex items-start gap-4 p-4 rounded-lg border cursor-pointer transition ${
               sellerTier === 'public_offplatform'
                 ? 'border-blue-500 bg-blue-500/10'
@@ -325,6 +326,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
             }`}
           >
             <input
+              id="seller-tier-direct"
               type="radio"
               name="sellerTier"
               value="public_offplatform"
@@ -339,6 +341,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
           </label>
 
           <label
+            htmlFor="seller-tier-protected"
             className={`flex items-start gap-4 p-4 rounded-lg border cursor-pointer transition ${
               sellerTier === 'public_onplatform'
                 ? 'border-blue-500 bg-blue-500/10'
@@ -346,6 +349,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
             }`}
           >
             <input
+              id="seller-tier-protected"
               type="radio"
               name="sellerTier"
               value="public_onplatform"
@@ -360,6 +364,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
           </label>
 
           <label
+            htmlFor="seller-tier-trusted"
             className={`flex items-start gap-4 p-4 rounded-lg border cursor-pointer transition ${
               sellerTier === 'trust_gated'
                 ? 'border-blue-500 bg-blue-500/10'
@@ -367,6 +372,7 @@ export function ListingForm({ initialData, onSubmit, submitLabel, isLoading, err
             }`}
           >
             <input
+              id="seller-tier-trusted"
               type="radio"
               name="sellerTier"
               value="trust_gated"

--- a/apps/market/app/settings/page.tsx
+++ b/apps/market/app/settings/page.tsx
@@ -92,7 +92,7 @@ export default function SettingsPage() {
                 <div className="w-11 h-6 bg-gray-800 rounded-full" />
               </div>
             ) : (
-              <label className="flex items-center justify-between gap-4 cursor-pointer select-none">
+              <label htmlFor="show-market-items" className="flex items-center justify-between gap-4 cursor-pointer select-none">
                 <div>
                   <p className="text-sm font-medium text-gray-100">Show listings on my profile</p>
                   <p className="text-xs text-gray-400 mt-0.5">
@@ -100,6 +100,7 @@ export default function SettingsPage() {
                   </p>
                 </div>
                 <button
+                  id="show-market-items"
                   role="switch"
                   aria-checked={showMarketItems}
                   disabled={saving}

--- a/packages/input/src/FileAttachment.tsx
+++ b/packages/input/src/FileAttachment.tsx
@@ -46,6 +46,7 @@ export function FileAttachment({
   const [error, setError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const fileInputId = React.useId();
 
   const processFile = useCallback(
     (file: File) => {
@@ -138,6 +139,7 @@ export function FileAttachment({
   return (
     <div className="relative">
       <input
+        id={fileInputId}
         ref={inputRef}
         type="file"
         accept={accept}
@@ -149,6 +151,7 @@ export function FileAttachment({
         renderTrigger(openPicker)
       ) : (
         <label
+          htmlFor={fileInputId}
           className={`p-2 text-gray-500 hover:text-orange-400 transition-colors cursor-pointer inline-block ${
             disabled ? 'opacity-40 cursor-not-allowed' : ''
           } ${isDragging ? 'text-orange-400' : ''}`}


### PR DESCRIPTION
## Summary
Fixes all 187 S6853 label accessibility issues across 41 files.

### Fix patterns
- **htmlFor + id pairs** (~165 instances): Added \htmlFor\ to \<label>\ and \id\ to the associated \<input>\/\<select>\/\<textarea>\
- **label → span conversion** (~14 instances): Converted heading-type \<label>\ elements that aren't associated with any form control to \<span>\
- **Explicit htmlFor on wrapping labels** (~8 instances): Added explicit \htmlFor\/\id\ to checkbox/radio labels already wrapping inputs (to satisfy static analysis)

### Scope
- **apps/kernel/** — 107 issues across 29 files
- **apps/events/** — 49 issues across 5 files
- **apps/dykil, coffee, learn, links, market + packages/input** — 31 issues across 7 files

### Validation
- Lint passes (kernel, events)
- No visual changes — identical runtime behavior
- No imports, exports, or function signatures changed

Co-Authored-By: Oz <oz-agent@warp.dev>