### PR TITLE
fix(media): render markdown assets on frontmatter title, not status: POSTED

### DIFF
--- a/apps/kernel/app/media/api/assets/[id]/route.ts
+++ b/apps/kernel/app/media/api/assets/[id]/route.ts
@@ -380,8 +380,13 @@ export async function GET(
   }
 
   // 5a. Auto-render markdown articles as HTML
-  // If it's text/markdown with frontmatter status: POSTED and the client
-  // isn't requesting raw bytes, render as a styled article page.
+  // If it's text/markdown carrying a frontmatter `title` and the client isn't
+  // requesting raw bytes, render as a styled article page. Presence of a
+  // `title` is the signal it's an article; `status` no longer gates rendering
+  // (a DRAFT/REVIEW doc should still render for anyone allowed to access it —
+  // access control already ran above, so private assets stay auth-gated). The
+  // public article index filters on DB `metadata.article.status` separately, so
+  // rendering here never publishes or lists a doc.
   if (
     asset.mimeType === "text/markdown" &&
     !download &&
@@ -391,7 +396,7 @@ export async function GET(
     const matter = (await import("gray-matter")).default;
     const { data: fm, content: body } = matter(mdContent);
 
-    if (fm.status === "POSTED" && fm.title) {
+    if (fm.title) {
       const { remark } = await import("remark");
       const remarkGfm = (await import("remark-gfm")).default;
       const remarkHtml = (await import("remark-html")).default;


### PR DESCRIPTION
## Problem

The asset-serve route (`/media/api/assets/[id]`) auto-renders markdown assets to styled HTML, but only when the frontmatter has **both** `status: POSTED` **and** a `title`:

```js
if (fm.status === "POSTED" && fm.title) {
```

That conflates *workflow state* with *should-this-render*. A markdown asset that's a `DRAFT`, in `REVIEW`, or has no `status` at all falls through and is served as raw `text/markdown` — which browsers display/download as plain text rather than rendering. So the owner can't even preview their own document as a styled page until they flip it to `POSTED`, which is also a publish signal.

**Concrete repro:** uploaded a private `.md` document, fetched it, got raw markdown (`content-type: text/markdown`, `x-fair-access: public`) instead of the rendered article page that a `POSTED` doc gets.

## Fix

Gate rendering on the presence of a frontmatter **`title`** alone — the real signal that a markdown file is an article worth rendering. One-line logic change + an explanatory comment.

```js
if (fm.title) {
```

## Why this is safe (isolated, no leak)

- **Access control already ran earlier in the handler.** Private/`trust-graph`/`conversation` assets still require auth before reaching this branch, so softening the *render* gate does not expose anything. Frontmatter controls *rendering*; the `.fair` `access` field controls *who can fetch*.
- **The public article index is a separate path.** `apps/kernel/src/lib/www/articles.ts` lists articles by querying DB `metadata.article.status = 'POSTED'` (set by the `publish-as-article` action) — **not** the markdown frontmatter `fm.status` this route reads. Rendering here never publishes or lists a doc.
- **No behavior change for non-article files.** A plain `.md` with no `title` still serves raw, exactly as before.
- **Existing POSTED articles unaffected** — they have a `title`, so they still render.

## Test

- `.md` asset with `title` + no/`DRAFT`/`REVIEW` status → now renders as styled HTML (previously raw).
- `.md` asset with `title` + `status: POSTED` → still renders (unchanged).
- `.md` asset with no `title` → still served raw (unchanged).
- Private `.md` with `title`, unauthenticated → still 403 (access control unchanged).
- No DB/schema change; migration check passed on push.
