### PR TITLE
fix: inline-styled markdown rendering for broadcast emails

### DIFF
--- a/docs/rfcs/RFC-33-agent-ci-pipeline.md
+++ b/docs/rfcs/RFC-33-agent-ci-pipeline.md
@@ -1,0 +1,154 @@
+# RFC-33: Agent CI Pipeline — Automated Quality Gates
+
+**Status:** Draft
+**Authors:** Ryan Veteze, Jin
+**Created:** May 23, 2026
+**Related:** RFC-27 (Multi-Agent Coordination), RFC-31 (Agent Execution Sandbox), RFC-32 (Agent Protocol Interoperability)
+
+---
+
+## Summary
+
+PRs go through a multi-agent pipeline where each agent has a defined role, identity, and accountability. The human architects. Agents implement, refine, and validate. The human merges.
+
+Today this pipeline exists but the human is the router — manually handing work between agents. This RFC defines the automation layer that removes the human from mechanical coordination while preserving human authority over architecture and merge decisions.
+
+---
+
+## Problem
+
+The current workflow:
+
+1. **Jin (OpenClaw/Opus)** — architecture, design, first-pass implementation → opens PR
+2. **Ryan** — reviews, spots issues, routes to Oz
+3. **Oz (Warp)** — refinement, mechanical cleanup, SonarCloud fixes → pushes to branch
+4. **Ryan** — re-reviews, merges
+
+Steps 2 and 3 are mechanical routing. Ryan shouldn't need to read SonarCloud output and copy-paste it to Oz. The quality gate should be agent-to-agent.
+
+---
+
+## Design
+
+### Pipeline Stages
+
+```
+PR opened/updated
+  → CI (lint, test, build)
+  → SonarCloud analysis
+  → Quality Gate check
+    → If new issues > 0: trigger refinement agent
+    → If clean: ready for human review
+  → Human merges
+```
+
+### Agent Roles
+
+| Agent | Role | Trigger | Identity |
+|-------|------|---------|----------|
+| Jin (OpenClaw) | Architecture, design, first-pass code | Human conversation | `did:imajin:...` (agent DID, delegated from @jin) |
+| Oz (Warp) | Refinement, mechanical cleanup, missing pieces | API trigger from CI | `Co-Authored-By` today, DID future |
+| SonarCloud | Static analysis, quality validation | PR webhook | Service account (no DID yet) |
+| GitHub Actions | Orchestrator — connects stages | PR events | Workflow identity |
+
+### Trigger Flow
+
+**GitHub Action: `quality-gate.yml`**
+
+```yaml
+on:
+  # Runs after CI and SonarCloud complete
+  check_suite:
+    types: [completed]
+
+jobs:
+  quality-gate:
+    # 1. Query SonarCloud API for new issues on this PR
+    # 2. If issues > 0, call Warp API to trigger Oz
+    # 3. Oz prompt includes: PR number, branch, issue list, fix instructions
+    # 4. Oz pushes fixes → CI re-runs → quality gate re-checks
+    # 5. If clean after N iterations, label PR "ready-for-review"
+```
+
+**Warp API Call:**
+
+```typescript
+import { OzClient } from '@anthropic-ai/oz-sdk';
+
+const oz = new OzClient({ apiKey: process.env.WARP_API_KEY });
+
+const run = await oz.agent.run({
+  prompt: `Review and fix SonarCloud issues on PR #${prNumber} in ima-jin/imajin-ai.
+    Branch: ${branch}
+    Issues: ${JSON.stringify(issues)}
+    Fix all issues. Push to the branch. Do not change functionality.`,
+  config: {
+    name: 'sonar-refinement',
+    // environment, model, etc.
+  },
+});
+```
+
+### Iteration Limit
+
+The pipeline caps at 3 refinement cycles per PR. If Oz can't resolve all issues in 3 passes, the PR gets labeled `needs-human` and Ryan reviews manually. This prevents infinite loops on issues that require architectural decisions.
+
+### Attribution
+
+Each agent's commits carry identity:
+- **Today:** `Co-Authored-By: Oz <oz-agent@warp.dev>` in commit messages
+- **Future (RFC-27):** Agent DIDs in .fair manifests on every PR. The merge commit carries a manifest showing who contributed what — architect (Jin), refinement (Oz), validation (SonarCloud).
+
+---
+
+## Scope — What's In and Out
+
+### In scope
+- GitHub Action that queries SonarCloud API after analysis completes
+- Warp API integration to trigger Oz cloud agent runs
+- Prompt engineering for the refinement agent
+- Iteration limit and `needs-human` escape hatch
+- PR labeling for pipeline status
+
+### Out of scope (future)
+- Agent DIDs for Oz and SonarCloud (RFC-27 dependency)
+- .fair manifests on PRs (RFC-27 + .fair integration)
+- Bidirectional communication (Jin ↔ Oz conversation, not just handoff)
+- Other quality gates beyond SonarCloud (security scanning, performance benchmarks)
+- Self-merging (human always merges for now)
+
+---
+
+## Implementation Path
+
+### Phase 1 — Manual trigger (now)
+Ryan triggers Oz manually via Warp UI or CLI. Current workflow, documented.
+
+### Phase 2 — Semi-automated (next)
+GitHub Action queries SonarCloud, formats the issue list, but posts it as a PR comment instead of triggering Oz. Ryan copy-pastes to Oz. Removes the "read SonarCloud" step from human.
+
+### Phase 3 — Fully automated (target)
+GitHub Action triggers Oz cloud agent directly via API. Human only sees the final clean PR. Merge is still manual.
+
+### Phase 4 — Identity (RFC-27)
+Agents get DIDs. .fair manifests on PRs. Full attribution chain. The PR itself becomes a signed record of multi-agent coordination.
+
+---
+
+## Open Questions
+
+1. **Warp cloud agent pricing** — How many runs per month? Cost per run? Need to understand economics before automating.
+2. **Oz environment setup** — Does the cloud agent need repo access pre-configured, or is it per-run?
+3. **Conflict resolution** — What happens if Oz's fixes break the build? Who retries — the Action, or does it escalate to human?
+4. **PR ownership** — If Jin opens a PR and Oz pushes 3 commits to it, who "owns" the PR for review purposes?
+5. **Beyond SonarCloud** — Should the quality gate also check for test coverage, bundle size, or other metrics?
+
+---
+
+## Why This Matters
+
+This is the first concrete instance of RFC-27 (Multi-Agent Coordination) applied to the development process itself. The codebase is the coordination surface. GitHub is the message bus. PRs are the transactions. .fair manifests (eventually) are the attribution layer.
+
+If this works for code quality, the same pattern generalizes to any multi-agent workflow: design → implement → review → validate → ship, with humans holding the architecture and merge authority.
+
+The moat isn't the agents. The moat is the coordination layer with accountability.

--- a/packages/email/src/templates/broadcast.ts
+++ b/packages/email/src/templates/broadcast.ts
@@ -1,6 +1,64 @@
-import { marked } from 'marked';
+import { marked, Renderer } from 'marked';
 import { emailWrapper } from './base';
 import { stripHtml } from '../send';
+
+/**
+ * Custom marked renderer that outputs inline-styled HTML for email clients.
+ * Email clients strip <style> tags and ignore CSS classes, so every element
+ * needs explicit inline styles.
+ */
+function createEmailRenderer(): Renderer {
+  const renderer = new Renderer();
+
+  renderer.heading = ({ text, depth }) => {
+    const sizes: Record<number, string> = {
+      1: 'font-size:28px;line-height:1.2;',
+      2: 'font-size:22px;line-height:1.3;',
+      3: 'font-size:18px;line-height:1.4;',
+      4: 'font-size:16px;line-height:1.4;',
+      5: 'font-size:14px;line-height:1.4;',
+      6: 'font-size:13px;line-height:1.4;',
+    };
+    return `<h${depth} style="margin:24px 0 8px;${sizes[depth] ?? sizes[4]}font-weight:600;color:#ffffff;">${text}</h${depth}>\n`;
+  };
+
+  renderer.paragraph = ({ text }) =>
+    `<p style="margin:0 0 16px;color:#e4e4e7;font-size:15px;line-height:1.6;">${text}</p>\n`;
+
+  renderer.link = ({ href, text }) =>
+    `<a href="${href}" style="color:#ffffff;text-decoration:underline;text-underline-offset:2px;" target="_blank">${text}</a>`;
+
+  renderer.strong = ({ text }) =>
+    `<strong style="color:#ffffff;font-weight:600;">${text}</strong>`;
+
+  renderer.em = ({ text }) =>
+    `<em style="color:#d4d4d8;font-style:italic;">${text}</em>`;
+
+  renderer.list = ({ body, ordered }) => {
+    const tag = ordered ? 'ol' : 'ul';
+    return `<${tag} style="margin:0 0 16px;padding-left:24px;color:#e4e4e7;">${body}</${tag}>\n`;
+  };
+
+  renderer.listitem = ({ text }) =>
+    `<li style="margin:0 0 6px;font-size:15px;line-height:1.6;color:#e4e4e7;">${text}</li>\n`;
+
+  renderer.blockquote = ({ text }) =>
+    `<blockquote style="margin:0 0 16px;padding:12px 16px;border-left:3px solid #a1a1aa;background-color:#1a1a1a;color:#d4d4d8;font-size:15px;line-height:1.6;">${text}</blockquote>\n`;
+
+  renderer.code = ({ text }) =>
+    `<pre style="margin:0 0 16px;padding:16px;background-color:#1a1a1a;border-radius:6px;overflow-x:auto;"><code style="color:#e4e4e7;font-family:'SFMono-Regular',Consolas,monospace;font-size:13px;line-height:1.5;">${text}</code></pre>\n`;
+
+  renderer.codespan = ({ text }) =>
+    `<code style="background-color:#1a1a1a;color:#e4e4e7;padding:2px 6px;border-radius:3px;font-family:'SFMono-Regular',Consolas,monospace;font-size:13px;">${text}</code>`;
+
+  renderer.hr = () =>
+    `<hr style="margin:24px 0;border:none;border-top:1px solid #27272a;" />\n`;
+
+  renderer.image = ({ href, text }) =>
+    `<img src="${href}" alt="${text ?? ''}" style="max-width:100%;height:auto;border-radius:6px;margin:0 0 16px;display:block;" />\n`;
+
+  return renderer;
+}
 
 export interface EventContext {
   title: string;
@@ -17,7 +75,7 @@ export function renderBroadcastEmail(
   markdown: string,
   eventContext?: EventContext,
 ): { html: string; text: string } {
-  const bodyHtml = marked.parse(markdown, { breaks: true }) as string;
+  const bodyHtml = marked.parse(markdown, { breaks: true, renderer: createEmailRenderer() }) as string;
 
   const eventImage = eventContext?.imageUrl
     ? `


### PR DESCRIPTION
Email clients strip `<style>` tags and ignore CSS classes, so marked's default HTML output rendered as unstyled text in newsletter emails.

**Fix:** Custom `marked` renderer that applies inline styles to every element — headings, links, lists, blockquotes, code blocks, images, etc.

**Colors:** White links, light gray body text, neutral accents on dark bg. No orange.