### PR TITLE
spike(auth): short-lived scoped app tokens (#1069 / #799 P3)

### DIFF
--- a/apps/kernel/app/auth/api/apps/token/route.ts
+++ b/apps/kernel/app/auth/api/apps/token/route.ts
@@ -1,0 +1,134 @@
+/**
+ * POST /auth/api/apps/token  (#1069 / #799 P3)
+ *
+ * Mint a short-lived, scoped app token. Replaces passing the raw attestationId
+ * around as a long-lived bearer.
+ *
+ * The app proves possession of its keypair (signature over a challenge that
+ * includes the attestationId + a fresh nonce + timestamp), the kernel validates
+ * the user's `app.authorized` attestation, then mints a ~10min EdDSA token that
+ * downstream services verify locally against the kernel public key.
+ *
+ * Body: {
+ *   appDid: string,
+ *   attestationId: string,
+ *   scope?: string,          // optional single scope to narrow to (must be granted)
+ *   aud?: string,            // optional target service
+ *   nonce: string,           // client-generated, >= 16 chars
+ *   timestamp: string,       // ISO; must be within 60s
+ *   signature: string        // ed25519 hex over `${appDid}:${attestationId}:${nonce}:${timestamp}`
+ * }
+ * Returns: { token, expiresIn, scopes }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { db, attestations, identities } from '@/src/db';
+import { eq, and } from 'drizzle-orm';
+import { corsHeaders } from '@imajin/config';
+import { createDbResolver } from '@imajin/auth';
+import { verifySignature } from '@/src/lib/auth/crypto';
+import { createAppToken } from '@/src/lib/auth/jwt';
+import { createLogger } from '@imajin/logger';
+
+const log = createLogger('kernel');
+const resolveDid = createDbResolver(db, identities);
+
+const MAX_CLOCK_SKEW_MS = 60_000;
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  const { appDid, attestationId, scope, aud, nonce, timestamp, signature } = body as {
+    appDid?: string;
+    attestationId?: string;
+    scope?: string;
+    aud?: string;
+    nonce?: string;
+    timestamp?: string;
+    signature?: string;
+  };
+
+  if (!appDid || !attestationId || !nonce || !timestamp || !signature) {
+    return NextResponse.json(
+      { error: 'appDid, attestationId, nonce, timestamp, signature are required' },
+      { status: 400, headers: cors }
+    );
+  }
+
+  if (nonce.length < 16) {
+    return NextResponse.json({ error: 'nonce too short' }, { status: 400, headers: cors });
+  }
+
+  // Freshness: reject stale/future timestamps (replay window bound)
+  const ts = Date.parse(timestamp);
+  if (Number.isNaN(ts) || Math.abs(Date.now() - ts) > MAX_CLOCK_SKEW_MS) {
+    return NextResponse.json({ error: 'timestamp outside allowed window' }, { status: 401, headers: cors });
+  }
+
+  // Proof of possession: app must sign with its own key
+  const resolved = await resolveDid(appDid);
+  if (!resolved?.publicKey) {
+    return NextResponse.json({ error: 'Unknown app DID' }, { status: 404, headers: cors });
+  }
+
+  const challenge = `${appDid}:${attestationId}:${nonce}:${timestamp}`;
+  const pop = await verifySignature(challenge, signature, resolved.publicKey);
+  if (!pop) {
+    return NextResponse.json({ error: 'Invalid proof-of-possession signature' }, { status: 401, headers: cors });
+  }
+
+  // Validate the user's authorization attestation (same checks as /apps/validate)
+  const [att] = await db
+    .select()
+    .from(attestations)
+    .where(
+      and(
+        eq(attestations.id, attestationId),
+        eq(attestations.subjectDid, appDid),
+        eq(attestations.type, 'app.authorized'),
+      )
+    );
+
+  if (!att) {
+    return NextResponse.json({ error: 'Authorization not found' }, { status: 404, headers: cors });
+  }
+  if (att.revokedAt) {
+    return NextResponse.json({ error: 'Authorization has been revoked' }, { status: 403, headers: cors });
+  }
+
+  const payload = att.payload as { scopes?: string[] } | null;
+  const approvedScopes = payload?.scopes ?? [];
+
+  // If the app narrows to a single scope, it must be one of the granted ones.
+  if (scope && !approvedScopes.includes(scope)) {
+    return NextResponse.json({ error: `Scope '${scope}' was not granted` }, { status: 403, headers: cors });
+  }
+
+  const grantedScopes = scope ? [scope] : approvedScopes;
+
+  const token = await createAppToken({
+    sub: att.issuerDid,
+    azp: appDid,
+    scope: grantedScopes.join(' '),
+    aud,
+    attestationId,
+  });
+
+  log.info({ appDid, userDid: att.issuerDid, scopes: grantedScopes }, 'minted app token');
+
+  return NextResponse.json(
+    { token, expiresIn: 600, scopes: grantedScopes },
+    { headers: cors }
+  );
+}

--- a/apps/kernel/app/auth/api/apps/token/verify/route.ts
+++ b/apps/kernel/app/auth/api/apps/token/verify/route.ts
@@ -1,0 +1,58 @@
+/**
+ * POST /auth/api/apps/token/verify  (#1069)
+ *
+ * Stateless verification of a short-lived app token. Checks the EdDSA signature
+ * and expiry locally against the kernel public key — no DB lookup. Optionally
+ * enforces that a required scope is present in the token's granted scopes.
+ *
+ * Body: { token: string, scope?: string }
+ * Returns: { appDid, userDid, scopes, attestationId }  (AppAuthContext shape)
+ *
+ * Note: this is the interim transport for the local fast-path. Verification can
+ * later move fully in-process in @imajin/auth (jose + published public key) to
+ * remove this round-trip — tracked in #1069.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { corsHeaders } from '@imajin/config';
+import { verifyAppToken } from '@/src/lib/auth/jwt';
+
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
+}
+
+export async function POST(request: NextRequest) {
+  const cors = corsHeaders(request);
+
+  let body: { token?: string; scope?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: cors });
+  }
+
+  if (!body.token) {
+    return NextResponse.json({ error: 'token required' }, { status: 400, headers: cors });
+  }
+
+  const payload = await verifyAppToken(body.token);
+  if (!payload) {
+    return NextResponse.json({ error: 'Invalid or expired app token' }, { status: 401, headers: cors });
+  }
+
+  const scopes = payload.scope ? payload.scope.split(' ').filter(Boolean) : [];
+
+  if (body.scope && !scopes.includes(body.scope)) {
+    return NextResponse.json({ error: `Scope '${body.scope}' was not granted` }, { status: 403, headers: cors });
+  }
+
+  return NextResponse.json(
+    {
+      appDid: payload.azp,
+      userDid: payload.sub,
+      scopes,
+      attestationId: payload.attestationId,
+    },
+    { headers: cors }
+  );
+}

--- a/apps/kernel/src/lib/auth/jwt.ts
+++ b/apps/kernel/src/lib/auth/jwt.ts
@@ -131,6 +131,71 @@ export async function verifySessionToken(token: string): Promise<SessionPayload 
   }
 }
 
+// ============================================================================
+// App tokens (#1069 / #799 P3) — short-lived, scoped, app-bound delegated tokens.
+//
+// Minted by POST /auth/api/apps/token after the app proves possession of its
+// keypair and the kernel validates the user's app.authorized attestation.
+// Services verify these LOCALLY against the kernel public key (same EdDSA key
+// as session tokens) — no per-call round-trip to the kernel.
+// ============================================================================
+
+const APP_TOKEN_EXPIRY_SECONDS = 600; // 10 minutes
+
+export interface AppTokenPayload {
+  sub: string;          // user DID (the resource owner)
+  azp: string;          // authorized party = app DID
+  scope: string;        // space-delimited granted scopes
+  aud?: string;         // optional target service/audience
+  attestationId: string; // source app.authorized attestation (for revocation correlation)
+}
+
+/**
+ * Mint a short-lived app token. Caller MUST have already validated the
+ * attestation and the app's proof-of-possession.
+ */
+export async function createAppToken(payload: AppTokenPayload): Promise<string> {
+  const { privateKey } = await getKeyPair();
+
+  return new jose.SignJWT({
+    azp: payload.azp,
+    scope: payload.scope,
+    attestationId: payload.attestationId,
+  })
+    .setProtectedHeader({ alg: 'EdDSA', typ: 'app+jwt' })
+    .setSubject(payload.sub)
+    .setIssuer(JWT_ISSUER)
+    .setIssuedAt()
+    .setExpirationTime(`${APP_TOKEN_EXPIRY_SECONDS}s`)
+    .setAudience(payload.aud ?? 'imajin:apps')
+    .sign(privateKey);
+}
+
+/**
+ * Verify an app token locally. Returns the payload or null.
+ * Does NOT check revocation — short TTL bounds the revocation window; callers
+ * needing instant revocation should fall back to the attestation-validate path.
+ */
+export async function verifyAppToken(token: string): Promise<AppTokenPayload | null> {
+  try {
+    const { publicKey } = await getKeyPair();
+    const { payload, protectedHeader } = await jose.jwtVerify(token, publicKey, {
+      issuer: JWT_ISSUER,
+    });
+    if (protectedHeader.typ !== 'app+jwt') return null; // reject session tokens used as app tokens
+    return {
+      sub: payload.sub as string,
+      azp: payload.azp as string,
+      scope: (payload.scope as string) || '',
+      aud: payload.aud as string | undefined,
+      attestationId: payload.attestationId as string,
+    };
+  } catch (error) {
+    log.error({ err: String(error) }, 'App token verification failed');
+    return null;
+  }
+}
+
 // Re-export from @imajin/config — auth's own callers can keep importing from here
 export { getSessionCookieOptions } from '@imajin/config';
 

--- a/packages/auth/src/require-app-auth.ts
+++ b/packages/auth/src/require-app-auth.ts
@@ -13,6 +13,37 @@ export type AppAuthResult = { appAuth: AppAuthContext } | { error: string; statu
 const getAuthUrl = () => process.env.AUTH_SERVICE_URL!;
 
 /**
+ * Verify a short-lived app token (#1069). Calls the kernel's stateless verify
+ * endpoint, which checks the EdDSA signature + expiry locally (no DB hit) and
+ * returns the AppAuthContext. The short TTL bounds the revocation window.
+ *
+ * Follow-up: move verification fully in-process (jose + published kernel public
+ * key) to drop this round-trip entirely — tracked in #1069.
+ */
+async function verifyBearerAppToken(token: string, scope?: string): Promise<AppAuthResult> {
+  const authUrl = getAuthUrl();
+  if (!authUrl) {
+    return { error: 'Auth service unavailable', status: 503 };
+  }
+  try {
+    const res = await fetch(`${authUrl}/api/apps/token/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, scope }),
+      cache: 'no-store',
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      return { error: data.error ?? 'Invalid app token', status: res.status };
+    }
+    return { appAuth: (await res.json()) as AppAuthContext };
+  } catch (err) {
+    log.error({ err: String(err) }, '[APP-AUTH] Token verify request failed');
+    return { error: 'Auth service unavailable', status: 503 };
+  }
+}
+
+/**
  * Require app authentication via X-App-DID + X-App-Authorization headers.
  *
  * X-App-DID:           The app's DID (received at registration)
@@ -26,11 +57,18 @@ export async function requireAppAuth(
   request: Request,
   options?: { scope?: string }
 ): Promise<AppAuthResult> {
+  // Preferred path (#1069): short-lived scoped app token via Authorization: Bearer.
+  const bearer = request.headers.get('authorization');
+  if (bearer?.startsWith('Bearer ')) {
+    return verifyBearerAppToken(bearer.slice(7), options?.scope);
+  }
+
+  // Legacy path: static attestationId as bearer. Kept during migration.
   const appDid = request.headers.get('x-app-did');
   const attestationId = request.headers.get('x-app-authorization');
 
   if (!appDid || !attestationId) {
-    return { error: 'X-App-DID and X-App-Authorization headers required', status: 401 };
+    return { error: 'Authorization Bearer <app-token>, or X-App-DID + X-App-Authorization headers required', status: 401 };
   }
 
   const authUrl = getAuthUrl();


### PR DESCRIPTION
## Spike — short-lived scoped app tokens (#1069 / #799 P3)

**Draft / spike.** Implements the scoped app-token primitive from the #1069 design so #799's "delegated session token minted from handshake (scoped, time-limited)" (P3) has a concrete shape. Not for merge as-is — see "Not in this spike" below.

### What this adds

**1. App token sign/verify** — `apps/kernel/src/lib/auth/jwt.ts`
- `createAppToken()` / `verifyAppToken()`. Reuses the existing kernel EdDSA keypair. Tokens are `typ: app+jwt` (so a session token can't be replayed as an app token), ~10 min TTL, claims: `sub`=userDid, `azp`=appDid, `scope` (space-delimited), `aud`, `attestationId`.

**2. Mint endpoint** — `POST /auth/api/apps/token`
- App proves possession of its keypair: signs `${appDid}:${attestationId}:${nonce}:${timestamp}`; kernel resolves the app DID's public key (`createDbResolver`) and verifies via the existing `verifySignature`. Rejects stale/future timestamps (60s window) and short nonces.
- Then runs the **same** `app.authorized` attestation checks as `/apps/validate` (existence, `revokedAt`, scope grant), and mints the token. Optional `scope` narrows to a single granted scope.

**3. Stateless verify endpoint** — `POST /auth/api/apps/token/verify`
- Verifies signature + expiry locally (no DB hit), enforces required scope, returns the `AppAuthContext` shape.

**4. `requireAppAuth` Bearer fast-path** — `packages/auth/src/require-app-auth.ts`
- New preferred path: `Authorization: Bearer <app-token>` → `verifyBearerAppToken()`. Falls back to the legacy `X-App-DID` + `X-App-Authorization` (static attestationId) path during migration. **No existing behavior removed.**

### Why this matters for third-party apps

The static `X-App-Authorization: <attestationId>` bearer is long-lived and replayable. This replaces it with a short-lived, app-key-bound token while keeping the existing consent/scope/revocation system (#799 P1) authoritative. Short TTL bounds the revocation window without a per-call DB lookup.

### Verification
- `tsc --noEmit` across `apps/kernel`: **0 errors.**
- No schema changes. No migration needed.

### NOT in this spike (follow-ups on #1069)
- **Cookie isolation** — narrowing the session cookie from `domain=.imajin.ai` to host-only, and the staged rollout. This is the other half of #1069 and the actual security fix; the token is the prerequisite.
- **Fully in-process verify** — `verifyBearerAppToken` currently calls the kernel `/token/verify` endpoint (stateless, but still a round-trip). Moving jose + the published kernel public key into `@imajin/auth` removes it entirely.
- **PoP nonce single-use** — timestamp window bounds replay; a true nonce cache would harden it further.
- Wiring apps to actually request/use tokens (first-party dogfood) — pairs with the #799 P1 wiring in the companion PR.

Related: #1069, #799, #244
