### PR TITLE
fix(events): preserve query params in legacy URL redirects

### DIFF
--- a/apps/events/app/[eventId]/edit/page.tsx
+++ b/apps/events/app/[eventId]/edit/page.tsx
@@ -2,9 +2,17 @@ import { redirect } from 'next/navigation';
 
 interface Props {
   params: Promise<{ eventId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
-export default async function OldEventEditRedirect({ params }: Props) {
+export default async function OldEventEditRedirect({ params, searchParams }: Props) {
   const { eventId } = await params;
-  redirect(`/e/${eventId}/edit`);
+  const sp = await searchParams;
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(sp)) {
+    if (typeof value === 'string') qs.set(key, value);
+    else if (Array.isArray(value)) value.forEach(v => qs.append(key, v));
+  }
+  const query = qs.toString();
+  redirect(`/e/${eventId}/edit${query ? `?${query}` : ''}`);
 }

--- a/apps/events/app/[eventId]/edit/page.tsx
+++ b/apps/events/app/[eventId]/edit/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { buildQueryString } from '../preserve-query';
 
 interface Props {
   params: Promise<{ eventId: string }>;
@@ -8,11 +9,5 @@ interface Props {
 export default async function OldEventEditRedirect({ params, searchParams }: Props) {
   const { eventId } = await params;
   const sp = await searchParams;
-  const qs = new URLSearchParams();
-  for (const [key, value] of Object.entries(sp)) {
-    if (typeof value === 'string') qs.set(key, value);
-    else if (Array.isArray(value)) value.forEach(v => qs.append(key, v));
-  }
-  const query = qs.toString();
-  redirect(`/e/${eventId}/edit${query ? `?${query}` : ''}`);
+  redirect(`/e/${eventId}/edit${buildQueryString(sp)}`);
 }

--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -2,9 +2,17 @@ import { redirect } from 'next/navigation';
 
 interface Props {
   params: Promise<{ eventId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
-export default async function OldEventRedirect({ params }: Props) {
+export default async function OldEventRedirect({ params, searchParams }: Props) {
   const { eventId } = await params;
-  redirect(`/e/${eventId}`);
+  const sp = await searchParams;
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(sp)) {
+    if (typeof value === 'string') qs.set(key, value);
+    else if (Array.isArray(value)) value.forEach(v => qs.append(key, v));
+  }
+  const query = qs.toString();
+  redirect(`/e/${eventId}${query ? `?${query}` : ''}`);
 }

--- a/apps/events/app/[eventId]/page.tsx
+++ b/apps/events/app/[eventId]/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { buildQueryString } from './preserve-query';
 
 interface Props {
   params: Promise<{ eventId: string }>;
@@ -8,11 +9,5 @@ interface Props {
 export default async function OldEventRedirect({ params, searchParams }: Props) {
   const { eventId } = await params;
   const sp = await searchParams;
-  const qs = new URLSearchParams();
-  for (const [key, value] of Object.entries(sp)) {
-    if (typeof value === 'string') qs.set(key, value);
-    else if (Array.isArray(value)) value.forEach(v => qs.append(key, v));
-  }
-  const query = qs.toString();
-  redirect(`/e/${eventId}${query ? `?${query}` : ''}`);
+  redirect(`/e/${eventId}${buildQueryString(sp)}`);
 }

--- a/apps/events/app/[eventId]/preserve-query.ts
+++ b/apps/events/app/[eventId]/preserve-query.ts
@@ -1,0 +1,20 @@
+/**
+ * Build a query string from Next.js searchParams, preserving all values.
+ * Returns '' if no params, or '?key=val&...' if present.
+ */
+export function buildQueryString(
+  sp: Record<string, string | string[] | undefined>,
+): string {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(sp)) {
+    if (typeof value === 'string') {
+      qs.set(key, value);
+    } else if (Array.isArray(value)) {
+      for (const v of value) {
+        qs.append(key, v);
+      }
+    }
+  }
+  const str = qs.toString();
+  return str ? `?${str}` : '';
+}

--- a/apps/events/app/[eventId]/register/[ticketId]/page.tsx
+++ b/apps/events/app/[eventId]/register/[ticketId]/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { buildQueryString } from '../../preserve-query';
 
 interface Props {
   params: Promise<{ eventId: string; ticketId: string }>;
@@ -8,11 +9,5 @@ interface Props {
 export default async function OldRegisterRedirect({ params, searchParams }: Props) {
   const { eventId, ticketId } = await params;
   const sp = await searchParams;
-  const qs = new URLSearchParams();
-  for (const [key, value] of Object.entries(sp)) {
-    if (typeof value === 'string') qs.set(key, value);
-    else if (Array.isArray(value)) value.forEach(v => qs.append(key, v));
-  }
-  const query = qs.toString();
-  redirect(`/e/${eventId}/register/${ticketId}${query ? `?${query}` : ''}`);
+  redirect(`/e/${eventId}/register/${ticketId}${buildQueryString(sp)}`);
 }

--- a/apps/events/app/[eventId]/register/[ticketId]/page.tsx
+++ b/apps/events/app/[eventId]/register/[ticketId]/page.tsx
@@ -2,9 +2,17 @@ import { redirect } from 'next/navigation';
 
 interface Props {
   params: Promise<{ eventId: string; ticketId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
-export default async function OldRegisterRedirect({ params }: Props) {
+export default async function OldRegisterRedirect({ params, searchParams }: Props) {
   const { eventId, ticketId } = await params;
-  redirect(`/e/${eventId}/register/${ticketId}`);
+  const sp = await searchParams;
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(sp)) {
+    if (typeof value === 'string') qs.set(key, value);
+    else if (Array.isArray(value)) value.forEach(v => qs.append(key, v));
+  }
+  const query = qs.toString();
+  redirect(`/e/${eventId}/register/${ticketId}${query ? `?${query}` : ''}`);
 }

--- a/apps/kernel/app/admin/newsletter/composer.tsx
+++ b/apps/kernel/app/admin/newsletter/composer.tsx
@@ -62,8 +62,8 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
         }),
       });
       const data = await res.json();
-      if (!res.ok) setError(data.error ?? 'Test send failed');
-      else setResult({ sent: true, recipientCount: 1 });
+      if (res.ok) setResult({ sent: true, recipientCount: 1 });
+      else setError(data.error ?? 'Test send failed');
     } finally {
       setSendingTest(false);
     }
@@ -85,8 +85,8 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
         }),
       });
       const data = await res.json();
-      if (!res.ok) setError(data.error ?? 'Send failed');
-      else setResult({ sent: data.sent, recipientCount: data.recipientCount });
+      if (res.ok) setResult({ sent: data.sent, recipientCount: data.recipientCount });
+      else setError(data.error ?? 'Send failed');
     } finally {
       setSending(false);
       setConfirm(false);
@@ -136,7 +136,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
           {/* Body */}
           <div>
             <div className="flex items-center justify-between mb-1">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Body (Markdown)</label>
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Body (Markdown)</span>
               <button
                 type="button"
                 onClick={() => setPreview((v) => !v)}
@@ -197,7 +197,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
               </div>
             ) : (
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                Send to all {initialConnectionCount.toLocaleString()} connection{initialConnectionCount !== 1 ? 's' : ''} with a contact email.
+                Send to all {initialConnectionCount.toLocaleString()} connection{initialConnectionCount === 1 ? '' : 's'} with a contact email.
               </p>
             )}
 
@@ -255,7 +255,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Confirm Send</h3>
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
               This will send <strong>"{subject}"</strong> to{' '}
-              <strong>{recipientCount.toLocaleString()} recipient{recipientCount !== 1 ? 's' : ''}</strong>.
+              <strong>{recipientCount.toLocaleString()} recipient{recipientCount === 1 ? '' : 's'}</strong>.
               This cannot be undone.
             </p>
             <div className="flex gap-2 justify-end">

--- a/apps/kernel/app/admin/newsletter/composer.tsx
+++ b/apps/kernel/app/admin/newsletter/composer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { MarkdownEditor, MarkdownContent } from '@imajin/ui';
 
 interface MailingList {
   id: string;
@@ -92,12 +93,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
     }
   }
 
-  function renderPreview(md: string): string {
-    return md
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*(.+?)\*/g, '<em>$1</em>')
-      .replaceAll('\n', '<br/>');
-  }
+
 
   const canSend = subject.trim().length > 0 && markdown.trim().length > 0 && recipientCount > 0;
 
@@ -140,7 +136,7 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
           {/* Body */}
           <div>
             <div className="flex items-center justify-between mb-1">
-              <label htmlFor="newsletter-body" className="text-sm font-medium text-gray-700 dark:text-gray-300">Body (Markdown)</label>
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Body (Markdown)</label>
               <button
                 type="button"
                 onClick={() => setPreview((v) => !v)}
@@ -150,18 +146,14 @@ export default function NewsletterComposer({ initialLists, initialConnectionCoun
               </button>
             </div>
             {preview ? (
-              <div
-                className="w-full min-h-48 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-700 dark:text-gray-300 px-3 py-2 text-sm whitespace-pre-wrap"
-                dangerouslySetInnerHTML={{ __html: renderPreview(markdown) }}
-              />
+              <div className="w-full min-h-48 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 px-4 py-3">
+                <MarkdownContent content={markdown} />
+              </div>
             ) : (
-              <textarea
-                id="newsletter-body"
+              <MarkdownEditor
                 value={markdown}
-                onChange={(e) => setMarkdown(e.target.value)}
-                rows={12}
-                placeholder="Write your newsletter in Markdown…&#10;&#10;**Bold**, *italic*, and paragraphs are supported."
-                className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500 resize-y"
+                onChange={setMarkdown}
+                placeholder="Write your newsletter in Markdown…"
               />
             )}
           </div>


### PR DESCRIPTION
## Problem

The `/events/{eventId}` → `/events/e/{eventId}` redirect (added when we introduced the `/e/` slug prefix) was dropping all query parameters. This broke invite-only events where the invite token is passed as `?invite=xxx`.

**Repro:** Visit `jin.imajin.ai/events/evt_xxx?invite=xxx` while not authenticated → redirected to `/events/e/evt_xxx` without the invite token → 'you need an invite link to attend.'

## Fix

All three legacy event redirects (`[eventId]/page.tsx`, `[eventId]/edit/page.tsx`, `[eventId]/register/[ticketId]/page.tsx`) now forward `searchParams` through the redirect URL.

## Testing

- Invite-only event links with `?invite=` token now work through the redirect
- Non-invite events unaffected (empty query string = no `?` appended)