### PR TITLE
fix(sonar): flip remaining multi-line negated conditions (S7735)

### DIFF
--- a/apps/coffee/app/[handle]/tip-form.tsx
+++ b/apps/coffee/app/[handle]/tip-form.tsx
@@ -116,9 +116,9 @@ export default function TipForm({ page, primaryColor, sellerConnected = true }: 
             type="button"
             onClick={() => setIsRecurring(false)}
             className={`px-6 py-2 rounded-lg font-medium transition ${
-              !isRecurring
-                ? 'bg-white shadow text-gray-900'
-                : 'text-gray-500'
+              isRecurring
+                ? 'text-gray-500'
+                : 'bg-white shadow text-gray-900'
             }`}
           >
             One-time

--- a/apps/coffee/app/edit/page.tsx
+++ b/apps/coffee/app/edit/page.tsx
@@ -405,9 +405,9 @@ export default function EditPage() {
                   type="button"
                   onClick={() => setShowThankYouPreview(false)}
                   className={`px-3 py-1.5 rounded-lg text-sm font-medium transition ${
-                    !showThankYouPreview
-                      ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400'
-                      : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+                    showThankYouPreview
+                      ? 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+                      : 'bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400'
                   }`}
                 >
                   Edit

--- a/apps/coffee/app/page.tsx
+++ b/apps/coffee/app/page.tsx
@@ -45,7 +45,7 @@ export default function CoffeePage() {
                   Go to Dashboard →
                 </Link>
               ) : (
-                <a href={`${AUTH_URL}/login?next=${encodeURIComponent(typeof window !== 'undefined' ? globalThis.location.origin + '/dashboard' : '/dashboard')}`} className="inline-block px-8 py-4 bg-orange-500 text-white rounded-xl font-semibold text-lg hover:bg-orange-600 transition hover:shadow-lg">
+                <a href={`${AUTH_URL}/login?next=${encodeURIComponent(typeof window === 'undefined' ? '/dashboard' : globalThis.location.origin + '/dashboard')}`} className="inline-block px-8 py-4 bg-orange-500 text-white rounded-xl font-semibold text-lg hover:bg-orange-600 transition hover:shadow-lg">
                   Sign In to Get Started
                 </a>
               )

--- a/apps/dykil/app/(chrome)/create/page.tsx
+++ b/apps/dykil/app/(chrome)/create/page.tsx
@@ -294,10 +294,10 @@ function CreateSurveyContent() {
     }
 
     const newElements = [...survey.fields.elements];
-    if (editingFieldIndex !== null) {
-      newElements[editingFieldIndex] = fieldForm;
-    } else {
+    if (editingFieldIndex === null) {
       newElements.push(fieldForm);
+    } else {
+      newElements[editingFieldIndex] = fieldForm;
     }
 
     setSurvey({ ...survey, fields: { elements: newElements } });

--- a/apps/dykil/app/(chrome)/page.tsx
+++ b/apps/dykil/app/(chrome)/page.tsx
@@ -45,7 +45,7 @@ export default function Home() {
                   Go to Dashboard →
                 </Link>
               ) : (
-                <a href={`${AUTH_URL}/login?next=${encodeURIComponent(typeof window !== 'undefined' ? globalThis.location.origin + '/dashboard' : '/dashboard')}`} className="inline-block px-8 py-4 bg-orange-500 text-white rounded-xl font-semibold text-lg hover:bg-orange-600 transition hover:shadow-lg">
+                <a href={`${AUTH_URL}/login?next=${encodeURIComponent(typeof window === 'undefined' ? '/dashboard' : globalThis.location.origin + '/dashboard')}`} className="inline-block px-8 py-4 bg-orange-500 text-white rounded-xl font-semibold text-lg hover:bg-orange-600 transition hover:shadow-lg">
                   Sign In to Get Started
                 </a>
               )

--- a/apps/events/app/admin/[eventId]/message-composer.tsx
+++ b/apps/events/app/admin/[eventId]/message-composer.tsx
@@ -99,13 +99,13 @@ export function MessageComposer({ eventId, recipientCount: initialCount, tiers }
 
       const data = await res.json();
 
-      if (!res.ok) {
-        setError(data.error || 'Failed to send message');
-      } else {
+      if (res.ok) {
         setResult(data);
         setSubject('');
         setMarkdown('');
         setPreview(false);
+      } else {
+        setError(data.error || 'Failed to send message');
       }
     } catch {
       setError('Network error — please try again');
@@ -258,7 +258,7 @@ export function MessageComposer({ eventId, recipientCount: initialCount, tiers }
             disabled={!canSend}
             className="px-5 py-2 rounded-md bg-orange-500 hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
           >
-            {sending ? 'Sending…' : `Send to ${recipientCount} attendee${recipientCount !== 1 ? 's' : ''}`}
+            {sending ? 'Sending…' : `Send to ${recipientCount} attendee${recipientCount === 1 ? '' : 's'}`}
             {/* Note: the inner pluralization ternary (recipientCount !== 1) is inside a template literal within one branch — not a nested ternary */}
           </button>
         </div>

--- a/apps/events/app/api/checkout/route.ts
+++ b/apps/events/app/api/checkout/route.ts
@@ -123,7 +123,7 @@ export const POST = withLogger('events', async (request, { log, correlationId })
         const available = tt.quantity - (tt.sold ?? 0);
         if (available < item.quantity) {
           return NextResponse.json(
-            { error: `Only ${available} ${tt.name} ticket${available !== 1 ? 's' : ''} available` },
+            { error: `Only ${available} ${tt.name} ticket${available === 1 ? '' : 's'} available` },
             { status: 409 }
           );
         }

--- a/apps/events/app/api/events/[id]/tickets/[ticketId]/resend-email/route.ts
+++ b/apps/events/app/api/events/[id]/tickets/[ticketId]/resend-email/route.ts
@@ -171,12 +171,12 @@ export async function POST(
     } else {
       const qrCodeDataUri = await generateQRCode(ticket.id);
       const formattedPrice =
-        ticket.pricePaid !== null
-          ? new Intl.NumberFormat('en-US', {
+        ticket.pricePaid === null
+          ? 'Free'
+          : new Intl.NumberFormat('en-US', {
               style: 'currency',
               currency: (ticket.currency || 'USD').toUpperCase(),
-            }).format(ticket.pricePaid / 100)
-          : 'Free';
+            }).format(ticket.pricePaid / 100);
 
       publish('ticket.confirmed', {
         issuer: did,

--- a/apps/events/app/api/register/[ticketId]/route.ts
+++ b/apps/events/app/api/register/[ticketId]/route.ts
@@ -150,12 +150,12 @@ export const POST = withLogger('events', async (request, { log }) => {
           isVirtual: event.isVirtual ?? false,
           venue: event.venue ?? undefined,
           price:
-            ticket.pricePaid != null
-              ? new Intl.NumberFormat('en-US', {
+            ticket.pricePaid == null
+              ? 'Included'
+              : new Intl.NumberFormat('en-US', {
                   style: 'currency',
                   currency: ticket.currency || 'USD',
-                }).format(ticket.pricePaid / 100)
-              : 'Included',
+                }).format(ticket.pricePaid / 100),
           magicLink: eventUrl(EVENTS_URL, event.id),
           eventImageUrl,
           eventUrl: eventUrl(EVENTS_URL, event.id),

--- a/apps/events/app/e/[eventId]/event-chat-button.tsx
+++ b/apps/events/app/e/[eventId]/event-chat-button.tsx
@@ -12,9 +12,9 @@ export function EventChatButton({ eventId, chatUrl }: Readonly<EventChatButtonPr
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const baseChatUrl = chatUrl || (typeof window !== 'undefined'
-    ? `${globalThis.location.protocol}//${globalThis.location.hostname.replaceAll('events', 'chat')}`
-    : 'https://chat.imajin.ai');
+  const baseChatUrl = chatUrl || (typeof window === 'undefined'
+    ? 'https://chat.imajin.ai'
+    : `${globalThis.location.protocol}//${globalThis.location.hostname.replaceAll('events', 'chat')}`);
 
   useEffect(() => {
     async function checkAccess() {

--- a/apps/events/app/e/[eventId]/tickets-section.tsx
+++ b/apps/events/app/e/[eventId]/tickets-section.tsx
@@ -732,14 +732,7 @@ function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken
       {/* Unlock hidden tiers */}
       {hasHiddenTiers && (
         <div className="pt-4">
-          {!showUnlock ? (
-            <button
-              onClick={() => setShowUnlock(true)}
-              className="text-sm text-orange-500 hover:text-orange-600 font-medium flex items-center gap-1"
-            >
-              🔑 Have an access code?
-            </button>
-          ) : (
+          {showUnlock ? (
             <div className="flex items-start gap-2">
               <div className="flex-1">
                 <input
@@ -768,6 +761,13 @@ function PurchaseUI({ eventId, eventTitle, tickets, userOrders = [], inviteToken
                 Cancel
               </button>
             </div>
+          ) : (
+            <button
+              onClick={() => setShowUnlock(true)}
+              className="text-sm text-orange-500 hover:text-orange-600 font-medium flex items-center gap-1"
+            >
+              🔑 Have an access code?
+            </button>
           )}
         </div>
       )}
@@ -1161,7 +1161,7 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
           <>
             <p className="text-sm text-gray-600 dark:text-gray-300">
               We sent a verification link to <strong className="text-gray-800 dark:text-gray-100">{verifySentTo}</strong>.
-              Click it to confirm your email and we'll reserve your {totalQty} ticket{totalQty !== 1 ? 's' : ''} automatically.
+              Click it to confirm your email and we'll reserve your {totalQty} ticket{totalQty === 1 ? '' : 's'} automatically.
             </p>
             <p className="text-xs text-gray-500 dark:text-gray-400">
               Link expires in 15 minutes. Check spam if you don't see it.
@@ -1300,7 +1300,7 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
           </div>
         </div>
         <div className="flex gap-2">
-          <button onClick={startEtransfer} disabled={!emtEmail.includes('@')} className={`px-5 py-2.5 rounded-lg font-semibold transition ${!emtEmail.includes('@') ? 'bg-gray-300 dark:bg-gray-700 text-gray-500 cursor-not-allowed' : 'bg-orange-500 text-white hover:bg-orange-600'}`}>Reserve My Ticket</button>
+          <button onClick={startEtransfer} disabled={!emtEmail.includes('@')} className={`px-5 py-2.5 rounded-lg font-semibold transition ${emtEmail.includes('@') ? 'bg-orange-500 text-white hover:bg-orange-600' : 'bg-gray-300 dark:bg-gray-700 text-gray-500 cursor-not-allowed'}`}>Reserve My Ticket</button>
           <button onClick={() => setStep('idle')} className="px-3 py-2.5 text-sm text-gray-500 hover:text-gray-700">Back</button>
         </div>
       </div>

--- a/apps/kernel/app/admin/events/events-client.tsx
+++ b/apps/kernel/app/admin/events/events-client.tsx
@@ -332,7 +332,7 @@ export default function EventsClient() {
                       <tr
                         key={row.id}
                         onClick={() => hasPayload && toggleRow(row.id)}
-                        className={`hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors ${hasPayload ? 'cursor-pointer' : ''} ${row.status !== 'success' ? 'bg-red-50/40 dark:bg-red-900/10' : ''}`}
+                        className={`hover:bg-gray-50 dark:hover:bg-gray-700/40 transition-colors ${hasPayload ? 'cursor-pointer' : ''} ${row.status === 'success' ? '' : 'bg-red-50/40 dark:bg-red-900/10'}`}
                       >
                         <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap font-mono">
                           {formatTs(row.created_at)}

--- a/apps/kernel/app/admin/newsletter/composer.tsx
+++ b/apps/kernel/app/admin/newsletter/composer.tsx
@@ -61,8 +61,8 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
         }),
       });
       const data = await res.json();
-      if (!res.ok) setError(data.error ?? 'Test send failed');
-      else setResult({ sent: true, recipientCount: 1 });
+      if (res.ok) setResult({ sent: true, recipientCount: 1 });
+      else setError(data.error ?? 'Test send failed');
     } finally {
       setSendingTest(false);
     }
@@ -84,8 +84,8 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
         }),
       });
       const data = await res.json();
-      if (!res.ok) setError(data.error ?? 'Send failed');
-      else setResult({ sent: data.sent, recipientCount: data.recipientCount });
+      if (res.ok) setResult({ sent: data.sent, recipientCount: data.recipientCount });
+      else setError(data.error ?? 'Send failed');
     } finally {
       setSending(false);
       setConfirm(false);

--- a/apps/kernel/app/admin/services/page.tsx
+++ b/apps/kernel/app/admin/services/page.tsx
@@ -49,17 +49,17 @@ export default async function AdminServicesPage() {
         <ServicesRefresh />
       </div>
 
-      {!data ? (
+      {data ? (
+        <>
+          <ServiceSection title="Kernel Services" services={kernelServices} />
+          <ServiceSection title="Userspace Services" services={userspaceServices} />
+        </>
+      ) : (
         <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-8 text-center">
           <p className="text-gray-500 dark:text-gray-400 text-sm">
             Could not fetch service health. Check admin authentication.
           </p>
         </div>
-      ) : (
-        <>
-          <ServiceSection title="Kernel Services" services={kernelServices} />
-          <ServiceSection title="Userspace Services" services={userspaceServices} />
-        </>
       )}
     </div>
   );

--- a/apps/kernel/app/admin/telemetry/page.tsx
+++ b/apps/kernel/app/admin/telemetry/page.tsx
@@ -98,13 +98,7 @@ export default async function TelemetryPage() {
         </p>
       </div>
 
-      {!data ? (
-        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-8 text-center">
-          <p className="text-gray-500 dark:text-gray-400 text-sm">
-            No telemetry data. Set <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">ENABLE_REQUEST_LOG=true</code> to start collecting.
-          </p>
-        </div>
-      ) : (
+      {data ? (
         <div className="space-y-8">
           {/* Request Volume Chart */}
           <Section title="Request Volume (24h)">
@@ -140,6 +134,12 @@ export default async function TelemetryPage() {
           >
             <RecentErrorsTable rows={errorsData?.rows ?? []} />
           </Section>
+        </div>
+      ) : (
+        <div className="rounded-xl bg-white dark:bg-gray-800 shadow border border-gray-100 dark:border-gray-700 p-8 text-center">
+          <p className="text-gray-500 dark:text-gray-400 text-sm">
+            No telemetry data. Set <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">ENABLE_REQUEST_LOG=true</code> to start collecting.
+          </p>
         </div>
       )}
     </div>

--- a/apps/kernel/app/auth/api/onboard/join/route.ts
+++ b/apps/kernel/app/auth/api/onboard/join/route.ts
@@ -86,14 +86,7 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
   }
 
   try {
-    if (!existing) {
-      await db.insert(identityMembers).values({
-        identityDid: scopeDid,
-        memberDid: session.did,
-        role: 'member',
-        addedBy: scopeDid,
-      });
-    } else {
+    if (existing) {
       // Re-add previously removed member
       await db.update(identityMembers)
         .set({ removedAt: null, role: 'member', addedBy: scopeDid, addedAt: new Date() })
@@ -101,6 +94,13 @@ export const POST = withLogger('kernel', async (request: NextRequest, { log }) =
           eq(identityMembers.identityDid, scopeDid),
           eq(identityMembers.memberDid, session.did)
         ));
+    } else {
+      await db.insert(identityMembers).values({
+        identityDid: scopeDid,
+        memberDid: session.did,
+        role: 'member',
+        addedBy: scopeDid,
+      });
     }
 
     publish('identity.member_added', {

--- a/apps/kernel/app/auth/attestations/components/DocumentViewer.tsx
+++ b/apps/kernel/app/auth/attestations/components/DocumentViewer.tsx
@@ -8,9 +8,9 @@ interface Props {
 }
 
 export default function DocumentViewer({ assetId, mimeType, filename, hash }: Readonly<Props>) {
-  const baseUrl = typeof window !== 'undefined'
-    ? `${globalThis.location.origin}/media/api/assets/${assetId}`
-    : `/media/api/assets/${assetId}`;
+  const baseUrl = typeof window === 'undefined'
+    ? `/media/api/assets/${assetId}`
+    : `${globalThis.location.origin}/media/api/assets/${assetId}`;
 
   const isPdf = mimeType === 'application/pdf';
   const isImage = mimeType.startsWith('image/');

--- a/apps/kernel/app/auth/components/IdentityMembersPanel.tsx
+++ b/apps/kernel/app/auth/components/IdentityMembersPanel.tsx
@@ -71,9 +71,9 @@ export default function IdentityMembersPanel({ groupDid }: Readonly<{ groupDid: 
   async function loadConfig() {
     try {
       const profileUrl =
-        typeof window !== 'undefined'
-          ? globalThis.location.origin
-          : (process.env.NEXT_PUBLIC_PROFILE_URL ?? '');
+        typeof window === 'undefined'
+          ? (process.env.NEXT_PUBLIC_PROFILE_URL ?? '')
+          : globalThis.location.origin;
       const res = await fetch(
         `${profileUrl}/api/forest/${encodeURIComponent(groupDid)}/config`,
         { credentials: 'include' }

--- a/apps/kernel/app/auth/developer/apps/[appId]/components/AppDetailClient.tsx
+++ b/apps/kernel/app/auth/developer/apps/[appId]/components/AppDetailClient.tsx
@@ -380,14 +380,7 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
             Revoking this app will immediately invalidate all active sessions and prevent any new authorizations.
           </p>
 
-          {!showRevoke ? (
-            <button
-              onClick={() => setShowRevoke(true)}
-              className="px-4 py-2 border border-red-900/60 text-red-400 hover:bg-red-900/20 rounded-lg text-sm transition-colors"
-            >
-              Revoke App
-            </button>
-          ) : (
+          {showRevoke ? (
             <div className="space-y-3">
               <p className="text-sm text-red-300">
                 Are you sure you want to revoke <strong>{app.name}</strong>? This cannot be undone.
@@ -413,6 +406,13 @@ export default function AppDetailClient({ app: initialApp }: Readonly<Props>) {
                 </button>
               </div>
             </div>
+          ) : (
+            <button
+              onClick={() => setShowRevoke(true)}
+              className="px-4 py-2 border border-red-900/60 text-red-400 hover:bg-red-900/20 rounded-lg text-sm transition-colors"
+            >
+              Revoke App
+            </button>
           )}
         </div>
       )}

--- a/apps/kernel/app/chat/api/conversations/[id]/route.ts
+++ b/apps/kernel/app/chat/api/conversations/[id]/route.ts
@@ -102,14 +102,7 @@ export async function PATCH(
       where: eq(conversationsV2.did, conversationDid),
     });
 
-    if (!conv) {
-      // Auto-create if it doesn't exist yet
-      await db.insert(conversationsV2).values({
-        did: conversationDid,
-        name: name || null,
-        createdBy: effectiveDid,
-      }).onConflictDoNothing();
-    } else {
+    if (conv) {
       if (conv.createdBy !== effectiveDid) {
         return errorResponse('Only the creator can update the name', 403);
       }
@@ -117,6 +110,13 @@ export async function PATCH(
         .update(conversationsV2)
         .set({ name: name || null, updatedAt: new Date() })
         .where(eq(conversationsV2.did, conversationDid));
+    } else {
+      // Auto-create if it doesn't exist yet
+      await db.insert(conversationsV2).values({
+        did: conversationDid,
+        name: name || null,
+        createdBy: effectiveDid,
+      }).onConflictDoNothing();
     }
 
     return jsonResponse({ ok: true });

--- a/apps/kernel/app/chat/conversations/[type]/[slug]/page.tsx
+++ b/apps/kernel/app/chat/conversations/[type]/[slug]/page.tsx
@@ -374,9 +374,9 @@ function DIDConversationView({ did }: Readonly<{ did: string }>) {
                   }}
                   title="Click to rename"
                 >
-                  {!(convName || nameParam)
-                    ? <span className="text-gray-400 italic font-normal">Untitled Group</span>
-                    : displayName}
+                  {(convName || nameParam)
+                    ? displayName
+                    : <span className="text-gray-400 italic font-normal">Untitled Group</span>}
                 </button>
               );
             }
@@ -391,7 +391,7 @@ function DIDConversationView({ did }: Readonly<{ did: string }>) {
               onClick={() => setShowMembers(!showMembers)}
               className="text-xs text-gray-500 mt-0.5 hover:text-orange-500 transition-colors text-left"
             >
-              {memberCount ? `${memberCount} member${memberCount !== 1 ? 's' : ''}` : 'Group conversation'}
+              {memberCount ? `${memberCount} member${memberCount === 1 ? '' : 's'}` : 'Group conversation'}
             </button>
           )}
           {parsed.type === 'event' && (

--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -101,10 +101,10 @@ let verifyKeyPromise: Promise<import('jose').KeyLike> | null = null;
 function getVerifyKey(): Promise<import('jose').KeyLike> {
   if (!verifyKeyPromise) {
     const privateKeyHex = process.env.AUTH_PRIVATE_KEY;
-    if (!privateKeyHex) {
-      verifyKeyPromise = Promise.reject(new Error('AUTH_PRIVATE_KEY not configured'));
-    } else {
+    if (privateKeyHex) {
       verifyKeyPromise = loadVerifyKey(privateKeyHex);
+    } else {
+      verifyKeyPromise = Promise.reject(new Error('AUTH_PRIVATE_KEY not configured'));
     }
   }
   return verifyKeyPromise;

--- a/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/settle/confirm/route.ts
@@ -27,10 +27,10 @@ let signKeyPromise: Promise<import("jose").KeyLike> | null = null;
 function getSignKey(): Promise<import("jose").KeyLike> {
   if (!signKeyPromise) {
     const privateKeyHex = process.env.AUTH_PRIVATE_KEY;
-    if (!privateKeyHex) {
-      signKeyPromise = Promise.reject(new Error("AUTH_PRIVATE_KEY not configured"));
-    } else {
+    if (privateKeyHex) {
       signKeyPromise = loadSigningKey(privateKeyHex);
+    } else {
+      signKeyPromise = Promise.reject(new Error("AUTH_PRIVATE_KEY not configured"));
     }
   }
   return signKeyPromise;

--- a/apps/kernel/app/pay/api/settle/route.ts
+++ b/apps/kernel/app/pay/api/settle/route.ts
@@ -165,7 +165,10 @@ export async function POST(request: NextRequest) {
     let signatureVerified = false;
 
     if (!funded) {
-      if (fair_manifest.signature !== undefined) {
+      if (fair_manifest.signature === undefined) {
+        // Unsigned manifest — allow but warn (transitional period)
+        log.warn({ fromDid: from_did, service }, 'Settlement received unsigned fair_manifest');
+      } else {
         const resolver = createDbResolver(db, identities);
         const wrappedResolver = async (did: string): Promise<string> => {
           const identity = await resolver(did);
@@ -183,9 +186,6 @@ export async function POST(request: NextRequest) {
             { status: 400, headers: cors }
           );
         }
-      } else {
-        // Unsigned manifest — allow but warn (transitional period)
-        log.warn({ fromDid: from_did, service }, 'Settlement received unsigned fair_manifest');
       }
     }
 

--- a/apps/kernel/app/pay/api/webhook/route.ts
+++ b/apps/kernel/app/pay/api/webhook/route.ts
@@ -552,11 +552,11 @@ async function notifyEventsService(
       }),
     });
     
-    if (!response.ok) {
+    if (response.ok) {
+      log.info({}, 'Events service notified successfully');
+    } else {
       const error = await response.text();
       log.error({ error }, 'Events service webhook failed');
-    } else {
-      log.info({}, 'Events service notified successfully');
     }
   } catch (error) {
     log.error({ err: String(error) }, 'Failed to notify events service');
@@ -599,11 +599,11 @@ async function notifyCoffeeService(
       }),
     });
 
-    if (!response.ok) {
+    if (response.ok) {
+      log.info({}, 'Coffee service notified successfully');
+    } else {
       const error = await response.text();
       log.error({ error }, 'Coffee service webhook failed');
-    } else {
-      log.info({}, 'Coffee service notified successfully');
     }
   } catch (error) {
     log.error({ err: String(error) }, 'Failed to notify coffee service');
@@ -726,11 +726,11 @@ async function notifyCoffeeServiceSubscription(
       }),
     });
 
-    if (!response.ok) {
+    if (response.ok) {
+      log.info({ type }, 'Coffee service notified of subscription event');
+    } else {
       const error = await response.text();
       log.error({ error }, 'Coffee service subscription webhook failed');
-    } else {
-      log.info({ type }, 'Coffee service notified of subscription event');
     }
   } catch (error) {
     log.error({ err: String(error) }, 'Failed to notify coffee service of subscription event');

--- a/apps/kernel/app/pay/payouts/page.tsx
+++ b/apps/kernel/app/pay/payouts/page.tsx
@@ -68,21 +68,29 @@ export default async function PayoutsPage() {
 
       {/* Payout Status Card */}
       <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-6">
-        {!status ? (
-          // State A - Not connected
-          <div className="text-center space-y-4">
-            <div>
-              <h2 className="text-xl font-semibold text-white mb-2">Set up payouts</h2>
-              <p className="text-zinc-400 max-w-2xl mx-auto">
-                Connect your bank account to receive payouts from events, tips, and sales.
+        {status ? (
+          status.onboardingComplete ? (
+          // State C - Connected
+          <div className="space-y-6">
+            <div className="text-center">
+              <div className="text-green-400 text-4xl mb-3">✅</div>
+              <h2 className="text-xl font-semibold text-white mb-2">Payouts enabled</h2>
+              <p className="text-zinc-400">
+                Default currency: {status.defaultCurrency}
               </p>
             </div>
-            <PayoutActions
-              status="not_connected"
-              did={did}
-            />
+
+            <div className="text-center">
+              <PayoutActions
+                status="connected"
+                did={did}
+              />
+              <p className="text-xs text-zinc-500 mt-3">
+                View payout schedule, bank details, and transaction history in the Stripe Dashboard
+              </p>
+            </div>
           </div>
-        ) : !status.onboardingComplete ? (
+        ) : (
           // State B - Onboarding incomplete
           <div className="space-y-6">
             <div>
@@ -125,26 +133,20 @@ export default async function PayoutsPage() {
               did={did}
             />
           </div>
+        )
         ) : (
-          // State C - Connected
-          <div className="space-y-6">
-            <div className="text-center">
-              <div className="text-green-400 text-4xl mb-3">✅</div>
-              <h2 className="text-xl font-semibold text-white mb-2">Payouts enabled</h2>
-              <p className="text-zinc-400">
-                Default currency: {status.defaultCurrency}
+          // State A - Not connected
+          <div className="text-center space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold text-white mb-2">Set up payouts</h2>
+              <p className="text-zinc-400 max-w-2xl mx-auto">
+                Connect your bank account to receive payouts from events, tips, and sales.
               </p>
             </div>
-
-            <div className="text-center">
-              <PayoutActions
-                status="connected"
-                did={did}
-              />
-              <p className="text-xs text-zinc-500 mt-3">
-                View payout schedule, bank details, and transaction history in the Stripe Dashboard
-              </p>
-            </div>
+            <PayoutActions
+              status="not_connected"
+              did={did}
+            />
           </div>
         )}
       </div>

--- a/apps/kernel/app/pay/topup/page.tsx
+++ b/apps/kernel/app/pay/topup/page.tsx
@@ -254,9 +254,9 @@ export default function TopupPage() {
               <button
                 onClick={() => setAbsorbFees(false)}
                 className={`flex-1 py-2 text-sm font-medium rounded-md transition-all ${
-                  !absorbFees
-                    ? 'bg-zinc-700 text-white'
-                    : 'text-zinc-500 hover:text-zinc-300'
+                  absorbFees
+                    ? 'text-zinc-500 hover:text-zinc-300'
+                    : 'bg-zinc-700 text-white'
                 }`}
               >
                 Me

--- a/apps/kernel/app/pay/topup/success/page.tsx
+++ b/apps/kernel/app/pay/topup/success/page.tsx
@@ -38,9 +38,9 @@ export default async function TopupSuccessPage({ searchParams }: Readonly<Succes
         <div className="text-6xl mb-4">✅</div>
         <h1 className="text-3xl font-bold text-white">Funds Added!</h1>
         <p className="text-zinc-400">
-          {amount !== null
-            ? `$${amount.toFixed(2)} CAD has been credited to your MJNx balance.`
-            : 'Your top-up has been processed successfully.'}
+          {amount === null
+            ? 'Your top-up has been processed successfully.'
+            : `$${amount.toFixed(2)} CAD has been credited to your MJNx balance.`}
         </p>
       </div>
 

--- a/apps/kernel/app/profile/api/profile/[id]/route.ts
+++ b/apps/kernel/app/profile/api/profile/[id]/route.ts
@@ -302,7 +302,14 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     let updated;
-    if (!existing) {
+    if (existing) {
+      // Update existing profile
+      [updated] = await db
+        .update(profiles)
+        .set(updates)
+        .where(eq(profiles.did, existing.did))
+        .returning();
+    } else {
       // Create new profile for bare identity
       [updated] = await db
         .insert(profiles)
@@ -318,13 +325,6 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
           featureToggles: feature_toggles || {},
           agentPricing: agentPricing || null,
         })
-        .returning();
-    } else {
-      // Update existing profile
-      [updated] = await db
-        .update(profiles)
-        .set(updates)
-        .where(eq(profiles.did, existing.did))
         .returning();
     }
 

--- a/apps/kernel/src/lib/registry/relay/postgres-store.ts
+++ b/apps/kernel/src/lib/registry/relay/postgres-store.ts
@@ -254,9 +254,9 @@ export class PostgresRelayStore implements RelayStore {
       .orderBy(relayOperationLog.seq)
       .limit(params.limit);
 
-    const rows = cursorSeq !== null
-      ? await query.where(gt(relayOperationLog.seq, cursorSeq))
-      : await query;
+    const rows = cursorSeq === null
+      ? await query
+      : await query.where(gt(relayOperationLog.seq, cursorSeq));
 
     const entries: LogEntry[] = rows.map((row) => ({
       cid: row.cid,

--- a/apps/learn/app/course/[slug]/page.tsx
+++ b/apps/learn/app/course/[slug]/page.tsx
@@ -282,7 +282,7 @@ export default function CourseDetailPage() {
               return (
               <OnboardGate
                 action={isDeck ? `view "${course.title}"` : `enroll in "${course.title}"`}
-                redirectUrl={`${typeof window !== 'undefined' ? globalThis.location.origin : ''}/course/${slug}?enroll=1`}
+                redirectUrl={`${typeof window === 'undefined' ? '' : globalThis.location.origin}/course/${slug}?enroll=1`}
                 onIdentity={() => handleEnroll()}
                 authUrl={process.env.NEXT_PUBLIC_AUTH_URL}
               >

--- a/apps/links/app/page.tsx
+++ b/apps/links/app/page.tsx
@@ -45,7 +45,7 @@ export default function Home() {
                   Go to Dashboard →
                 </Link>
               ) : (
-                <a href={`${AUTH_URL}/login?next=${encodeURIComponent(typeof window !== 'undefined' ? globalThis.location.origin + '/edit' : '/edit')}`} className="inline-block px-8 py-4 bg-orange-500 text-white rounded-xl font-semibold text-lg hover:bg-orange-600 transition hover:shadow-lg">
+                <a href={`${AUTH_URL}/login?next=${encodeURIComponent(typeof window === 'undefined' ? '/edit' : globalThis.location.origin + '/edit')}`} className="inline-block px-8 py-4 bg-orange-500 text-white rounded-xl font-semibold text-lg hover:bg-orange-600 transition hover:shadow-lg">
                   Sign In to Get Started
                 </a>
               )

--- a/apps/market/app/listings/[id]/ListingDetail.tsx
+++ b/apps/market/app/listings/[id]/ListingDetail.tsx
@@ -279,7 +279,7 @@ export default function ListingDetail() {
             This listing is only available to verified members.
           </p>
           <a
-            href={`${authUrl}/login?next=${encodeURIComponent(typeof window !== 'undefined' ? globalThis.location.href : '')}`}
+            href={`${authUrl}/login?next=${encodeURIComponent(typeof window === 'undefined' ? '' : globalThis.location.href)}`}
             className="inline-block px-6 py-3 bg-orange-500 hover:bg-orange-600 text-white font-semibold rounded-xl transition"
           >
             Sign in to view

--- a/apps/market/app/listings/[id]/edit/page.tsx
+++ b/apps/market/app/listings/[id]/edit/page.tsx
@@ -215,15 +215,7 @@ export default function EditListingPage() {
         {/* Delete section */}
         <div className="mt-10 pt-8 border-t border-gray-800">
           <h3 className="text-sm font-medium text-gray-400 mb-3">Danger Zone</h3>
-          {!showDeleteConfirm ? (
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(true)}
-              className="px-4 py-2 bg-red-900/40 border border-red-800 text-red-400 hover:bg-red-800/50 hover:text-red-300 rounded-lg text-sm font-medium transition"
-            >
-              Delete Listing
-            </button>
-          ) : (
+          {showDeleteConfirm ? (
             <div className="p-4 bg-red-900/20 border border-red-800 rounded-lg space-y-3">
               <p className="text-sm text-red-300">
                 Are you sure? This will permanently remove the listing. This cannot be undone.
@@ -246,6 +238,14 @@ export default function EditListingPage() {
                 </button>
               </div>
             </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="px-4 py-2 bg-red-900/40 border border-red-800 text-red-400 hover:bg-red-800/50 hover:text-red-300 rounded-lg text-sm font-medium transition"
+            >
+              Delete Listing
+            </button>
           )}
         </div>
       </div>

--- a/apps/market/app/page.tsx
+++ b/apps/market/app/page.tsx
@@ -100,7 +100,7 @@ function MarketPageContent() {
           <div>
             <h1 className="text-3xl font-bold mb-2">Browse Listings</h1>
             <p className="text-gray-500 dark:text-gray-400">
-              Local commerce with trust.{total > 0 && ` ${total} listing${total !== 1 ? 's' : ''} available.`}
+              Local commerce with trust.{total > 0 && ` ${total} listing${total === 1 ? '' : 's'} available.`}
             </p>
           </div>
           <Link

--- a/packages/auth/src/require-auth.ts
+++ b/packages/auth/src/require-auth.ts
@@ -180,11 +180,11 @@ export async function requireAuth(
       const chainRes = await fetch(
         `${getAuthUrl()}/api/identity/${encodeURIComponent(result.identity.id)}/verify`
       );
-      if (!chainRes.ok) {
-        result.identity.chainVerified = false;
-      } else {
+      if (chainRes.ok) {
         const chainData = await chainRes.json();
         result.identity.chainVerified = chainData.chain?.valid ?? false;
+      } else {
+        result.identity.chainVerified = false;
       }
     } catch (err) {
       log.error({ err: String(err) }, "[AUTH] Chain verification failed");

--- a/packages/auth/src/sign.ts
+++ b/packages/auth/src/sign.ts
@@ -137,10 +137,10 @@ export function canonicalize(obj: unknown): string {
 export function createChallenge(): string {
   // 32 random bytes as hex
   const bytes = new Uint8Array(32);
-  if (typeof globalThis.crypto !== 'undefined') {
-    globalThis.crypto.getRandomValues(bytes);
-  } else {
+  if (typeof globalThis.crypto === 'undefined') {
     throw new TypeError('Secure random source unavailable');
+  } else {
+    globalThis.crypto.getRandomValues(bytes);
   }
   return crypto.bytesToHex(bytes);
 }

--- a/packages/bus/src/reactors/mjn.ts
+++ b/packages/bus/src/reactors/mjn.ts
@@ -59,11 +59,11 @@ export const mjnReactor: ReactorHandler = async (event, config) => {
         }),
       });
 
-      if (!response.ok) {
+      if (response.ok) {
+        log.info({ amount, targetDid: targetDid.slice(0, 24), attestationType, reason: rule.reason }, '[mjn] MJN credited');
+      } else {
         const text = await response.text().catch(() => '');
         log.error({ status: response.status, text, targetDid, attestationType }, '[mjn] Emission credit failed');
-      } else {
-        log.info({ amount, targetDid: targetDid.slice(0, 24), attestationType, reason: rule.reason }, '[mjn] MJN credited');
       }
     } catch (err) {
       log.error({ err: String(err), targetDid, attestationType }, '[mjn] Emission request error');

--- a/packages/fair/src/agent-pricing.ts
+++ b/packages/fair/src/agent-pricing.ts
@@ -94,9 +94,7 @@ export function validateAgentPricingManifest(
     errors.push('pricing must be an object');
   }
 
-  if (!Array.isArray(m.fees)) {
-    errors.push('fees must be an array');
-  } else {
+  if (Array.isArray(m.fees)) {
     const validRoles = ['protocol', 'node', 'buyer_credit', 'scope'];
     for (let i = 0; i < m.fees.length; i++) {
       const fee = m.fees[i] as Record<string, unknown>;
@@ -110,6 +108,8 @@ export function validateAgentPricingManifest(
         errors.push(`fees[${i}].rateBps must be a number between 0 and 10000`);
       }
     }
+  } else {
+    errors.push('fees must be an array');
   }
 
   return { valid: errors.length === 0, errors };

--- a/packages/fair/src/buildManifest.ts
+++ b/packages/fair/src/buildManifest.ts
@@ -63,15 +63,15 @@ export function buildFairManifest(params: {
   const protocolShare = bpsToShare(PROTOCOL_FEE_BPS);
 
   // Node fee: clamped to operator bounds
-  const nodeFeeBps = params.nodeFeeBps != null
-    ? clamp(params.nodeFeeBps, NODE_FEE_MIN_BPS, NODE_FEE_MAX_BPS)
-    : NODE_FEE_DEFAULT_BPS;
+  const nodeFeeBps = params.nodeFeeBps == null
+    ? NODE_FEE_DEFAULT_BPS
+    : clamp(params.nodeFeeBps, NODE_FEE_MIN_BPS, NODE_FEE_MAX_BPS);
   const nodeShare = bpsToShare(nodeFeeBps);
 
   // Buyer credit: clamped to operator bounds
-  const buyerCreditBps = params.buyerCreditBps != null
-    ? clamp(params.buyerCreditBps, BUYER_CREDIT_MIN_BPS, BUYER_CREDIT_MAX_BPS)
-    : BUYER_CREDIT_DEFAULT_BPS;
+  const buyerCreditBps = params.buyerCreditBps == null
+    ? BUYER_CREDIT_DEFAULT_BPS
+    : clamp(params.buyerCreditBps, BUYER_CREDIT_MIN_BPS, BUYER_CREDIT_MAX_BPS);
   const buyerCreditShare = bpsToShare(buyerCreditBps);
 
   // Scope fee: only when scopeDid AND scopeFeeBps are both provided

--- a/packages/fair/src/validate.ts
+++ b/packages/fair/src/validate.ts
@@ -104,12 +104,12 @@ function validateV1_1(manifest: Record<string, unknown>): string[] {
       }
     }
     if (access.allowedDids !== undefined) {
-      if (!Array.isArray(access.allowedDids)) {
-        errors.push("access.allowedDids must be an array");
-      } else {
+      if (Array.isArray(access.allowedDids)) {
         for (const did of access.allowedDids) {
           if (typeof did !== "string" || !did) errors.push("each allowedDid must be a non-empty string");
         }
+      } else {
+        errors.push("access.allowedDids must be an array");
       }
     }
   } else {
@@ -171,15 +171,15 @@ function validateV1_1(manifest: Record<string, unknown>): string[] {
         errors.push("settlement.endpoint must be a string when present");
       }
       if (settlement.schemes !== undefined) {
-        if (!Array.isArray(settlement.schemes)) {
-          errors.push("settlement.schemes must be an array when present");
-        } else {
+        if (Array.isArray(settlement.schemes)) {
           const validSchemes = new Set(["x402", "stripe-link", "mjnx-direct", "solana-pay", "lightning"]);
           for (const s of settlement.schemes) {
             if (typeof s !== "string" || !validSchemes.has(s)) {
               errors.push(`settlement.schemes contains invalid scheme: ${s}`);
             }
           }
+        } else {
+          errors.push("settlement.schemes must be an array when present");
         }
       }
       if (settlement.fallback !== undefined) {
@@ -230,12 +230,12 @@ function validateV1_0(manifest: Record<string, unknown>): string[] {
       }
     }
     if (access.allowedDids !== undefined) {
-      if (!Array.isArray(access.allowedDids)) {
-        errors.push("access.allowedDids must be an array");
-      } else {
+      if (Array.isArray(access.allowedDids)) {
         for (const did of access.allowedDids) {
           if (typeof did !== "string" || !did) errors.push("each allowedDid must be a non-empty string");
         }
+      } else {
+        errors.push("access.allowedDids must be an array");
       }
     }
   } else {
@@ -243,9 +243,7 @@ function validateV1_0(manifest: Record<string, unknown>): string[] {
   }
 
   // Attribution validation
-  if (!Array.isArray(manifest.attribution)) {
-    errors.push("attribution must be an array");
-  } else {
+  if (Array.isArray(manifest.attribution)) {
     let shareSum = 0;
     for (let i = 0; i < manifest.attribution.length; i++) {
       const entry = manifest.attribution[i] as Record<string, unknown>;
@@ -264,6 +262,8 @@ function validateV1_0(manifest: Record<string, unknown>): string[] {
     if (shareSum > 1.0001) {
       errors.push(`attribution shares sum to ${shareSum.toFixed(4)}, must not exceed 1.0`);
     }
+  } else {
+    errors.push("attribution must be an array");
   }
 
   // Transfer validation (optional)

--- a/packages/onboard/src/OnboardGate.tsx
+++ b/packages/onboard/src/OnboardGate.tsx
@@ -34,9 +34,9 @@ export function OnboardGate({
 
   // Resolve auth URL from props or env
   const authUrl = authUrlProp || (
-    typeof window !== 'undefined'
-      ? `${globalThis.location.origin}/auth`
-      : ''
+    typeof window === 'undefined'
+      ? ''
+      : `${globalThis.location.origin}/auth`
   );
 
   const checkSession = useCallback(async () => {

--- a/packages/ui/src/nav-bar.tsx
+++ b/packages/ui/src/nav-bar.tsx
@@ -272,7 +272,7 @@ export function NavBar({
     }
   }, [showDropdown]);
 
-  return !isEmbed ? (
+  return isEmbed ? null : (
     <nav className="w-full border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm relative z-50">
       {isDev && (
         <div className="w-full bg-amber-500/90 text-black text-xs font-bold text-center py-1 tracking-wide">
@@ -609,5 +609,5 @@ export function NavBar({
         </div>
       )}
     </nav>
-  ) : null;
+  );
 }

--- a/packages/ui/src/notification-bell.tsx
+++ b/packages/ui/src/notification-bell.tsx
@@ -41,13 +41,13 @@ export function NotificationBell() {
   const panelRef = useRef<HTMLDivElement>(null);
 
   const handleOpen = useCallback(async () => {
-    if (!open) {
+    if (open) {
+      setOpen(false);
+    } else {
       setOpen(true);
       setLoading(true);
       await refresh();
       setLoading(false);
-    } else {
-      setOpen(false);
     }
   }, [open, refresh]);
 


### PR DESCRIPTION
﻿## Summary
Flip all remaining ~60 multi-line S7735 "Unexpected negated condition" issues across the monorepo.

### Changes
- **Multi-line if/else** (15): Flip `!response.ok`, `!conv`, `!existing`, `!privateKeyHex`, `!open`, `!chainRes.ok` etc. — swap branches so the positive condition comes first
- **JSX ternaries** (12): Flip `!showUnlock`, `!showRevoke`, `!status`, `!data`, `!isEmbed`, `!showDeleteConfirm`, `!showThankYouPreview`, `!isRecurring`, `!absorbFees`, `!(convName || nameParam)`
- **Template literal ternaries** (6): Flip `!== 1 ? 's' : ''` → `=== 1 ? '' : 's'` in pluralization patterns; flip `!emtEmail.includes('@')` in className
- **typeof checks** (10): Flip `typeof window !== 'undefined'` → `typeof window === 'undefined'` with swapped branches
- **Validation patterns** (12): Flip `!Array.isArray()` guards, `!= null` / `!== null` ternaries, `!== undefined` checks, `editingFieldIndex !== null`
- **Misc** (5): `fair_manifest.signature !== undefined`, `cursorSeq !== null`, `row.status !== 'success'`, etc.

### Approach
- Only condition flip + branch swap — no logic changes
- Preserves identical runtime behavior
- Formatting kept consistent with surrounding code

_Conversation: https://app.warp.dev/conversation/1bcc54d4-61ed-4660-ab5f-b9fbf0c74cfc_
_Run: https://oz.warp.dev/runs/019e56b1-751e-7679-9cee-5fc7deb83b42_
_This PR was generated with [Oz](https://warp.dev/oz)._
