### PR TITLE
fix(events): repair broken free-checkout route (main build is red)

### DIFF
--- a/apps/events/app/api/checkout/free/route.ts
+++ b/apps/events/app/api/checkout/free/route.ts
@@ -13,8 +13,7 @@ import { db, events, ticketTypes, tickets, eventInvites } from '@/src/db';
 import { eq, and, sql } from 'drizzle-orm';
 import { optionalAuth } from '@imajin/auth';
 import { resolveCheckoutIdentity } from '@/src/lib/checkout-common';
-import { rateLimit, getClientIP } from '@/src/lib/rate-limit';
-import { eventUrl } from '@imajin/config';
+import { rateLimit, getClientIP, eventUrl } from '@imajin/config';
 import { generateQRCode } from '@/src/lib/email';
 import { publish } from '@imajin/bus';
 import { getClient } from '@imajin/db';
@@ -145,22 +144,14 @@ export const POST = withLogger('events', async (request, { log }) => {
     );
 
     if (!resolved.did) {
-      if (body.email) {
-        await attachEmailToProfile(ownerDid, body.email);
-      }
-    } else if (body.email) {
-      // Anonymous â€” create soft DID
-      ownerDid = await getOrCreateSoftDid(body.email, body.name);
-      ownerEmail = body.email;
-    } else {
       return NextResponse.json(
-        { error: 'Please provide an email address to RSVP' },
+        { error: 'Could not resolve a ticket owner — please provide an email address to RSVP' },
         { status: 400 }
       );
     }
 
     const ownerDid: string = resolved.did;
-    let ownerEmail: string | null = resolved.email ?? null;
+    const ownerEmail: string | null = resolved.email ?? null;
 
     // Idempotency: check if this DID already has a ticket for this event
     const [existingTicket] = await db


### PR DESCRIPTION
## main is red — events build broken

The free RSVP checkout route (`apps/events/app/api/checkout/free/route.ts`) doesn't compile **on `main`**, so every PR branched from or rebased onto current main inherits a red Build check. Two defects, both left over from the canonical-checkout-identity refactor:

### 1. `const` reassignment (the reported error)
```
x cannot reassign to a variable declared with `const`
  153 | ownerDid = await getOrCreateSoftDid(body.email, body.name);
  162 | const ownerDid: string = resolved.did;
```
A dead fragment of the pre-refactor logic survived: it reassigned `const ownerDid`/`ownerEmail` and called `getOrCreateSoftDid` / `attachEmailToProfile` — functions that are no longer imported. `resolveCheckoutIdentity(..., { createSoftDid: true })` already does soft-DID minting + email resolution, so the block is pure dead code. Removed it; the route now returns 400 when no owner DID can be resolved.

### 2. Missing module
```
Module not found: Can't resolve '@/src/lib/rate-limit'
```
`rateLimit` / `getClientIP` were imported from a path that doesn't exist. The canonical location is `@imajin/config` (`packages/config/src/rate-limit.ts`) — matching the sibling `checkout/balance/route.ts`. Fixed and merged with the existing `@imajin/config` import line.

## Verification
- `pnpm --filter @imajin/events build` → **✓ Compiled successfully** (was "Failed to compile").
- `ownerEmail` confirmed read-only after the change → declared `const`.
- No schema change; migration check passed on push.

## Why direct hotfix to main
Per AGENTS.md, build-breaking bugs on main are hotfix territory. This unblocks #1071, #1072, and any other open PR currently failing Build on the same inherited error.
