### PR TITLE
fix(sonar): remove dead stores and useless assignments (S1854)

### DIFF
--- a/apps/coffee/app/api/webhook/payment/route.ts
+++ b/apps/coffee/app/api/webhook/payment/route.ts
@@ -44,7 +44,6 @@ export async function POST(request: NextRequest) {
 
         // Resolve page info for emails and settlement
         let recipientDid = to_did;
-        let handle = pageHandle;
         let pageTitle: string | undefined;
         if (pageId) {
           const page = await db.query.coffeePages.findFirst({
@@ -52,7 +51,6 @@ export async function POST(request: NextRequest) {
           });
           if (page) {
             recipientDid = recipientDid || page.did;
-            handle = handle || page.handle;
             pageTitle = page.title || page.handle;
           }
         }

--- a/apps/coffee/src/lib/settle.ts
+++ b/apps/coffee/src/lib/settle.ts
@@ -23,7 +23,7 @@ interface SettleTipParams {
 }
 
 export async function settleTip(params: SettleTipParams): Promise<void> {
-  const { tipId, recipientDid, fromDid, amount, currency, stripeSessionId } = params;
+  const { tipId, recipientDid, fromDid, amount, stripeSessionId } = params;
 
   const totalDollars = amount / 100;
   const platformAmount = Number.parseFloat((totalDollars * (PLATFORM_FEE_PERCENT / 100)).toFixed(2));

--- a/apps/dykil/app/api/surveys/handle/[handle]/route.ts
+++ b/apps/dykil/app/api/surveys/handle/[handle]/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // In production, you should have a profiles service or table
     // that maps handles to DIDs
 
-    const allSurveys = await db.query.surveys.findMany({
+    await db.query.surveys.findMany({
       where: (surveys, { eq }) => eq(surveys.status, 'published'),
       orderBy: (surveys, { desc }) => [desc(surveys.createdAt)],
     });

--- a/apps/events/app/api/events/[id]/message/route.ts
+++ b/apps/events/app/api/events/[id]/message/route.ts
@@ -33,8 +33,6 @@ async function checkAuth(request: NextRequest, eventId: string) {
 }
 
 async function queryRecipients(eventId: string, filter?: MessageFilter) {
-  const baseWhere = sql`event_id = ${eventId} AND status IN ('valid', 'used') AND owner_did IS NOT NULL`;
-
   if (filter) {
     switch (filter.type) {
       case 'ticket_type':

--- a/apps/events/app/api/events/[id]/sales/route.ts
+++ b/apps/events/app/api/events/[id]/sales/route.ts
@@ -240,11 +240,6 @@ export async function GET(
     // Summary — include orphan revenue
     const orphanRevenue = orphans.reduce((sum: number, o: any) => sum + (o.pricePaid ?? 0), 0) / 100;
     const totalRevenue = sales.reduce((sum, s) => sum + s.amount, 0) + orphanRevenue;
-    const summary = {
-      totalSales: sales.length,
-      totalRevenue: Number.parseFloat(totalRevenue.toFixed(2)),
-      currency: sales[0]?.currency ?? eventRow.currency ?? 'USD',
-    };
 
     // Export format?
     const url = new URL(request.url);

--- a/apps/events/app/api/webhook/payment/route.ts
+++ b/apps/events/app/api/webhook/payment/route.ts
@@ -552,7 +552,7 @@ async function handlePaymentFailed(payload: PaymentWebhookPayload) {
     return;
   }
 
-  const [ticketType] = await db
+  await db
     .select()
     .from(ticketTypes)
     .where(eq(ticketTypes.id, metadata.ticketTypeId))

--- a/apps/events/app/e/[eventId]/ticket-purchase.tsx
+++ b/apps/events/app/e/[eventId]/ticket-purchase.tsx
@@ -53,10 +53,6 @@ export function TicketPurchase({ eventId, eventTitle, ticket, inviteToken, etran
     ? null
     : ticket.quantity - (ticket.sold ?? 0);
 
-  const available = availableCount === null
-    ? 'Unlimited'
-    : `${availableCount} left`;
-
   const soldOut = ticket.quantity !== null && (ticket.sold ?? 0) >= ticket.quantity;
 
   // Effective max: per-type override > prop > default 10, capped at 20

--- a/apps/events/app/e/[eventId]/tickets-section.tsx
+++ b/apps/events/app/e/[eventId]/tickets-section.tsx
@@ -1005,7 +1005,7 @@ function UnifiedCheckoutBar({ eventId, inviteToken, cartItems, totalQty, formatt
         setStep('idle');
         return;
       }
-      const data = await res.json();
+      await res.json();
       // Balance checkout is instant — go straight to success
       router.push(`/checkout/success?event=${eventId}`);
       router.refresh();

--- a/apps/kernel/app/auth/api/authenticate/route.ts
+++ b/apps/kernel/app/auth/api/authenticate/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
 
     // Verify signature
     // The signature should be over the challenge string directly
-    const { verify } = await import('@imajin/auth');
+    await import('@imajin/auth');
     
     // For challenge-response, we verify a raw signature over the challenge string
     // Not a full SignedMessage - just signature(challenge, privateKey)
@@ -137,8 +137,6 @@ async function verifyRawSignature(
   publicKeyHex: string
 ): Promise<boolean> {
   try {
-    // Import the low-level verify function
-    const { verify } = await import('@noble/ed25519');
     const { sha512 } = await import('@noble/hashes/sha2.js');
     const ed = await import('@noble/ed25519');
     

--- a/apps/kernel/app/auth/developer/apps/components/DevAppsShell.tsx
+++ b/apps/kernel/app/auth/developer/apps/components/DevAppsShell.tsx
@@ -130,7 +130,7 @@ function AppCard({ app }: Readonly<{ app: App }>) {
 }
 
 export default function DevAppsShell({ apps: initialApps }: Readonly<Props>) {
-  const [apps, setApps] = useState<App[]>(initialApps);
+  const [apps] = useState<App[]>(initialApps);
   const [showForm, setShowForm] = useState(false);
   const [newApp, setNewApp] = useState<RegisteredApp | null>(null);
 

--- a/apps/kernel/app/auth/stubs/new/page.tsx
+++ b/apps/kernel/app/auth/stubs/new/page.tsx
@@ -58,7 +58,6 @@ export default function NewStubPage() {
   const [resolvedLat, setResolvedLat] = useState<number | null>(null);
   const [resolvedLon, setResolvedLon] = useState<number | null>(null);
   const [geocodeSource, setGeocodeSource] = useState<'address' | 'device' | null>(null);
-  const [geocoding, setGeocoding] = useState(false);
   const [suggestions, setSuggestions] = useState<GeoResult[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
 

--- a/apps/kernel/app/connections/invite/[did]/[code]/page.tsx
+++ b/apps/kernel/app/connections/invite/[did]/[code]/page.tsx
@@ -64,7 +64,6 @@ export default async function InvitePage({
 
   const displayName = invite.fromHandle ? `@${invite.fromHandle}` : invite.fromDid.slice(0, 20) + '...';
   const connectionsUrl = buildPublicUrl('connections');
-  const acceptUrl = `/connections/api/invites/${params.code}/accept`;
   const loginUrl = `${AUTH_URL}/login?next=${encodeURIComponent(`${connectionsUrl}/invite/${params.did}/${params.code}`)}`;
 
   return (

--- a/apps/kernel/app/connections/page.tsx
+++ b/apps/kernel/app/connections/page.tsx
@@ -120,7 +120,7 @@ function NicknameEditor({
 }
 
 export default function ConnectionsPage() {
-  const { did, handle, isLoggedIn, loading } = useIdentity();
+  const { did, isLoggedIn, loading } = useIdentity();
   const [activeTab, setActiveTab] = useState<'connections' | 'groups' | 'invitations'>('connections');
   const [invitePending, setInvitePending] = useState(0);
   const [inviteRemaining, setInviteRemaining] = useState<number | null>(null);

--- a/apps/kernel/app/media/api/assets/route.ts
+++ b/apps/kernel/app/media/api/assets/route.ts
@@ -394,7 +394,6 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url);
   let ownerDid: string;
-  let uploadedBy: string | undefined;
   let isAgentQuery = false;
   if (bearerToken && internalApiKey && bearerToken === internalApiKey) {
     const ownerDidHeader = request.headers.get("X-Owner-DID");
@@ -402,8 +401,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "X-Owner-DID header required" }, { status: 400, headers: cors });
     }
     ownerDid = ownerDidHeader;
-    // NEW: capture uploaded-by from internal caller
-    uploadedBy = request.headers.get("X-Uploaded-By") || ownerDidHeader;
   } else {
     const authResult = await requireAuth(request);
     if ("error" in authResult) {
@@ -423,7 +420,6 @@ export async function GET(request: NextRequest) {
 
   const search = searchParams.get("search");      // filename search
   const type = searchParams.get("type");          // e.g. "image"
-  const sort = searchParams.get("sort") || "created";
   const order = searchParams.get("order") || "desc";
   const limit = Math.min(Number.parseInt(searchParams.get("limit") || "50", 10), 200);
   const offset = Number.parseInt(searchParams.get("offset") || "0", 10);

--- a/apps/kernel/app/profile/components/profiles/BusinessProfile.tsx
+++ b/apps/kernel/app/profile/components/profiles/BusinessProfile.tsx
@@ -16,7 +16,6 @@ export async function BusinessProfile({ profile, identity, viewer, counts, links
   const isMaintainer = viewerRole === 'maintainer' || viewerRole === 'owner' || viewerRole === 'admin';
 
   // For unclaimed stubs: show maintainers. For claimed: show owners/admins.
-  const memberRoleFilter = isUnclaimed ? 'maintainer' : 'owner';
   const memberTitle = isUnclaimed ? '🔧 Maintainers' : '👑 Owners & Admins';
 
   return (

--- a/apps/kernel/app/registry/api/builds/verify/route.ts
+++ b/apps/kernel/app/registry/api/builds/verify/route.ts
@@ -25,7 +25,7 @@ import { withLogger } from '@imajin/logger';
 export const POST = withLogger('kernel', async (request: NextRequest, { log }) => {
   try {
     const body = await request.json();
-    const { buildHash, version } = body;
+    const { buildHash } = body;
 
     if (!buildHash) {
       return NextResponse.json(

--- a/apps/learn/app/api/courses/route.ts
+++ b/apps/learn/app/api/courses/route.ts
@@ -96,7 +96,6 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const creatorDid = searchParams.get('creator_did');
-  const tag = searchParams.get('tag');
   const status = searchParams.get('status') || 'published';
   const limit = Math.min(Number.parseInt(searchParams.get('limit') || '20'), 100);
   const offset = Number.parseInt(searchParams.get('offset') || '0');

--- a/apps/learn/app/dashboard/[slug]/page.tsx
+++ b/apps/learn/app/dashboard/[slug]/page.tsx
@@ -39,7 +39,6 @@ interface Course {
 
 export default function CourseEditorPage() {
   const params = useParams();
-  const router = useRouter();
   const { toast } = useToast();
   const slug = params.slug as string;
 

--- a/apps/market/app/listings/[id]/ListingDetail.tsx
+++ b/apps/market/app/listings/[id]/ListingDetail.tsx
@@ -358,10 +358,6 @@ export default function ListingDetail() {
   const tierLabel = TIER_LABEL_MAP[listing.sellerTier] ?? 'Direct';
   const tierColor = TIER_COLOR_MAP[listing.sellerTier] ?? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300';
 
-  const showContactSection =
-    listing.sellerTier === 'public_offplatform' ||
-    (isOnplatform && listing.showContactInfo && listing.contactInfo);
-
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100">
       <div className="container mx-auto px-4 py-8 max-w-4xl">


### PR DESCRIPTION
﻿## Fix S1854 — Dead stores / useless assignments

Remove 22 dead store issues across 19 files flagged by SonarCloud rule S1854.

### Changes
- **Remove unused variable assignments**: uploadedBy, sort, geocoding, summary, aseWhere, vailable, memberRoleFilter, showContactSection, cceptUrl
- **Remove unused destructured values**: erify (from @imajin/auth and @noble/ed25519), currency (settle.ts), ersion (builds/verify), handle (connections, coffee webhook), 	ag (courses)
- **Strip assignment from expressions with side effects**: wait res.json() (balance checkout), DB queries (payment webhook, dykil surveys)
- **Remove unused React state setters**: setApps (DevAppsShell)
- **Remove unused hook calls**: useRouter() (course editor page)

### Approach
- Side-effect calls (DB queries, es.json()) are preserved as bare wait expressions
- Dynamic imports kept for potential module-level side effects (wait import('@imajin/auth'))
- No changes to imports, exports, or function signatures
- Runtime behavior is identical

_Conversation: https://app.warp.dev/conversation/00ed2da7-9b60-414e-89f7-1acbc2317115_
_Run: https://oz.warp.dev/runs/019e56e9-435a-78f8-a997-78f8b77fbb66_

_This PR was generated with [Oz](https://warp.dev/oz)._
